### PR TITLE
chore: run CI only on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
## Summary

Remove duplicate CI trigger - tests already run on PRs before merge, no need to run again after merge.

## Changes

- Removed `push: branches: [master]` trigger from tests workflow
- CI now only runs on `pull_request` events

## Test plan

- [x] Workflow syntax is valid