### PR TITLE
feat(api): add PUT endpoints for trip and segment updates

### DIFF
--- a/Models/Dtos/SegmentUpdateRequestDto.cs
+++ b/Models/Dtos/SegmentUpdateRequestDto.cs
@@ -1,0 +1,13 @@
+namespace Wayfarer.Models.Dtos
+{
+    /// <summary>
+    /// Request body to update an existing Segment's notes.
+    /// </summary>
+    public class SegmentUpdateRequestDto
+    {
+        /// <summary>
+        /// Optional notes (HTML content). Set to null to clear notes.
+        /// </summary>
+        public string? Notes { get; set; }
+    }
+}

--- a/Models/Dtos/TripUpdateRequestDto.cs
+++ b/Models/Dtos/TripUpdateRequestDto.cs
@@ -1,0 +1,19 @@
+namespace Wayfarer.Models.Dtos
+{
+    /// <summary>
+    /// Request body to update an existing Trip's metadata.
+    /// Only provided fields will be updated (partial update).
+    /// </summary>
+    public class TripUpdateRequestDto
+    {
+        /// <summary>
+        /// Optional new name for the trip.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Optional notes (HTML content).
+        /// </summary>
+        public string? Notes { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PUT /api/trips/{tripId}` endpoint for updating trip metadata (name, notes) - closes #14
- Adds `PUT /api/trips/segments/{segmentId}` endpoint for updating segment notes - closes #15

## Changes
- Created `TripUpdateRequestDto` and `SegmentUpdateRequestDto` DTOs
- Added `UpdateTrip` and `UpdateSegmentNotes` endpoints to TripsController
- Added 14 unit tests covering authentication, authorization, and functionality

## Test plan
- [x] All 999 existing tests pass
- [x] 14 new tests pass for both endpoints
- [x] Manual testing with mobile app API calls