### PR TITLE
fix(ui): render region and area notes conditionally (#17)

### DIFF
--- a/Areas/User/Views/Trip/Partials/_AreaItemPartial.cshtml
+++ b/Areas/User/Views/Trip/Partials/_AreaItemPartial.cshtml
@@ -5,6 +5,7 @@
     var geomJson = Model.Geometry != null
         ? new GeoJsonWriter().Write(Model.Geometry)
         : "null";
+    var hasNotes = !string.IsNullOrWhiteSpace(Model.Notes);
 }
 
 <li class="area-list-item list-group-item d-flex align-items-center"
@@ -22,6 +23,16 @@
     </span>
 
     <div class="btn-group btn-group-sm ms-auto">
+        @if (hasNotes)
+        {
+            <button type="button"
+                    class="btn btn-outline-secondary"
+                    data-bs-toggle="modal"
+                    data-bs-target="#areaNotes-@Model.Id"
+                    title="View notes">
+                <i class="bi bi-info-circle"></i>
+            </button>
+        }
         <button type="button"
                 class="btn btn-outline-primary btn-edit-area"
                 data-area-id="@Model.Id"
@@ -36,3 +47,28 @@
         </button>
     </div>
 </li>
+
+@if (hasNotes)
+{
+    <div class="modal fade" id="areaNotes-@Model.Id" tabindex="-1"
+         aria-labelledby="areaNotesLabel-@Model.Id" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-scrollable modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="areaNotesLabel-@Model.Id">
+                        Notes for <span class="fw-semibold">@Model.Name</span>
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"
+                            aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    @Html.LinkifyHtml(Model.Notes)
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-sm btn-secondary"
+                            data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}

--- a/Areas/User/Views/Trip/Partials/_RegionItemPartial.cshtml
+++ b/Areas/User/Views/Trip/Partials/_RegionItemPartial.cshtml
@@ -64,11 +64,14 @@
                 </div>
             }
 
-            <div class="row">
-                <div class="col-12 mt-2">
-                    @Html.LinkifyHtml(Model.Notes)
+            @if (!string.IsNullOrWhiteSpace(Model.Notes))
+            {
+                <div class="row">
+                    <div class="col-12 mt-2">
+                        @Html.LinkifyHtml(Model.Notes)
+                    </div>
                 </div>
-            </div>
+            }
 
             <!-- Action buttons -->
             @if (Model.Name != "Unassigned Places")


### PR DESCRIPTION
## Summary
- Adds conditional check before rendering region notes (prevents empty whitespace when notes are null/empty)
- Adds info button and modal for area notes display (matching the pattern used by segments and places)

Closes #17

## Test plan
- [ ] Verify region notes only render when they contain content
- [ ] Verify area notes info button appears when notes exist
- [ ] Verify area notes modal opens and displays content correctly
- [ ] Verify no button/modal appears for areas without notes