### PR TITLE
fix(ui): use showConfirmationModal for leave group (#5)

### DIFF
--- a/wwwroot/js/Areas/User/Groups/Index.js
+++ b/wwwroot/js/Areas/User/Groups/Index.js
@@ -42,7 +42,17 @@
     if (!btn) return;
     const gid = btn.getAttribute('data-group-id');
     if (!gid) return;
-    if (confirm('Leave this group?')) leaveGroup(gid);
+
+    if (wayfarer.showConfirmationModal) {
+      wayfarer.showConfirmationModal({
+        title: 'Leave Group',
+        message: 'Are you sure you want to leave this group?',
+        confirmText: 'Leave',
+        onConfirm: () => leaveGroup(gid)
+      });
+    } else if (confirm('Leave this group?')) {
+      leaveGroup(gid);
+    }
   });
 
   loadJoined();


### PR DESCRIPTION
## Summary
- Replaces native browser `confirm()` dialog with the custom `wayfarer.showConfirmationModal` utility
- Provides consistent UX with other confirmation dialogs in the app
- Includes fallback to native confirm if modal utility is unavailable

Closes #5

## Test plan
- [ ] Verify styled confirmation modal appears when clicking "Leave" button
- [ ] Verify "Leave" action only triggers after confirming in modal
- [ ] Verify cancel/close dismisses modal without leaving group