### PR TITLE
fix(ui): enforce minimum 16px font in readable view (#13)

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1570,3 +1570,60 @@ img.js-lazy[src] {
     overflow-wrap: break-word;
     hyphens: auto;
 }
+
+/* ============================================
+   Readable View Modal - Font Size Overrides
+   Issue #13: Ensure imported Google MyMaps content is readable
+   ============================================ */
+
+/* Base content font size for readable modal - override inline styles from imports */
+#readableViewModal .modal-body {
+    font-size: 16px !important;
+}
+
+/* Trip notes section - ensure readable font size */
+#readableViewModal .trip-notes-readable,
+#readableViewModal .trip-notes-readable * {
+    font-size: 16px !important;
+}
+
+/* Region notes - override inline font-size from imported content */
+#readableViewModal .region-readable,
+#readableViewModal .region-readable > div {
+    font-size: 16px !important;
+}
+
+/* Place item notes - ensure minimum readable size */
+#readableViewModal .place-item .text-muted,
+#readableViewModal .place-item div,
+#readableViewModal .place-item p,
+#readableViewModal .place-item span {
+    font-size: 16px !important;
+    line-height: 1.5 !important;
+}
+
+/* Preserve heading sizes - they should remain as designed */
+#readableViewModal h1,
+#readableViewModal h2,
+#readableViewModal h3,
+#readableViewModal h4,
+#readableViewModal h5,
+#readableViewModal h6 {
+    font-size: revert !important;
+}
+
+/* Preserve small metadata labels (like "Trip by:", "Updated:") */
+#readableViewModal .row.small,
+#readableViewModal .mb-3 > .small {
+    font-size: 0.875rem !important;
+}
+
+/* Preserve badge font sizes */
+#readableViewModal .badge {
+    font-size: 0.875rem !important;
+}
+
+/* Dark mode compatibility - ensure text remains readable */
+[data-bs-theme="dark"] #readableViewModal .modal-body {
+    color: var(--bs-body-color);
+}


### PR DESCRIPTION
## Summary
- Enforces minimum 16px font size for content in the trips readable view modal
- Overrides inline styles from imported Google MyMaps content that use 14px fonts
- Preserves heading hierarchy and UI label sizing
- Adds dark mode compatibility

Closes #13

## Changes
- Added CSS rules to `site.css` targeting `#readableViewModal`:
  - Trip notes, region notes, and place notes set to 16px with `!important`
  - Headings use `revert` to maintain hierarchy
  - UI labels and badges preserved at 0.875rem

## Test plan
- [ ] Open a trip with imported Google MyMaps content in readable view
- [ ] Verify notes content displays at 16px (not 14px)
- [ ] Verify headings maintain proper sizing (h5, h6)
- [ ] Verify metadata labels remain appropriately small
- [ ] Test in dark mode