### PR TITLE
fix(admin): resolve log viewer JS loading and remove hover shadows

### DIFF
--- a/Areas/Admin/Views/Logs/Index.cshtml
+++ b/Areas/Admin/Views/Logs/Index.cshtml
@@ -134,5 +134,5 @@
 }
 
 @section Scripts {
-    <script src="~/js/Areas/Admin/Logs/Index.js" asp-append-version="true"></script>
+    @Html.FrontendViewScripts()
 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1397,14 +1397,9 @@ img.js-lazy[src] {
     }
 }
 
-/* Card hover effects for grid view */
+/* Card styles with subtle permanent shadow */
 .card {
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important;
+    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary
- Fix admin log viewer JS not loading by using `@Html.FrontendViewScripts()` instead of direct script tag, aligning with MvcFrontendKit conventions used throughout the project
- Replace distracting hover shadows on cards with subtle permanent shadows for improved UX

## Changes
1. **Log Viewer Fix** (`Areas/Admin/Views/Logs/Index.cshtml`)
   - Replaced `<script src="~/js/Areas/Admin/Logs/Index.js">` with `@Html.FrontendViewScripts()`
   - This aligns with how other Admin views load their JavaScript (e.g., Settings)

2. **Hover Shadow Removal** (`wwwroot/css/site.css`)
   - Removed `.card:hover` transform and shadow effects
   - Added subtle permanent shadow (`box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075)`) to `.card`

## Test plan
- [x] Build succeeds
- [x] All 1022 tests pass
- [ ] Manually verify admin log viewer loads and functions correctly
- [ ] Verify cards across the app have subtle permanent shadows instead of hover effects