### PR TITLE
fix(image): replace SkiaSharp with ImageSharp for cross-platform support

### DIFF
--- a/Wayfarer.csproj
+++ b/Wayfarer.csproj
@@ -43,7 +43,7 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
         <PackageReference Include="Serilog.Sinks.PostgreSQL" Version="2.3.0" />
-        <PackageReference Include="SkiaSharp" Version="3.119.1" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
 
         <!-- Swashbuckle locked at 9.0.1 -->
         <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />


### PR DESCRIPTION
## Summary
Replace SkiaSharp with SixLabors.ImageSharp to fix the linux-arm64 deployment issue where `libSkiaSharp.so` native library was missing.

## Problem
On the production server (linux-arm64), the application was failing to optimize images because SkiaSharp requires native binaries that weren't being deployed:
```
System.DllNotFoundException: Unable to load shared library 'libSkiaSharp'
/var/www/wayfarer/runtimes/linux-arm64/native/libSkiaSharp.so: cannot open shared object file
```

The app gracefully fell back to serving unoptimized images, but this defeated the purpose of the optimization feature.

## Solution
Replace SkiaSharp with **SixLabors.ImageSharp**, which is:
- Pure managed C# code - no native dependencies
- Works on any platform (Windows, Linux x64, ARM64, macOS)
- More maintainable for cross-platform deployments
- Industry standard for .NET image processing

## Changes
1. **Package Reference** (`Wayfarer.csproj`)
   - Remove: `SkiaSharp 3.119.1`
   - Add: `SixLabors.ImageSharp 3.1.12`

2. **Image Optimization** (`Areas/Public/Controllers/TripViewerController.cs`)
   - Rewrite `OptimizeImage` method using ImageSharp APIs
   - Same functionality: resize with aspect ratio, transparency detection, PNG/JPEG output
   - Uses Lanczos3 resampler for high-quality resizing

## Test plan
- [x] Build succeeds
- [x] All 1022 tests pass
- [ ] Manually verify image proxy with optimization works
- [x] Deploy to linux-arm64 and verify no more libSkiaSharp errors