### PR TITLE
feat(trip-viewer): display region and segment notes in sidebar

### DIFF
--- a/Util/HtmlHelpers.cs
+++ b/Util/HtmlHelpers.cs
@@ -53,5 +53,31 @@ namespace Wayfarer.Util
 
             return new HtmlString(linked);
         }
+
+        // Regex to strip HTML tags for content detection
+        private static readonly Regex _htmlTagRegex = new Regex(
+            @"<[^>]+>",
+            RegexOptions.Compiled
+        );
+
+        /// <summary>
+        /// Checks if HTML content has actual visible text content.
+        /// Returns false for null, empty, whitespace-only, or Quill's empty states like &lt;p&gt;&lt;/p&gt; or &lt;p&gt;&lt;br&gt;&lt;/p&gt;.
+        /// </summary>
+        public static bool HasVisibleContent(string? htmlContent)
+        {
+            if (string.IsNullOrWhiteSpace(htmlContent))
+                return false;
+
+            // Strip all HTML tags and check if any visible text remains
+            var textOnly = _htmlTagRegex.Replace(htmlContent, "");
+
+            // Also handle HTML entities for whitespace
+            textOnly = textOnly
+                .Replace("&nbsp;", " ")
+                .Replace("&#160;", " ");
+
+            return !string.IsNullOrWhiteSpace(textOnly);
+        }
     }
 }

--- a/Views/Trip/Partials/_RegionReadonly.cshtml
+++ b/Views/Trip/Partials/_RegionReadonly.cshtml
@@ -40,6 +40,13 @@
 
     <div id="reg-body-@Model.Id" class="accordion-collapse show">
         <div class="accordion-body p-0">
+            @* Region notes - shown if present *@
+            @if (HtmlHelpers.HasVisibleContent(Model.Notes))
+            {
+                <div class="small text-muted px-2 py-1 border-bottom">
+                    @Html.Raw(Model.Notes)
+                </div>
+            }
             <ul class="list-group list-group-flush">
 
                 @foreach (var p in Model.Places?.OrderBy(pl => pl.DisplayOrder)
@@ -108,10 +115,10 @@
                                     </div>
 
                                     <!-- second row: rich-text notes -->
-                                    @if (!string.IsNullOrWhiteSpace(area.Notes))
+                                    @if (HtmlHelpers.HasVisibleContent(area.Notes))
                                     {
                                         <div class="small text-muted">
-                                            @Html.Raw(area.Notes)     <!-- renders stored HTML instead of &lt;p&gt; -->
+                                            @Html.Raw(area.Notes)
                                         </div>
                                     }
                                 </div>

--- a/Views/Trip/Partials/_SegmentReadonlyList.cshtml
+++ b/Views/Trip/Partials/_SegmentReadonlyList.cshtml
@@ -90,6 +90,12 @@
                                 <div title="To: @toName (@toRegion)">
                                     <strong>To:</strong> @toName (@toRegion)
                                 </div>
+                                @if (HtmlHelpers.HasVisibleContent(seg?.Notes))
+                                {
+                                    <div class="text-muted mt-1 segment-notes-preview">
+                                        @Html.Raw(seg?.Notes)
+                                    </div>
+                                }
                             </div>
                         </div>
 

--- a/tests/Wayfarer.Tests/Util/HtmlHelpersTests.cs
+++ b/tests/Wayfarer.Tests/Util/HtmlHelpersTests.cs
@@ -52,4 +52,38 @@ public class HtmlHelpersTests
         Assert.Contains("<a href=\"http://example.com\" target=\"_blank\" rel=\"noopener noreferrer\">http://example.com</a>", rendered);
         Assert.Contains("<a href=\"http://already.com\">existing</a>", rendered);
     }
+
+    #region HasVisibleContent Tests
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("<p></p>", false)]
+    [InlineData("<p><br></p>", false)]
+    [InlineData("<p><br/></p>", false)]
+    [InlineData("<div></div>", false)]
+    [InlineData("<p>&nbsp;</p>", false)]
+    [InlineData("<p>&#160;</p>", false)]
+    [InlineData("<p>  </p>", false)]
+    public void HasVisibleContent_ReturnsFalse_ForEmptyContent(string? input, bool expected)
+    {
+        var result = HtmlHelpers.HasVisibleContent(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("<p>Hello</p>", true)]
+    [InlineData("<p>Some <strong>bold</strong> text</p>", true)]
+    [InlineData("<div><p>Nested content</p></div>", true)]
+    [InlineData("Plain text without tags", true)]
+    [InlineData("<p>Text with &nbsp; space</p>", true)]
+    [InlineData("<img src='test.jpg' alt='Image'>", false)] // Image without text returns false
+    public void HasVisibleContent_ReturnsTrue_ForContentWithText(string input, bool expected)
+    {
+        var result = HtmlHelpers.HasVisibleContent(input);
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
Add notes display for regions and segments in the trip viewer sidebar (both private `/User/Trip/View/...` and public `/Public/Trips/...` views).

## Problem
- **Region notes**: Not displayed at all in the sidebar
- **Segment notes**: Only stored in data attributes for JavaScript, not visually displayed
- **Area notes**: Already displayed correctly

## Solution
Display region and segment notes inline, using the same styling as existing area notes (`.small .text-muted`).

## Changes

### New Helper (`Util/HtmlHelpers.cs`)
- Add `HasVisibleContent(string? htmlContent)` method
- Detects empty Quill editor content like `<p></p>`, `<p><br></p>`, `<p>&nbsp;</p>`
- Strips HTML tags and checks if any visible text remains

### Region Notes (`Views/Trip/Partials/_RegionReadonly.cshtml`)
- Display notes below region name in accordion header
- Uses same `.small .text-muted` styling as area notes

### Segment Notes (`Views/Trip/Partials/_SegmentReadonlyList.cshtml`)
- Display notes below segment details (From/To info)
- Uses `.text-muted mt-1 segment-notes-preview` styling

### Tests (`tests/.../HtmlHelpersTests.cs`)
- Add 16 new tests for `HasVisibleContent` method
- Test empty content detection (null, whitespace, empty tags)
- Test visible content detection (text, nested HTML)

## Test plan
- [x] Build succeeds
- [x] All 1022+ tests pass
- [x] Manually verify notes appear in private trip view
- [x] Manually verify notes appear in public trip view
- [x] Verify empty notes (Quill's `<p></p>`) don't show