### PR TITLE
fix(trips): display region images and add scrollable notes

### DIFF
--- a/Views/Trip/Partials/_RegionReadonly.cshtml
+++ b/Views/Trip/Partials/_RegionReadonly.cshtml
@@ -40,10 +40,17 @@
 
     <div id="reg-body-@Model.Id" class="accordion-collapse show">
         <div class="accordion-body p-0">
-            @* Region notes - shown if present *@
+            @* Region cover image - shown if present *@
+            @if (!string.IsNullOrWhiteSpace(Model.CoverImageUrl))
+            {
+                <div class="region-cover-image px-2 py-1 border-bottom">
+                    <img src="@Model.CoverImageUrl" alt="@Model.Name" class="img-fluid rounded" style="max-height: 150px; object-fit: cover; width: 100%;" />
+                </div>
+            }
+            @* Region notes - shown if present, scrollable like trip notes *@
             @if (HtmlHelpers.HasVisibleContent(Model.Notes))
             {
-                <div class="small text-muted px-2 py-1 border-bottom">
+                <div class="small text-muted px-2 py-1 border-bottom" style="max-height: 150px; overflow-y: auto;">
                     @Html.Raw(Model.Notes)
                 </div>
             }
@@ -114,10 +121,10 @@
                                         <strong class="area-name ms-2">@area.Name</strong>
                                     </div>
 
-                                    <!-- second row: rich-text notes -->
+                                    <!-- second row: rich-text notes (scrollable) -->
                                     @if (HtmlHelpers.HasVisibleContent(area.Notes))
                                     {
-                                        <div class="small text-muted">
+                                        <div class="small text-muted" style="max-height: 100px; overflow-y: auto;">
                                             @Html.Raw(area.Notes)
                                         </div>
                                     }

--- a/Views/Trip/Partials/_SegmentReadonlyList.cshtml
+++ b/Views/Trip/Partials/_SegmentReadonlyList.cshtml
@@ -92,7 +92,7 @@
                                 </div>
                                 @if (HtmlHelpers.HasVisibleContent(seg?.Notes))
                                 {
-                                    <div class="text-muted mt-1 segment-notes-preview">
+                                    <div class="text-muted mt-1 segment-notes-preview" style="max-height: 100px; overflow-y: auto;">
                                         @Html.Raw(seg?.Notes)
                                     </div>
                                 }

--- a/Views/Trip/Viewer.cshtml
+++ b/Views/Trip/Viewer.cshtml
@@ -395,6 +395,13 @@
                         <div class="region-readable mb-4 pb-3 border-bottom">
                             <h5 class="mb-2">@region.Name</h5>
 
+                            @if (!string.IsNullOrWhiteSpace(region.CoverImageUrl))
+                            {
+                                <div class="mb-3">
+                                    <img src="@region.CoverImageUrl" alt="@region.Name" class="img-fluid rounded" style="max-height: 200px; object-fit: cover; width: 100%;" />
+                                </div>
+                            }
+
                             @if (!string.IsNullOrWhiteSpace(region.Notes))
                             {
                                 <div class="mb-3 text-muted">


### PR DESCRIPTION
## Summary
- Display region cover images in trip viewer sidebar and readable/print view
- Add scrollable containers for region, area, and segment notes (consistent with trip notes)

## Changes
- **_RegionReadonly.cshtml**: Show region cover image (if exists) and make notes scrollable (150px)
- **_SegmentReadonlyList.cshtml**: Make segment notes scrollable (100px)  
- **Viewer.cshtml**: Show region cover image in readable view (if exists)

## Test plan
- [ ] View a trip with regions that have cover images - images should display
- [ ] View a trip with long region/area/segment notes - notes should scroll
- [ ] Open readable view (print modal) - region images should appear
- [ ] Verify order: Region name → Image → Notes → Places → Areas