### PR TITLE
fix(sse): restore per-user broadcasts for timeline views

### DIFF
--- a/Areas/User/Controllers/LocationController.cs
+++ b/Areas/User/Controllers/LocationController.cs
@@ -189,6 +189,13 @@ namespace Wayfarer.Areas.User.Controllers
                 LogAction("CreateLocation", $"Location added for user {model.UserId}");
                 SetAlert("The location has been successfully created.", "success");
 
+                // Per-user broadcast for timeline views (User/Timeline, Public/Timeline, Embed)
+                await _sse.BroadcastAsync($"location-update-{user?.UserName ?? model.UserId}", JsonSerializer.Serialize(new
+                {
+                    LocationId = location.Id,
+                    TimeStamp = location.Timestamp,
+                }));
+
                 // Broadcast to all group channels
                 var groupIds = await _dbContext.GroupMembers
                     .Where(m => m.UserId == model.UserId && m.Status == GroupMember.MembershipStatuses.Active)

--- a/tests/Wayfarer.Tests/Controllers/LocationControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/LocationControllerTests.cs
@@ -142,9 +142,10 @@ namespace Wayfarer.Tests.Controllers;
         Assert.Equal(model.Longitude, saved.Coordinates.X);
         Assert.Equal("Test note", saved.Notes);
 
-        // Verify broadcast goes to group channel only
-        var message = Assert.Single(sse.Messages);
-        Assert.Equal($"group-{group.Id}", message.Channel);
+        // Verify broadcasts go to both per-user (for timeline views) and group channels
+        Assert.Equal(2, sse.Messages.Count);
+        Assert.Single(sse.Messages, m => m.Channel == $"location-update-{currentUser.UserName}");
+        Assert.Single(sse.Messages, m => m.Channel == $"group-{group.Id}");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Restores per-user SSE broadcasts that were incorrectly removed during group SSE consolidation
- Timeline views (User/Timeline, Public/Timeline, Embed) subscribe to `location-update-{username}` channel and need these events
- Both per-user and group broadcasts now occur for location additions and check-ins

## Changes
- `User/LocationController.cs`: Added per-user broadcast for manual location additions
- `Api/LocationController.cs`: Added per-user broadcast for API check-ins and log-location
- Updated tests to verify both per-user and group broadcasts occur

## Test plan
- [x] Build succeeds
- [x] All 1067 tests pass
- [ ] Verify User/Timeline view receives live location updates
- [ ] Verify Public/Users/Timeline view receives live updates  
- [ ] Verify Embed timeline view receives live updates