### PR TITLE
docs: add place visit detection documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Wayfarer is a self-hosted travel companion that lets you keep a private location
 ## What you get
 
 - **Your own location journal** – record live points, import historical data, and publish a public view with hidden-area privacy controls if you choose.
-- **Trip planning tools** – organise places, areas, and routes, add notes and colours, and export itineraries to PDF or KML.
+- **Trip planning tools** – organise places, areas, and routes, add notes and colours, and export itineraries to PDF or KML. Automatic visit detection records when you arrive at planned places.
 - **Trusted sharing** – managers you approve can follow your latest positions; shared dashboards update instantly via server-sent events.
 - **Offline-friendly maps** – tile caching keeps base maps fast and respects tile provider limits; higher zoom levels are pruned automatically.
 - **Admin controls** – manage users, thresholds, caches, jobs, audit logs, and reverse-geocoding tokens from a dedicated admin area.

--- a/docs/03-Features.md
+++ b/docs/03-Features.md
@@ -12,6 +12,7 @@ Timeline
 Trips
 - Organize a trip into Regions, Places (points), Areas (polygons), and Segments (routes).
 - Add notes, colors, and travel modes. Export to PDF or KML.
+- **Automatic visit detection** — when GPS pings arrive near a planned place, the system records a visit event with timestamps and place snapshot data.
 
 Groups
 - Share live or recent locations among trusted members. Joining is by invitation.

--- a/docs/04-Trips.md
+++ b/docs/04-Trips.md
@@ -23,6 +23,13 @@ Exporting a Trip
   - Cancel export at any time during generation
 - **KML** — Wayfarer or Google MyMaps compatible formats.
 
+Automatic Visit Detection
+- When you receive GPS pings (from the mobile app or API), the system checks if you're near any planned places in your trips.
+- After two consecutive pings within a configurable radius, a **visit event** is recorded automatically.
+- Visit events capture arrival time, departure time, and a snapshot of the place details (name, location, notes) at the time of visit.
+- This works with all location sources: mobile app tracking, manual check-ins, and web app location entries.
+- Settings like detection radius, accuracy thresholds, and confirmation requirements can be adjusted in Admin > Settings.
+
 Tips
 - Keep names concise for cleaner export filenames.
 - Use Areas for boundaries and Segments for movement between Places.

--- a/docs/20-Services.md
+++ b/docs/20-Services.md
@@ -17,6 +17,11 @@ Selected Services and Responsibilities
 - `SseService` — server‑sent events for progress/notifications (e.g., imports).
 - `RegistrationService` — registration controls, depending on `ApplicationSettings.IsRegistrationOpen`.
 - `LocationService`, `LocationStatsService` — location data access and analytics.
+- `PlaceVisitDetectionService` — detects when users visit planned trip places based on GPS pings.
+  - Uses PostGIS spatial queries (ST_DWithin) with a GiST index for efficient lookup at scale.
+  - Two-hit candidate confirmation reduces false positives from GPS noise.
+  - Creates `PlaceVisitEvent` records with snapshot data (place name, location, notes) preserved even if the place is later deleted.
+  - Event-driven cleanup of stale visits and candidates on each ping.
 - `GroupService`, `GroupTimelineService` — groups, access context, and timeline queries.
 - `RazorViewRenderer` — render Razor views to string (e.g., PDF export).
 - `MobileCurrentUserAccessor` — resolves current user in mobile/API contexts.


### PR DESCRIPTION
## Summary

Adds documentation for the automatic place visit detection feature introduced in #41.

## Changes

- **README.md** — Brief mention under "Trip planning tools"
- **docs/03-Features.md** — Added visit detection to Trips section
- **docs/04-Trips.md** — New "Automatic Visit Detection" section with details
- **docs/20-Services.md** — Added PlaceVisitDetectionService description

## Test Plan

- [x] Verify docs render correctly in Docsify