### PR TITLE
feat(ui): add visited badge to sidebar place list

### DIFF
--- a/Areas/User/Views/Trip/Partials/_RegionItemPartial.cshtml
+++ b/Areas/User/Views/Trip/Partials/_RegionItemPartial.cshtml
@@ -119,9 +119,13 @@
 
                                 @if (place.Location != null)
                                 {
-                                    <span title="This place has coordinates set, click to see which marker is on map">
+                                    <span class="sidebar-place-icon" title="This place has coordinates set, click to see which marker is on map">
                                         @await Html.PartialAsync("~/Areas/User/Views/Trip/Partials/_MapIcon.cshtml",
                                         (place.IconName, place.MarkerColor))
+                                        @if (visitCount > 0)
+                                        {
+                                            <span class="sidebar-visit-badge" title="@(visitCount == 1 ? "Visited" : $"Visited {visitCount} times")">@(visitCount == 1 ? "✓" : visitCount)</span>
+                                        }
                                     </span>
                                 }
 

--- a/Views/Trip/Partials/_RegionReadonly.cshtml
+++ b/Views/Trip/Partials/_RegionReadonly.cshtml
@@ -94,8 +94,14 @@
                             }
                             title="Click to view details">
 
-                            @await Html.PartialAsync("~/Areas/User/Views/Trip/Partials/_MapIcon.cshtml",
-                                (iconName, bgClass))
+                            <span class="sidebar-place-icon">
+                                @await Html.PartialAsync("~/Areas/User/Views/Trip/Partials/_MapIcon.cshtml",
+                                    (iconName, bgClass))
+                                @if (visitCount > 0)
+                                {
+                                    <span class="sidebar-visit-badge" title="@(visitCount == 1 ? "Visited" : $"Visited {visitCount} times")">@(visitCount == 1 ? "✓" : visitCount)</span>
+                                }
+                            </span>
                             <span class="flex-grow-1">@p.Name</span>
 
                             <div class="d-none place-notes">

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1656,3 +1656,32 @@ img.js-lazy[src] {
     box-shadow: 0 1px 2px rgba(0,0,0,0.3);
     z-index: 10;
 }
+
+/* ─────────────────────────────────────────────────────────
+   Sidebar Place Visit Badge
+   Displays a small green checkmark/count badge on sidebar icons
+───────────────────────────────────────────────────────── */
+.sidebar-place-icon {
+    position: relative;
+    display: inline-block;
+}
+
+.sidebar-visit-badge {
+    position: absolute;
+    top: -2px;
+    right: -4px;
+    min-width: 14px;
+    height: 14px;
+    padding: 0 2px;
+    background: #198754;
+    color: white;
+    border-radius: 7px;
+    font-size: 9px;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1.5px solid white;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    z-index: 10;
+}


### PR DESCRIPTION
## Summary
- Adds green checkmark/count badge overlay on sidebar place icons (similar to map markers)
- Shows ✓ for single visit, displays count for multiple visits
- Works in both Edit and View modes (owner only for privacy)

## Changes
- Wrap sidebar place icons in `sidebar-place-icon` container
- Add `sidebar-visit-badge` element when visitCount > 0
- Add CSS styling (14px badge, slightly smaller than map marker badge)

## Privacy
- Badge only shown to trip owner, never in public views

## Test plan
- [x] Edit view shows badges on sidebar place icons
- [x] View mode shows badges on sidebar place icons
- [x] Verify public view does not show badges