### PR TITLE
feat(sse): add visit started notifications (Phase 5)

### DIFF
--- a/Models/Dtos/VisitSseEventDto.cs
+++ b/Models/Dtos/VisitSseEventDto.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Wayfarer.Models.Dtos;
+
+/// <summary>
+/// SSE event payload for visit notifications.
+/// Broadcast when a user's visit to a planned place is confirmed.
+/// </summary>
+public sealed class VisitSseEventDto
+{
+    /// <summary>
+    /// Event type discriminator. Currently only "visit_started".
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "visit_started";
+
+    /// <summary>
+    /// The unique identifier of the visit event.
+    /// </summary>
+    [JsonPropertyName("visitId")]
+    public Guid VisitId { get; init; }
+
+    /// <summary>
+    /// The trip ID containing the visited place.
+    /// </summary>
+    [JsonPropertyName("tripId")]
+    public Guid TripId { get; init; }
+
+    /// <summary>
+    /// The trip name (snapshot at visit time).
+    /// </summary>
+    [JsonPropertyName("tripName")]
+    public string TripName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The place ID that was visited (null if place was deleted).
+    /// </summary>
+    [JsonPropertyName("placeId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Guid? PlaceId { get; init; }
+
+    /// <summary>
+    /// The place name (snapshot at visit time).
+    /// </summary>
+    [JsonPropertyName("placeName")]
+    public string PlaceName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The region name containing the place.
+    /// </summary>
+    [JsonPropertyName("regionName")]
+    public string RegionName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// UTC timestamp when the visit was confirmed.
+    /// </summary>
+    [JsonPropertyName("arrivedAtUtc")]
+    public DateTime ArrivedAtUtc { get; init; }
+
+    /// <summary>
+    /// Latitude of the visited place.
+    /// </summary>
+    [JsonPropertyName("latitude")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Latitude { get; init; }
+
+    /// <summary>
+    /// Longitude of the visited place.
+    /// </summary>
+    [JsonPropertyName("longitude")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Longitude { get; init; }
+
+    /// <summary>
+    /// Icon name for the place marker.
+    /// </summary>
+    [JsonPropertyName("iconName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? IconName { get; init; }
+
+    /// <summary>
+    /// Marker color for the place.
+    /// </summary>
+    [JsonPropertyName("markerColor")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MarkerColor { get; init; }
+
+    /// <summary>
+    /// Creates a visit_started event from a PlaceVisitEvent.
+    /// </summary>
+    public static VisitSseEventDto FromVisitEvent(PlaceVisitEvent visit) => new()
+    {
+        Type = "visit_started",
+        VisitId = visit.Id,
+        TripId = visit.TripIdSnapshot,
+        TripName = visit.TripNameSnapshot ?? string.Empty,
+        PlaceId = visit.PlaceId,
+        PlaceName = visit.PlaceNameSnapshot ?? string.Empty,
+        RegionName = visit.RegionNameSnapshot ?? string.Empty,
+        ArrivedAtUtc = visit.ArrivedAtUtc,
+        Latitude = visit.PlaceLocationSnapshot?.Y,
+        Longitude = visit.PlaceLocationSnapshot?.X,
+        IconName = visit.IconNameSnapshot,
+        MarkerColor = visit.MarkerColorSnapshot
+    };
+}

--- a/tests/Wayfarer.Tests/Integration/PlaceVisitDetectionIntegrationTests.cs
+++ b/tests/Wayfarer.Tests/Integration/PlaceVisitDetectionIntegrationTests.cs
@@ -61,6 +61,7 @@ public class PlaceVisitDetectionIntegrationTests : TestBase
         var visitDetectionService = new PlaceVisitDetectionService(
             db,
             settingsService,
+            sseService,
             NullLogger<PlaceVisitDetectionService>.Instance);
 
         var controller = new LocationController(

--- a/tests/Wayfarer.Tests/Integration/VisitSseBroadcastsTests.cs
+++ b/tests/Wayfarer.Tests/Integration/VisitSseBroadcastsTests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NetTopologySuite.Geometries;
+using Wayfarer.Models;
+using Wayfarer.Models.Dtos;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Xunit;
+
+namespace Wayfarer.Tests.Integration;
+
+/// <summary>
+/// Integration tests for SSE broadcasts when visits are created.
+/// Note: Full spatial query testing requires PostgreSQL+PostGIS.
+/// These tests verify the broadcast infrastructure and DTO serialization.
+/// </summary>
+public class VisitSseBroadcastsTests
+{
+    /// <summary>
+    /// Test SSE service that captures broadcast messages.
+    /// </summary>
+    private sealed class TestSseService : SseService
+    {
+        public List<(string Channel, string Data)> Messages { get; } = new();
+
+        public override Task BroadcastAsync(string channel, string data)
+        {
+            Messages.Add((channel, data));
+            return Task.CompletedTask;
+        }
+    }
+
+    private static ApplicationDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options, new ServiceCollection().BuildServiceProvider());
+    }
+
+    [Fact]
+    public void VisitSseEventDto_SerializesToCorrectChannelFormat()
+    {
+        // Arrange
+        var userId = "user123";
+        var expectedChannel = $"user-visits-{userId}";
+
+        var visit = new PlaceVisitEvent
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PlaceId = Guid.NewGuid(),
+            TripIdSnapshot = Guid.NewGuid(),
+            TripNameSnapshot = "Test Trip",
+            RegionNameSnapshot = "Test Region",
+            PlaceNameSnapshot = "Test Place",
+            ArrivedAtUtc = DateTime.UtcNow,
+            PlaceLocationSnapshot = new Point(23.72, 37.97) { SRID = 4326 },
+            IconNameSnapshot = "marker",
+            MarkerColorSnapshot = "bg-blue"
+        };
+
+        // Act
+        var dto = VisitSseEventDto.FromVisitEvent(visit);
+        var json = JsonSerializer.Serialize(dto);
+
+        // Assert
+        Assert.Equal(expectedChannel, $"user-visits-{visit.UserId}");
+        Assert.Contains("\"type\":\"visit_started\"", json);
+        Assert.Contains("\"placeName\":\"Test Place\"", json);
+        Assert.Contains("\"tripName\":\"Test Trip\"", json);
+    }
+
+    [Fact]
+    public async Task TestSseService_CapturesBroadcastMessages()
+    {
+        // Arrange
+        var sseService = new TestSseService();
+        var channel = "user-visits-user123";
+        var dto = new VisitSseEventDto
+        {
+            VisitId = Guid.NewGuid(),
+            TripId = Guid.NewGuid(),
+            TripName = "Trip",
+            PlaceName = "Place",
+            RegionName = "Region",
+            ArrivedAtUtc = DateTime.UtcNow
+        };
+        var json = JsonSerializer.Serialize(dto);
+
+        // Act
+        await sseService.BroadcastAsync(channel, json);
+
+        // Assert
+        Assert.Single(sseService.Messages);
+        Assert.Equal(channel, sseService.Messages[0].Channel);
+        Assert.Contains("visit_started", sseService.Messages[0].Data);
+    }
+
+    [Fact]
+    public void PlaceVisitDetectionService_CanBeConstructedWithSseService()
+    {
+        // Arrange
+        var db = CreateDb();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+
+        db.ApplicationSettings.Add(new ApplicationSettings
+        {
+            Id = 1,
+            LocationTimeThresholdMinutes = 5,
+            LocationDistanceThresholdMeters = 15,
+            VisitedRequiredHits = 2,
+            VisitedMinRadiusMeters = 35,
+            VisitedMaxRadiusMeters = 100,
+            VisitedAccuracyMultiplier = 2.0,
+            VisitedAccuracyRejectMeters = 200,
+            VisitedMaxSearchRadiusMeters = 150
+        });
+        db.SaveChanges();
+
+        var settingsService = new ApplicationSettingsService(db, cache);
+        var sseService = new TestSseService();
+        var logger = NullLogger<PlaceVisitDetectionService>.Instance;
+
+        // Act
+        var service = new PlaceVisitDetectionService(db, settingsService, sseService, logger);
+
+        // Assert
+        Assert.NotNull(service);
+    }
+
+    [Fact]
+    public void VisitSseEventDto_DeserializesCorrectly()
+    {
+        // Arrange
+        var visitId = Guid.NewGuid();
+        var tripId = Guid.NewGuid();
+        var placeId = Guid.NewGuid();
+        var arrivedAt = new DateTime(2025, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+
+        var dto = new VisitSseEventDto
+        {
+            VisitId = visitId,
+            TripId = tripId,
+            TripName = "My Trip",
+            PlaceId = placeId,
+            PlaceName = "Acropolis",
+            RegionName = "Athens",
+            ArrivedAtUtc = arrivedAt,
+            Latitude = 37.97,
+            Longitude = 23.72,
+            IconName = "museum",
+            MarkerColor = "bg-orange"
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(dto);
+        var deserialized = JsonSerializer.Deserialize<VisitSseEventDto>(json);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal("visit_started", deserialized.Type);
+        Assert.Equal(visitId, deserialized.VisitId);
+        Assert.Equal(tripId, deserialized.TripId);
+        Assert.Equal("My Trip", deserialized.TripName);
+        Assert.Equal(placeId, deserialized.PlaceId);
+        Assert.Equal("Acropolis", deserialized.PlaceName);
+        Assert.Equal("Athens", deserialized.RegionName);
+        Assert.Equal(arrivedAt, deserialized.ArrivedAtUtc);
+        Assert.Equal(37.97, deserialized.Latitude);
+        Assert.Equal(23.72, deserialized.Longitude);
+        Assert.Equal("museum", deserialized.IconName);
+        Assert.Equal("bg-orange", deserialized.MarkerColor);
+    }
+}

--- a/tests/Wayfarer.Tests/Models/VisitSseEventDtoTests.cs
+++ b/tests/Wayfarer.Tests/Models/VisitSseEventDtoTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using NetTopologySuite.Geometries;
+using Wayfarer.Models;
+using Wayfarer.Models.Dtos;
+using Xunit;
+
+namespace Wayfarer.Tests.Models;
+
+/// <summary>
+/// Tests for <see cref="VisitSseEventDto"/>.
+/// </summary>
+public class VisitSseEventDtoTests
+{
+    [Fact]
+    public void FromVisitEvent_MapsAllProperties()
+    {
+        // Arrange
+        var visitId = Guid.NewGuid();
+        var tripId = Guid.NewGuid();
+        var placeId = Guid.NewGuid();
+        var arrivedAt = DateTime.UtcNow;
+
+        var visit = new PlaceVisitEvent
+        {
+            Id = visitId,
+            UserId = "user1",
+            PlaceId = placeId,
+            TripIdSnapshot = tripId,
+            TripNameSnapshot = "My Trip",
+            RegionNameSnapshot = "Athens",
+            PlaceNameSnapshot = "Acropolis",
+            ArrivedAtUtc = arrivedAt,
+            PlaceLocationSnapshot = new Point(23.72, 37.97) { SRID = 4326 },
+            IconNameSnapshot = "museum",
+            MarkerColorSnapshot = "bg-orange"
+        };
+
+        // Act
+        var dto = VisitSseEventDto.FromVisitEvent(visit);
+
+        // Assert
+        Assert.Equal("visit_started", dto.Type);
+        Assert.Equal(visitId, dto.VisitId);
+        Assert.Equal(tripId, dto.TripId);
+        Assert.Equal("My Trip", dto.TripName);
+        Assert.Equal(placeId, dto.PlaceId);
+        Assert.Equal("Acropolis", dto.PlaceName);
+        Assert.Equal("Athens", dto.RegionName);
+        Assert.Equal(arrivedAt, dto.ArrivedAtUtc);
+        Assert.Equal(37.97, dto.Latitude);
+        Assert.Equal(23.72, dto.Longitude);
+        Assert.Equal("museum", dto.IconName);
+        Assert.Equal("bg-orange", dto.MarkerColor);
+    }
+
+    [Fact]
+    public void FromVisitEvent_HandlesNullLocation()
+    {
+        // Arrange
+        var visit = new PlaceVisitEvent
+        {
+            Id = Guid.NewGuid(),
+            UserId = "user1",
+            PlaceId = Guid.NewGuid(),
+            TripIdSnapshot = Guid.NewGuid(),
+            TripNameSnapshot = "Trip",
+            RegionNameSnapshot = "Region",
+            PlaceNameSnapshot = "Place",
+            ArrivedAtUtc = DateTime.UtcNow,
+            PlaceLocationSnapshot = null
+        };
+
+        // Act
+        var dto = VisitSseEventDto.FromVisitEvent(visit);
+
+        // Assert
+        Assert.Null(dto.Latitude);
+        Assert.Null(dto.Longitude);
+    }
+
+    [Fact]
+    public void FromVisitEvent_HandlesNullOptionalFields()
+    {
+        // Arrange
+        var visit = new PlaceVisitEvent
+        {
+            Id = Guid.NewGuid(),
+            UserId = "user1",
+            PlaceId = Guid.NewGuid(),
+            TripIdSnapshot = Guid.NewGuid(),
+            TripNameSnapshot = null,
+            RegionNameSnapshot = null,
+            PlaceNameSnapshot = null,
+            ArrivedAtUtc = DateTime.UtcNow,
+            IconNameSnapshot = null,
+            MarkerColorSnapshot = null
+        };
+
+        // Act
+        var dto = VisitSseEventDto.FromVisitEvent(visit);
+
+        // Assert
+        Assert.Equal(string.Empty, dto.TripName);
+        Assert.Equal(string.Empty, dto.RegionName);
+        Assert.Equal(string.Empty, dto.PlaceName);
+        Assert.Null(dto.IconName);
+        Assert.Null(dto.MarkerColor);
+    }
+
+    [Fact]
+    public void Serialization_OmitsNullFields()
+    {
+        // Arrange
+        var dto = new VisitSseEventDto
+        {
+            VisitId = Guid.NewGuid(),
+            TripId = Guid.NewGuid(),
+            TripName = "Trip",
+            PlaceName = "Place",
+            RegionName = "Region",
+            ArrivedAtUtc = DateTime.UtcNow,
+            // Leave nullable fields null
+            PlaceId = null,
+            Latitude = null,
+            Longitude = null,
+            IconName = null,
+            MarkerColor = null
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(dto);
+
+        // Assert
+        Assert.DoesNotContain("placeId", json);
+        Assert.DoesNotContain("latitude", json);
+        Assert.DoesNotContain("longitude", json);
+        Assert.DoesNotContain("iconName", json);
+        Assert.DoesNotContain("markerColor", json);
+    }
+
+    [Fact]
+    public void Serialization_IncludesAllFieldsWhenPresent()
+    {
+        // Arrange
+        var dto = new VisitSseEventDto
+        {
+            VisitId = Guid.NewGuid(),
+            TripId = Guid.NewGuid(),
+            TripName = "Trip",
+            PlaceId = Guid.NewGuid(),
+            PlaceName = "Place",
+            RegionName = "Region",
+            ArrivedAtUtc = DateTime.UtcNow,
+            Latitude = 37.97,
+            Longitude = 23.72,
+            IconName = "marker",
+            MarkerColor = "bg-blue"
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(dto);
+
+        // Assert
+        Assert.Contains("\"type\":\"visit_started\"", json);
+        Assert.Contains("\"visitId\"", json);
+        Assert.Contains("\"tripId\"", json);
+        Assert.Contains("\"tripName\":\"Trip\"", json);
+        Assert.Contains("\"placeId\"", json);
+        Assert.Contains("\"placeName\":\"Place\"", json);
+        Assert.Contains("\"regionName\":\"Region\"", json);
+        Assert.Contains("\"latitude\":37.97", json);
+        Assert.Contains("\"longitude\":23.72", json);
+        Assert.Contains("\"iconName\":\"marker\"", json);
+        Assert.Contains("\"markerColor\":\"bg-blue\"", json);
+    }
+}

--- a/tests/Wayfarer.Tests/Services/PlaceVisitDetectionServiceTests.cs
+++ b/tests/Wayfarer.Tests/Services/PlaceVisitDetectionServiceTests.cs
@@ -24,7 +24,7 @@ public class PlaceVisitDetectionServiceTests : TestBase
     /// <summary>
     /// Creates a test service with default settings.
     /// </summary>
-    private (PlaceVisitDetectionService Service, ApplicationDbContext Db) CreateService(
+    private (PlaceVisitDetectionService Service, ApplicationDbContext Db, SseService Sse) CreateService(
         ApplicationSettings? settings = null)
     {
         var db = CreateDbContext();
@@ -35,10 +35,11 @@ public class PlaceVisitDetectionServiceTests : TestBase
         db.SaveChanges();
 
         var settingsService = new ApplicationSettingsService(db, cache);
+        var sseService = new SseService();
         var logger = NullLogger<PlaceVisitDetectionService>.Instance;
-        var service = new PlaceVisitDetectionService(db, settingsService, logger);
+        var service = new PlaceVisitDetectionService(db, settingsService, sseService, logger);
 
-        return (service, db);
+        return (service, db, sseService);
     }
 
     /// <summary>
@@ -70,7 +71,7 @@ public class PlaceVisitDetectionServiceTests : TestBase
         // Arrange
         var settings = CreateDefaultSettings();
         settings.VisitedAccuracyRejectMeters = 100; // 100m threshold
-        var (service, db) = CreateService(settings);
+        var (service, db, _) = CreateService(settings);
 
         var user = TestDataFixtures.CreateUser();
         db.Users.Add(user);
@@ -93,7 +94,7 @@ public class PlaceVisitDetectionServiceTests : TestBase
         // Arrange
         var settings = CreateDefaultSettings();
         settings.VisitedAccuracyRejectMeters = 100;
-        var (service, db) = CreateService(settings);
+        var (service, db, _) = CreateService(settings);
 
         var user = TestDataFixtures.CreateUser();
         db.Users.Add(user);
@@ -116,7 +117,7 @@ public class PlaceVisitDetectionServiceTests : TestBase
         // Arrange
         var settings = CreateDefaultSettings();
         settings.VisitedAccuracyRejectMeters = 0; // Disabled
-        var (service, db) = CreateService(settings);
+        var (service, db, _) = CreateService(settings);
 
         var user = TestDataFixtures.CreateUser();
         db.Users.Add(user);
@@ -138,7 +139,7 @@ public class PlaceVisitDetectionServiceTests : TestBase
         // Arrange
         var settings = CreateDefaultSettings();
         settings.VisitedAccuracyRejectMeters = 100;
-        var (service, db) = CreateService(settings);
+        var (service, db, _) = CreateService(settings);
 
         var user = TestDataFixtures.CreateUser();
         db.Users.Add(user);
@@ -164,7 +165,7 @@ public class PlaceVisitDetectionServiceTests : TestBase
         // Arrange
         var settings = CreateDefaultSettings();
         // With LocationTimeThresholdMinutes=5, VisitedEndVisitAfterMinutes = 5 * 9 = 45
-        var (service, db) = CreateService(settings);
+        var (service, db, _) = CreateService(settings);
 
         var user = TestDataFixtures.CreateUser();
         db.Users.Add(user);
@@ -203,7 +204,7 @@ public class PlaceVisitDetectionServiceTests : TestBase
     {
         // Arrange
         var settings = CreateDefaultSettings();
-        var (service, db) = CreateService(settings);
+        var (service, db, _) = CreateService(settings);
 
         var user = TestDataFixtures.CreateUser();
         db.Users.Add(user);
@@ -246,7 +247,7 @@ public class PlaceVisitDetectionServiceTests : TestBase
         // Arrange
         var settings = CreateDefaultSettings();
         // With LocationTimeThresholdMinutes=5, VisitedCandidateStaleMinutes = 5 * 12 = 60
-        var (service, db) = CreateService(settings);
+        var (service, db, _) = CreateService(settings);
 
         var user = TestDataFixtures.CreateUser();
         var trip = TestDataFixtures.CreateTrip(user);
@@ -288,7 +289,7 @@ public class PlaceVisitDetectionServiceTests : TestBase
     {
         // Arrange
         var settings = CreateDefaultSettings();
-        var (service, db) = CreateService(settings);
+        var (service, db, _) = CreateService(settings);
 
         var user = TestDataFixtures.CreateUser();
         var trip = TestDataFixtures.CreateTrip(user);
@@ -443,7 +444,7 @@ public class PlaceVisitDetectionServiceTests : TestBase
     public void Constructor_InitializesSuccessfully()
     {
         // Arrange & Act
-        var (service, _) = CreateService();
+        var (service, _, _) = CreateService();
 
         // Assert
         Assert.NotNull(service);


### PR DESCRIPTION
## Summary
- Add SSE endpoint for real-time visit notifications when mobile users visit planned places
- Broadcast `visit_started` event when a visit is confirmed by PlaceVisitDetectionService
- Complete implementation of Issue #40 Phase 5

## Changes
- **VisitSseEventDto**: Event payload with trip/place/location details
- **MobileSseController**: New `/api/mobile/sse/visits` endpoint for subscribing to visit notifications
- **PlaceVisitDetectionService**: Inject SseService and broadcast on visit confirmation

## SSE Channel Format
- Channel: `user-visits-{userId}`
- Event type: `visit_started`

## Test plan
- [x] All 1121 existing tests pass
- [x] New tests for SSE endpoint authentication
- [x] New tests for DTO serialization/deserialization
- [x] New tests for broadcast infrastructure

Closes Phase 5 of #40