### PR TITLE
feat(security): enable account lockout to prevent brute-force attacks

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -300,6 +300,11 @@ static void ConfigureIdentity(WebApplicationBuilder builder)
         {
             options.SignIn.RequireConfirmedAccount = false; // Disables confirmed email requirement
             options.User.RequireUniqueEmail = false; // Allows non-unique email addresses
+
+            // Account lockout settings to protect against brute-force attacks
+            options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(15);
+            options.Lockout.MaxFailedAccessAttempts = 5;
+            options.Lockout.AllowedForNewUsers = true;
         })
         .AddRoles<IdentityRole>() // Adds role-based authorization
         .AddEntityFrameworkStores<ApplicationDbContext>() // Uses EF Core for user store

--- a/docs/25-Security.md
+++ b/docs/25-Security.md
@@ -10,6 +10,11 @@ Passwords
 - Admin seeding creates a protected admin account; change credentials immediately after first run.
 - Policy: minimum eight characters with at least one upper-case letter, one lower-case letter, one digit, and one special character.
 
+Account Lockout
+- Accounts are locked after 5 failed login attempts to protect against brute-force attacks.
+- Lockout duration: 15 minutes.
+- Applies to all users including new accounts.
+
 API Tokens
 - **Wayfarer API tokens** (used for mobile app and API authentication) are stored as SHA-256 hashes—never in plain text. If the database is compromised, the tokens cannot be recovered or reused.
 - Tokens are shown **only once** when created or regenerated. Users must copy and store them securely.


### PR DESCRIPTION
## Summary

- Enable ASP.NET Core Identity account lockout to protect against brute-force login attacks
- Accounts lock after 5 failed attempts for 15 minutes
- Applies to all users including newly created accounts

## Changes

- **Program.cs**: Added lockout configuration in `ConfigureIdentity()`:
  ```csharp
  options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(15);
  options.Lockout.MaxFailedAccessAttempts = 5;
  options.Lockout.AllowedForNewUsers = true;
  ```

- **docs/25-Security.md**: Added Account Lockout section documenting the feature

## Test plan

- [ ] Verify login works normally with correct credentials
- [ ] Verify account locks after 5 failed attempts
- [ ] Verify lockout message is shown on Login page
- [ ] Verify account unlocks after 15 minutes

## Notes

- No new tests added - this is built-in ASP.NET Core Identity functionality, just needs configuration
- The Login page already has a Lockout redirect handler (`Login.cshtml.cs:116`)