### PR TITLE
fix(auth): add hashed token support to MobileCurrentUserAccessor

### DIFF
--- a/Services/MobileCurrentUserAccessor.cs
+++ b/Services/MobileCurrentUserAccessor.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Wayfarer.Models;
+using Wayfarer.Util;
 
 namespace Wayfarer.Services;
 
@@ -14,13 +17,18 @@ public class MobileCurrentUserAccessor : IMobileCurrentUserAccessor
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ApplicationDbContext _dbContext;
+    private readonly ILogger<MobileCurrentUserAccessor> _logger;
     private ApplicationUser? _user;
     private bool _resolved;
 
-    public MobileCurrentUserAccessor(IHttpContextAccessor httpContextAccessor, ApplicationDbContext dbContext)
+    public MobileCurrentUserAccessor(
+        IHttpContextAccessor httpContextAccessor,
+        ApplicationDbContext dbContext,
+        ILogger<MobileCurrentUserAccessor> logger)
     {
         _httpContextAccessor = httpContextAccessor;
         _dbContext = dbContext;
+        _logger = logger;
     }
 
     public async Task<ApplicationUser?> GetCurrentUserAsync(CancellationToken cancellationToken = default)
@@ -28,31 +36,75 @@ public class MobileCurrentUserAccessor : IMobileCurrentUserAccessor
         if (_resolved) return _user;
         _resolved = true;
 
-        var context = _httpContextAccessor.HttpContext;
-        if (context == null) return null;
+        try
+        {
+            var context = _httpContextAccessor.HttpContext;
+            if (context == null) return null;
 
-        var authorization = context.Request.Headers["Authorization"].FirstOrDefault();
-        if (string.IsNullOrWhiteSpace(authorization)) return null;
+            var authorization = context.Request.Headers["Authorization"].FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(authorization)) return null;
 
-        var token = authorization.Split(' ').LastOrDefault();
-        if (string.IsNullOrWhiteSpace(token)) return null;
+            var token = authorization.Split(' ').LastOrDefault();
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                _logger.LogWarning("Token is missing or empty.");
+                return null;
+            }
 
-        var apiToken = await _dbContext.ApiTokens
-            .AsNoTracking()
-            .FirstOrDefaultAsync(t => t.Token == token, cancellationToken);
+            // Hash the incoming token for comparison with stored hashes
+            var tokenHash = ApiTokenService.HashToken(token);
 
-        if (apiToken?.UserId == null) return null;
+            // Check for hashed token first, then fall back to plain text (third-party tokens)
+            var apiToken = await _dbContext.ApiTokens
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.TokenHash == tokenHash || t.Token == token, cancellationToken);
 
-        _user = await _dbContext.Users
-            .Include(u => u.ApiTokens)
-            .FirstOrDefaultAsync(u => u.Id == apiToken.UserId, cancellationToken);
+            // Security: Log minimal token info for identification without exposing full secret
+            var tokenInfo = GetSecureTokenInfo(token);
 
-        return _user;
+            if (apiToken?.UserId == null)
+            {
+                _logger.LogWarning("Token does not match any user. Token info: {TokenInfo}", tokenInfo);
+                return null;
+            }
+
+            _user = await _dbContext.Users
+                .Include(u => u.ApiTokens)
+                .FirstOrDefaultAsync(u => u.Id == apiToken.UserId, cancellationToken);
+
+            if (_user != null)
+            {
+                _logger.LogInformation("Mobile API request authenticated. Token info: {TokenInfo}, User: {UserName}",
+                    tokenInfo, _user.UserName);
+            }
+
+            return _user;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve user from token.");
+            return null;
+        }
     }
 
     public void Reset()
     {
         _resolved = false;
         _user = null;
+    }
+
+    /// <summary>
+    /// Gets a secure representation of a token for logging purposes.
+    /// Shows format type and partial identifier without exposing the full secret.
+    /// </summary>
+    /// <param name="token">The token to get info for.</param>
+    /// <returns>A safe string representation for logging.</returns>
+    private static string GetSecureTokenInfo(string? token)
+    {
+        if (string.IsNullOrEmpty(token))
+            return "empty";
+        if (token.StartsWith("wf_") && token.Length >= 7)
+            return $"{token.Substring(0, 7)}... (len={token.Length})";
+        return $"old-format (len={token.Length})";
     }
 }

--- a/tests/Wayfarer.Tests/Controllers/MobileApiControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/MobileApiControllerTests.cs
@@ -46,7 +46,7 @@ public class MobileApiControllerTests : TestBase
         await db.SaveChangesAsync();
 
         var httpContext = CreateHttpContext("token-123");
-        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db);
+        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db, NullLogger<MobileCurrentUserAccessor>.Instance);
         var controller = new TestController(db, accessor);
         controller.SetHttpContext(httpContext);
 
@@ -64,7 +64,7 @@ public class MobileApiControllerTests : TestBase
         // Arrange
         var db = CreateDbContext();
         var httpContext = CreateHttpContext();
-        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db);
+        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db, NullLogger<MobileCurrentUserAccessor>.Instance);
         var controller = new TestController(db, accessor);
         controller.SetHttpContext(httpContext);
 
@@ -88,7 +88,7 @@ public class MobileApiControllerTests : TestBase
         await db.SaveChangesAsync();
 
         var httpContext = CreateHttpContext("inactive-token");
-        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db);
+        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db, NullLogger<MobileCurrentUserAccessor>.Instance);
         var controller = new TestController(db, accessor);
         controller.SetHttpContext(httpContext);
 

--- a/tests/Wayfarer.Tests/Controllers/MobileGroupLocationsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/MobileGroupLocationsControllerTests.cs
@@ -42,7 +42,7 @@ public class MobileGroupLocationsControllerTests
     private static MobileGroupsController MakeController(ApplicationDbContext db, string? token = null, IConfiguration? configuration = null)
     {
         var httpContext = CreateContext(token);
-        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db);
+        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db, NullLogger<MobileCurrentUserAccessor>.Instance);
         configuration ??= new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
         var timeline = new GroupTimelineService(db, new LocationService(db), configuration);
         var color = new UserColorService();

--- a/tests/Wayfarer.Tests/Controllers/MobileGroupsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/MobileGroupsControllerTests.cs
@@ -36,7 +36,7 @@ public class MobileGroupsControllerTests
     private static MobileGroupsController MakeController(ApplicationDbContext db, string? token = null, IConfiguration? configuration = null)
     {
         var httpContext = CreateContext(token);
-        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db);
+        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db, NullLogger<MobileCurrentUserAccessor>.Instance);
         configuration ??= new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
         var timeline = new GroupTimelineService(db, new LocationService(db), configuration);
         var color = new UserColorService();

--- a/tests/Wayfarer.Tests/Controllers/MobileSseControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/MobileSseControllerTests.cs
@@ -39,7 +39,7 @@ public class MobileSseControllerTests : TestBase
             httpContext.Request.Headers["Authorization"] = $"Bearer {token}";
         }
 
-        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db);
+        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db, NullLogger<MobileCurrentUserAccessor>.Instance);
         var controller = new MobileSseController(db, NullLogger<BaseApiController>.Instance, accessor, sse, timeline, sseOptions)
         {
             ControllerContext = new ControllerContext { HttpContext = httpContext }

--- a/tests/Wayfarer.Tests/Controllers/MobileVisitsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/MobileVisitsControllerTests.cs
@@ -354,7 +354,8 @@ public class MobileVisitsControllerTests : TestBase
 
         var accessor = new MobileCurrentUserAccessor(
             new HttpContextAccessor { HttpContext = httpContext },
-            db);
+            db,
+            NullLogger<MobileCurrentUserAccessor>.Instance);
 
         var controller = new MobileVisitsController(
             db,

--- a/tests/Wayfarer.Tests/Integration/MobileIntegrationTests.cs
+++ b/tests/Wayfarer.Tests/Integration/MobileIntegrationTests.cs
@@ -58,7 +58,7 @@ public class MobileIntegrationTests
         SeedData(db);
 
         var httpContext = new DefaultHttpContext();
-        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db);
+        var accessor = new MobileCurrentUserAccessor(new HttpContextAccessor { HttpContext = httpContext }, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         var userColor = new UserColorService();
         var locationService = new LocationService(db);

--- a/tests/Wayfarer.Tests/Services/MobileCurrentUserAccessorTests.cs
+++ b/tests/Wayfarer.Tests/Services/MobileCurrentUserAccessorTests.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using Wayfarer.Models;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
+using Wayfarer.Util;
 using Xunit;
 
 namespace Wayfarer.Tests.Services;
@@ -24,7 +26,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns((HttpContext?)null);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();
@@ -42,7 +44,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();
@@ -61,7 +63,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();
@@ -80,7 +82,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();
@@ -99,7 +101,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();
@@ -133,7 +135,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();
@@ -169,7 +171,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();
@@ -204,7 +206,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();
@@ -247,7 +249,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();
@@ -287,7 +289,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result1 = await accessor.GetCurrentUserAsync();
@@ -309,7 +311,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result1 = await accessor.GetCurrentUserAsync();
@@ -365,7 +367,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result1 = await accessor.GetCurrentUserAsync();
@@ -416,7 +418,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result1 = await accessor.GetCurrentUserAsync();
@@ -432,6 +434,156 @@ public class MobileCurrentUserAccessorTests : TestBase
         Assert.NotNull(result2);
         Assert.Equal(user1.Id, result1.Id);
         Assert.Equal(user2.Id, result2.Id);
+    }
+
+    #endregion
+
+    #region Hashed Token Tests
+
+    [Fact]
+    public async Task GetCurrentUserAsync_ReturnsUser_WithHashedWayfarerToken()
+    {
+        // Arrange - Wayfarer tokens have TokenHash set and Token is null
+        var db = CreateDbContext();
+        var user = TestDataFixtures.CreateUser();
+        var plainToken = "wf_test-hashed-token-abc123";
+        var apiToken = new ApiToken
+        {
+            UserId = user.Id,
+            User = user,
+            Token = null, // Wayfarer tokens don't store plain text
+            TokenHash = ApiTokenService.HashToken(plainToken),
+            Name = "Wayfarer Mobile Token",
+            CreatedAt = DateTime.UtcNow
+        };
+        user.ApiTokens = new List<ApiToken> { apiToken };
+
+        db.Users.Add(user);
+        db.ApiTokens.Add(apiToken);
+        await db.SaveChangesAsync();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Authorization"] = $"Bearer {plainToken}";
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
+
+        // Act
+        var result = await accessor.GetCurrentUserAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(user.Id, result.Id);
+        Assert.Equal(user.UserName, result.UserName);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserAsync_ReturnsNull_WhenHashedTokenDoesNotMatch()
+    {
+        // Arrange
+        var db = CreateDbContext();
+        var user = TestDataFixtures.CreateUser();
+        var apiToken = new ApiToken
+        {
+            UserId = user.Id,
+            User = user,
+            Token = null,
+            TokenHash = ApiTokenService.HashToken("wf_correct-token"),
+            Name = "Hashed Token",
+            CreatedAt = DateTime.UtcNow
+        };
+        user.ApiTokens = new List<ApiToken> { apiToken };
+
+        db.Users.Add(user);
+        db.ApiTokens.Add(apiToken);
+        await db.SaveChangesAsync();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Authorization"] = "Bearer wf_wrong-token";
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
+
+        // Act
+        var result = await accessor.GetCurrentUserAsync();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserAsync_PrefersHashedTokenOverPlainText()
+    {
+        // Arrange - Token has both Token and TokenHash set (edge case during migration)
+        var db = CreateDbContext();
+        var user = TestDataFixtures.CreateUser();
+        var plainToken = "wf_dual-token";
+        var apiToken = new ApiToken
+        {
+            UserId = user.Id,
+            User = user,
+            Token = "different-plain-value", // Different plain value
+            TokenHash = ApiTokenService.HashToken(plainToken), // Hash matches what client sends
+            Name = "Dual Token",
+            CreatedAt = DateTime.UtcNow
+        };
+        user.ApiTokens = new List<ApiToken> { apiToken };
+
+        db.Users.Add(user);
+        db.ApiTokens.Add(apiToken);
+        await db.SaveChangesAsync();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Authorization"] = $"Bearer {plainToken}";
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
+
+        // Act
+        var result = await accessor.GetCurrentUserAsync();
+
+        // Assert - Should match via TokenHash
+        Assert.NotNull(result);
+        Assert.Equal(user.Id, result.Id);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserAsync_FallsBackToPlainToken_WhenHashNotSet()
+    {
+        // Arrange - Third-party tokens only have Token set (no hash)
+        var db = CreateDbContext();
+        var user = TestDataFixtures.CreateUser();
+        var apiToken = new ApiToken
+        {
+            UserId = user.Id,
+            User = user,
+            Token = "third-party-api-key-123",
+            TokenHash = null, // No hash for third-party tokens
+            Name = "Mapbox",
+            CreatedAt = DateTime.UtcNow
+        };
+        user.ApiTokens = new List<ApiToken> { apiToken };
+
+        db.Users.Add(user);
+        db.ApiTokens.Add(apiToken);
+        await db.SaveChangesAsync();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Authorization"] = "Bearer third-party-api-key-123";
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
+
+        // Act
+        var result = await accessor.GetCurrentUserAsync();
+
+        // Assert - Should match via plain Token
+        Assert.NotNull(result);
+        Assert.Equal(user.Id, result.Id);
     }
 
     #endregion
@@ -464,7 +616,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();
@@ -503,7 +655,7 @@ public class MobileCurrentUserAccessorTests : TestBase
         var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db);
+        var accessor = new MobileCurrentUserAccessor(mockHttpContextAccessor.Object, db, NullLogger<MobileCurrentUserAccessor>.Instance);
 
         // Act
         var result = await accessor.GetCurrentUserAsync();


### PR DESCRIPTION
## Summary
- Fix 401 Unauthorized errors on mobile SSE endpoints after token hashing migration
- `MobileCurrentUserAccessor` now supports both hashed and plain text tokens
- Added logging and exception handling consistent with `BaseApiController`

## Problem
After the `AddTokenHashToApiToken` migration, Wayfarer-generated tokens have:
- `Token = null`
- `TokenHash = SHA256(original_token)`

`MobileCurrentUserAccessor` was only checking `t.Token == token`, which always failed for hashed tokens.

## Changes

### Core Fix: `MobileCurrentUserAccessor.cs`
| Change | Description |
|--------|-------------|
| Token lookup | Added `t.TokenHash == tokenHash \|\| t.Token == token` |
| Logging | Added `ILogger<MobileCurrentUserAccessor>` |
| Exception handling | Added try-catch matching `BaseApiController` |
| Security | Added `GetSecureTokenInfo()` for safe token logging |

### Tests: 4 new + 7 files updated
- `GetCurrentUserAsync_ReturnsUser_WithHashedWayfarerToken`
- `GetCurrentUserAsync_ReturnsNull_WhenHashedTokenDoesNotMatch`
- `GetCurrentUserAsync_PrefersHashedTokenOverPlainText`
- `GetCurrentUserAsync_FallsBackToPlainToken_WhenHashNotSet`

## Test plan
- [x] All 49 Mobile-related tests pass
- [x] All 19 MobileCurrentUserAccessor tests pass
- [ ] Deploy and verify SSE endpoints authenticate correctly
- [ ] Verify mobile app connects without re-saving token