### PR TITLE
fix(nullability): add null check for apiToken.Token in geocoding calls

### DIFF
--- a/Areas/Api/Controllers/LocationController.cs
+++ b/Areas/Api/Controllers/LocationController.cs
@@ -552,7 +552,7 @@ public class LocationController : BaseApiController
             try
             {
                 var apiToken = user.ApiTokens.FirstOrDefault(t => t.Name == "Mapbox");
-                if (apiToken != null)
+                if (apiToken?.Token != null)
                 {
                     var locationInfo = await _reverseGeocodingService.GetReverseGeocodingDataAsync(
                         dto.Latitude, dto.Longitude, apiToken.Token, apiToken.Name);
@@ -914,7 +914,7 @@ public class LocationController : BaseApiController
                 try
                 {
                     var apiToken = user.ApiTokens.FirstOrDefault(t => t.Name == "Mapbox");
-                    if (apiToken != null)
+                    if (apiToken?.Token != null)
                     {
                         var lat = location.Coordinates.Y;
                         var lon = location.Coordinates.X;

--- a/Areas/User/Controllers/LocationController.cs
+++ b/Areas/User/Controllers/LocationController.cs
@@ -170,7 +170,7 @@ namespace Wayfarer.Areas.User.Controllers
                 };
 
 
-                if (apiToken != null)
+                if (apiToken?.Token != null)
                 {
                     ReverseLocationResults locationInfo =
                         await _reverseGeocodingService.GetReverseGeocodingDataAsync(location.Coordinates.Y,
@@ -391,7 +391,7 @@ namespace Wayfarer.Areas.User.Controllers
                 .FirstOrDefaultAsync(u => u.Id == model.UserId);
             ApiToken? apiToken = user?.ApiTokens.Where(t => t.Name == "Mapbox").FirstOrDefault();
 
-            if (apiToken != null)
+            if (apiToken?.Token != null)
             {
                 ReverseLocationResults locationInfo =
                     await _reverseGeocodingService.GetReverseGeocodingDataAsync(location.Coordinates.Y,

--- a/Areas/User/Controllers/PlacesController.cs
+++ b/Areas/User/Controllers/PlacesController.cs
@@ -107,7 +107,7 @@ public class PlacesController : BaseController
                     .FirstOrDefaultAsync(u => u.Id == userId);
 
                 var apiToken = user?.ApiTokens.FirstOrDefault(t => t.Name == "Mapbox");
-                if (apiToken != null)
+                if (apiToken?.Token != null)
                 {
                     var locationInfo = await _reverseGeocodingService.GetReverseGeocodingDataAsync(
                         lat.Value, lon.Value, apiToken.Token, apiToken.Name);
@@ -132,7 +132,7 @@ public class PlacesController : BaseController
                     .FirstOrDefaultAsync(u => u.Id == userId);
 
                 var apiToken = user?.ApiTokens.FirstOrDefault(t => t.Name == "Mapbox");
-                if (apiToken != null)
+                if (apiToken?.Token != null)
                 {
                     var locationInfo = await _reverseGeocodingService.GetReverseGeocodingDataAsync(
                         lat.Value, lon.Value, apiToken.Token, apiToken.Name);


### PR DESCRIPTION
## Summary
Fix 6 CS8604 nullability warnings by adding null check for `apiToken.Token`.

## Problem
`ApiToken.Token` is nullable:
- `null` for hashed Wayfarer tokens
- Populated for third-party tokens (e.g., Mapbox)

The compiler warned about passing potentially null values to `ReverseGeocodingService.GetReverseGeocodingDataAsync()`.

## Fix
Changed condition from:
```csharp
if (apiToken != null)
```
to:
```csharp
if (apiToken?.Token != null)
```

## Files Changed
| File | Occurrences |
|------|-------------|
| `Areas/User/Controllers/LocationController.cs` | 2 |
| `Areas/User/Controllers/PlacesController.cs` | 2 |
| `Areas/Api/Controllers/LocationController.cs` | 2 |

## Test plan
- [x] Build succeeds with only 1 warning (ASP0000 - unrelated)
- [x] 226 Location-related tests pass