### PR TITLE
Fix: Simplify live-to-latest marker transition logic

### DIFF
--- a/wwwroot/js/Areas/Manager/Groups/Map.js
+++ b/wwwroot/js/Areas/Manager/Groups/Map.js
@@ -663,7 +663,8 @@ import {
     const nowMin = Math.floor(Date.now()/60000);
     const locMin = Math.floor(new Date(location.localTimestamp).getTime()/60000);
     const isLive = (nowMin - locMin) <= (location.locationTimeThresholdMinutes||10);
-    const isLatest = !!location.isLatestLocation;
+    // In group map context, displayed locations are always the latest for each user
+    const isLatest = !isLive;
     const badge = isLive ? '<span class=\"badge bg-danger float-end ms-2\">LIVE LOCATION</span>' : (isLatest ? '<span class=\"badge bg-success float-end ms-2\">LATEST LOCATION</span>' : '');
     const notes = location.notes || '';
     const hasNotes = !!notes && notes.length>0;

--- a/wwwroot/js/Areas/Public/UsersTimeline/Embed.js
+++ b/wwwroot/js/Areas/Public/UsersTimeline/Embed.js
@@ -148,29 +148,14 @@ const buildLayers = (locations) => {
     const nowMinGlobal = Math.floor(Date.now() / 60000);
     const thresholdFor = (location) => location.locationTimeThresholdMinutes ?? 10;
 
-    let liveCandidate = null;
-    let latestCandidate = null;
-
-    locations.forEach(location => {
-        const locMin = Math.floor(new Date(location.localTimestamp).getTime() / 60000);
-        const isLive = (nowMinGlobal - locMin) <= thresholdFor(location);
-
-        if (isLive) {
-            if (!liveCandidate || locMin > liveCandidate.locMin) {
-                liveCandidate = { location, locMin };
-            }
-        } else if (location.isLatestLocation) {
-            if (!latestCandidate || locMin > latestCandidate.locMin) {
-                latestCandidate = { location, locMin };
-            }
-        }
-    });
-
-    const highlightCandidate = liveCandidate
-        ? { location: liveCandidate.location, type: 'live' }
-        : latestCandidate
-            ? { location: latestCandidate.location, type: 'latest' }
-            : null;
+    // Find the backend-designated latest location and determine if it's currently live
+    const latestLocation = locations.find(loc => loc.isLatestLocation);
+    let highlightCandidate = null;
+    if (latestLocation) {
+        const locMin = Math.floor(new Date(latestLocation.localTimestamp).getTime() / 60000);
+        const isLive = (nowMinGlobal - locMin) <= thresholdFor(latestLocation);
+        highlightCandidate = { location: latestLocation, type: isLive ? 'live' : 'latest' };
+    }
     const highlightId = highlightCandidate?.location?.id ?? null;
 
     locations.forEach(location => {

--- a/wwwroot/js/Areas/Public/UsersTimeline/Timeline.js
+++ b/wwwroot/js/Areas/Public/UsersTimeline/Timeline.js
@@ -142,29 +142,14 @@ const buildLayers = (locations) => {
     const nowMinGlobal = Math.floor(Date.now() / 60000);
     const thresholdFor = (location) => location.locationTimeThresholdMinutes ?? 10;
 
-    let liveCandidate = null;
-    let latestCandidate = null;
-
-    locations.forEach(location => {
-        const locMin = Math.floor(new Date(location.localTimestamp).getTime() / 60000);
-        const isLive = (nowMinGlobal - locMin) <= thresholdFor(location);
-
-        if (isLive) {
-            if (!liveCandidate || locMin > liveCandidate.locMin) {
-                liveCandidate = { location, locMin };
-            }
-        } else if (location.isLatestLocation) {
-            if (!latestCandidate || locMin > latestCandidate.locMin) {
-                latestCandidate = { location, locMin };
-            }
-        }
-    });
-
-    const highlightCandidate = liveCandidate
-        ? { location: liveCandidate.location, type: 'live' }
-        : latestCandidate
-            ? { location: latestCandidate.location, type: 'latest' }
-            : null;
+    // Find the backend-designated latest location and determine if it's currently live
+    const latestLocation = locations.find(loc => loc.isLatestLocation);
+    let highlightCandidate = null;
+    if (latestLocation) {
+        const locMin = Math.floor(new Date(latestLocation.localTimestamp).getTime() / 60000);
+        const isLive = (nowMinGlobal - locMin) <= thresholdFor(latestLocation);
+        highlightCandidate = { location: latestLocation, type: isLive ? 'live' : 'latest' };
+    }
     const highlightId = highlightCandidate?.location?.id ?? null;
 
     locations.forEach(location => {

--- a/wwwroot/js/Areas/User/Groups/Map.js
+++ b/wwwroot/js/Areas/User/Groups/Map.js
@@ -624,7 +624,8 @@ import {
     const nowMin = Math.floor(Date.now()/60000);
     const locMin = Math.floor(new Date(location.localTimestamp).getTime()/60000);
     const isLive = (nowMin - locMin) <= (location.locationTimeThresholdMinutes||10);
-    const isLatest = !!location.isLatestLocation;
+    // In group map context, displayed locations are always the latest for each user
+    const isLatest = !isLive;
     const badge = isLive ? '<span class="badge bg-danger float-end ms-2">LIVE LOCATION</span>' : (isLatest ? '<span class="badge bg-success float-end ms-2">LATEST LOCATION</span>' : '');
     const notes = location.notes || '';
     const hasNotes = !!notes && notes.length>0;

--- a/wwwroot/js/Areas/User/Location/Index.js
+++ b/wwwroot/js/Areas/User/Location/Index.js
@@ -264,29 +264,14 @@ const buildLayers = (locations) => {
     const nowMinGlobal = Math.floor(Date.now() / 60000);
     const thresholdFor = (location) => location.locationTimeThresholdMinutes ?? 10;
 
-    let liveCandidate = null;
-    let latestCandidate = null;
-
-    locations.forEach(location => {
-        const locMin = Math.floor(new Date(location.localTimestamp).getTime() / 60000);
-        const isLive = (nowMinGlobal - locMin) <= thresholdFor(location);
-
-        if (isLive) {
-            if (!liveCandidate || locMin > liveCandidate.locMin) {
-                liveCandidate = { location, locMin };
-            }
-        } else if (location.isLatestLocation) {
-            if (!latestCandidate || locMin > latestCandidate.locMin) {
-                latestCandidate = { location, locMin };
-            }
-        }
-    });
-
-    const highlightCandidate = liveCandidate
-        ? { location: liveCandidate.location, type: 'live' }
-        : latestCandidate
-            ? { location: latestCandidate.location, type: 'latest' }
-            : null;
+    // Find the backend-designated latest location and determine if it's currently live
+    const latestLocation = locations.find(loc => loc.isLatestLocation);
+    let highlightCandidate = null;
+    if (latestLocation) {
+        const locMin = Math.floor(new Date(latestLocation.localTimestamp).getTime() / 60000);
+        const isLive = (nowMinGlobal - locMin) <= thresholdFor(latestLocation);
+        highlightCandidate = { location: latestLocation, type: isLive ? 'live' : 'latest' };
+    }
     const highlightId = highlightCandidate?.location?.id ?? null;
 
     locations.forEach(location => {

--- a/wwwroot/js/Areas/User/Timeline/Index.js
+++ b/wwwroot/js/Areas/User/Timeline/Index.js
@@ -177,29 +177,14 @@ const buildLayers = (locations) => {
     const nowMinGlobal = Math.floor(Date.now() / 60000);
     const thresholdFor = (location) => location.locationTimeThresholdMinutes ?? 10;
 
-    let liveCandidate = null;
-    let latestCandidate = null;
-
-    locations.forEach(location => {
-        const locMin = Math.floor(new Date(location.localTimestamp).getTime() / 60000);
-        const isLive = (nowMinGlobal - locMin) <= thresholdFor(location);
-
-        if (isLive) {
-            if (!liveCandidate || locMin > liveCandidate.locMin) {
-                liveCandidate = { location, locMin };
-            }
-        } else if (location.isLatestLocation) {
-            if (!latestCandidate || locMin > latestCandidate.locMin) {
-                latestCandidate = { location, locMin };
-            }
-        }
-    });
-
-    const highlightCandidate = liveCandidate
-        ? { location: liveCandidate.location, type: 'live' }
-        : latestCandidate
-            ? { location: latestCandidate.location, type: 'latest' }
-            : null;
+    // Find the backend-designated latest location and determine if it's currently live
+    const latestLocation = locations.find(loc => loc.isLatestLocation);
+    let highlightCandidate = null;
+    if (latestLocation) {
+        const locMin = Math.floor(new Date(latestLocation.localTimestamp).getTime() / 60000);
+        const isLive = (nowMinGlobal - locMin) <= thresholdFor(latestLocation);
+        highlightCandidate = { location: latestLocation, type: isLive ? 'live' : 'latest' };
+    }
     const highlightId = highlightCandidate?.location?.id ?? null;
 
     locations.forEach(location => {


### PR DESCRIPTION
## Summary
Fixes #64

Simpler alternative to PR #65. Instead of dynamically calculating the latest location by timestamp, trust the backend `isLatestLocation` flag which is already kept current via SSE updates.

## Changes Made
- **User/Timeline/Index.js**: Find backend-designated latest location, check if currently live
- **User/Location/Index.js**: Same simplified logic
- **Public/UsersTimeline/Timeline.js & Embed.js**: Same simplified logic
- **User/Groups/Map.js & Manager/Groups/Map.js**: Simplified to `isLatest = !isLive` (in group context, displayed locations are always the latest for each user)

## Technical Details
The original issue was that `scheduleMarkerTransition` timer fired correctly, but the code used `location.isLatestLocation` in a way that didn't account for time-based transitions.

The fix trusts the backend flag and only recalculates `isLive` based on timestamp vs threshold:
- Backend sets `isLatestLocation = true` on one location
- If that location is within threshold → LIVE marker
- If past threshold → LATEST marker
- Timer triggers re-render, `isLive` recalculates to false, marker transitions

This approach is simpler because SSE keeps `isLatestLocation` current when new locations arrive.

## Stats
- **+36/-94 lines** (net reduction of 58 lines)
- 6 files changed

## Test Plan
- [ ] Load a timeline with a recent location (within time threshold)
- [ ] Verify the location shows a red "LIVE LOCATION" badge
- [ ] Wait for the threshold to expire (or reduce threshold in settings)
- [ ] Verify marker transitions to green "LATEST LOCATION" badge
- [ ] Test on User Timeline, Location, and Public Timeline views
- [ ] Test on Group Maps (User and Manager)