### PR TITLE
Feature: Expose accuracy and speed properties in frontend views

### DIFF
--- a/Areas/User/Views/Location/AllLocations.cshtml
+++ b/Areas/User/Views/Location/AllLocations.cshtml
@@ -113,6 +113,7 @@
             <th>Latitude</th>
             <th>Longitude</th>
             <th class="text-center">Accuracy (m)</th>
+            <th class="text-center">Speed (km/h)</th>
             <th class="text-center">Altitude (m)</th>
             <th>Activity</th>
             <th>Address</th>

--- a/Areas/User/Views/Location/Index.cshtml
+++ b/Areas/User/Views/Location/Index.cshtml
@@ -92,6 +92,7 @@
                 <th>Latitude</th>
                 <th>Longitude</th>
                 <th class="text-center">Accuracy (m)</th>
+                <th class="text-center">Speed (km/h)</th>
                 <th class="text-center">Altitude (m)</th>
                 <th>Activity</th>
                 <th>Address</th>

--- a/wwwroot/js/Areas/Public/UsersTimeline/Embed.js
+++ b/wwwroot/js/Areas/Public/UsersTimeline/Embed.js
@@ -329,10 +329,14 @@ const generateLocationModalContent = (location, { isLive, isLatest }) => {
             </div>
         </div>
         <div class="row mb-2">
-            <div class="col-6"><strong>Activity:</strong>   
+            <div class="col-6"><strong>Activity:</strong>
             <span>${(location.activityType && location.activityType !== 'Unknown') ? location.activityType :
         '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</span></div>
-             <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude || '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude != null ? location.altitude + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+        </div>
+        <div class="row mb-2">
+            <div class="col-6"><strong>Accuracy:</strong> <span>${location.accuracy != null ? location.accuracy + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
+            <div class="col-6"><strong>Speed:</strong> <span>${location.speed != null ? location.speed + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
         </div>
         <div class="row mb-2">
             <div class="col-12"><strong>Address:</strong> <span>${location.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i> '}</span><br/>

--- a/wwwroot/js/Areas/Public/UsersTimeline/Timeline.js
+++ b/wwwroot/js/Areas/Public/UsersTimeline/Timeline.js
@@ -326,10 +326,14 @@ const generateLocationModalContent = (location, {isLive, isLatest}) => {
             </div>
         </div>
         <div class="row mb-2">
-            <div class="col-6"><strong>Activity:</strong>   
+            <div class="col-6"><strong>Activity:</strong>
             <span>${(location.activityType && location.activityType !== 'Unknown') ? location.activityType :
         '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</span></div>
-             <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude || '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude != null ? location.altitude + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+        </div>
+        <div class="row mb-2">
+            <div class="col-6"><strong>Accuracy:</strong> <span>${location.accuracy != null ? location.accuracy + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
+            <div class="col-6"><strong>Speed:</strong> <span>${location.speed != null ? location.speed + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
         </div>
         <div class="row mb-2">
             <div class="col-12"><strong>Address:</strong> <span>${location.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i> '}</span><br/>

--- a/wwwroot/js/Areas/User/Location/AllLocations.js
+++ b/wwwroot/js/Areas/User/Location/AllLocations.js
@@ -228,8 +228,9 @@ const displayLocationsInTable = (locations) => {
         </td>
         <td>${loc.coordinates.latitude}</td>
         <td>${loc.coordinates.longitude}</td>
-        <td class="text-center">${loc.accuracy ?? '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</td>
-        <td class="text-center">${loc.altitude ?? '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</td>
+        <td class="text-center">${loc.accuracy != null ? loc.accuracy : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</td>
+        <td class="text-center">${loc.speed != null ? loc.speed : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</td>
+        <td class="text-center">${loc.altitude != null ? loc.altitude : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</td>
         <td>${loc.activityType || loc.activity || '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</td>
         <td>${loc.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i>'}</td>
         <td>${loc.place || '<i class="bi bi-patch-question" title="No available data for Place"></i>'}</td>

--- a/wwwroot/js/Areas/User/Location/Index.js
+++ b/wwwroot/js/Areas/User/Location/Index.js
@@ -439,12 +439,16 @@ const generateLocationModalContent = location => {
             </div>
         </div>
         <div class="row mb-2">
-            <div class="col-6"><strong>Activity:</strong>   <span>${
+            <div class="col-6"><strong>Activity:</strong> <span>${
         (location.activityType && location.activityType !== 'Unknown')
             ? location.activityType
             : '<i class="bi bi-patch-question" title="No available data for Activity"></i>'
     }</span></div>
-            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude || '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude != null ? location.altitude + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+        </div>
+        <div class="row mb-2">
+            <div class="col-6"><strong>Accuracy:</strong> <span>${location.accuracy != null ? location.accuracy + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
+            <div class="col-6"><strong>Speed:</strong> <span>${location.speed != null ? location.speed + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
         </div>
         <div class="row mb-2">
             <div class="col-12"><strong>Address:</strong> <span>${location.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i> '}</span>
@@ -631,8 +635,9 @@ const displayLocationsInTable = (locations) => {
                 </td>
                 <td>${location.coordinates.latitude}</td>
                 <td>${location.coordinates.longitude}</td>
-                <td class="text-center">${location.accuracy || '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</td>
-                <td class="text-center">${location.altitude || '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</td>
+                <td class="text-center">${location.accuracy != null ? location.accuracy : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</td>
+                <td class="text-center">${location.speed != null ? location.speed : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</td>
+                <td class="text-center">${location.altitude != null ? location.altitude : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</td>
                 <td>${location.activityType || '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</td>
                 <td>${location.address || '<i class="bi bi-patch-question" title="No available data for Address"></i>'}</td>
                 <td>${location.place || '<i class="bi bi-patch-question" title="No available data for Place"></i>'}</td>

--- a/wwwroot/js/Areas/User/Timeline/Chronological.js
+++ b/wwwroot/js/Areas/User/Timeline/Chronological.js
@@ -916,7 +916,11 @@ const generateLocationModalContent = (location, {isLive, isLatest}) => {
             <div class="col-6"><strong>Activity:</strong>
             <span>${(location.activityType && location.activityType !== 'Unknown') ? location.activityType :
         '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</span></div>
-             <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude || '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude != null ? location.altitude + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+        </div>
+        <div class="row mb-2">
+            <div class="col-6"><strong>Accuracy:</strong> <span>${location.accuracy != null ? location.accuracy + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
+            <div class="col-6"><strong>Speed:</strong> <span>${location.speed != null ? location.speed + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
         </div>
         <div class="row mb-2">
             <div class="col-12"><strong>Address:</strong> <span>${location.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i> '}</span><br/>

--- a/wwwroot/js/Areas/User/Timeline/Index.js
+++ b/wwwroot/js/Areas/User/Timeline/Index.js
@@ -359,10 +359,14 @@ const generateLocationModalContent = (location, {isLive, isLatest}) => {
             </div>
         </div>
         <div class="row mb-2">
-            <div class="col-6"><strong>Activity:</strong>   
+            <div class="col-6"><strong>Activity:</strong>
             <span>${(location.activityType && location.activityType !== 'Unknown') ? location.activityType :
         '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</span></div>
-             <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude || '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude != null ? location.altitude + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+        </div>
+        <div class="row mb-2">
+            <div class="col-6"><strong>Accuracy:</strong> <span>${location.accuracy != null ? location.accuracy + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
+            <div class="col-6"><strong>Speed:</strong> <span>${location.speed != null ? location.speed + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
         </div>
         <div class="row mb-2">
             <div class="col-12"><strong>Address:</strong> <span>${location.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i> '}</span><br/>


### PR DESCRIPTION
## Summary
Fixes #67

Exposes the `accuracy` and `speed` location properties in frontend tables and modals.

## Changes Made

### Tables (added Speed column between Accuracy and Altitude)
- `Areas/User/Views/Location/Index.cshtml` - added Speed header
- `Areas/User/Views/Location/AllLocations.cshtml` - added Speed header
- `wwwroot/js/Areas/User/Location/Index.js` - added Speed data column
- `wwwroot/js/Areas/User/Location/AllLocations.js` - added Speed data column

### Modals (added Accuracy/Speed row after Activity/Altitude)
- `wwwroot/js/Areas/User/Location/Index.js`
- `wwwroot/js/Areas/User/Timeline/Index.js`
- `wwwroot/js/Areas/User/Timeline/Chronological.js`
- `wwwroot/js/Areas/Public/UsersTimeline/Timeline.js`
- `wwwroot/js/Areas/Public/UsersTimeline/Embed.js`

### Technical Details
- Added unit labels: `m` for accuracy/altitude, `km/h` for speed
- Used `!= null` check instead of `||` for numeric values (to correctly display `0` values)
- Consistent fallback icon with tooltip when data is unavailable

## Test Plan
- [ ] View location table in User/Location page - verify Speed column displays
- [ ] Click a location marker on any map - verify modal shows Accuracy and Speed
- [ ] Test with location that has speed=0 - should show "0 km/h" not the question mark icon
- [ ] Test on Public timeline views