### PR TITLE
fix(clustering): exclude live/latest markers from clustering

### DIFF
--- a/wwwroot/js/Areas/Public/UsersTimeline/Embed.js
+++ b/wwwroot/js/Areas/Public/UsersTimeline/Embed.js
@@ -206,6 +206,7 @@ const buildLayers = (locations) => {
 
     if (highlightLayer) {
         highlightLayer.addTo(mapContainer);
+        highlightLayer.bringToFront(); // Ensure live/latest marker is always on top
     }
 
     // Schedule marker transition when live marker expires
@@ -512,7 +513,12 @@ const onZoomOrMoveChanges = () => {
                 mapContainer.addLayer(clusterLayer);
             }
         }
-        
+
+        // Keep highlight layer on top after layer changes
+        if (highlightLayer) {
+            highlightLayer.bringToFront();
+        }
+
         mapBounds = mapContainer.getBounds();
         zoomLevel = mapContainer.getZoom();
         debouncedGetUserLocations();

--- a/wwwroot/js/Areas/Public/UsersTimeline/Timeline.js
+++ b/wwwroot/js/Areas/Public/UsersTimeline/Timeline.js
@@ -200,6 +200,7 @@ const buildLayers = (locations) => {
 
     if (highlightLayer) {
         highlightLayer.addTo(mapContainer);
+        highlightLayer.bringToFront(); // Ensure live/latest marker is always on top
     }
 
     // Schedule marker transition when live marker expires
@@ -511,7 +512,12 @@ const onZoomOrMoveChanges = () => {
                 mapContainer.addLayer(clusterLayer);
             }
         }
-        
+
+        // Keep highlight layer on top after layer changes
+        if (highlightLayer) {
+            highlightLayer.bringToFront();
+        }
+
         mapBounds = mapContainer.getBounds();
         zoomLevel = mapContainer.getZoom();
         debouncedGetUserLocations();

--- a/wwwroot/js/Areas/User/Location/Index.js
+++ b/wwwroot/js/Areas/User/Location/Index.js
@@ -322,6 +322,7 @@ const buildLayers = (locations) => {
 
     if (highlightLayer) {
         highlightLayer.addTo(mapContainer);
+        highlightLayer.bringToFront(); // Ensure live/latest marker is always on top
     }
 
     // Schedule marker transition when live marker expires
@@ -744,7 +745,12 @@ const onZoomOrMoveChanges = () => {
                 mapContainer.addLayer(clusterLayer);
             }
         }
-        
+
+        // Keep highlight layer on top after layer changes
+        if (highlightLayer) {
+            highlightLayer.bringToFront();
+        }
+
         mapBounds = mapContainer.getBounds();
         zoomLevel = mapContainer.getZoom();
         debouncedGetUserLocations();

--- a/wwwroot/js/Areas/User/Timeline/Index.js
+++ b/wwwroot/js/Areas/User/Timeline/Index.js
@@ -235,6 +235,7 @@ const buildLayers = (locations) => {
 
     if (highlightLayer) {
         highlightLayer.addTo(mapContainer);
+        highlightLayer.bringToFront(); // Ensure live/latest marker is always on top
     }
 
     // Schedule marker transition when live marker expires
@@ -540,7 +541,12 @@ const onZoomOrMoveChanges = () => {
                 mapContainer.addLayer(clusterLayer);
             }
         }
-        
+
+        // Keep highlight layer on top after layer changes
+        if (highlightLayer) {
+            highlightLayer.bringToFront();
+        }
+
         mapBounds = mapContainer.getBounds();
         zoomLevel = mapContainer.getZoom();
         debouncedGetUserLocations();


### PR DESCRIPTION
## Summary
- Fixed live/latest location markers being absorbed by marker clusters at higher zoom levels
- Added `highlightLayer` to `Chronological.js` for separate rendering of special markers
- Added `bringToFront()` calls in all 5 affected files to ensure highlight layer stays on top after layer changes

## Affected Files
- `wwwroot/js/Areas/User/Timeline/Chronological.js` - main fix: added highlightLayer infrastructure
- `wwwroot/js/Areas/User/Timeline/Index.js` - added bringToFront() calls
- `wwwroot/js/Areas/User/Location/Index.js` - added bringToFront() calls
- `wwwroot/js/Areas/Public/UsersTimeline/Timeline.js` - added bringToFront() calls
- `wwwroot/js/Areas/Public/UsersTimeline/Embed.js` - added bringToFront() calls

## Test plan
- [ ] Verify live marker stays visible at all zoom levels in /User/Timeline/Chronological
- [ ] Verify latest marker stays visible at all zoom levels in /User/Timeline
- [ ] Verify latest marker stays visible at all zoom levels in /User/Location
- [ ] Verify markers stay visible in public timeline views
- [ ] Verify markers stay visible in embedded timeline views

Closes #71