### PR TITLE
fix(dark-theme): cluster count and stats modal contrast

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1927,3 +1927,25 @@ html[data-bs-theme="dark"] .ql-editor a {
 [data-bs-theme="dark"] code.bg-body-tertiary {
     color: var(--bs-body-color) !important;
 }
+
+/* ─────────────────────────────────────────────────────────
+   Dark Theme: Marker Cluster Count Fix
+   Cluster backgrounds are light green, so text must be dark
+───────────────────────────────────────────────────────── */
+[data-bs-theme="dark"] .marker-cluster div,
+[data-bs-theme="dark"] .marker-cluster span {
+    color: #212529 !important; /* Dark text for light cluster backgrounds */
+}
+
+/* ─────────────────────────────────────────────────────────
+   Dark Theme: Location Statistics Modal Fix
+   Fix bg-light highlight and headings in stats modal
+───────────────────────────────────────────────────────── */
+[data-bs-theme="dark"] #statsModal .bg-light {
+    background-color: #2c3034 !important;
+    border-color: #495057 !important;
+}
+
+[data-bs-theme="dark"] #statsModal h6 {
+    color: var(--bs-body-color) !important;
+}


### PR DESCRIPTION
## Summary
- Fixed marker cluster count showing light text on light green background in dark mode
- Fixed Location Statistics modal highlight using `bg-light` class not adapting to dark theme
- Fixed `<h6>` headings in stats modal having improper text color in dark mode

## CSS Rules Added
```css
/* Force dark text on cluster markers */
[data-bs-theme="dark"] .marker-cluster div,
[data-bs-theme="dark"] .marker-cluster span {
    color: #212529 !important;
}

/* Fix stats modal highlight background */
[data-bs-theme="dark"] #statsModal .bg-light {
    background-color: #2c3034 !important;
    border-color: #495057 !important;
}

/* Fix stats modal headings */
[data-bs-theme="dark"] #statsModal h6 {
    color: var(--bs-body-color) !important;
}
```

## Affected Views
- /User/Timeline/Chronological
- /User/Timeline
- /User/Location
- /Public/Users/Timeline/[username]
- /Public/Users/Timeline/[username]/embed

## Test plan
- [ ] Enable dark theme
- [ ] Verify cluster count numbers are readable (dark text on light green)
- [ ] Open Location Statistics modal and verify headings are readable
- [ ] Verify highlighted section (Countries/Regions/Cities) has proper dark background

Closes #73