### PR TITLE
fix(clustering): use featureGroup for highlightLayer

### DIFF
--- a/wwwroot/js/Areas/Public/UsersTimeline/Embed.js
+++ b/wwwroot/js/Areas/Public/UsersTimeline/Embed.js
@@ -123,7 +123,7 @@ const initializeMap = () => {
     addZoomLevelControl(mapContainer);
 
     if (!highlightLayer) {
-        highlightLayer = L.layerGroup();
+        highlightLayer = L.featureGroup();
     } else {
         highlightLayer.clearLayers();
     }

--- a/wwwroot/js/Areas/Public/UsersTimeline/Timeline.js
+++ b/wwwroot/js/Areas/Public/UsersTimeline/Timeline.js
@@ -117,7 +117,7 @@ const initializeMap = () => {
     addZoomLevelControl(mapContainer);
 
     if (!highlightLayer) {
-        highlightLayer = L.layerGroup();
+        highlightLayer = L.featureGroup();
     } else {
         highlightLayer.clearLayers();
     }

--- a/wwwroot/js/Areas/User/Location/Index.js
+++ b/wwwroot/js/Areas/User/Location/Index.js
@@ -207,7 +207,7 @@ const initializeMap = () => {
     addZoomLevelControl(mapContainer);
 
     if (!highlightLayer) {
-        highlightLayer = L.layerGroup();
+        highlightLayer = L.featureGroup();
     } else {
         highlightLayer.clearLayers();
     }

--- a/wwwroot/js/Areas/User/Timeline/Chronological.js
+++ b/wwwroot/js/Areas/User/Timeline/Chronological.js
@@ -723,7 +723,7 @@ const initializeMap = () => {
 
     // Create highlight layer for live/latest markers (always visible, not clustered)
     if (!highlightLayer) {
-        highlightLayer = L.layerGroup();
+        highlightLayer = L.featureGroup();
     } else {
         highlightLayer.clearLayers();
     }

--- a/wwwroot/js/Areas/User/Timeline/Index.js
+++ b/wwwroot/js/Areas/User/Timeline/Index.js
@@ -152,7 +152,7 @@ const initializeMap = () => {
     addZoomLevelControl(mapContainer);
 
     if (!highlightLayer) {
-        highlightLayer = L.layerGroup();
+        highlightLayer = L.featureGroup();
     } else {
         highlightLayer.clearLayers();
     }


### PR DESCRIPTION
## Summary
Fixes regression from PR #72 where `bringToFront()` was called on a `L.layerGroup()` which doesn't have that method.

## Root Cause
- `L.layerGroup()` does NOT have `bringToFront()` method
- `L.featureGroup()` DOES have `bringToFront()` method

## Fix
Changed all 5 files from `L.layerGroup()` to `L.featureGroup()`:
- `wwwroot/js/Areas/User/Timeline/Index.js`
- `wwwroot/js/Areas/User/Timeline/Chronological.js`
- `wwwroot/js/Areas/User/Location/Index.js`
- `wwwroot/js/Areas/Public/UsersTimeline/Timeline.js`
- `wwwroot/js/Areas/Public/UsersTimeline/Embed.js`

## Test plan
- [ ] Verify no console errors when loading timeline views
- [ ] Verify live/latest markers still display correctly
- [ ] Verify clustering still works as expected