### PR TITLE
fix(2fa): add white background to QR code for dark theme readability

### DIFF
--- a/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml
+++ b/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml
@@ -22,7 +22,7 @@
         </li>
         <li>
             <p>Scan the QR Code or enter this key <kbd>@Model.SharedKey</kbd> into your two factor authenticator app. Spaces and casing do not matter.</p>
-            <div id="qrCode"></div>
+            <div id="qrCode" class="d-inline-block p-3 bg-white rounded"></div>
             <div id="qrCodeData" data-url="@Model.AuthenticatorUri"></div>
         </li>
         <li>


### PR DESCRIPTION
## Summary
- Adds `bg-white` and padding classes to the 2FA QR code container
- Ensures QR code is scannable in dark theme by providing a white background
- Matches the styling pattern already used in the ApiToken page

## Test plan
- [x] Enable dark theme
- [x] Navigate to `/Identity/Account/Manage/TwoFactorAuthentication`
- [x] Verify QR code is displayed with white background
- [ ] Scan QR code with mobile authenticator app

Fixes #78