### PR TITLE
fix(groups): use location userId instead of array index for marker mapping

### DIFF
--- a/tests/Wayfarer.Tests/Integration/PlaceVisitDetectionIntegrationTests.cs
+++ b/tests/Wayfarer.Tests/Integration/PlaceVisitDetectionIntegrationTests.cs
@@ -97,7 +97,7 @@ public class PlaceVisitDetectionIntegrationTests : TestBase
         db.ApiTokens.Add(token);
         await db.SaveChangesAsync();
 
-        return (user, token.Token);
+        return (user, token.Token!);
     }
 
     /// <summary>

--- a/wwwroot/js/Areas/Manager/Groups/Map.js
+++ b/wwwroot/js/Areas/Manager/Groups/Map.js
@@ -147,7 +147,7 @@ import {
       });
     }
     const data = await postJson(url, { includeUserIds: include });
-    (Array.isArray(data)?data:[]).forEach((loc,idx)=>{ const uid=include[idx]; if (uid) upsertLatestForUser(uid, loc); });
+    (Array.isArray(data)?data:[]).forEach(loc=>{ const uid=loc.userId; if (uid) upsertLatestForUser(uid, loc); });
     // Only fit bounds when loading all users, not for single-user SSE updates
     if (!skipMarkerCleanup) {
       const latlngs=Array.from(latestMarkers.values()).map(m=>m.getLatLng()); if (latlngs.length) map.fitBounds(L.latLngBounds(latlngs), { padding:[20,20] });

--- a/wwwroot/js/Areas/User/Groups/Map.js
+++ b/wwwroot/js/Areas/User/Groups/Map.js
@@ -147,7 +147,7 @@ import {
       });
     }
     const data = await postJson(url, { includeUserIds: include });
-    (Array.isArray(data)?data:[]).forEach((loc,idx)=>{ const uid=include[idx]; if (uid) upsertLatestForUser(uid, loc); });
+    (Array.isArray(data)?data:[]).forEach(loc=>{ const uid=loc.userId; if (uid) upsertLatestForUser(uid, loc); });
     // Only fit bounds when loading all users, not for single-user SSE updates
     if (!skipMarkerCleanup) {
       const latlngs=Array.from(latestMarkers.values()).map(m=>m.getLatLng()); if (latlngs.length) map.fitBounds(L.latLngBounds(latlngs), { padding:[20,20] });


### PR DESCRIPTION
## Summary
- Fixes wrong user info in marker tooltips when hovering on group map
- Fixes scattered markers on SSE location updates
- Uses `loc.userId` directly from each location object instead of assuming response array order matches request

## Root cause
The `loadLatest` function assumed the API response array would be in the same order as the request's `includeUserIds`. When the API returned locations in a different order (or skipped users), the wrong userId was used for tooltips and marker positioning.

## Changes
- `wwwroot/js/Areas/User/Groups/Map.js` - Fix userId mapping in loadLatest
- `wwwroot/js/Areas/Manager/Groups/Map.js` - Same fix for Manager area
- `tests/.../PlaceVisitDetectionIntegrationTests.cs` - Fix CS8619 nullability warning

## Test plan
- [ ] Open a group map with multiple users
- [ ] Hover over each user's marker - verify correct username in tooltip
- [ ] Have a user update their location via SSE - verify marker updates at correct position

Fixes #80