### PR TITLE
feat(api-settings): display location logging thresholds in user area

### DIFF
--- a/Areas/User/Views/ApiToken/Index.cshtml
+++ b/Areas/User/Views/ApiToken/Index.cshtml
@@ -342,6 +342,59 @@
                 </div>
             </div>
 
+            <!-- Location Logging Thresholds Information -->
+            <div class="card shadow-sm mb-4">
+                <div class="card-header text-bg-info">
+                    <h2>⚙️ Location Logging Thresholds</h2>
+                </div>
+                <div class="card-body">
+                    <p class="mb-3">
+                        The server applies the following thresholds to incoming location data. These settings help reduce
+                        battery drain on mobile devices and avoid storing redundant location points.
+                    </p>
+
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <div class="card bg-body-tertiary h-100">
+                                <div class="card-body">
+                                    <h6 class="card-title">
+                                        <i class="bi bi-clock me-2"></i>Time Threshold
+                                    </h6>
+                                    <p class="display-6 mb-2 text-primary">@Model.LocationTimeThresholdMinutes min</p>
+                                    <p class="small text-muted mb-0">
+                                        Locations sent within <strong>@Model.LocationTimeThresholdMinutes minutes</strong>
+                                        of the previous logged location are skipped.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <div class="card bg-body-tertiary h-100">
+                                <div class="card-body">
+                                    <h6 class="card-title">
+                                        <i class="bi bi-geo-alt me-2"></i>Distance Threshold
+                                    </h6>
+                                    <p class="display-6 mb-2 text-primary">@Model.LocationDistanceThresholdMeters m</p>
+                                    <p class="small text-muted mb-0">
+                                        Locations within <strong>@Model.LocationDistanceThresholdMeters meters</strong>
+                                        of the previous logged location are skipped.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="alert alert-secondary mb-0">
+                        <small>
+                            <i class="bi bi-info-circle me-1"></i>
+                            <strong>Note:</strong> Both thresholds must be exceeded for a new location to be logged.
+                            The <strong>Check-in</strong> endpoint bypasses these thresholds for manual location logging.
+                            These settings are configured by the server administrator.
+                        </small>
+                    </div>
+                </div>
+            </div>
+
             <!-- Third Party Tokens Section (if any exist) -->
             @{
                 var thirdPartyTokens = Model.Tokens?.Where(t => !t.Name.Equals("Wayfarer Incoming Location Data API Token")).ToList();

--- a/Models/ViewModels/ApiTokenViewModel.cs
+++ b/Models/ViewModels/ApiTokenViewModel.cs
@@ -1,9 +1,25 @@
 ﻿namespace Wayfarer.Models.ViewModels
 {
+    /// <summary>
+    /// View model for the API Token management page.
+    /// Contains user information, tokens, and location logging threshold settings.
+    /// </summary>
     public class ApiTokenViewModel
     {
         public string UserId { get; set; } = string.Empty;
         public string UserName { get; set; } = string.Empty;
         public List<ApiToken> Tokens { get; set; } = new();
+
+        /// <summary>
+        /// Location time threshold in minutes. Locations logged within this time window
+        /// of the previous location are skipped.
+        /// </summary>
+        public int LocationTimeThresholdMinutes { get; set; }
+
+        /// <summary>
+        /// Location distance threshold in meters. Locations logged within this distance
+        /// of the previous location are skipped.
+        /// </summary>
+        public int LocationDistanceThresholdMeters { get; set; }
     }
 }

--- a/tests/Wayfarer.Tests/Controllers/UserApiTokenControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/UserApiTokenControllerTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using Wayfarer.Areas.User.Controllers;
 using Wayfarer.Models;
 using Wayfarer.Models.ViewModels;
+using Wayfarer.Parsers;
 using Wayfarer.Tests.Infrastructure;
 using Wayfarer.Util;
 using Xunit;
@@ -36,6 +37,9 @@ public class UserApiTokenControllerTests : TestBase
         var vm = Assert.IsType<ApiTokenViewModel>(view.Model);
         Assert.Equal("alice", vm.UserName);
         Assert.Equal(2, vm.Tokens.Count);
+        // Verify threshold values are populated from settings
+        Assert.Equal(5, vm.LocationTimeThresholdMinutes);
+        Assert.Equal(15, vm.LocationDistanceThresholdMeters);
     }
 
     [Fact]
@@ -174,7 +178,12 @@ public class UserApiTokenControllerTests : TestBase
     {
         var userManager = MockUserManager(user);
         var apiTokenService = new ApiTokenService(db, userManager.Object);
-        var controller = new ApiTokenController(apiTokenService, NullLogger<BaseController>.Instance, db);
+        var settingsService = MockSettingsService();
+        var controller = new ApiTokenController(
+            apiTokenService,
+            NullLogger<BaseController>.Instance,
+            db,
+            settingsService.Object);
         var http = new DefaultHttpContext
         {
             User = new ClaimsPrincipal(new ClaimsIdentity(new[]
@@ -186,6 +195,18 @@ public class UserApiTokenControllerTests : TestBase
         controller.ControllerContext = new ControllerContext { HttpContext = http };
         controller.TempData = new TempDataDictionary(http, Mock.Of<ITempDataProvider>());
         return controller;
+    }
+
+    private static Mock<IApplicationSettingsService> MockSettingsService()
+    {
+        var settings = new ApplicationSettings
+        {
+            LocationTimeThresholdMinutes = 5,
+            LocationDistanceThresholdMeters = 15
+        };
+        var mock = new Mock<IApplicationSettingsService>();
+        mock.Setup(m => m.GetSettings()).Returns(settings);
+        return mock;
     }
 
     private static Mock<UserManager<ApplicationUser>> MockUserManager(ApplicationUser user)


### PR DESCRIPTION
## Summary
- Display current time/distance thresholds for the log-location feature in User Area API settings page
- Added threshold properties to `ApiTokenViewModel` and populated from `ApplicationSettings`
- Created informational card showing time threshold (minutes) and distance threshold (meters)
- Includes explanatory note about threshold behavior and check-in bypass

Closes #85

## Test plan
- [x] Build succeeds
- [x] All 1152 tests pass
- [x] Test assertions added for threshold values in view model
- [ ] Manual verification: Navigate to User Area > API Token Management and verify thresholds display correctly