### PR TITLE
feat(admin): expand distance threshold options in settings

### DIFF
--- a/Areas/Admin/Views/Settings/Index.cshtml
+++ b/Areas/Admin/Views/Settings/Index.cshtml
@@ -65,10 +65,83 @@
                                 <label for="LocationDistanceThresholdMeters" class="form-label">Distance Threshold (in
                                     meters):</label>
                                 <select asp-for="LocationDistanceThresholdMeters" class="form-control">
-                                    <option value="5">5</option>
-                                    <option value="15">15</option>
-                                    <option value="30">30</option>
-                                    <option value="50">50</option>
+                                    <optgroup label="Fine (5-50m)">
+                                        <option value="5">5 m</option>
+                                        <option value="10">10 m</option>
+                                        <option value="15">15 m (Default)</option>
+                                        <option value="20">20 m</option>
+                                        <option value="25">25 m</option>
+                                        <option value="30">30 m</option>
+                                        <option value="35">35 m</option>
+                                        <option value="40">40 m</option>
+                                        <option value="45">45 m</option>
+                                        <option value="50">50 m</option>
+                                    </optgroup>
+                                    <optgroup label="Medium (55-150m)">
+                                        <option value="55">55 m</option>
+                                        <option value="60">60 m</option>
+                                        <option value="65">65 m</option>
+                                        <option value="70">70 m</option>
+                                        <option value="75">75 m</option>
+                                        <option value="80">80 m</option>
+                                        <option value="85">85 m</option>
+                                        <option value="90">90 m</option>
+                                        <option value="95">95 m</option>
+                                        <option value="100">100 m</option>
+                                        <option value="105">105 m</option>
+                                        <option value="110">110 m</option>
+                                        <option value="115">115 m</option>
+                                        <option value="120">120 m</option>
+                                        <option value="125">125 m</option>
+                                        <option value="130">130 m</option>
+                                        <option value="135">135 m</option>
+                                        <option value="140">140 m</option>
+                                        <option value="145">145 m</option>
+                                        <option value="150">150 m</option>
+                                    </optgroup>
+                                    <optgroup label="Coarse (200m-1km)">
+                                        <option value="200">200 m</option>
+                                        <option value="250">250 m</option>
+                                        <option value="300">300 m</option>
+                                        <option value="350">350 m</option>
+                                        <option value="400">400 m</option>
+                                        <option value="450">450 m</option>
+                                        <option value="500">500 m</option>
+                                        <option value="550">550 m</option>
+                                        <option value="600">600 m</option>
+                                        <option value="650">650 m</option>
+                                        <option value="700">700 m</option>
+                                        <option value="750">750 m</option>
+                                        <option value="800">800 m</option>
+                                        <option value="850">850 m</option>
+                                        <option value="900">900 m</option>
+                                        <option value="950">950 m</option>
+                                        <option value="1000">1 km</option>
+                                    </optgroup>
+                                    <optgroup label="Very Coarse (1.5-5km)">
+                                        <option value="1500">1.5 km</option>
+                                        <option value="2000">2 km</option>
+                                        <option value="2500">2.5 km</option>
+                                        <option value="3000">3 km</option>
+                                        <option value="3500">3.5 km</option>
+                                        <option value="4000">4 km</option>
+                                        <option value="4500">4.5 km</option>
+                                        <option value="5000">5 km</option>
+                                    </optgroup>
+                                    <optgroup label="Regional (10-50km)">
+                                        <option value="10000">10 km</option>
+                                        <option value="15000">15 km</option>
+                                        <option value="20000">20 km</option>
+                                        <option value="25000">25 km</option>
+                                        <option value="30000">30 km</option>
+                                        <option value="35000">35 km</option>
+                                        <option value="40000">40 km</option>
+                                        <option value="45000">45 km</option>
+                                        <option value="50000">50 km</option>
+                                    </optgroup>
+                                    <optgroup label="Maximum (100km)">
+                                        <option value="100000">100 km</option>
+                                    </optgroup>
                                 </select>
                                 <span asp-validation-for="LocationDistanceThresholdMeters" class="text-danger"></span>
                             </div>

--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -19,7 +19,7 @@ public class ApplicationSettings
     public int LocationTimeThresholdMinutes { get; set; } = 5;
 
     [Required]
-    [Range(1, 500, ErrorMessage = "Distance threshold must be between 1 and 500 meters.")]
+    [Range(1, 100000, ErrorMessage = "Distance threshold must be between 1 and 100,000 meters.")]
     public int LocationDistanceThresholdMeters { get; set; } = 15;
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Expanded distance threshold dropdown from 4 options to 63 options (5m to 100km)
- Organized options into labeled groups for better UX: Fine (5-50m), Medium (55-150m), Coarse (200m-1km), Very Coarse (1.5-5km), Regional (10-50km), Maximum (100km)
- Updated validation range in `ApplicationSettings.cs` from 500m to 100,000m
- Default remains 15 meters

Closes #84

## Test plan
- [x] Build succeeds
- [x] All 1152 tests pass
- [ ] Manual verification: Navigate to Admin > Settings and verify dropdown shows all new options with groupings
- [ ] Manual verification: Select a new value and save, verify it persists