### PR TITLE
feat(api): add PUT /api/trips/areas/{areaId} endpoint for updating Area

### DIFF
--- a/Models/Dtos/AreaUpdateRequestDto.cs
+++ b/Models/Dtos/AreaUpdateRequestDto.cs
@@ -1,0 +1,28 @@
+namespace Wayfarer.Models.Dtos
+{
+    /// <summary>
+    /// Request body to update an existing Area. Region association is immutable.
+    /// </summary>
+    public class AreaUpdateRequestDto
+    {
+        /// <summary>
+        /// Optional new name for the area.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Optional notes (HTML content).
+        /// </summary>
+        public string? Notes { get; set; }
+
+        /// <summary>
+        /// Optional hex fill colour, e.g. "#ff6600".
+        /// </summary>
+        public string? FillHex { get; set; }
+
+        /// <summary>
+        /// Optional explicit display order.
+        /// </summary>
+        public int? DisplayOrder { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Added `PUT /api/trips/areas/{areaId}` endpoint to update area properties
- Created `AreaUpdateRequestDto` with optional fields: Name, Notes, FillHex, DisplayOrder
- Follows existing patterns from UpdateRegion, UpdateSegmentNotes endpoints
- Ownership verification via Area -> Region -> Trip -> User navigation

Closes #86

## API Contract

**Request:**
```json
{
  "notes": "<html content>"
}
```

**Response:**
```json
{
  "success": true,
  "id": "guid",
  "notes": "<html content>"
}
```

## Test plan
- [x] Build succeeds
- [x] All 1160 tests pass (8 new tests added)
- [x] Tests cover: unauthorized access, not found, wrong owner, notes update, multiple field update, empty request, success response format, clearing notes
- [ ] Manual verification: Call endpoint from mobile app or API client