### PR TITLE
feat(admin): expand time threshold options with helpful labels

### DIFF
--- a/Areas/Admin/Views/Settings/Index.cshtml
+++ b/Areas/Admin/Views/Settings/Index.cshtml
@@ -46,11 +46,32 @@
                                 <label for="LocationTimeThresholdMinutes" class="form-label">Time Threshold (in
                                     minutes):</label>
                                 <select asp-for="LocationTimeThresholdMinutes" class="form-control" id="timeThresholdSelect">
-                                    <option value="2" class="text-danger fw-bold">2 ⚠️ (High resource usage)</option>
-                                    <option value="3">3</option>
-                                    <option value="5">5 (Recommended)</option>
-                                    <option value="10">10</option>
-                                    <option value="15">15</option>
+                                    <optgroup label="Frequent (2-5 min) - High battery usage">
+                                        <option value="2" class="text-danger fw-bold">2 min ⚠️ (High resource usage)</option>
+                                        <option value="3">3 min</option>
+                                        <option value="4">4 min</option>
+                                        <option value="5">5 min (Recommended)</option>
+                                    </optgroup>
+                                    <optgroup label="Moderate (10-15 min) - Balanced">
+                                        <option value="10">10 min</option>
+                                        <option value="15">15 min</option>
+                                    </optgroup>
+                                    <optgroup label="Hourly (30-60 min) - Low power">
+                                        <option value="30">30 min (twice per hour)</option>
+                                        <option value="45">45 min</option>
+                                        <option value="60">60 min (1 hour)</option>
+                                    </optgroup>
+                                    <optgroup label="Multi-hour (2-6 hours) - Minimal tracking">
+                                        <option value="120">120 min (2 hours)</option>
+                                        <option value="180">180 min (3 hours)</option>
+                                        <option value="240">240 min (4 hours)</option>
+                                        <option value="300">300 min (5 hours)</option>
+                                        <option value="360">360 min (6 hours / 4× daily)</option>
+                                    </optgroup>
+                                    <optgroup label="Daily (12-24 hours) - Check-in only">
+                                        <option value="720">720 min (12 hours / twice daily)</option>
+                                        <option value="1440">1440 min (24 hours / once daily)</option>
+                                    </optgroup>
                                 </select>
                                 <small id="timeThresholdWarning" class="form-text text-danger d-none">
                                     <i class="bi bi-exclamation-triangle-fill me-1"></i>

--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -15,7 +15,7 @@ public class ApplicationSettings
     public int Id { get; set; } = 1;
 
     [Required]
-    [Range(1, 60, ErrorMessage = "Time threshold must be between 1 and 60 minutes.")]
+    [Range(1, 1440, ErrorMessage = "Time threshold must be between 1 and 1440 minutes (24 hours).")]
     public int LocationTimeThresholdMinutes { get; set; } = 5;
 
     [Required]


### PR DESCRIPTION
## Summary
- Added new time threshold options: 4, 30, 45, 60, 120, 180, 240, 300, 360, 720, 1440 minutes
- Organized options into labeled groups for better UX:
  - **Frequent (2-5 min)** - High battery usage
  - **Moderate (10-15 min)** - Balanced
  - **Hourly (30-60 min)** - Low power
  - **Multi-hour (2-6 hours)** - Minimal tracking
  - **Daily (12-24 hours)** - Check-in only
- Each option includes human-readable hints (e.g., "twice daily", "once daily")
- Updated validation range from 60 to 1440 minutes (24 hours)
- Default remains 5 minutes

## Quick Reference
| Minutes | Interval | Label |
|---------|----------|-------|
| 60 | 1 hour | hourly |
| 360 | 6 hours | 4× daily |
| 720 | 12 hours | twice daily |
| 1440 | 24 hours | once daily |

## Test plan
- [x] Build succeeds
- [x] All 1160 tests pass
- [ ] Manual verification: Navigate to Admin > Settings and verify dropdown shows grouped options with labels