### PR TITLE
style(settings): use primary header style for threshold section

### DIFF
--- a/Areas/User/Views/Settings/Index.cshtml
+++ b/Areas/User/Views/Settings/Index.cshtml
@@ -61,7 +61,7 @@
                         <a class="btn btn-outline-primary" asp-area="User" asp-controller="Timeline" asp-action="Settings">Manage Timeline Settings</a>
                     </div>
 
-                    <div class="card-header text-bg-info my-4">
+                    <div class="card-header text-bg-primary my-4">
                         <h2>Location Logging Thresholds</h2>
                     </div>
 


### PR DESCRIPTION
## Summary
Changed the Location Logging Thresholds header from `text-bg-info` (blue) to `text-bg-primary` to match the other section headers in the User Settings page.

## Test plan
- [ ] Visual verification: All section headers now have consistent primary (blue) background