### PR TITLE
fix(#93): prevent duplicate locations from race conditions

### DIFF
--- a/tests/Wayfarer.Tests/Controllers/ApiLocationControllerLogTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/ApiLocationControllerLogTests.cs
@@ -155,12 +155,99 @@ public class ApiLocationControllerLogTests : TestBase
         Assert.Equal(1, db.Locations.Count());
     }
 
-    private LocationController BuildController(ApplicationDbContext db, bool includeAuth = true)
+    /// <summary>
+    /// Tests that a location request is skipped when a record with the same
+    /// LocalTimestamp already exists for the user (duplicate detection).
+    /// </summary>
+    [Fact]
+    public async Task LogLocation_ReturnsSkipped_WhenDuplicateLocalTimestampExists()
     {
-        SeedSettings(db);
+        var db = CreateDbContext();
+        var controller = BuildController(db);
+        var duplicateTimestamp = DateTime.SpecifyKind(new DateTime(2026, 1, 8, 6, 32, 23, 615, DateTimeKind.Utc), DateTimeKind.Utc);
+
+        // First location - should succeed
+        var firstResult = await controller.LogLocation(new GpsLoggerLocationDto
+        {
+            Latitude = 10,
+            Longitude = 20,
+            Timestamp = duplicateTimestamp
+        });
+        Assert.IsType<OkObjectResult>(firstResult);
+        Assert.Equal(1, db.Locations.Count());
+
+        // Second location - same LocalTimestamp but passes time/distance thresholds
+        // (different coordinates, timestamp appears old relative to server time)
+        // Should be skipped due to duplicate LocalTimestamp check
+        var secondResult = await controller.LogLocation(new GpsLoggerLocationDto
+        {
+            Latitude = 15,  // Different location (passes distance threshold)
+            Longitude = 25,
+            Timestamp = duplicateTimestamp  // Same LocalTimestamp as first
+        });
+
+        var ok = Assert.IsType<OkObjectResult>(secondResult);
+        Assert.Equal(1, db.Locations.Count()); // No new location created
+
+        // Verify response format: { success: true, skipped: true, locationId: null }
+        var response = ok.Value;
+        var responseType = response!.GetType();
+        Assert.True((bool)responseType.GetProperty("success")!.GetValue(response)!);
+        Assert.True((bool)responseType.GetProperty("skipped")!.GetValue(response)!);
+        Assert.Null(responseType.GetProperty("locationId")!.GetValue(response));
+    }
+
+    /// <summary>
+    /// Tests that concurrent requests with the same LocalTimestamp result in only
+    /// one location being saved (race condition prevention).
+    /// </summary>
+    [Fact]
+    public async Task LogLocation_PreventsDuplicates_UnderConcurrentRequests()
+    {
+        var db = CreateDbContext();
+        var duplicateTimestamp = DateTime.SpecifyKind(new DateTime(2026, 1, 9, 4, 47, 46, 72, DateTimeKind.Utc), DateTimeKind.Utc);
+
+        // Create multiple controllers sharing the same DB context to simulate concurrent requests
+        var controller1 = BuildController(db, userId: "u-race");
+        var controller2 = BuildControllerForExistingUser(db, "u-race");
+
+        var dto = new GpsLoggerLocationDto
+        {
+            Latitude = 40.8497,
+            Longitude = 25.8693,
+            Timestamp = duplicateTimestamp
+        };
+
+        // Fire concurrent requests
+        var task1 = controller1.LogLocation(dto);
+        var task2 = controller2.LogLocation(dto);
+
+        await Task.WhenAll(task1, task2);
+
+        // Only one location should be saved
+        var locationCount = db.Locations.Count(l => l.UserId == "u-race");
+        Assert.Equal(1, locationCount);
+
+        // Both requests should return success (one saved, one skipped)
+        var result1 = Assert.IsType<OkObjectResult>(task1.Result);
+        var result2 = Assert.IsType<OkObjectResult>(task2.Result);
+
+        var response1 = result1.Value!.GetType();
+        var response2 = result2.Value!.GetType();
+
+        var skipped1 = (bool)response1.GetProperty("skipped")!.GetValue(result1.Value)!;
+        var skipped2 = (bool)response2.GetProperty("skipped")!.GetValue(result2.Value)!;
+
+        // Exactly one should be skipped, one should be saved
+        Assert.True(skipped1 ^ skipped2, "Expected exactly one request to be skipped and one to be saved");
+    }
+
+    private LocationController BuildController(ApplicationDbContext db, bool includeAuth = true, string? userId = null)
+    {
+        SeedSettingsIfNeeded(db);
         var cache = new MemoryCache(new MemoryCacheOptions());
         var settings = new ApplicationSettingsService(db, cache);
-        var user = SeedUserWithToken(db, "tok");
+        var user = SeedUserWithToken(db, "tok", userId ?? "u-log");
         var reverseGeocoding = new ReverseGeocodingService(new HttpClient(new FakeHandler()), NullLogger<BaseApiController>.Instance);
         var locationService = new LocationService(db);
         var sse = new SseService();
@@ -189,19 +276,55 @@ public class ApiLocationControllerLogTests : TestBase
         return controller;
     }
 
-    private static ApplicationUser SeedUserWithToken(ApplicationDbContext db, string token)
+    /// <summary>
+    /// Builds a controller for an existing user (does not create user again).
+    /// Used for concurrent request testing where multiple controllers share the same user.
+    /// </summary>
+    private LocationController BuildControllerForExistingUser(ApplicationDbContext db, string userId)
     {
-        var user = TestDataFixtures.CreateUser(id: "u-log");
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var settings = new ApplicationSettingsService(db, cache);
+        var reverseGeocoding = new ReverseGeocodingService(new HttpClient(new FakeHandler()), NullLogger<BaseApiController>.Instance);
+        var locationService = new LocationService(db);
+        var sse = new SseService();
+        var stats = new LocationStatsService(db);
+
+        var controller = new LocationController(
+            db,
+            NullLogger<BaseApiController>.Instance,
+            cache,
+            settings,
+            reverseGeocoding,
+            locationService,
+            sse,
+            stats,
+            locationService,
+            new NullPlaceVisitDetectionService());
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Authorization"] = "Bearer tok";
+        httpContext.User = BuildHttpContextWithUser(userId).User;
+
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        return controller;
+    }
+
+    private static ApplicationUser SeedUserWithToken(ApplicationDbContext db, string token, string userId)
+    {
+        var user = TestDataFixtures.CreateUser(id: userId);
         db.Users.Add(user);
         db.ApiTokens.Add(new ApiToken { Token = token, UserId = user.Id, Name = "test", User = user });
         db.SaveChanges();
         return user;
     }
 
-    private static void SeedSettings(ApplicationDbContext db)
+    private static void SeedSettingsIfNeeded(ApplicationDbContext db)
     {
-        db.ApplicationSettings.Add(new ApplicationSettings { Id = 1 });
-        db.SaveChanges();
+        if (!db.ApplicationSettings.Any())
+        {
+            db.ApplicationSettings.Add(new ApplicationSettings { Id = 1 });
+            db.SaveChanges();
+        }
     }
 
     private sealed class FakeHandler : HttpMessageHandler


### PR DESCRIPTION
## Summary

- Fixes race condition in `log-location` endpoint where concurrent requests could both pass cache-based threshold checks and save duplicate records
- Adds database query after time/distance thresholds pass to verify no location with same `LocalTimestamp` exists for the user
- Preserves cache performance benefits (most requests still filtered without DB query)

## Root Cause

When two requests arrive within milliseconds:
1. Both read the same cached `lastLocation` 
2. Both pass time/distance threshold checks
3. Both save to database → **duplicate records**

Example from production: Records 94786/94787 had identical `LocalTimestamp` but server timestamps 34ms apart.

## Solution

```csharp
// After threshold checks pass, before saving:
var duplicateExists = await _dbContext.Locations
    .AnyAsync(l => l.UserId == user.Id && l.LocalTimestamp == utcTimestamp);

if (duplicateExists)
    return Ok(new { success = true, skipped = true, locationId = (int?)null });
```

## Test plan

- [x] Added unit test: `LogLocation_ReturnsSkipped_WhenDuplicateLocalTimestampExists`
- [x] Added integration test: `LogLocation_PreventsDuplicates_UnderConcurrentRequests`
- [x] All 9 `ApiLocationControllerLogTests` pass

Closes #93