### PR TITLE
fix: GPS accuracy threshold persistence and change default to 50m

### DIFF
--- a/Areas/Admin/Controllers/SettingsController.cs
+++ b/Areas/Admin/Controllers/SettingsController.cs
@@ -123,6 +123,7 @@ namespace Wayfarer.Areas.Admin.Controllers
                     Track("IsRegistrationOpen", currentSettings.IsRegistrationOpen, updatedSettings.IsRegistrationOpen);
                     Track("LocationTimeThresholdMinutes", currentSettings.LocationTimeThresholdMinutes, updatedSettings.LocationTimeThresholdMinutes);
                     Track("LocationDistanceThresholdMeters", currentSettings.LocationDistanceThresholdMeters, updatedSettings.LocationDistanceThresholdMeters);
+                    Track("LocationAccuracyThresholdMeters", currentSettings.LocationAccuracyThresholdMeters, updatedSettings.LocationAccuracyThresholdMeters);
                     Track("MaxCacheTileSizeInMB", currentSettings.MaxCacheTileSizeInMB, updatedSettings.MaxCacheTileSizeInMB);
                     Track("UploadSizeLimitMB", currentSettings.UploadSizeLimitMB, updatedSettings.UploadSizeLimitMB);
 
@@ -138,6 +139,7 @@ namespace Wayfarer.Areas.Admin.Controllers
                     currentSettings.IsRegistrationOpen = updatedSettings.IsRegistrationOpen;
                     currentSettings.LocationTimeThresholdMinutes = updatedSettings.LocationTimeThresholdMinutes;
                     currentSettings.LocationDistanceThresholdMeters = updatedSettings.LocationDistanceThresholdMeters;
+                    currentSettings.LocationAccuracyThresholdMeters = updatedSettings.LocationAccuracyThresholdMeters;
                     currentSettings.MaxCacheTileSizeInMB = updatedSettings.MaxCacheTileSizeInMB;
                     currentSettings.UploadSizeLimitMB = updatedSettings.UploadSizeLimitMB;
 

--- a/Areas/Admin/Views/Settings/Index.cshtml
+++ b/Areas/Admin/Views/Settings/Index.cshtml
@@ -181,14 +181,14 @@
                                         <option value="20">20 m</option>
                                         <option value="25">25 m</option>
                                     </optgroup>
-                                    <optgroup label="Good Precision (30-50m)">
+                                    <optgroup label="Good Precision (30-50m) - Recommended">
                                         <option value="30">30 m</option>
                                         <option value="35">35 m</option>
                                         <option value="40">40 m</option>
                                         <option value="45">45 m</option>
-                                        <option value="50">50 m</option>
+                                        <option value="50">50 m (Default)</option>
                                     </optgroup>
-                                    <optgroup label="Moderate Precision (55-100m) - Recommended">
+                                    <optgroup label="Moderate Precision (55-100m)">
                                         <option value="55">55 m</option>
                                         <option value="60">60 m</option>
                                         <option value="65">65 m</option>
@@ -198,7 +198,7 @@
                                         <option value="85">85 m</option>
                                         <option value="90">90 m</option>
                                         <option value="95">95 m</option>
-                                        <option value="100">100 m (Default)</option>
+                                        <option value="100">100 m</option>
                                     </optgroup>
                                     <optgroup label="Relaxed (105-200m) - Accept more data">
                                         <option value="105">105 m</option>

--- a/Areas/Api/Controllers/LocationController.cs
+++ b/Areas/Api/Controllers/LocationController.cs
@@ -22,7 +22,7 @@ public class LocationController : BaseApiController
     // Constants for default threshold settings
     private const int DefaultLocationTimeThresholdMinutes = 5; // Default to 5 minutes
     private const double DefaultLocationDistanceThresholdMeters = 15; // Default to 15 meters
-    private const int DefaultLocationAccuracyThresholdMeters = 100; // Default to 100 meters
+    private const int DefaultLocationAccuracyThresholdMeters = 50; // Default to 50 meters
 
     // Constants for check-in rate limiting
     private const int CheckInMinIntervalSeconds = 10; // Minimum 10 seconds between check-ins

--- a/Migrations/20260110185354_AddLocationAccuracyThreshold.cs
+++ b/Migrations/20260110185354_AddLocationAccuracyThreshold.cs
@@ -15,7 +15,7 @@ namespace Wayfarer.Migrations
                 table: "ApplicationSettings",
                 type: "integer",
                 nullable: false,
-                defaultValue: 100);
+                defaultValue: 50);
         }
 
         /// <inheritdoc />

--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -26,11 +26,11 @@ public class ApplicationSettings
     /// Maximum acceptable GPS accuracy in meters for location logging.
     /// Locations with accuracy worse (higher) than this value are rejected.
     /// This helps filter out unreliable GPS readings from poor signal conditions.
-    /// Default is 100 meters.
+    /// Default is 50 meters.
     /// </summary>
     [Required]
     [Range(10, 1000, ErrorMessage = "Accuracy threshold must be between 10 and 1000 meters.")]
-    public int LocationAccuracyThresholdMeters { get; set; } = 100;
+    public int LocationAccuracyThresholdMeters { get; set; } = 50;
 
     /// <summary>
     /// The max tile cache size (in MegaBytes [MB]) to store in file system for zoom levels >= 9.


### PR DESCRIPTION
## Summary

- Fix GPS accuracy threshold not persisting when changed in Admin Settings
- Add missing `Track()` call for LocationAccuracyThresholdMeters audit logging
- Add missing assignment of LocationAccuracyThresholdMeters in Update method
- Change default accuracy threshold from 100m to 50m (more practical for most use cases)

## Changes

- `Areas/Admin/Controllers/SettingsController.cs`: Add Track() and assignment for accuracy field
- `Models/ApplicationSettings.cs`: Update default from 100 to 50
- `Migrations/20260110185354_AddLocationAccuracyThreshold.cs`: Update migration default
- `Areas/Api/Controllers/LocationController.cs`: Update fallback constant
- `Areas/Admin/Views/Settings/Index.cshtml`: Update UI to show 50m as default, adjust option group labels

## Test plan

- [ ] Navigate to Admin > Settings
- [ ] Change GPS Accuracy Threshold to a value other than 50m
- [ ] Save settings
- [ ] Verify the setting persists after page reload
- [ ] Check database to confirm value was saved