### PR TITLE
fix: popup dark theme and API endpoint DTO responses (#101, #102)

### DIFF
--- a/Areas/Api/Controllers/TripsController.cs
+++ b/Areas/Api/Controllers/TripsController.cs
@@ -526,7 +526,23 @@ return Ok(dto);
 
         _dbContext.Places.Add(place);
         await _dbContext.SaveChangesAsync();
-        return Ok(new { success = true, place });
+
+        // Return DTO to ensure consistent serialization (location as double[] not GeoJSON)
+        var placeDto = new ApiTripPlaceDto
+        {
+            Id = place.Id,
+            Name = place.Name,
+            Notes = place.Notes,
+            DisplayOrder = place.DisplayOrder,
+            IconName = place.IconName,
+            MarkerColor = place.MarkerColor,
+            Address = place.Address,
+            Location = place.Location != null
+                ? new[] { place.Location.X, place.Location.Y }
+                : null
+        };
+
+        return Ok(new { success = true, place = placeDto });
     }
 
     /// <summary>
@@ -620,10 +636,25 @@ return Ok(dto);
             anyChange = true;
         }
 
-        if (!anyChange) return Ok(new { success = true, message = "No changes applied.", place });
+        // Return DTO to ensure consistent serialization (location as double[] not GeoJSON)
+        var placeDto = new ApiTripPlaceDto
+        {
+            Id = place.Id,
+            Name = place.Name,
+            Notes = place.Notes,
+            DisplayOrder = place.DisplayOrder,
+            IconName = place.IconName,
+            MarkerColor = place.MarkerColor,
+            Address = place.Address,
+            Location = place.Location != null
+                ? new[] { place.Location.X, place.Location.Y }
+                : null
+        };
+
+        if (!anyChange) return Ok(new { success = true, message = "No changes applied.", place = placeDto });
 
         await _dbContext.SaveChangesAsync();
-        return Ok(new { success = true, place });
+        return Ok(new { success = true, place = placeDto });
     }
 
     /// <summary>
@@ -690,7 +721,21 @@ return Ok(dto);
 
         _dbContext.Regions.Add(region);
         await _dbContext.SaveChangesAsync();
-        return Ok(new { success = true, region });
+
+        // Return DTO to ensure consistent serialization (center as double[] not GeoJSON)
+        var regionDto = new ApiTripRegionDto
+        {
+            Id = region.Id,
+            Name = region.Name,
+            Notes = region.Notes,
+            DisplayOrder = region.DisplayOrder,
+            CoverImageUrl = region.CoverImageUrl,
+            Center = region.Center != null
+                ? new[] { region.Center.X, region.Center.Y }
+                : null
+        };
+
+        return Ok(new { success = true, region = regionDto });
     }
 
     /// <summary>
@@ -819,10 +864,23 @@ return Ok(dto);
             anyChange = true;
         }
 
-        if (!anyChange) return Ok(new { success = true, message = "No changes applied.", region });
+        // Return DTO to ensure consistent serialization (center as double[] not GeoJSON)
+        var regionDto = new ApiTripRegionDto
+        {
+            Id = region.Id,
+            Name = region.Name,
+            Notes = region.Notes,
+            DisplayOrder = region.DisplayOrder,
+            CoverImageUrl = region.CoverImageUrl,
+            Center = region.Center != null
+                ? new[] { region.Center.X, region.Center.Y }
+                : null
+        };
+
+        if (!anyChange) return Ok(new { success = true, message = "No changes applied.", region = regionDto });
 
         await _dbContext.SaveChangesAsync();
-        return Ok(new { success = true, region });
+        return Ok(new { success = true, region = regionDto });
     }
 
     /// <summary>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1116,6 +1116,56 @@ thead th {
     margin-right: 0.2rem;
 }
 
+/* ─────────────────────────────────────────────────────────────
+   Dark Theme: Trip Tooltips and Popups
+   Fix for issue #101 - popup hovers on trips dark/light theme
+   ───────────────────────────────────────────────────────────── */
+[data-bs-theme="dark"] .leaflet-tooltip.trip-rich-tooltip {
+    background: #2c3034;
+    border-color: #495057;
+    color: var(--bs-body-color);
+}
+[data-bs-theme="dark"] .leaflet-tooltip.trip-rich-tooltip::before {
+    border-right-color: #2c3034;
+}
+
+/* Dark theme for trip popup content */
+[data-bs-theme="dark"] .trip-popup {
+    color: var(--bs-body-color);
+}
+[data-bs-theme="dark"] .trip-popup .popup-header strong {
+    color: #6ea8fe; /* Bootstrap link blue for dark mode */
+}
+[data-bs-theme="dark"] .trip-popup .popup-coords,
+[data-bs-theme="dark"] .trip-popup .popup-address,
+[data-bs-theme="dark"] .trip-popup .popup-details,
+[data-bs-theme="dark"] .trip-popup .popup-region {
+    color: #adb5bd;
+}
+[data-bs-theme="dark"] .trip-popup .popup-notes {
+    background: #343a40;
+    color: var(--bs-body-color);
+}
+[data-bs-theme="dark"] .trip-popup .popup-footer {
+    border-top-color: #495057;
+    color: #adb5bd;
+}
+
+/* Dark theme for Leaflet popup wrapper and tip (affects all Leaflet popups) */
+[data-bs-theme="dark"] .leaflet-popup-content-wrapper,
+[data-bs-theme="dark"] .leaflet-popup-tip {
+    background: #2c3034;
+    color: var(--bs-body-color);
+}
+[data-bs-theme="dark"] .leaflet-popup-content-wrapper {
+    border: 1px solid #495057;
+}
+
+/* Dark theme for segment tooltip */
+[data-bs-theme="dark"] .leaflet-tooltip.segment-tooltip {
+    background-color: #0a58ca; /* Slightly darker blue for dark mode */
+}
+
 .segment-highlight {
     animation: flash-border 1s ease-in-out;
     border: 2px solid var(--bs-primary);


### PR DESCRIPTION
## Summary

- **Issue #101**: Add dark mode CSS for trip tooltips and popups on hover
- **Issue #102**: Fix API endpoints to return DTOs instead of raw entities with GeoJSON geometry

## Changes

### CSS Dark Theme (Issue #101)
- Added dark mode styles for `.leaflet-tooltip.trip-rich-tooltip`
- Added dark mode styles for `.trip-popup` content (header, coords, notes, footer)
- Added dark mode styles for `.leaflet-popup-content-wrapper` and `.leaflet-popup-tip`
- Added dark mode for segment tooltips

### API DTO Responses (Issue #102 + related)
- `POST /api/trips/{tripId}/places` - now returns `ApiTripPlaceDto`
- `PUT /api/trips/places/{placeId}` - now returns `ApiTripPlaceDto`
- `POST /api/trips/{tripId}/regions` - now returns `ApiTripRegionDto`
- `PUT /api/trips/regions/{regionId}` - now returns `ApiTripRegionDto`

The API endpoints now return consistent DTO format with `location`/`center` as `double[]` arrays instead of GeoJSON Point objects, preventing deserialization failures in the mobile client.

## Test plan

- [ ] Toggle dark theme and hover over place markers on `/User/Trip/View`, `/Public/Trips/`, `/User/Trip/Edit/`
- [ ] Verify popup backgrounds are dark with readable text
- [ ] Test mobile client place creation and updates work without JSON errors
- [ ] Verify region creation/updates work correctly via API

Closes #101
Closes #102