### PR TITLE
chore: update references from master to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -47,7 +47,7 @@ chmod +x install.sh deploy.sh uninstall.sh
 ./install.sh
 
 
-# Deploy from master
+# Deploy from main
 ./deployment/deploy.sh
 
 # Deploy specific branch/tag

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -15,7 +15,7 @@
 # - Ensure your system user has sudo privileges for systemctl
 #
 # USAGE:
-#   # Deploy from master branch:
+#   # Deploy from main branch:
 #   ./deploy.sh
 #
 #   # Deploy from a specific branch:
@@ -67,7 +67,7 @@ APP_USER="${APP_USER:-wayfarer}"
 DOTNET_ENVIRONMENT="${DOTNET_ENVIRONMENT:-Production}"
 
 # Git branch/tag to deploy (can be overridden with REF env variable)
-REF="${REF:-master}"
+REF="${REF:-main}"
 
 # ============================================================================
 # DEPLOYMENT PROCESS

--- a/deployment/install.sh
+++ b/deployment/install.sh
@@ -32,7 +32,7 @@ done
 APP_USER="${APP_USER:-wayfarer}"
 DEPLOY_DIR="${DEPLOY_DIR:-/var/www/wayfarer}"
 SERVICE_NAME="${SERVICE_NAME:-wayfarer}"
-REF="${REF:-master}"
+REF="${REF:-main}"
 
 DB_NAME="${DB_NAME:-wayfarer}"
 DB_USER="${DB_USER:-wayfarer_user}"
@@ -240,7 +240,7 @@ prompt_default "SERVICE_NAME" "Systemd service name" "wayfarer"
 
 echo ""
 echo "We need to know which Git ref (branch or tag) to deploy."
-prompt_default "REF" "Git ref to deploy (branch or tag)" "master"
+prompt_default "REF" "Git ref to deploy (branch or tag)" "main"
 
 # ------------------------------
 # 2. Database configuration

--- a/docs/26-Deployment.md
+++ b/docs/26-Deployment.md
@@ -967,7 +967,7 @@ nano deployment/deploy.sh
 # Update APP_DIR, DEPLOY_DIR, APP_USER, SERVICE_NAME if needed
 ```
 
-**Deploy latest from master:**
+**Deploy latest from main:**
 
 ```bash
 cd /home/youruser/Wayfarer
@@ -1020,7 +1020,7 @@ cd /home/youruser/Wayfarer  # Your repository clone location
 git stash
 
 # Pull latest changes
-git pull origin master
+git pull origin main
 
 # Or checkout specific release
 # git fetch --tags


### PR DESCRIPTION
## Summary
- Updates all references from `master` to `main` after branch rename

## Files changed
- `.github/workflows/tests.yml` - CI trigger branch
- `deployment/install.sh` - default REF
- `deployment/deploy.sh` - default REF and comment
- `deployment/README.md` - documentation
- `docs/26-Deployment.md` - documentation

## Test plan
- [x] Verify CI workflow triggers on `main`
- [x] Deployment scripts default to `main`