### PR TITLE
fix: format accuracy, speed, altitude to 2 decimal places in UI

### DIFF
--- a/wwwroot/js/Areas/Public/UsersTimeline/Embed.js
+++ b/wwwroot/js/Areas/Public/UsersTimeline/Embed.js
@@ -35,6 +35,7 @@ import {addZoomLevelControl, latestLocationMarker, liveMarker} from '../../../ma
 import {
     formatViewerAndSourceTimes,
     formatDate,
+    formatDecimal,
     getViewerTimeZone,
 } from '../../../util/datetime.js';
 
@@ -333,11 +334,11 @@ const generateLocationModalContent = (location, { isLive, isLatest }) => {
             <div class="col-6"><strong>Activity:</strong>
             <span>${(location.activityType && location.activityType !== 'Unknown') ? location.activityType :
         '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</span></div>
-            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude != null ? location.altitude + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+            <div class="col-6"><strong>Altitude:</strong> <span>${formatDecimal(location.altitude) != null ? formatDecimal(location.altitude) + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
         </div>
         <div class="row mb-2">
-            <div class="col-6"><strong>Accuracy:</strong> <span>${location.accuracy != null ? location.accuracy + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
-            <div class="col-6"><strong>Speed:</strong> <span>${location.speed != null ? location.speed + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
+            <div class="col-6"><strong>Accuracy:</strong> <span>${formatDecimal(location.accuracy) != null ? formatDecimal(location.accuracy) + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
+            <div class="col-6"><strong>Speed:</strong> <span>${formatDecimal(location.speed) != null ? formatDecimal(location.speed) + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
         </div>
         <div class="row mb-2">
             <div class="col-12"><strong>Address:</strong> <span>${location.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i> '}</span><br/>

--- a/wwwroot/js/Areas/Public/UsersTimeline/Timeline.js
+++ b/wwwroot/js/Areas/Public/UsersTimeline/Timeline.js
@@ -33,6 +33,7 @@ import {addZoomLevelControl, latestLocationMarker, liveMarker} from '../../../ma
 import {
     formatViewerAndSourceTimes,
     formatDate,
+    formatDecimal,
     getViewerTimeZone,
 } from '../../../util/datetime.js';
 
@@ -330,11 +331,11 @@ const generateLocationModalContent = (location, {isLive, isLatest}) => {
             <div class="col-6"><strong>Activity:</strong>
             <span>${(location.activityType && location.activityType !== 'Unknown') ? location.activityType :
         '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</span></div>
-            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude != null ? location.altitude + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+            <div class="col-6"><strong>Altitude:</strong> <span>${formatDecimal(location.altitude) != null ? formatDecimal(location.altitude) + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
         </div>
         <div class="row mb-2">
-            <div class="col-6"><strong>Accuracy:</strong> <span>${location.accuracy != null ? location.accuracy + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
-            <div class="col-6"><strong>Speed:</strong> <span>${location.speed != null ? location.speed + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
+            <div class="col-6"><strong>Accuracy:</strong> <span>${formatDecimal(location.accuracy) != null ? formatDecimal(location.accuracy) + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
+            <div class="col-6"><strong>Speed:</strong> <span>${formatDecimal(location.speed) != null ? formatDecimal(location.speed) + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
         </div>
         <div class="row mb-2">
             <div class="col-12"><strong>Address:</strong> <span>${location.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i> '}</span><br/>

--- a/wwwroot/js/Areas/User/Location/AllLocations.js
+++ b/wwwroot/js/Areas/User/Location/AllLocations.js
@@ -2,6 +2,7 @@
 import {
     formatViewerAndSourceTimes,
     formatDate,
+    formatDecimal,
     currentDateInputValue,
     getViewerTimeZone,
 } from '../../../util/datetime.js';
@@ -228,9 +229,9 @@ const displayLocationsInTable = (locations) => {
         </td>
         <td>${loc.coordinates.latitude}</td>
         <td>${loc.coordinates.longitude}</td>
-        <td class="text-center">${loc.accuracy != null ? loc.accuracy : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</td>
-        <td class="text-center">${loc.speed != null ? loc.speed : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</td>
-        <td class="text-center">${loc.altitude != null ? loc.altitude : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</td>
+        <td class="text-center">${formatDecimal(loc.accuracy) != null ? formatDecimal(loc.accuracy) : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</td>
+        <td class="text-center">${formatDecimal(loc.speed) != null ? formatDecimal(loc.speed) : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</td>
+        <td class="text-center">${formatDecimal(loc.altitude) != null ? formatDecimal(loc.altitude) : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</td>
         <td>${loc.activityType || loc.activity || '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</td>
         <td>${loc.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i>'}</td>
         <td>${loc.place || '<i class="bi bi-patch-question" title="No available data for Place"></i>'}</td>
@@ -376,7 +377,7 @@ const generateLocationModalContent = (location) => {
             <strong>Activity:</strong> ${location.activityType || '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}
         </div>
         <div class="col-6">
-            <strong>Altitude:</strong> ${location.altitude || '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}
+            <strong>Altitude:</strong> ${formatDecimal(location.altitude) != null ? formatDecimal(location.altitude) + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}
         </div>
       </div>
       <div class="row mb-2">

--- a/wwwroot/js/Areas/User/Location/Index.js
+++ b/wwwroot/js/Areas/User/Location/Index.js
@@ -11,6 +11,7 @@ import {addZoomLevelControl, latestLocationMarker, liveMarker} from '../../../ma
 import {
     formatViewerAndSourceTimes,
     formatDate,
+    formatDecimal,
     currentDateInputValue,
     getViewerTimeZone,
 } from '../../../util/datetime.js';
@@ -445,11 +446,11 @@ const generateLocationModalContent = location => {
             ? location.activityType
             : '<i class="bi bi-patch-question" title="No available data for Activity"></i>'
     }</span></div>
-            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude != null ? location.altitude + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+            <div class="col-6"><strong>Altitude:</strong> <span>${formatDecimal(location.altitude) != null ? formatDecimal(location.altitude) + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
         </div>
         <div class="row mb-2">
-            <div class="col-6"><strong>Accuracy:</strong> <span>${location.accuracy != null ? location.accuracy + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
-            <div class="col-6"><strong>Speed:</strong> <span>${location.speed != null ? location.speed + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
+            <div class="col-6"><strong>Accuracy:</strong> <span>${formatDecimal(location.accuracy) != null ? formatDecimal(location.accuracy) + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
+            <div class="col-6"><strong>Speed:</strong> <span>${formatDecimal(location.speed) != null ? formatDecimal(location.speed) + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
         </div>
         <div class="row mb-2">
             <div class="col-12"><strong>Address:</strong> <span>${location.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i> '}</span>
@@ -636,9 +637,9 @@ const displayLocationsInTable = (locations) => {
                 </td>
                 <td>${location.coordinates.latitude}</td>
                 <td>${location.coordinates.longitude}</td>
-                <td class="text-center">${location.accuracy != null ? location.accuracy : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</td>
-                <td class="text-center">${location.speed != null ? location.speed : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</td>
-                <td class="text-center">${location.altitude != null ? location.altitude : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</td>
+                <td class="text-center">${formatDecimal(location.accuracy) != null ? formatDecimal(location.accuracy) : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</td>
+                <td class="text-center">${formatDecimal(location.speed) != null ? formatDecimal(location.speed) : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</td>
+                <td class="text-center">${formatDecimal(location.altitude) != null ? formatDecimal(location.altitude) : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</td>
                 <td>${location.activityType || '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</td>
                 <td>${location.address || '<i class="bi bi-patch-question" title="No available data for Address"></i>'}</td>
                 <td>${location.place || '<i class="bi bi-patch-question" title="No available data for Place"></i>'}</td>

--- a/wwwroot/js/Areas/User/Timeline/Chronological.js
+++ b/wwwroot/js/Areas/User/Timeline/Chronological.js
@@ -9,6 +9,7 @@ import {addZoomLevelControl, latestLocationMarker, liveMarker} from '../../../ma
 import {
     formatViewerAndSourceTimes,
     formatDate,
+    formatDecimal,
     currentDateInputValue,
     currentMonthInputValue,
     currentYearInputValue,
@@ -947,11 +948,11 @@ const generateLocationModalContent = (location, {isLive, isLatest}) => {
             <div class="col-6"><strong>Activity:</strong>
             <span>${(location.activityType && location.activityType !== 'Unknown') ? location.activityType :
         '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</span></div>
-            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude != null ? location.altitude + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+            <div class="col-6"><strong>Altitude:</strong> <span>${formatDecimal(location.altitude) != null ? formatDecimal(location.altitude) + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
         </div>
         <div class="row mb-2">
-            <div class="col-6"><strong>Accuracy:</strong> <span>${location.accuracy != null ? location.accuracy + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
-            <div class="col-6"><strong>Speed:</strong> <span>${location.speed != null ? location.speed + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
+            <div class="col-6"><strong>Accuracy:</strong> <span>${formatDecimal(location.accuracy) != null ? formatDecimal(location.accuracy) + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
+            <div class="col-6"><strong>Speed:</strong> <span>${formatDecimal(location.speed) != null ? formatDecimal(location.speed) + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
         </div>
         <div class="row mb-2">
             <div class="col-12"><strong>Address:</strong> <span>${location.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i> '}</span><br/>

--- a/wwwroot/js/Areas/User/Timeline/Index.js
+++ b/wwwroot/js/Areas/User/Timeline/Index.js
@@ -10,6 +10,7 @@ import {addZoomLevelControl, latestLocationMarker, liveMarker} from '../../../ma
 import {
     formatViewerAndSourceTimes,
     formatDate,
+    formatDecimal,
     getViewerTimeZone,
 } from '../../../util/datetime.js';
 
@@ -363,11 +364,11 @@ const generateLocationModalContent = (location, {isLive, isLatest}) => {
             <div class="col-6"><strong>Activity:</strong>
             <span>${(location.activityType && location.activityType !== 'Unknown') ? location.activityType :
         '<i class="bi bi-patch-question" title="No available data for Activity"></i>'}</span></div>
-            <div class="col-6"><strong>Altitude:</strong> <span>${location.altitude != null ? location.altitude + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
+            <div class="col-6"><strong>Altitude:</strong> <span>${formatDecimal(location.altitude) != null ? formatDecimal(location.altitude) + ' m' : '<i class="bi bi-patch-question" title="No available data for Altitude"></i>'}</span></div>
         </div>
         <div class="row mb-2">
-            <div class="col-6"><strong>Accuracy:</strong> <span>${location.accuracy != null ? location.accuracy + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
-            <div class="col-6"><strong>Speed:</strong> <span>${location.speed != null ? location.speed + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
+            <div class="col-6"><strong>Accuracy:</strong> <span>${formatDecimal(location.accuracy) != null ? formatDecimal(location.accuracy) + ' m' : '<i class="bi bi-patch-question" title="No available data for Accuracy"></i>'}</span></div>
+            <div class="col-6"><strong>Speed:</strong> <span>${formatDecimal(location.speed) != null ? formatDecimal(location.speed) + ' km/h' : '<i class="bi bi-patch-question" title="No available data for Speed"></i>'}</span></div>
         </div>
         <div class="row mb-2">
             <div class="col-12"><strong>Address:</strong> <span>${location.fullAddress || '<i class="bi bi-patch-question" title="No available data for Address"></i> '}</span><br/>

--- a/wwwroot/js/util/datetime.js
+++ b/wwwroot/js/util/datetime.js
@@ -1,7 +1,22 @@
 /**
- * Shared helpers for formatting location timestamps.
+ * Shared helpers for formatting location timestamps and numeric values.
  * Provides deterministic output (YYYY-MM-DD HH:mm) regardless of navigator language.
  */
+
+/**
+ * Formats a numeric value to a specified number of decimal places for display.
+ * Coordinates should NOT use this function - they need full precision.
+ * Use for: accuracy, speed, altitude, and other float/double display values.
+ * @param {number|string|null|undefined} value - The value to format
+ * @param {number} [decimals=2] - Number of decimal places (default: 2)
+ * @returns {string|null} Formatted number string, or null if value is null/undefined
+ */
+export const formatDecimal = (value, decimals = 2) => {
+    if (value == null) return null;
+    const num = typeof value === 'string' ? parseFloat(value) : value;
+    if (Number.isNaN(num)) return null;
+    return num.toFixed(decimals);
+};
 
 const DEFAULT_LOCALE = 'en-GB';
 const DEFAULT_DATETIME_PARTS = {


### PR DESCRIPTION
## Summary
- Adds `formatDecimal(value, decimals)` utility function to `datetime.js`
- Formats accuracy, speed, and altitude values to 2 decimal places in display-only views
- Coordinates (latitude/longitude) retain full precision as required

## Affected Views
- `/User/Timeline` (Index, Chronological) - modal popups
- `/User/Location` (Index, AllLocations) - tables and modal popups  
- `/Public/UsersTimeline` (Timeline, Embed) - modal popups

## Not Changed (per issue requirements)
- Create/Edit forms - keep full data accuracy for input
- Backend data - unchanged, only UI display affected

Closes #108

## Test plan
- [x] Navigate to `/User/Timeline` and click a location marker - verify accuracy, speed, altitude show 2 decimals
- [x] Navigate to `/User/Location` and check table columns for accuracy, speed, altitude
- [x] Click "View" on a location to open modal - verify 2 decimal formatting
- [x] Navigate to `/User/Location/AllLocations` - same checks as above
- [ ] Test public timeline views if available
- [ ] Verify Edit/Create forms still show full precision values