### PR TITLE
fix: add CSRF protection to admin endpoints

### DIFF
--- a/Areas/Admin/Controllers/ApiTokenController.cs
+++ b/Areas/Admin/Controllers/ApiTokenController.cs
@@ -50,6 +50,7 @@ namespace Wayfarer.Areas.Admin.Controllers
         /// <param name="id">The ID of the user for whom the token will be generated.</param>
         /// <param name="name">The name or purpose of the token.</param>
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(string id, string name)
         {
             if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(name))
@@ -88,6 +89,8 @@ namespace Wayfarer.Areas.Admin.Controllers
         /// </summary>
         /// <param name="id">The ID of the user for whom the token will be regenerated.</param>
         /// <param name="name">The name of the token to regenerate.</param>
+        [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Regenerate(string id, string name)
         {
             if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(name))
@@ -118,6 +121,8 @@ namespace Wayfarer.Areas.Admin.Controllers
         /// </summary>
         /// <param name="id">The ID of the user for whom the token will be deleted.</param>
         /// <param name="tokenId">The ID of the token to delete.</param>
+        [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Delete(string id, int tokenId)
         {
             if (string.IsNullOrEmpty(id) || tokenId == 0)

--- a/Areas/Admin/Controllers/JobsController.cs
+++ b/Areas/Admin/Controllers/JobsController.cs
@@ -111,6 +111,7 @@ namespace Wayfarer.Areas.Admin.Controllers
         /// <param name="jobGroup">Job Group</param>
         /// <returns></returns>
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> StartJob(string jobName, string jobGroup)
         {
             JobKey jobKey = new JobKey(jobName, jobGroup);
@@ -171,6 +172,7 @@ namespace Wayfarer.Areas.Admin.Controllers
         /// <param name="jobName">Job name</param>
         /// <param name="jobGroup">Job group</param>
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> PauseJob(string jobName, string jobGroup)
         {
             JobKey jobKey = new JobKey(jobName, jobGroup);
@@ -187,6 +189,7 @@ namespace Wayfarer.Areas.Admin.Controllers
         /// <param name="jobName">Job name</param>
         /// <param name="jobGroup">Job group</param>
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> ResumeJob(string jobName, string jobGroup)
         {
             JobKey jobKey = new JobKey(jobName, jobGroup);
@@ -204,6 +207,7 @@ namespace Wayfarer.Areas.Admin.Controllers
         /// <param name="jobName">Job name</param>
         /// <param name="jobGroup">Job group</param>
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> CancelJob(string jobName, string jobGroup)
         {
             JobKey jobKey = new JobKey(jobName, jobGroup);

--- a/Areas/Admin/Views/ApiToken/Index.cshtml
+++ b/Areas/Admin/Views/ApiToken/Index.cshtml
@@ -29,20 +29,24 @@
                                     </p>
                                 </div>
                                 <div class="btn-group">
-                                    <a asp-action="Regenerate"
-                                       asp-controller="ApiToken"
-                                       asp-area="Admin"
-                                       asp-route-id="@Model.UserId"
-                                       asp-route-name="@token.Name"
-                                       class="btn btn-success btn-sm">Regenerate</a>
+                                    <form method="post" asp-action="Regenerate" asp-controller="ApiToken" asp-area="Admin" class="d-inline">
+                                        <input type="hidden" name="id" value="@Model.UserId" />
+                                        <input type="hidden" name="name" value="@token.Name" />
+                                        <button type="submit" class="btn btn-success btn-sm"
+                                                onclick="return confirm('Regenerate this token? The old token will stop working immediately.')">
+                                            Regenerate
+                                        </button>
+                                    </form>
                                     @if (!token.Name.Equals("Wayfarer Incoming Location Data API Token"))
                                     {
-                                        <a asp-action="Delete"
-                                           asp-controller="ApiToken"
-                                           asp-area="Admin"
-                                           asp-route-id="@Model.UserId"
-                                           asp-route-tokenId="@token.Id"
-                                           class="btn btn-danger btn-sm">Delete</a>
+                                        <form method="post" asp-action="Delete" asp-controller="ApiToken" asp-area="Admin" class="d-inline ms-1">
+                                            <input type="hidden" name="id" value="@Model.UserId" />
+                                            <input type="hidden" name="tokenId" value="@token.Id" />
+                                            <button type="submit" class="btn btn-danger btn-sm"
+                                                    onclick="return confirm('Delete this token? This action cannot be undone.')">
+                                                Delete
+                                            </button>
+                                        </form>
                                     }
                                 </div>
                             </div>

--- a/Areas/Manager/Controllers/ApiTokenController.cs
+++ b/Areas/Manager/Controllers/ApiTokenController.cs
@@ -49,6 +49,8 @@ namespace Wayfarer.Areas.Manager.Controllers
         /// </summary>
         /// <param name="id">The ID of the user for whom the token will be generated.</param>
         /// <param name="name">The name or purpose of the token.</param>
+        [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(string id, string name)
         {
             if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(name))
@@ -87,6 +89,8 @@ namespace Wayfarer.Areas.Manager.Controllers
         /// </summary>
         /// <param name="id">The ID of the user for whom the token will be regenerated.</param>
         /// <param name="name">The name of the token to regenerate.</param>
+        [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Regenerate(string id, string name)
         {
             if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(name))
@@ -117,6 +121,8 @@ namespace Wayfarer.Areas.Manager.Controllers
         /// </summary>
         /// <param name="id">The ID of the user for whom the token will be deleted.</param>
         /// <param name="tokenId">The ID of the token to delete.</param>
+        [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Delete(string id, int tokenId)
         {
             if (string.IsNullOrEmpty(id) || tokenId == 0)

--- a/Areas/Manager/Views/ApiToken/Index.cshtml
+++ b/Areas/Manager/Views/ApiToken/Index.cshtml
@@ -29,20 +29,24 @@
                                     </p>
                                 </div>
                                 <div class="btn-group">
-                                    <a asp-action="Regenerate"
-                                       asp-controller="ApiToken"
-                                       asp-area="Manager"
-                                       asp-route-id="@Model.UserId"
-                                       asp-route-name="@token.Name"
-                                       class="btn btn-success btn-sm">Regenerate</a>
+                                    <form method="post" asp-action="Regenerate" asp-controller="ApiToken" asp-area="Manager" class="d-inline">
+                                        <input type="hidden" name="id" value="@Model.UserId" />
+                                        <input type="hidden" name="name" value="@token.Name" />
+                                        <button type="submit" class="btn btn-success btn-sm"
+                                                onclick="return confirm('Regenerate this token? The old token will stop working immediately.')">
+                                            Regenerate
+                                        </button>
+                                    </form>
                                     @if (!token.Name.Equals("Wayfarer Incoming Location Data API Token"))
                                     {
-                                        <a asp-action="Delete"
-                                           asp-controller="ApiToken"
-                                           asp-area="Manager"
-                                           asp-route-id="@Model.UserId"
-                                           asp-route-tokenId="@token.Id"
-                                           class="btn btn-danger btn-sm">Delete</a>
+                                        <form method="post" asp-action="Delete" asp-controller="ApiToken" asp-area="Manager" class="d-inline ms-1">
+                                            <input type="hidden" name="id" value="@Model.UserId" />
+                                            <input type="hidden" name="tokenId" value="@token.Id" />
+                                            <button type="submit" class="btn btn-danger btn-sm"
+                                                    onclick="return confirm('Delete this token? This action cannot be undone.')">
+                                                Delete
+                                            </button>
+                                        </form>
                                     }
                                 </div>
                             </div>

--- a/Areas/User/Controllers/ApiTokenController.cs
+++ b/Areas/User/Controllers/ApiTokenController.cs
@@ -49,6 +49,7 @@ namespace Wayfarer.Areas.User.Controllers
 
         // POST: ApiToken/Create
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(string name)
         {
             string? userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -85,6 +86,7 @@ namespace Wayfarer.Areas.User.Controllers
         /// <param name="token">Token</param>
         /// <returns></returns>
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> StoreThirdPartyToken(string thirdPartyServiceName, string thirdPartyToken)
         {
             string? userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -120,6 +122,7 @@ namespace Wayfarer.Areas.User.Controllers
         /// Returns JSON for AJAX requests with the new token (shown once only).
         /// </summary>
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Regenerate(string name)
         {
             string? userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -176,6 +179,7 @@ namespace Wayfarer.Areas.User.Controllers
 
         // POST: ApiToken/Delete
         [HttpPost("Delete")]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int tokenId)
         {
             string? userId = User.FindFirstValue(ClaimTypes.NameIdentifier); // Get current user's ID


### PR DESCRIPTION
## Summary
- Add `[ValidateAntiForgeryToken]` to all POST endpoints in JobsController, Admin/ApiTokenController, User/ApiTokenController, and Manager/ApiTokenController
- Add `[HttpPost]` to Admin/ApiTokenController and Manager/ApiTokenController endpoints that were previously accessible via GET (Create, Regenerate, Delete)
- Update Admin and Manager ApiToken views to use POST forms instead of GET links for state-changing operations

## Test plan
- [x] Build succeeds with no errors
- [x] All 1211 tests pass
- [x] Manual test: Admin Jobs page - Start/Pause/Resume/Cancel buttons work correctly
- [ ] Manual test: Admin/Manager API Token pages - Create/Regenerate/Delete buttons work correctly
- [x] Manual test: User API Token page - Create/Store/Regenerate/Delete functions work correctly

Closes #116