### PR TITLE
Add navigation from Visit to underlying Location records

### DIFF
--- a/Areas/User/Views/Visit/Edit.cshtml
+++ b/Areas/User/Views/Visit/Edit.cshtml
@@ -163,6 +163,51 @@
                      data-color="@(Model.MarkerColorSnapshot ?? "bg-blue")"></div>
             </div>
         </div>
+
+        <!-- Relevant Locations Card -->
+        <div class="card shadow-sm mt-3" id="locationPingsCard" data-visit-id="@Model.Id">
+            <div class="card-header d-flex justify-content-between align-items-center"
+                 role="button" data-bs-toggle="collapse" data-bs-target="#locationPingsCollapse"
+                 aria-expanded="true" aria-controls="locationPingsCollapse">
+                <h2 class="fs-5 mb-0">
+                    <i class="bi bi-geo-alt me-1"></i>Relevant Locations
+                    <span id="locationPingsCount" class="badge bg-secondary ms-2">...</span>
+                </h2>
+                <i class="bi bi-chevron-up" id="collapseIcon"></i>
+            </div>
+            <div id="locationPingsCollapse" class="collapse show">
+                <div class="card-body p-2">
+                    <div id="locationPingsLoading" class="text-center py-3">
+                        <div class="spinner-border spinner-border-sm" role="status"></div>
+                        <span class="ms-2">Loading...</span>
+                    </div>
+                    <div class="table-responsive" id="locationPingsTableWrapper" style="display:none; max-height:220px; overflow-y:auto;">
+                        <table class="table table-sm table-hover mb-0" id="locationPingsTable">
+                            <thead class="sticky-top bg-white">
+                                <tr>
+                                    <th>Timestamp</th>
+                                    <th>Coordinates</th>
+                                    <th class="text-end">Accuracy</th>
+                                    <th class="text-end">Speed</th>
+                                    <th>Activity</th>
+                                    <th>Address</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody id="locationPingsBody"></tbody>
+                        </table>
+                    </div>
+                    <div id="locationPingsLoadMore" class="text-center mt-2" style="display:none;">
+                        <button class="btn btn-outline-primary btn-sm" id="loadMoreLocationsBtn">
+                            Show More
+                        </button>
+                    </div>
+                    <div id="locationPingsEmpty" class="text-muted text-center py-3" style="display:none;">
+                        No relevant locations found for this visit.
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/Areas/User/Views/Visit/Index.cshtml
+++ b/Areas/User/Views/Visit/Index.cshtml
@@ -77,6 +77,9 @@
                 <th>Trip</th>
                 <th>Region</th>
                 <th class="text-center">Dwell Time</th>
+                <th class="text-center" title="GPS pings recorded during this visit within the place's proximity radius">
+                    Locations <i class="bi bi-info-circle text-muted" style="font-size: 0.75rem;"></i>
+                </th>
                 <th class="text-center">Status</th>
                 <th>Actions</th>
             </tr>


### PR DESCRIPTION
## Summary
- Adds ability to view GPS location pings that triggered a visit detection
- Shows relevant locations in Visit/Edit page and Visit Index modal
- Lazy-loads location counts in Visit Index for better performance

## Changes
- **API**: `GET /api/visit/{id}/locations` - paginated locations within visit time/proximity
- **API**: `POST /api/visit/location-counts` - batch counts for lazy-loading
- **Visit/Edit**: Relevant Locations card (expanded by default, 220px scrollable, sticky header)
- **Visit Index**: Locations column with spinner → count badge, tooltip explanation
- **Visit Modal**: Locations section with first 5 entries and edit buttons
- **Fix**: Map attribution on Visit/Edit now matches Timeline pattern

## Test plan
- [x] Navigate to Visit/Edit page, verify Relevant Locations card shows correct count and data
- [ ] Scroll the locations table, verify header stays sticky
- [x] Click Edit button on a location row, verify navigation works with returnUrl
- [x] Navigate to Visit Index, verify Locations column shows spinners then counts
- [x] Hover over Locations header, verify tooltip appears
- [x] Click View on a visit, verify modal shows locations with edit buttons
- [x] Verify map attribution on Visit/Edit matches Timeline format

Closes #122