### PR TITLE
fix: reduce visit badge z-index to prevent UI overlap

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1704,7 +1704,7 @@ img.js-lazy[src] {
     justify-content: center;
     border: 1.5px solid white;
     box-shadow: 0 1px 2px rgba(0,0,0,0.3);
-    z-index: 10;
+    z-index: 1;
 }
 
 /* ─────────────────────────────────────────────────────────
@@ -1733,7 +1733,7 @@ img.js-lazy[src] {
     justify-content: center;
     border: 1.5px solid white;
     box-shadow: 0 1px 2px rgba(0,0,0,0.3);
-    z-index: 10;
+    z-index: 1;
 }
 
 /* ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Reduced `z-index` from `10` to `1` for visit badges (`.place-marker .visit-badge` and `.sidebar-visit-badge`)
- Badges only need to stack above their sibling icon image, not above other UI elements

## Test plan
- [ ] Visit `/Public/Trips/{tripId}` and verify badges no longer overlap other elements
- [ ] Visit `/User/Trip/View/{tripId}` and verify badges no longer overlap other elements
- [ ] Confirm badges still appear correctly on top of their marker icons

Fixes #132