### PR TITLE
fix: include docs folder in publish output

### DIFF
--- a/Wayfarer.csproj
+++ b/Wayfarer.csproj
@@ -70,6 +70,11 @@
         <None Include="Tools\**\*.*" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
+    <!-- Include docs folder for local serving at /docs/ -->
+    <ItemGroup>
+        <Content Include="docs\**\*.*" CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
+
     <ItemGroup>
         <Content Update="Areas\Manager\Views\Users\Create.cshtml">
             <ExcludeFromSingleFile>true</ExcludeFromSingleFile>


### PR DESCRIPTION
## Summary

Fixes /docs/ returning 404 in production.

The docs folder wasn't being copied during `dotnet publish`, so it wasn't available in the deployed application.

## Changes

Added `Content Include` item in the project file to copy the docs folder to the publish output.

## Test Plan
- [ ] Run `dotnet publish -c Release -o ./out`
- [ ] Verify `out/docs/` folder exists with all documentation files
- [ ] Deploy and verify `/docs/` is accessible