### PR TITLE
docs: clarify project license in third-party notices

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,8 +1,10 @@
 THIRD-PARTY NOTICES
 
-This project incorporates components from the projects listed below. The original
-copyright notices and the licenses under which Wayfarer received such components
-are set forth below.
+This file documents third-party components used by Wayfarer. The Wayfarer project
+itself is MIT-licensed (see LICENSE.txt).
+
+The original copyright notices and the licenses under which Wayfarer received
+such components are set forth below.
 
 ================================================================================
 
@@ -484,15 +486,3 @@ limitations under the License.
 ================================================================================
 
 Copyright 2025 Stef Kariotidis / Wayfarer
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.


### PR DESCRIPTION
## Summary

- Added clarification at the top: "This file documents third-party components used by Wayfarer. The Wayfarer project itself is MIT-licensed (see LICENSE.txt)."
- Removed the duplicate Apache License block at the end of the file (after the copyright line)

## Why

The previous version had Apache 2.0 license text appearing twice:
1. In the LICENSE TEXTS reference section (correct - for reference)
2. After the copyright line at the end (confusing - made it look like the notices file itself was Apache-licensed)

This confused readers about whether the project was MIT or Apache licensed.

## Test plan

- [x] File still contains all third-party attributions
- [x] Apache 2.0 reference text still present in LICENSE TEXTS section
- [x] No duplicate Apache block at end
- [x] Clear statement about project being MIT-licensed