### PR TITLE
docs: improve third-party notices based on review feedback

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -87,6 +87,7 @@ https://github.com/Leaflet/Leaflet.Editable
 Copyright (c) 2015, Yohan Boniface
 
 Licensed under the WTFPL License.
+http://www.wtfpl.net/
 
 --------------------------------------------------------------------------------
 
@@ -207,8 +208,8 @@ Copyright (c) 2019 Morgan Herlocker
 
 Licensed under the MIT License.
 
-Note: Some Turf.js algorithms may use components licensed under GNU Affero
-General Public License. See the Turf.js repository for specific module licenses.
+Note: Some Turf.js submodules may have different licenses. Refer to the
+Turf.js repository for details.
 
 ================================================================================
 
@@ -371,9 +372,10 @@ Licensed under the Apache License, Version 2.0.
 
 MvcFrontendKit 1.0.0-preview.24
 -------------------------------
-NuGet package for ASP.NET Core MVC frontend utilities.
+https://www.nuget.org/packages/MvcFrontendKit
+https://github.com/nickofc/MvcFrontendKit
 
-Please check the package license on NuGet.org for specific license terms.
+Licensed under the MIT License.
 
 ================================================================================
 


### PR DESCRIPTION
## Summary

Address reviewer feedback on THIRD-PARTY-NOTICES.txt:

1. **Leaflet.Editable** - Added WTFPL license link (http://www.wtfpl.net/)
2. **Turf.js** - Simplified the license note to avoid implying Wayfarer becomes AGPL
3. **MvcFrontendKit** - Completed the entry with MIT license and proper URLs

## Changes

| Library | Before | After |
|---------|--------|-------|
| Leaflet.Editable | "Licensed under the WTFPL License." | Added link to http://www.wtfpl.net/ |
| Turf.js | "...may use components licensed under GNU Affero..." | "...submodules may have different licenses. Refer to the Turf.js repository for details." |
| MvcFrontendKit | "Please check the package license on NuGet.org..." | MIT License with NuGet and GitHub URLs |

## Test plan

- [x] All three entries updated correctly
- [x] No other entries affected