### PR TITLE
docs: update privacy page for open source release

### DIFF
--- a/Views/Home/Privacy.cshtml
+++ b/Views/Home/Privacy.cshtml
@@ -14,11 +14,11 @@
     <div class="row">
         <div class="col-md-7 mx-auto">
             <div class="pt-2 text-start fs-5" >
-                <p>This website <strong>https://wayfarer.stefk.me</strong> is build for <span class="text-decoration-underline">personal use</span>, 
+                <p>This instance of Wayfarer is deployed for <span class="text-decoration-underline">personal use</span>,
                     meaning registrations are not open. <br/><br/>
-                    If you like what you see, you will have to self host a Wayfarer instance on your own. To do this, you will have to contact me
-                    in order to discuss about gaining access to source code as the project currently is private.<br/><br/>
-                    You can find ways to contact me at <a href="https://stefk.me/contact" title="Contact Stef" target="_blank">https://stefk.me/contact</a>
+                    If you like what you see, you can self host a Wayfarer instance on your own. The project is open source!<br/><br/>
+                    <a href="https://github.com/stef-k/Wayfarer" title="Wayfarer on GitHub" target="_blank">GitHub Repository</a> |
+                    <a href="https://stef-k.github.io/Wayfarer" title="Wayfarer Documentation" target="_blank">Documentation</a>
                     </p>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Update privacy page text from "This website" to "This instance of Wayfarer is deployed for"
- Remove obsolete text about contacting for private source code access
- Add links to GitHub repository and documentation (both open in new tabs)

## Test plan
- [ ] Verify privacy page renders correctly
- [ ] Verify both links open in new tabs and point to correct URLs