### PR TITLE
Fix missing frontend.config.yaml in publish output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Fixed EF Core warnings for First/FirstOrDefault without OrderBy on ApplicationSettings queries (#159)
 - Fixed latent crash in LocationImportController when ApplicationSettings table is empty
 - Added deterministic ordering to in-memory GroupBy deduplication patterns
+- Fixed frontend.config.yaml missing from publish output causing startup warning (#160)
+- Upgraded MvcFrontendKit from 1.0.0-preview.24 to 1.0.0
 
 ## [2026-02-10]
 ### Changed

--- a/Wayfarer.csproj
+++ b/Wayfarer.csproj
@@ -28,7 +28,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
 
-        <PackageReference Include="MvcFrontendKit" Version="1.0.0-preview.24" />
+        <PackageReference Include="MvcFrontendKit" Version="1.0.0" />
         <PackageReference Include="NetTopologySuite" Version="2.6.0" />
         <PackageReference Include="NetTopologySuite.Features" Version="2.2.0" />
         <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
@@ -73,6 +73,11 @@
     <!-- Include docs folder for local serving at /docs/ -->
     <ItemGroup>
         <Content Include="docs\**\*.*" CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
+
+    <!-- Include frontend config so it's available in production (MvcFrontendKit reads it at runtime) -->
+    <ItemGroup>
+        <Content Include="frontend.config.yaml" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Added `<Content Include="frontend.config.yaml" CopyToPublishDirectory="PreserveNewest" />` to `.csproj` so the file is included in `dotnet publish` output
- Upgraded MvcFrontendKit from `1.0.0-preview.24` to `1.0.0` stable
- Opened stef-k/MvcFrontendKit#1 for the package to handle this automatically in `dotnet frontend init`

## Root cause
`FrontendConfigProvider` resolves config via `IHostEnvironment.ContentRootPath`, which works in dev but fails in production because the YAML file was never copied to the publish directory.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 1253 passed, 0 failed
- [ ] Deploy and verify no `[WRN] Frontend config file not found` in startup logs

Closes #160