### PR TITLE
fix: region headers dark theme + search clear button

### DIFF
--- a/Areas/User/Views/Trip/Index.cshtml
+++ b/Areas/User/Views/Trip/Index.cshtml
@@ -240,8 +240,14 @@ else
 
                     <!-- Search filter (shown with results) -->
                     <div id="backfill-search-wrapper" class="mb-2 d-none">
-                        <input type="text" class="form-control form-control-sm"
-                               id="backfill-search" placeholder="Search places, regions...">
+                        <div class="backfill-search-group">
+                            <input type="text" class="form-control form-control-sm pe-4"
+                                   id="backfill-search" placeholder="Search places, regions...">
+                            <button type="button" class="btn-search-clear d-none"
+                                    id="backfill-search-clear" title="Clear search">
+                                <i class="bi bi-x-lg"></i>
+                            </button>
+                        </div>
                     </div>
 
                     <!-- Tab Navigation -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [1.1.1] - 2026-02-27
+- Fixed region headers not respecting dark theme in trip analysis modal
+- Added inline clear button to analysis search field
+
 ## [1.1.0] - 2026-02-27
 - Improved trip analysis: group results by region and place name across all tabs (#163)
 - Added fuzzy search filtering across all analysis tabs (#163)

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -2177,3 +2177,40 @@ html[data-bs-theme="dark"] .ql-editor a {
 [data-bs-theme="dark"] .place-context-tooltip::before {
     border-top-color: #2c3034;
 }
+
+/* Backfill analysis region group headers */
+.backfill-region-header {
+    background-color: #f8f9fa;
+    color: #6c757d;
+    border-color: #dee2e6;
+}
+
+[data-bs-theme="dark"] .backfill-region-header {
+    background-color: #2b3035 !important;
+    color: #adb5bd !important;
+    border-color: #495057 !important;
+}
+
+/* Backfill search field with inline clear button */
+.backfill-search-group {
+    position: relative;
+}
+
+.backfill-search-group .btn-search-clear {
+    position: absolute;
+    right: 0.4rem;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    background: none;
+    padding: 0.1rem 0.35rem;
+    color: #6c757d;
+    cursor: pointer;
+    line-height: 1;
+    font-size: 0.85rem;
+    z-index: 2;
+}
+
+.backfill-search-group .btn-search-clear:hover {
+    color: #dc3545;
+}

--- a/wwwroot/js/Areas/User/Trip/Index.js
+++ b/wwwroot/js/Areas/User/Trip/Index.js
@@ -391,7 +391,7 @@ import {
             const region = item.regionName || 'Unknown';
             if (region !== currentRegion) {
                 currentRegion = region;
-                html += `<div class="list-group-item bg-light fw-semibold small text-muted py-1 pe-none user-select-none">${escapeHtml(region)}</div>`;
+                html += `<div class="list-group-item backfill-region-header fw-semibold small py-1 pe-none user-select-none">${escapeHtml(region)}</div>`;
             }
             html += renderItemFn(item);
         }
@@ -825,11 +825,25 @@ import {
     applyBtn?.addEventListener('click', handleApplyClick);
 
     // Search input handler: re-renders all tabs with filtered data (debounced to avoid
-    // excessive DOM rebuilds during fast typing)
+    // excessive DOM rebuilds during fast typing). Shows/hides the inline clear button.
     let searchDebounceTimer = null;
-    document.getElementById('backfill-search')?.addEventListener('input', (e) => {
+    const backfillSearchInput = document.getElementById('backfill-search');
+    const backfillSearchClear = document.getElementById('backfill-search-clear');
+
+    backfillSearchInput?.addEventListener('input', (e) => {
         clearTimeout(searchDebounceTimer);
-        searchDebounceTimer = setTimeout(() => rerenderBackfillTabs(e.target.value.trim()), 180);
+        const val = e.target.value.trim();
+        searchDebounceTimer = setTimeout(() => rerenderBackfillTabs(val), 180);
+        // Toggle clear button visibility
+        backfillSearchClear?.classList.toggle('d-none', !val);
+    });
+
+    // Clear button clears the search and re-renders all tabs immediately
+    backfillSearchClear?.addEventListener('click', () => {
+        if (backfillSearchInput) backfillSearchInput.value = '';
+        backfillSearchClear.classList.add('d-none');
+        rerenderBackfillTabs();
+        backfillSearchInput?.focus();
     });
 
     // Reset modal when hidden


### PR DESCRIPTION
## Summary
- Fixed region headers not respecting dark theme in trip analysis modal — replaced Bootstrap `bg-light` with custom `.backfill-region-header` class with dark theme override
- Added inline clear (×) button to the analysis search field for quick term clearing

## Test plan
- [x] Build passes (0 errors)
- [x] All 1259 tests pass
- [ ] Verify region headers render correctly in both light and dark themes
- [ ] Verify search clear button appears when text is entered and clears on click