### PR TITLE
fix: cancel pending debounce on search clear

### DIFF
--- a/wwwroot/js/Areas/User/Trip/Index.js
+++ b/wwwroot/js/Areas/User/Trip/Index.js
@@ -838,8 +838,9 @@ import {
         backfillSearchClear?.classList.toggle('d-none', !val);
     });
 
-    // Clear button clears the search and re-renders all tabs immediately
+    // Clear button cancels pending debounce, clears the search, and re-renders all tabs immediately
     backfillSearchClear?.addEventListener('click', () => {
+        clearTimeout(searchDebounceTimer);
         if (backfillSearchInput) backfillSearchInput.value = '';
         backfillSearchClear.classList.add('d-none');
         rerenderBackfillTabs();


### PR DESCRIPTION
## Summary
- Cancel the active `searchDebounceTimer` when the clear button is clicked, preventing a stale debounced callback from re-applying filtering after the input has been cleared

Fixes reviewer feedback on PR #165.

## Test plan
- [ ] Type in search field, click clear within 180ms — verify tabs show full unfiltered results immediately