### PR TITLE
fix: public trips grid title unreadable in dark theme

### DIFF
--- a/Areas/Public/Views/TripViewer/_PublicTripsGrid.cshtml
+++ b/Areas/Public/Views/TripViewer/_PublicTripsGrid.cshtml
@@ -89,7 +89,7 @@ else
                     <div class="card-body d-flex flex-column">
                         <!-- Title -->
                         <h5 class="card-title">
-                            <a href="/Public/Trips/@item.Id" class="text-decoration-none text-dark stretched-link">
+                            <a href="/Public/Trips/@item.Id" class="text-decoration-none text-body stretched-link">
                                 @item.Name
                             </a>
                         </h5>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [1.1.3] - 2026-03-01
+- Fixed public trips grid view title unreadable in dark theme (#168)
+
 ## [1.1.2] - 2026-02-27
 - Fixed search clear button not cancelling pending debounce timer (#166)
 


### PR DESCRIPTION
## Summary
- Replace `text-dark` with `text-body` on trip title links in `_PublicTripsGrid.cshtml` so they use Bootstrap's theme-aware `--bs-body-color` instead of a hardcoded dark color
- Titles now render correctly in both light (`#212529`) and dark (`#c9d1d9`) themes

## Test plan
- [ ] Navigate to `/Public/Trips/` in grid view
- [ ] Toggle dark theme — trip titles should be readable
- [ ] Toggle light theme — titles should remain dark
- [ ] Verify list view still works correctly in both themes