### PR TITLE
fix: trip progress share link not available in View/Index pages (#170)

### DIFF
--- a/Areas/User/Views/Trip/Index.cshtml
+++ b/Areas/User/Views/Trip/Index.cshtml
@@ -94,6 +94,17 @@ else
                                         Copy public trip page embed
                                     </a>
                                 </li>
+                                @if (trip.ShareProgressEnabled)
+                                {
+                                    <li>
+                                        <a class="dropdown-item copy-url"
+                                           href="#"
+                                           data-url="/Public/Trips/@trip.Id?progress=1"
+                                           title="Click to copy progress link to clipboard">
+                                            <i class="bi bi-broadcast me-1"></i>Copy progress link
+                                        </a>
+                                    </li>
+                                }
                             </ul>
                         </div>
                     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [1.1.4] - 2026-03-01
+- Added trip progress share link toggle and copy button to trip Viewer page (#170)
+- Added copy progress link option to trip Index public dropdown (#170)
+
 ## [1.1.3] - 2026-03-01
 - Fixed public trips grid view title unreadable in dark theme (#168)
 

--- a/Views/Trip/Viewer.cshtml
+++ b/Views/Trip/Viewer.cshtml
@@ -502,6 +502,12 @@
     </div>
 </div>
 
+@* Anti-forgery token for AJAX calls (owner only) *@
+@if (owner)
+{
+    <form id="__AjaxAntiForgeryForm" method="post" class="d-none">@Html.AntiForgeryToken()</form>
+}
+
 @* Visit History Modal - owner only *@
 @if (owner)
 {
@@ -609,18 +615,26 @@
                     </div>
                 </div>
                 <div class="modal-footer justify-content-between">
-                    <div class="d-flex align-items-center gap-2">
+                    <div class="d-flex align-items-center gap-3 flex-wrap">
                         @if (Model.IsPublic)
                         {
-                            @if (shareProgressEnabled)
-                            {
-                                <span class="badge bg-success"><i class="bi bi-broadcast me-1"></i>Progress visible to public</span>
-                            }
-                            else
-                            {
-                                <span class="badge bg-secondary"><i class="bi bi-eye-slash me-1"></i>Progress private</span>
-                            }
-                            <small class="text-muted">Change in <a asp-area="User" asp-controller="Trip" asp-action="Edit" asp-route-id="@Model.Id">Edit</a></small>
+                            <div class="form-check form-switch mb-0">
+                                <input class="form-check-input" type="checkbox" role="switch" id="modalShareProgressSwitch"
+                                       data-trip-id="@Model.Id"
+                                       @Html.Raw(shareProgressEnabled ? "checked=\"checked\"" : "")>
+                                <label class="form-check-label" for="modalShareProgressSwitch">
+                                    <i class="bi bi-broadcast me-1"></i>Share Progress
+                                </label>
+                            </div>
+                            <span id="modalShareStatus" class="badge @(shareProgressEnabled ? "bg-success" : "bg-secondary") small">
+                                @(shareProgressEnabled ? "Visible to public" : "Private")
+                            </span>
+                            <button type="button" id="btnCopyProgressLink"
+                                    class="btn btn-outline-success btn-sm @(shareProgressEnabled ? "" : "d-none")"
+                                    data-public-url="/Public/Trips/@Model.Id"
+                                    title="Copy shareable link to clipboard">
+                                <i class="bi bi-link-45deg me-1"></i>Copy Link
+                            </button>
                         }
                         else
                         {

--- a/wwwroot/js/Areas/User/Trip/shareProgressToggle.js
+++ b/wwwroot/js/Areas/User/Trip/shareProgressToggle.js
@@ -46,7 +46,7 @@ const syncToggles = (enabled) => {
  * @param {boolean} enabled - The new enabled state
  */
 const saveShareProgress = async (enabled) => {
-    const tripId = shareProgressSwitch?.dataset.tripId;
+    const tripId = shareProgressSwitch?.dataset.tripId || modalShareSwitch?.dataset.tripId;
     if (!tripId) return;
 
     // Show saving state

--- a/wwwroot/js/Trip/Viewer.js
+++ b/wwwroot/js/Trip/Viewer.js
@@ -25,6 +25,7 @@ import {
     generateWikipediaLinkHtml,
     initWikipediaPopovers,
 } from '../util/wikipedia-utils.js';
+import { initShareProgressToggle } from '../Areas/User/Trip/shareProgressToggle.js';
 
 const $ = (sel, el = document) => el.querySelector(sel);
 const $$ = (sel, el = document) => [...el.querySelectorAll(sel)];
@@ -790,6 +791,9 @@ const init = () => {
             }
         }
     }
+
+    /* ----- share progress toggle (owner only) ----- */
+    initShareProgressToggle();
 
 };
 


### PR DESCRIPTION
## Summary
- Replaced read-only badge in Viewer modal footer with interactive share progress toggle + copy link button
- Added "Copy progress link" dropdown item to trip Index public dropdown for trips with ShareProgressEnabled
- Updated `shareProgressToggle.js` to fall back to modal switch's `data-trip-id` when main form toggle is absent
- Added anti-forgery token form to Viewer for AJAX POST support

## Test plan
- [ ] `/User/Trip` — public trip with ShareProgressEnabled shows "Copy progress link" in Public dropdown; clicking copies `{origin}/Public/Trips/{id}?progress=1`
- [ ] `/User/Trip/View/{id}` — Visit History modal footer has working toggle + copy link
- [ ] Toggle share progress on/off in View page — persists via AJAX, badge updates
- [ ] Copy link in View page — copies correct URL with `?progress=1`
- [ ] `/User/Trip/Edit/{id}` — existing functionality unchanged