### PR TITLE
fix: flaky SSE broadcast test on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.1.4] - 2026-03-01
 - Added trip progress share link toggle and copy button to trip Viewer page (#170)
 - Added copy progress link option to trip Index public dropdown (#170)
+- Fixed flaky SSE broadcast test timing on slow CI runners
 
 ## [1.1.3] - 2026-03-01
 - Fixed public trips grid view title unreadable in dark theme (#168)

--- a/tests/Wayfarer.Tests/Services/SseServiceTests.cs
+++ b/tests/Wayfarer.Tests/Services/SseServiceTests.cs
@@ -59,12 +59,12 @@ public class SseServiceTests
         var context = new DefaultHttpContext();
         var stream = new MemoryStream();
         context.Response.Body = stream;
-        using var cts = new CancellationTokenSource(200);
+        using var cts = new CancellationTokenSource(2000);
 
         var subscribeTask = service.SubscribeAsync("channel", context.Response, cts.Token);
-        await Task.Delay(20);
+        await Task.Delay(100);
         await service.BroadcastAsync("channel", "{\"hello\":true}");
-        await Task.Delay(20);
+        await Task.Delay(100);
         cts.Cancel();
         await subscribeTask;
 


### PR DESCRIPTION
## Summary
- Increased `Task.Delay` from 20ms to 100ms and `CancellationTokenSource` timeout from 200ms to 2s in `BroadcastAsync_WritesDataToSubscribers` test
- Prevents race condition where subscription isn't fully registered before broadcast on slow CI runners

## Test plan
- [ ] All 3 SSE tests pass locally
- [ ] CI passes consistently