### PR TITLE
fix: trips missing cover image — show map snapshot fallback (#176)

### DIFF
--- a/Areas/Public/Views/TripViewer/_PublicTripsGrid.cshtml
+++ b/Areas/Public/Views/TripViewer/_PublicTripsGrid.cshtml
@@ -43,10 +43,10 @@ else
                         }
                         else if (item.CenterLat.HasValue && item.CenterLon.HasValue)
                         {
-                            <!-- Show map thumbnail if no cover image but has coordinates -->
-                            <img class="trip-photo js-lazy"
-                                 data-src="/thumbs/trips/@item.Id-800x450.jpg?v=@item.UpdatedAt.Ticks"
-                                 alt="Map of @item.Name">
+                            <!-- Show map thumbnail via async thumbnail system if no cover image but has coordinates -->
+                            <img class="trip-photo" data-thumb-placeholder
+                                 alt="Map of @item.Name"
+                                 style="background-color: #e9ecef;">
                         }
                         else
                         {

--- a/Areas/Public/Views/TripViewer/_PublicTripsList.cshtml
+++ b/Areas/Public/Views/TripViewer/_PublicTripsList.cshtml
@@ -52,6 +52,12 @@ else
                                     <img class="w-100 h-100 object-fit-cover js-lazy" data-src="@item.CoverImageUrl"
                                         alt="@item.Name" style="background-color: #e9ecef;" />
                                 }
+                                else if (item.CenterLat.HasValue && item.CenterLon.HasValue)
+                                {
+                                    <!-- Show map thumbnail via async thumbnail system if no cover image but has coordinates -->
+                                    <img class="w-100 h-100 object-fit-cover" data-thumb-placeholder
+                                        alt="Map of @item.Name" style="background-color: #e9ecef;" />
+                                }
                                 else
                                 {
                                     <div class="w-100 h-100 bg-body-secondary d-flex align-items-center justify-content-center">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [1.2.1] - 2026-03-07
+- Fixed trips with no cover image showing broken image instead of map snapshot fallback in grid view (#176)
+- Added map snapshot fallback to list view cover image column for trips with coordinates but no cover image (#176)
+
 ## [1.2.0] - 2026-03-01
 - Added disk-cached image proxy with LRU eviction for proxied images (#169)
 - Added SSRF protection to ProxyImage endpoint blocking private IPs and non-HTTP schemes (#169)


### PR DESCRIPTION
## Summary
- **Grid view** (`_PublicTripsGrid.cshtml`): Replaced direct `/thumbs/trips/{id}-800x450.jpg` static file URL with `data-thumb-placeholder` so `initAsyncThumbnails()` populates the image via the Thumbnail API endpoint. This prevents broken images when the on-demand file hasn't been generated yet.
- **List view** (`_PublicTripsList.cshtml`): Added an `else if` branch for trips that have coordinates but no cover image, rendering an `<img>` with `data-thumb-placeholder` — consistent with the grid view and map thumbnail column.
- Updated CHANGELOG for v1.2.1.

Closes #176

## Test plan
- [ ] Find/create a trip with no `CoverImageUrl` but with map coordinates
- [ ] Visit `/Public/Trips` in grid view — confirm map snapshot loads asynchronously (no broken image)
- [ ] Switch to list view — confirm the cover image column shows the map snapshot fallback
- [ ] Verify trips with a valid `CoverImageUrl` still show the cover image as before
- [ ] Verify trips with neither cover image nor coordinates show the gray icon placeholder