### PR TITLE
Fix map snapshot 404 + proxy notes images for cache consistency

### DIFF
--- a/Areas/Public/Controllers/TripViewerController.cs
+++ b/Areas/Public/Controllers/TripViewerController.cs
@@ -820,8 +820,12 @@ public class TripViewerController : BaseController
         }
 
         // The thumbnail URL is a relative path like /thumbs/trips/{id}-800x450.jpg
+        // Strip query string (?v=timestamp) used for browser cache busting
+        var queryIndex = thumbUrl.IndexOf('?');
+        var pathOnly = queryIndex >= 0 ? thumbUrl[..queryIndex] : thumbUrl;
+
         // Convert to a physical file path and serve directly
-        var relativePath = thumbUrl.TrimStart('/');
+        var relativePath = pathOnly.TrimStart('/');
         var wwwRoot = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "wwwroot"));
         var webRootPath = Path.GetFullPath(
             Path.Combine(wwwRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));

--- a/Areas/User/Views/Trip/Partials/_SegmentItemPartial.cshtml
+++ b/Areas/User/Views/Trip/Partials/_SegmentItemPartial.cshtml
@@ -122,7 +122,7 @@
                 <div class="modal-body">
                     @if (Model != null)
                     {
-                        @Html.Raw(Model.Notes ?? string.Empty)
+                        @Html.ProxyNotesImages(Model.Notes ?? string.Empty)
                     }
                 </div>
                 <div class="modal-footer">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [1.2.9] - 2026-03-07
+- Fixed map snapshot URL returning 404 due to query string not being stripped from file path
+- Added server-side proxy rewriting for external images in trip/region/place notes HTML
+- Notes images now load through /Public/ProxyImage cache endpoint instead of directly from external servers
+
 ## [1.2.8] - 2026-03-07
 - Routed public cover images through ProxiedImageCacheService disk cache instead of raw 302 redirects
 - Cover images in public trip grid, list, and Viewer hero are now served via /Public/Trips/{id}/CoverImage endpoint

--- a/Util/HtmlHelpers.cs
+++ b/Util/HtmlHelpers.cs
@@ -54,6 +54,35 @@ namespace Wayfarer.Util
             return new HtmlString(linked);
         }
 
+        /// <summary>
+        /// Matches external http(s):// URLs inside &lt;img src="..."&gt; attributes.
+        /// </summary>
+        private static readonly Regex _externalImgSrcRegex = new Regex(
+            @"(<img\b[^>]*?\bsrc\s*=\s*[""'])(?<url>https?://[^""']+)([""'])",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// Rewrites external &lt;img src="https://..."&gt; URLs in HTML content to go through
+        /// the /Public/ProxyImage cache endpoint, ensuring consistent caching and SSRF protection.
+        /// Leaves relative, data-URI, and already-proxied URLs unchanged.
+        /// </summary>
+        public static IHtmlContent ProxyNotesImages(this IHtmlHelper html, string? htmlContent)
+        {
+            if (string.IsNullOrEmpty(htmlContent))
+                return HtmlString.Empty;
+
+            var result = _externalImgSrcRegex.Replace(htmlContent, m =>
+            {
+                var prefix = m.Groups[1].Value;
+                var url = m.Groups["url"].Value;
+                var suffix = m.Groups[3].Value;
+                var encoded = System.Net.WebUtility.UrlEncode(url);
+                return $"{prefix}/Public/ProxyImage?url={encoded}{suffix}";
+            });
+
+            return new HtmlString(result);
+        }
+
         // Regex to strip HTML tags for content detection
         private static readonly Regex _htmlTagRegex = new Regex(
             @"<[^>]+>",

--- a/Views/Trip/Partials/_RegionReadonly.cshtml
+++ b/Views/Trip/Partials/_RegionReadonly.cshtml
@@ -57,7 +57,7 @@
             @if (HtmlHelpers.HasVisibleContent(Model.Notes))
             {
                 <div class="small text-muted px-2 py-1 border-bottom" style="max-height: 150px; overflow-y: auto;">
-                    @Html.Raw(Model.Notes)
+                    @Html.ProxyNotesImages(Model.Notes)
                 </div>
             }
             <ul class="list-group list-group-flush">
@@ -144,7 +144,7 @@
                                     @if (HtmlHelpers.HasVisibleContent(area.Notes))
                                     {
                                         <div class="small text-muted" style="max-height: 100px; overflow-y: auto;">
-                                            @Html.Raw(area.Notes)
+                                            @Html.ProxyNotesImages(area.Notes)
                                         </div>
                                     }
                                 </div>

--- a/Views/Trip/Partials/_SegmentReadonlyList.cshtml
+++ b/Views/Trip/Partials/_SegmentReadonlyList.cshtml
@@ -93,7 +93,7 @@
                                 @if (HtmlHelpers.HasVisibleContent(seg?.Notes))
                                 {
                                     <div class="text-muted mt-1 segment-notes-preview" style="max-height: 100px; overflow-y: auto;">
-                                        @Html.Raw(seg?.Notes)
+                                        @Html.ProxyNotesImages(seg?.Notes)
                                     </div>
                                 }
                             </div>

--- a/Views/Trip/Viewer.cshtml
+++ b/Views/Trip/Viewer.cshtml
@@ -468,7 +468,7 @@
                     <div class="trip-notes-readable mb-4">
                         <h6 class="text-muted mb-2">Notes</h6>
                         <div class="fs-6">
-                            @Html.Raw(Model.Notes)
+                            @Html.ProxyNotesImages(Model.Notes)
                         </div>
                     </div>
                 }
@@ -495,7 +495,7 @@
                             @if (!string.IsNullOrWhiteSpace(region.Notes))
                             {
                                 <div class="mb-3 text-muted">
-                                    @Html.Raw(region.Notes)
+                                    @Html.ProxyNotesImages(region.Notes)
                                 </div>
                             }
 
@@ -515,7 +515,7 @@
                                                     @if (!string.IsNullOrWhiteSpace(place.Notes))
                                                     {
                                                         <div class="small text-muted mt-1">
-                                                            @Html.Raw(place.Notes)
+                                                            @Html.ProxyNotesImages(place.Notes)
                                                         </div>
                                                     }
                                                 </div>

--- a/tests/Wayfarer.Tests/Controllers/PublicTripImagesTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/PublicTripImagesTests.cs
@@ -196,6 +196,49 @@ public class PublicTripImagesTests : TestBase
         Assert.Equal(429, status.StatusCode);
     }
 
+    [Fact]
+    public async Task MapSnapshot_ReturnsFile_WhenThumbnailUrlHasQueryString()
+    {
+        var db = CreateDbContext();
+        var tripId = Guid.NewGuid();
+        db.Users.Add(TestDataFixtures.CreateUser(id: "owner"));
+        db.Trips.Add(new Trip
+        {
+            Id = tripId, UserId = "owner", Name = "QS Trip",
+            IsPublic = true, CenterLat = 40.0, CenterLon = 25.0, Zoom = 10,
+            UpdatedAt = DateTime.UtcNow
+        });
+        db.SaveChanges();
+
+        // Create a temp thumbnail file in wwwroot/thumbs/trips/
+        var thumbDir = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "thumbs", "trips");
+        Directory.CreateDirectory(thumbDir);
+        var thumbFile = Path.Combine(thumbDir, $"{tripId}-800x450.jpg");
+
+        try
+        {
+            // Write a minimal JPEG header so the file exists
+            await System.IO.File.WriteAllBytesAsync(thumbFile, new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 });
+
+            // Mock thumbnail service to return URL with cache-busting query string
+            var thumbMock = new Mock<ITripThumbnailService>();
+            thumbMock.Setup(s => s.GetThumbUrlAsync(
+                    tripId, 40.0, 25.0, 10, null, It.IsAny<DateTime>(), "800x450", default))
+                .ReturnsAsync($"/thumbs/trips/{tripId}-800x450.jpg?v=638770000000000000");
+
+            var controller = BuildController(db, thumbnailService: thumbMock.Object);
+            var result = await controller.GetMapSnapshot(tripId);
+
+            var file = Assert.IsType<PhysicalFileResult>(result);
+            Assert.Equal("image/jpeg", file.ContentType);
+        }
+        finally
+        {
+            if (System.IO.File.Exists(thumbFile))
+                System.IO.File.Delete(thumbFile);
+        }
+    }
+
     private TripViewerController BuildController(
         ApplicationDbContext db,
         ITripThumbnailService? thumbnailService = null,

--- a/tests/Wayfarer.Tests/Util/HtmlHelpersTests.cs
+++ b/tests/Wayfarer.Tests/Util/HtmlHelpersTests.cs
@@ -19,6 +19,18 @@ public class HtmlHelpersTests
         return writer.ToString();
     }
 
+    /// <summary>
+    /// Extracts the raw string value from an IHtmlContent without HTML encoding.
+    /// Used for testing helpers that return pre-built HtmlString content.
+    /// </summary>
+    private static string RenderRaw(IHtmlContent content)
+    {
+        if (content is HtmlString hs)
+            return hs.Value ?? string.Empty;
+
+        return Render(content);
+    }
+
     [Fact]
     public void AutoLink_EncodesHtmlAndLinksUrls()
     {
@@ -83,6 +95,93 @@ public class HtmlHelpersTests
     {
         var result = HtmlHelpers.HasVisibleContent(input);
         Assert.Equal(expected, result);
+    }
+
+    #endregion
+
+    #region ProxyNotesImages Tests
+
+    [Fact]
+    public void ProxyNotesImages_RewritesExternalImgSrc()
+    {
+        var helper = Mock.Of<IHtmlHelper>();
+        var input = "<p>Photo: <img src=\"https://example.com/photo.jpg\" alt=\"pic\"></p>";
+
+        var result = RenderRaw(helper.ProxyNotesImages(input));
+
+        Assert.Contains("/Public/ProxyImage?url=", result);
+        Assert.DoesNotContain("src=\"https://example.com/photo.jpg\"", result);
+    }
+
+    [Fact]
+    public void ProxyNotesImages_LeavesRelativeImagesAlone()
+    {
+        var helper = Mock.Of<IHtmlHelper>();
+        var input = "<img src=\"/images/local.jpg\">";
+
+        var result = RenderRaw(helper.ProxyNotesImages(input));
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void ProxyNotesImages_LeavesDataUrisAlone()
+    {
+        var helper = Mock.Of<IHtmlHelper>();
+        var input = "<img src=\"data:image/png;base64,iVBOR\">";
+
+        var result = RenderRaw(helper.ProxyNotesImages(input));
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void ProxyNotesImages_LeavesAlreadyProxiedAlone()
+    {
+        var helper = Mock.Of<IHtmlHelper>();
+        var input = "<img src=\"/Public/ProxyImage?url=https%3A%2F%2Fexample.com%2Fphoto.jpg\">";
+
+        var result = RenderRaw(helper.ProxyNotesImages(input));
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void ProxyNotesImages_ReturnsEmptyForNull()
+    {
+        var helper = Mock.Of<IHtmlHelper>();
+
+        var result = RenderRaw(helper.ProxyNotesImages(null));
+
+        Assert.Equal(RenderRaw(HtmlString.Empty), result);
+    }
+
+    [Fact]
+    public void ProxyNotesImages_PreservesNonImageHtml()
+    {
+        var helper = Mock.Of<IHtmlHelper>();
+        var input = "<p>Hello <strong>world</strong></p>";
+
+        var result = RenderRaw(helper.ProxyNotesImages(input));
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void ProxyNotesImages_HandlesMultipleImages()
+    {
+        var helper = Mock.Of<IHtmlHelper>();
+        var input = "<img src=\"https://a.com/1.jpg\"><img src=\"/local.jpg\"><img src=\"https://b.com/2.png\">";
+
+        var result = RenderRaw(helper.ProxyNotesImages(input));
+
+        // External images should be proxied
+        Assert.DoesNotContain("src=\"https://a.com/1.jpg\"", result);
+        Assert.DoesNotContain("src=\"https://b.com/2.png\"", result);
+        // Local image should remain unchanged
+        Assert.Contains("src=\"/local.jpg\"", result);
+        // Proxy URLs should be present (2 external images)
+        Assert.Equal(2, System.Text.RegularExpressions.Regex.Matches(result, "/Public/ProxyImage").Count);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- **Fix map snapshot 404**: Strip `?v=timestamp` cache-busting query string from thumbnail URL before converting to physical file path in `TripViewerController.GetMapSnapshot()`
- **Proxy notes images server-side**: Add `ProxyNotesImages` HTML helper that rewrites external `<img src="https://...">` to `/Public/ProxyImage?url=...` before Razor renders, ensuring notes images go through the proxy cache instead of loading directly from external servers
- Replace `@Html.Raw()` with `@Html.ProxyNotesImages()` in 7 view locations (Viewer, _SegmentReadonlyList, _RegionReadonly, _SegmentItemPartial)

## Test plan
- [ ] 8 new tests added (1 map snapshot, 7 ProxyNotesImages helper) — all 1332 tests pass
- [ ] Create a public trip with coordinates → Copy Map Snapshot URL → paste in browser → should return JPEG (not 404)
- [ ] Create a trip with external images in notes → view trip → images should load through `/Public/ProxyImage` (check Network tab)
- [ ] Verify existing JS-based proxy rewriting still works (no double-proxying)