### PR TITLE
docs: document 256 MB minimum tile cache size

### DIFF
--- a/docs/16-Configuration.md
+++ b/docs/16-Configuration.md
@@ -26,6 +26,7 @@ Application
 
 CacheSettings
 - `CacheSettings:TileCacheDirectory` — local directory for map tile cache.
+- **Max Tile Cache Size** (Admin UI) — controls the LRU cache size for zoom >= 9 tiles. Default: 1024 MB. Minimum: 256 MB (OSM requires tiles cached for at least 7 days). Set to `-1` to disable the size limit (no LRU eviction). Zoom 0-8 tiles (~1 GB) are cached permanently and do not count against this limit.
 
 Tile Provider Settings (Admin UI)
 - **Tile Provider** — select from presets (OpenStreetMap, Carto Light/Dark, ESRI Satellite) or configure a custom URL template.

--- a/docs/20-Deployment.md
+++ b/docs/20-Deployment.md
@@ -34,7 +34,7 @@ This guide covers installation, deployment, logging, and operational commands fo
 **Minimum:**
 - 1 GB RAM
 - **5 GB disk space** minimum:
-  - ~2 GB for tile cache (zoom <= 8: ~1 GB, zoom >= 9: 1 GB configurable)
+  - ~2 GB for tile cache (zoom <= 8: ~1 GB permanent, zoom >= 9: 1 GB default, 256 MB minimum per OSM 7-day caching policy)
   - ~512 MB for image proxy cache (configurable in Admin Settings)
   - Plus storage for uploaded location data, logs, and application files
 - ARM or x64 CPU (Raspberry Pi 3+ or equivalent)


### PR DESCRIPTION
## Summary
- Update deployment docs to mention 256 MB minimum cache size (OSM 7-day policy)
- Update configuration docs to document `MaxCacheTileSizeInMB` setting, minimum, default, and `-1` disable option

Docs-only change, no version bump needed.