### PR TITLE
[Trip Editor] Complete read-state foundation

### DIFF
--- a/Areas/Api/Controllers/IconsController.cs
+++ b/Areas/Api/Controllers/IconsController.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.IO;
 using System.Linq;
 using Wayfarer.Models;
-using System.Text.RegularExpressions;
+using Wayfarer.Services;
 
 namespace Wayfarer.Areas.Api.Controllers;
 
@@ -12,13 +12,15 @@ namespace Wayfarer.Areas.Api.Controllers;
 public class IconsController : BaseApiController
 {
     private readonly IWebHostEnvironment _env;
+    private readonly IIconColorProvider _iconColorProvider;
 
     private record IconPreview(string Icon, string Color, string Url);
 
-    public IconsController(ApplicationDbContext dbContext, ILogger<IconsController> logger, IWebHostEnvironment env)
+    public IconsController(ApplicationDbContext dbContext, ILogger<IconsController> logger, IWebHostEnvironment env, IIconColorProvider iconColorProvider)
         : base(dbContext, logger)
     {
         _env = env;
+        _iconColorProvider = iconColorProvider;
     }
 
     /// GET: /api/icons?layout=marker|circle
@@ -48,35 +50,16 @@ public class IconsController : BaseApiController
     [HttpGet("colors")]
     public IActionResult GetAvailableColors()
     {
-        var cssPath = Path.Combine(_env.WebRootPath, "icons", "wayfarer-map-icons", "dist", "wayfarer-map-icons.css");
-
-        if (!System.IO.File.Exists(cssPath))
-            return NotFound("CSS file not found.");
-
         try
         {
-            var cssContent = System.IO.File.ReadAllText(cssPath);
-
-            // Match class selectors like ".bg-blue", ".color-purple", etc.
-            var bgMatches = Regex.Matches(cssContent, @"\.bg-[\w-]+");
-            var colorMatches = Regex.Matches(cssContent, @"\.color-[\w-]+");
-
-            var bgList = bgMatches
-                .Select(m => m.Value.TrimStart('.'))
-                .Distinct()
-                .OrderBy(x => x)
-                .ToList();
-
-            var colorList = colorMatches
-                .Select(m => m.Value.TrimStart('.'))
-                .Distinct()
-                .OrderBy(x => x)
-                .ToList();
+            var colors = _iconColorProvider.GetAvailableColors();
+            if (colors == null)
+                return NotFound("CSS file not found.");
 
             return Ok(new
             {
-                backgrounds = bgList,
-                glyphs = colorList
+                backgrounds = colors.Backgrounds,
+                glyphs = colors.Glyphs
             });
         }
         catch (Exception ex)

--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -1,5 +1,4 @@
 using System.Security.Claims;
-using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -19,6 +18,7 @@ public sealed class TripEditorController : ControllerBase
 {
     private readonly ApplicationDbContext _dbContext;
     private readonly IWebHostEnvironment _environment;
+    private readonly IIconColorProvider _iconColorProvider;
     private readonly ILogger<TripEditorController> _logger;
 
     /// <summary>
@@ -27,10 +27,12 @@ public sealed class TripEditorController : ControllerBase
     public TripEditorController(
         ApplicationDbContext dbContext,
         IWebHostEnvironment environment,
+        IIconColorProvider iconColorProvider,
         ILogger<TripEditorController> logger)
     {
         _dbContext = dbContext;
         _environment = environment;
+        _iconColorProvider = iconColorProvider;
         _logger = logger;
     }
 
@@ -82,14 +84,19 @@ public sealed class TripEditorController : ControllerBase
             .GroupBy(v => v.PlaceId!.Value)
             .ToDictionary(g => g.Key, g => (IReadOnlyList<PlaceVisitEvent>)g.ToList());
 
+        var publicUrl = trip.IsPublic ? GeneratePublicTripUrl(trip.Id) : null;
+        var progressPublicUrl = trip.IsPublic && trip.ShareProgressEnabled
+            ? GenerateProgressPublicTripUrl(trip.Id)
+            : null;
+
         try
         {
             return Ok(EditorTripStateMapper.ToEditorState(
                 trip,
                 visitsByPlaceId,
                 BuildOptions(),
-                GeneratePublicTripUrl(trip.Id),
-                GenerateProgressPublicTripUrl(trip.Id)));
+                publicUrl,
+                progressPublicUrl));
         }
         catch (EditorInvalidAreaGeometryException ex)
         {
@@ -98,15 +105,19 @@ public sealed class TripEditorController : ControllerBase
         }
     }
 
-    private EditorOptionsDto BuildOptions() =>
-        new(
+    private EditorOptionsDto BuildOptions()
+    {
+        var colors = _iconColorProvider.GetAvailableColors();
+
+        return new EditorOptionsDto(
             ReadIconNames(),
-            ReadMarkerColorClasses().Backgrounds,
-            ReadMarkerColorClasses().Glyphs,
+            colors?.Backgrounds ?? Array.Empty<string>(),
+            colors?.Glyphs ?? Array.Empty<string>(),
             SegmentTransportModes.Options,
             new EditorAreaDefaultsDto("Area", "#ff6600"),
             new EditorTagOptionsDto(25, 8, "Letters, numbers, spaces, hyphens, and apostrophes."),
             new EditorLimitsDto(6, 1));
+    }
 
     private string? GeneratePublicTripUrl(Guid tripId) =>
         Url.Action("View", "TripViewer", new { area = "Public", id = tripId }, Request.Scheme);
@@ -139,22 +150,4 @@ public sealed class TripEditorController : ControllerBase
             ? Directory.GetFiles(iconDir, "*.svg").Select(Path.GetFileNameWithoutExtension).Where(n => n != null).Cast<string>().OrderBy(n => n).ToList()
             : Array.Empty<string>();
     }
-
-    private (IReadOnlyList<string> Backgrounds, IReadOnlyList<string> Glyphs) ReadMarkerColorClasses()
-    {
-        var cssPath = Path.Combine(_environment.WebRootPath, "icons", "wayfarer-map-icons", "dist", "wayfarer-map-icons.css");
-        if (!System.IO.File.Exists(cssPath))
-        {
-            return (Array.Empty<string>(), Array.Empty<string>());
-        }
-
-        var css = System.IO.File.ReadAllText(cssPath);
-        return (ReadClasses(css, ".bg-"), ReadClasses(css, ".color-"));
-    }
-
-    private static IReadOnlyList<string> ReadClasses(string css, string prefix) =>
-        Regex.Matches(css, $@"\.{Regex.Escape(prefix.TrimStart('.'))}[\w-]+")
-            .Select(match => match.Value.TrimStart('.'))
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
 }

--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -1,9 +1,11 @@
 using System.Security.Claims;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Wayfarer.Models;
 using Wayfarer.Models.Dtos.Editor;
+using Wayfarer.Services;
 
 namespace Wayfarer.Areas.Api.Controllers;
 
@@ -17,14 +19,19 @@ public sealed class TripEditorController : ControllerBase
 {
     private readonly ApplicationDbContext _dbContext;
     private readonly IWebHostEnvironment _environment;
+    private readonly ILogger<TripEditorController> _logger;
 
     /// <summary>
     /// Initializes a new instance of the Trip Editor API controller.
     /// </summary>
-    public TripEditorController(ApplicationDbContext dbContext, IWebHostEnvironment environment)
+    public TripEditorController(
+        ApplicationDbContext dbContext,
+        IWebHostEnvironment environment,
+        ILogger<TripEditorController> logger)
     {
         _dbContext = dbContext;
         _environment = environment;
+        _logger = logger;
     }
 
     /// <summary>
@@ -75,7 +82,20 @@ public sealed class TripEditorController : ControllerBase
             .GroupBy(v => v.PlaceId!.Value)
             .ToDictionary(g => g.Key, g => (IReadOnlyList<PlaceVisitEvent>)g.ToList());
 
-        return Ok(EditorTripStateMapper.ToEditorState(trip, visitsByPlaceId, BuildOptions()));
+        try
+        {
+            return Ok(EditorTripStateMapper.ToEditorState(
+                trip,
+                visitsByPlaceId,
+                BuildOptions(),
+                GeneratePublicTripUrl(trip.Id),
+                GenerateProgressPublicTripUrl(trip.Id)));
+        }
+        catch (EditorInvalidAreaGeometryException ex)
+        {
+            _logger.LogError(ex, "Invalid area geometry while loading editor state for Trip {TripId}, Area {AreaId}.", ex.TripId, ex.AreaId);
+            return InvalidAreaGeometryProblem(ex);
+        }
     }
 
     private EditorOptionsDto BuildOptions() =>
@@ -83,16 +103,34 @@ public sealed class TripEditorController : ControllerBase
             ReadIconNames(),
             ReadMarkerColorClasses().Backgrounds,
             ReadMarkerColorClasses().Glyphs,
-            new[]
-            {
-                new EditorTransportModeDto("walk", "Walk", 5),
-                new EditorTransportModeDto("bike", "Bike", 15),
-                new EditorTransportModeDto("drive", "Drive", 60),
-                new EditorTransportModeDto("transit", "Transit", 35)
-            },
+            SegmentTransportModes.Options,
             new EditorAreaDefaultsDto("Area", "#ff6600"),
-            new EditorTagOptionsDto(25, 10, "Letters, numbers, spaces, hyphens, and apostrophes."),
-            new EditorLimitsDto(6, 2));
+            new EditorTagOptionsDto(25, 8, "Letters, numbers, spaces, hyphens, and apostrophes."),
+            new EditorLimitsDto(6, 1));
+
+    private string? GeneratePublicTripUrl(Guid tripId) =>
+        Url.Action("View", "TripViewer", new { area = "Public", id = tripId }, Request.Scheme);
+
+    private string? GenerateProgressPublicTripUrl(Guid tripId) =>
+        Url.Action("View", "TripViewer", new { area = "Public", id = tripId, progress = 1 }, Request.Scheme);
+
+    private static ObjectResult InvalidAreaGeometryProblem(EditorInvalidAreaGeometryException exception)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = StatusCodes.Status500InternalServerError,
+            Type = "https://wayfarer/errors/editor-invalid-area-geometry",
+            Title = "Invalid persisted area geometry."
+        };
+        problem.Extensions["areaId"] = exception.AreaId;
+        problem.Extensions["tripId"] = exception.TripId;
+
+        return new ObjectResult(problem)
+        {
+            StatusCode = StatusCodes.Status500InternalServerError,
+            ContentTypes = { "application/problem+json" }
+        };
+    }
 
     private IReadOnlyList<string> ReadIconNames()
     {
@@ -115,11 +153,8 @@ public sealed class TripEditorController : ControllerBase
     }
 
     private static IReadOnlyList<string> ReadClasses(string css, string prefix) =>
-        css.Split('{', StringSplitOptions.RemoveEmptyEntries)
-            .Select(part => part.Trim())
-            .Where(part => part.StartsWith(prefix, StringComparison.Ordinal))
-            .Select(part => part.Split(',', ' ', '\r', '\n', '\t').First().TrimStart('.'))
+        Regex.Matches(css, $@"\.{Regex.Escape(prefix.TrimStart('.'))}[\w-]+")
+            .Select(match => match.Value.TrimStart('.'))
             .Distinct(StringComparer.Ordinal)
-            .OrderBy(name => name)
             .ToList();
 }

--- a/Areas/User/Controllers/SegmentsController.cs
+++ b/Areas/User/Controllers/SegmentsController.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Geometries;
 using Wayfarer.Models;
 using Wayfarer.Models.Dtos;
+using Wayfarer.Services;
 
 namespace Wayfarer.Areas.User.Controllers;
 
@@ -22,21 +23,6 @@ public class SegmentsController : BaseController
         _logger = logger;
         _db = dbContext;
     }
-
-    // Transport modes and their travel speed in km/h
-    private static readonly Dictionary<string, double> ModeSpeedsKmh = new()
-    {
-        ["walk"] = 5,
-        ["bicycle"] = 15,
-        ["bike"] = 40,
-        ["car"] = 60,
-        ["bus"] = 35,
-        ["train"] = 100,
-        ["ferry"] = 30,
-        ["boat"] = 25,
-        ["flight"] = 800,
-        ["helicopter"] = 200
-    };
 
     // GET: /User/Segments/CreateOrUpdate?tripId=...
     [HttpGet]
@@ -105,7 +91,7 @@ public class SegmentsController : BaseController
         // Auto-calculate EstimatedDuration if missing but distance and mode are present
         if (model.EstimatedDistanceKm.HasValue && !model.EstimatedDuration.HasValue)
         {
-            if (ModeSpeedsKmh.TryGetValue(model.Mode?.ToLower() ?? "", out var speedKmh) && speedKmh > 0)
+            if (SegmentTransportModes.SpeedsKmh.TryGetValue(model.Mode ?? string.Empty, out var speedKmh) && speedKmh > 0)
             {
                 var hours = model.EstimatedDistanceKm.Value / speedKmh;
                 model.EstimatedDuration = TimeSpan.FromHours(hours);

--- a/ClientApps/trip-editor/src/types.ts
+++ b/ClientApps/trip-editor/src/types.ts
@@ -28,6 +28,8 @@ export interface EditorTripMetadata {
   zoom: number | null;
   coverImage: EditorImageReference | null;
   updatedAt: string;
+  publicUrl: string | null;
+  progressPublicUrl: string | null;
 }
 
 export interface EditorRegion {
@@ -64,7 +66,7 @@ export interface EditorArea {
   name: string;
   notesHtml: string;
   fillHex: string;
-  geometry: GeoJsonPolygon | null;
+  geometry: GeoJsonPolygon;
   displayOrder: number;
   capabilities: EditorEntityCapabilities;
 }
@@ -94,7 +96,7 @@ export interface EditorVisitProgress {
   visitedPlaces: number;
   percentVisited: number;
   placeSummariesByPlaceId: Record<Guid, EditorPlaceVisitSummary>;
-  historyRows: unknown[];
+  historyRows: EditorVisitHistoryRow[];
 }
 
 export interface EditorPlaceVisitSummary {
@@ -103,6 +105,15 @@ export interface EditorPlaceVisitSummary {
   isVisited: boolean;
   firstVisitAt: string | null;
   lastVisitAt: string | null;
+}
+
+export interface EditorVisitHistoryRow {
+  visitId: Guid;
+  placeId: Guid;
+  regionId: Guid;
+  startedAt: string;
+  endedAt: string | null;
+  durationMinutes: number | null;
 }
 
 export interface EditorOptions {

--- a/Models/Dtos/Editor/EditorTripStateDto.cs
+++ b/Models/Dtos/Editor/EditorTripStateDto.cs
@@ -63,7 +63,9 @@ public sealed record EditorTripMetadataDto(
     EditorCoordinateDto? Center,
     int? Zoom,
     EditorImageReferenceDto? CoverImage,
-    DateTime UpdatedAt);
+    DateTime UpdatedAt,
+    string? PublicUrl,
+    string? ProgressPublicUrl);
 
 /// <summary>Region DTO with explicit shadow/capability flags.</summary>
 public sealed record EditorRegionDto(
@@ -100,7 +102,7 @@ public sealed record EditorAreaDto(
     string Name,
     string NotesHtml,
     string FillHex,
-    JsonElement? Geometry,
+    JsonElement Geometry,
     int DisplayOrder,
     EditorEntityCapabilitiesDto Capabilities);
 
@@ -125,9 +127,9 @@ public sealed record EditorTagDto(Guid Id, string Name, string Slug);
 public sealed record EditorVisitProgressDto(
     int TotalPlaces,
     int VisitedPlaces,
-    int PercentVisited,
+    double PercentVisited,
     IReadOnlyDictionary<Guid, EditorPlaceVisitSummaryDto> PlaceSummariesByPlaceId,
-    IReadOnlyList<object> HistoryRows);
+    IReadOnlyList<EditorVisitHistoryRowDto> HistoryRows);
 
 /// <summary>Read-only visit summary for a single place.</summary>
 public sealed record EditorPlaceVisitSummaryDto(
@@ -136,6 +138,15 @@ public sealed record EditorPlaceVisitSummaryDto(
     bool IsVisited,
     DateTime? FirstVisitAt,
     DateTime? LastVisitAt);
+
+/// <summary>Read-only visit history row for the editor visit progress state.</summary>
+public sealed record EditorVisitHistoryRowDto(
+    Guid VisitId,
+    Guid PlaceId,
+    Guid RegionId,
+    DateTime StartedAt,
+    DateTime? EndedAt,
+    int? DurationMinutes);
 
 /// <summary>Deterministic options object for the read-only spike and future editors.</summary>
 public sealed record EditorOptionsDto(

--- a/Models/Dtos/Editor/EditorTripStateMapper.cs
+++ b/Models/Dtos/Editor/EditorTripStateMapper.cs
@@ -19,7 +19,9 @@ public static class EditorTripStateMapper
     public static EditorTripStateDto ToEditorState(
         Trip trip,
         IReadOnlyDictionary<Guid, IReadOnlyList<PlaceVisitEvent>> visitsByPlaceId,
-        EditorOptionsDto options)
+        EditorOptionsDto options,
+        string? publicUrl,
+        string? progressPublicUrl)
     {
         ArgumentNullException.ThrowIfNull(trip);
 
@@ -32,7 +34,7 @@ public static class EditorTripStateMapper
         return new EditorTripStateDto
         {
             TripId = trip.Id,
-            Metadata = MapMetadata(trip),
+            Metadata = MapMetadata(trip, publicUrl, progressPublicUrl),
             RegionsById = regions.ToDictionary(r => r.Id, MapRegion),
             RegionOrder = regions.Select(r => r.Id).ToList(),
             PlacesById = places.ToDictionary(p => p.Place.Id, p => MapPlace(trip.Id, p.Region.Id, p.Place, visitSummaries[p.Place.Id])),
@@ -43,7 +45,7 @@ public static class EditorTripStateMapper
             SegmentOrder = segments.Select(s => s.Id).ToList(),
             TagsBySlug = trip.Tags.OrderBy(t => t.Name).ToDictionary(t => t.Slug, t => new EditorTagDto(t.Id, t.Name, t.Slug)),
             TagOrder = trip.Tags.OrderBy(t => t.Name).Select(t => t.Slug).ToList(),
-            VisitProgress = BuildVisitProgress(visitSummaries),
+            VisitProgress = BuildVisitProgress(places, visitSummaries, visitsByPlaceId),
             Options = options,
             Permissions = new EditorPermissionsDto(true, true, true, true, true, true, true, true, true)
         };
@@ -64,7 +66,7 @@ public static class EditorTripStateMapper
         }
     }
 
-    private static EditorTripMetadataDto MapMetadata(Trip trip) =>
+    private static EditorTripMetadataDto MapMetadata(Trip trip, string? publicUrl, string? progressPublicUrl) =>
         new(
             trip.Id,
             trip.Name,
@@ -76,7 +78,9 @@ public static class EditorTripStateMapper
                 : null,
             trip.Zoom,
             ToImageReference(trip.CoverImageUrl),
-            trip.UpdatedAt);
+            trip.UpdatedAt,
+            publicUrl,
+            progressPublicUrl);
 
     private static EditorPlaceDto MapPlace(
         Guid tripId,
@@ -105,7 +109,7 @@ public static class EditorTripStateMapper
             area.Name,
             area.Notes ?? string.Empty,
             string.IsNullOrWhiteSpace(area.FillHex) ? "#ff6600" : area.FillHex,
-            ToGeoJson(area.Geometry),
+            ToAreaPolygonGeoJson(tripId, area),
             area.DisplayOrder ?? 0,
             EditableLeafCapabilities());
 
@@ -123,12 +127,22 @@ public static class EditorTripStateMapper
             segment.DisplayOrder,
             EditableLeafCapabilities());
 
-    private static EditorVisitProgressDto BuildVisitProgress(IReadOnlyDictionary<Guid, EditorPlaceVisitSummaryDto> summaries)
+    private static EditorVisitProgressDto BuildVisitProgress(
+        IReadOnlyList<(Region Region, Place Place)> places,
+        IReadOnlyDictionary<Guid, EditorPlaceVisitSummaryDto> summaries,
+        IReadOnlyDictionary<Guid, IReadOnlyList<PlaceVisitEvent>> visitsByPlaceId)
     {
         var totalPlaces = summaries.Count;
         var visitedPlaces = summaries.Values.Count(s => s.IsVisited);
-        var percentVisited = totalPlaces > 0 ? (int)Math.Round((double)visitedPlaces / totalPlaces * 100) : 0;
-        return new EditorVisitProgressDto(totalPlaces, visitedPlaces, percentVisited, summaries, Array.Empty<object>());
+        var percentVisited = totalPlaces > 0 ? Math.Round((double)visitedPlaces / totalPlaces * 100, 1) : 0;
+        var regionByPlaceId = places.ToDictionary(p => p.Place.Id, p => p.Region.Id);
+        var historyRows = visitsByPlaceId
+            .SelectMany(pair => pair.Value.Select(visit => MapHistoryRow(pair.Key, regionByPlaceId[pair.Key], visit)))
+            .OrderByDescending(row => row.StartedAt)
+            .ThenBy(row => row.VisitId)
+            .ToList();
+
+        return new EditorVisitProgressDto(totalPlaces, visitedPlaces, percentVisited, summaries, historyRows);
     }
 
     private static IReadOnlyDictionary<Guid, EditorPlaceVisitSummaryDto> BuildVisitSummaries(
@@ -167,6 +181,31 @@ public static class EditorTripStateMapper
         return document.RootElement.Clone();
     }
 
+    private static JsonElement ToAreaPolygonGeoJson(Guid tripId, Area area)
+    {
+        if (area.Geometry == null || area.Geometry.IsEmpty || area.Geometry.GeometryType != "Polygon")
+        {
+            throw new EditorInvalidAreaGeometryException(tripId, area.Id);
+        }
+
+        return ToGeoJson(area.Geometry)!.Value;
+    }
+
+    private static EditorVisitHistoryRowDto MapHistoryRow(Guid placeId, Guid regionId, PlaceVisitEvent visit)
+    {
+        var durationMinutes = visit.EndedAtUtc.HasValue
+            ? (int)Math.Floor((visit.EndedAtUtc.Value - visit.ArrivedAtUtc).TotalMinutes)
+            : (int?)null;
+
+        return new EditorVisitHistoryRowDto(
+            visit.Id,
+            placeId,
+            regionId,
+            visit.ArrivedAtUtc,
+            visit.EndedAtUtc,
+            durationMinutes);
+    }
+
     private static EditorImageReferenceDto? ToImageReference(string? rawUrl)
     {
         if (string.IsNullOrWhiteSpace(rawUrl))
@@ -188,4 +227,22 @@ public static class EditorTripStateMapper
 
     private static EditorEntityCapabilitiesDto EditableLeafCapabilities() =>
         new(true, true, true, true, true, false, false);
+}
+
+/// <summary>Exception raised when persisted area geometry cannot satisfy the editor read contract.</summary>
+public sealed class EditorInvalidAreaGeometryException : Exception
+{
+    /// <summary>Initializes a new invalid area geometry exception.</summary>
+    public EditorInvalidAreaGeometryException(Guid tripId, Guid areaId)
+        : base($"Area {areaId} on trip {tripId} has invalid editor geometry.")
+    {
+        TripId = tripId;
+        AreaId = areaId;
+    }
+
+    /// <summary>The trip containing the invalid area.</summary>
+    public Guid TripId { get; }
+
+    /// <summary>The invalid area identifier.</summary>
+    public Guid AreaId { get; }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -609,6 +609,7 @@ static void ConfigureServices(WebApplicationBuilder builder)
     builder.Services.AddScoped<IMobileCurrentUserAccessor, MobileCurrentUserAccessor>();
     builder.Services.AddScoped<ITripTagService, TripTagService>();
     builder.Services.AddSingleton<IUserColorService, UserColorService>();
+    builder.Services.AddSingleton<IIconColorProvider, IconColorProvider>();
     builder.Services.Configure<MobileSseOptions>(builder.Configuration.GetSection("MobileSse"));
     builder.Services.AddSingleton(sp => sp.GetRequiredService<IOptions<MobileSseOptions>>().Value);
 

--- a/Services/IconColorProvider.cs
+++ b/Services/IconColorProvider.cs
@@ -1,0 +1,57 @@
+using System.Text.RegularExpressions;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Provides the map icon color classes exposed by the icon CSS bundle.
+/// </summary>
+public interface IIconColorProvider
+{
+    /// <summary>
+    /// Reads the available background and glyph color classes, or returns <c>null</c> when the CSS bundle is missing.
+    /// </summary>
+    IconColorClasses? GetAvailableColors();
+}
+
+/// <summary>
+/// Background and glyph color classes available to map icons.
+/// </summary>
+public sealed record IconColorClasses(IReadOnlyList<string> Backgrounds, IReadOnlyList<string> Glyphs);
+
+/// <summary>
+/// Reads icon color classes from the generated Wayfarer map icon CSS file.
+/// </summary>
+public sealed class IconColorProvider : IIconColorProvider
+{
+    private readonly IWebHostEnvironment _environment;
+
+    /// <summary>
+    /// Initializes a provider backed by the current web root.
+    /// </summary>
+    public IconColorProvider(IWebHostEnvironment environment)
+    {
+        _environment = environment;
+    }
+
+    /// <inheritdoc />
+    public IconColorClasses? GetAvailableColors()
+    {
+        var cssPath = Path.Combine(_environment.WebRootPath, "icons", "wayfarer-map-icons", "dist", "wayfarer-map-icons.css");
+        if (!File.Exists(cssPath))
+        {
+            return null;
+        }
+
+        var cssContent = File.ReadAllText(cssPath);
+        return new IconColorClasses(
+            ReadClasses(cssContent, @"\.bg-[\w-]+"),
+            ReadClasses(cssContent, @"\.color-[\w-]+"));
+    }
+
+    private static IReadOnlyList<string> ReadClasses(string cssContent, string pattern) =>
+        Regex.Matches(cssContent, pattern)
+            .Select(match => match.Value.TrimStart('.'))
+            .Distinct()
+            .OrderBy(colorClass => colorClass)
+            .ToList();
+}

--- a/Services/SegmentTransportModes.cs
+++ b/Services/SegmentTransportModes.cs
@@ -1,0 +1,28 @@
+using Wayfarer.Models.Dtos.Editor;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Provides the legacy segment transport modes and speeds used for duration estimation.
+/// </summary>
+public static class SegmentTransportModes
+{
+    /// <summary>Exact legacy transport mode options in the order shown by the segment form.</summary>
+    public static readonly IReadOnlyList<EditorTransportModeDto> Options =
+    [
+        new("walk", "Walk", 5),
+        new("bicycle", "Bicycle", 15),
+        new("bike", "Bike (Motorbike)", 40),
+        new("car", "Car", 60),
+        new("bus", "Bus", 35),
+        new("train", "Train", 100),
+        new("ferry", "Ferry", 30),
+        new("boat", "Boat", 25),
+        new("flight", "Flight", 800),
+        new("helicopter", "Helicopter", 200)
+    ];
+
+    /// <summary>Speed lookup keyed by legacy segment mode value.</summary>
+    public static readonly IReadOnlyDictionary<string, double> SpeedsKmh =
+        Options.ToDictionary(mode => mode.Value, mode => mode.SpeedKmh, StringComparer.OrdinalIgnoreCase);
+}

--- a/tests/Wayfarer.Tests/Controllers/ApiIconsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/ApiIconsControllerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Wayfarer.Areas.Api.Controllers;
+using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
 using Xunit;
 
@@ -122,12 +123,8 @@ public class ApiIconsControllerTests : TestBase
 
         Assert.NotNull(bgList);
         Assert.NotNull(glyphList);
-        Assert.Equal(2, bgList.Count);
-        Assert.Contains("bg-blue", bgList);
-        Assert.Contains("bg-red", bgList);
-        Assert.Equal(2, glyphList.Count);
-        Assert.Contains("color-white", glyphList);
-        Assert.Contains("color-black", glyphList);
+        Assert.Equal(new[] { "bg-blue", "bg-red" }, bgList);
+        Assert.Equal(new[] { "color-black", "color-white" }, glyphList);
     }
 
     [Fact]
@@ -192,7 +189,7 @@ public class ApiIconsControllerTests : TestBase
 
     private IconsController BuildController(IWebHostEnvironment env)
     {
-        return new IconsController(CreateDbContext(), NullLogger<IconsController>.Instance, env);
+        return new IconsController(CreateDbContext(), NullLogger<IconsController>.Instance, env, new IconColorProvider(env));
     }
 
     private static IWebHostEnvironment CreateTempWebRoot()

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -83,8 +83,8 @@ public sealed class TripEditorControllerTests : TestBase
         var state = Assert.IsType<EditorTripStateDto>(ok.Value);
         Assert.Equal(trip.Id, state.TripId);
         Assert.Equal(trip.Name, state.Metadata.Name);
-        Assert.Equal("https://example.test/Public/Trips/" + trip.Id, state.Metadata.PublicUrl);
-        Assert.Equal("https://example.test/Public/Trips/" + trip.Id + "?progress=1", state.Metadata.ProgressPublicUrl);
+        Assert.Null(state.Metadata.PublicUrl);
+        Assert.Null(state.Metadata.ProgressPublicUrl);
         Assert.Equal(2, state.RegionOrder.Count);
         Assert.Equal(2, state.RegionsById.Count);
         Assert.Single(state.PlacesById);
@@ -104,6 +104,51 @@ public sealed class TripEditorControllerTests : TestBase
         Assert.True(state.Permissions.CanEditTrip);
         Assert.True(state.Permissions.CanToggleShareProgress);
         Assert.All(state.Permissions.GetType().GetProperties(), property => Assert.True((bool)property.GetValue(state.Permissions)!));
+    }
+
+    [Fact]
+    public async Task GetEditorStateForPrivateTripReturnsNullPublicUrls()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user", isPublic: false, shareProgressEnabled: true);
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
+
+        var metadata = Assert.IsType<EditorTripStateDto>(Assert.IsType<OkObjectResult>(result).Value).Metadata;
+        Assert.Null(metadata.PublicUrl);
+        Assert.Null(metadata.ProgressPublicUrl);
+    }
+
+    [Fact]
+    public async Task GetEditorStateForPublicTripWithProgressDisabledReturnsOnlyPublicUrl()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user", isPublic: true, shareProgressEnabled: false);
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
+
+        var metadata = Assert.IsType<EditorTripStateDto>(Assert.IsType<OkObjectResult>(result).Value).Metadata;
+        Assert.Equal("https://example.test/Public/Trips/" + trip.Id, metadata.PublicUrl);
+        Assert.Null(metadata.ProgressPublicUrl);
+    }
+
+    [Fact]
+    public async Task GetEditorStateForPublicTripWithProgressEnabledReturnsBothPublicUrls()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user", isPublic: true, shareProgressEnabled: true);
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
+
+        var metadata = Assert.IsType<EditorTripStateDto>(Assert.IsType<OkObjectResult>(result).Value).Metadata;
+        Assert.Equal("https://example.test/Public/Trips/" + trip.Id, metadata.PublicUrl);
+        Assert.Equal("https://example.test/Public/Trips/" + trip.Id + "?progress=1", metadata.ProgressPublicUrl);
     }
 
     [Fact]
@@ -165,13 +210,34 @@ public sealed class TripEditorControllerTests : TestBase
 
         var options = Assert.IsType<EditorTripStateDto>(Assert.IsType<OkObjectResult>(result).Value).Options;
         Assert.Equal(new[] { "alpha", "zulu" }, options.IconNames);
-        Assert.Equal(new[] { "bg-red", "bg-blue" }, options.MarkerColorClasses);
-        Assert.Equal(new[] { "color-yellow", "color-white" }, options.GlyphColorClasses);
+        Assert.Equal(new[] { "bg-blue", "bg-red" }, options.MarkerColorClasses);
+        Assert.Equal(new[] { "color-white", "color-yellow" }, options.GlyphColorClasses);
         Assert.Equal(SegmentTransportModes.Options.Select(m => m.Value), options.TransportModes.Select(m => m.Value));
         Assert.Equal(25, options.Tag.MaxTags);
         Assert.Equal(8, options.Tag.SuggestionTake);
         Assert.Equal(6, options.Limits.NominatimSearchLimit);
         Assert.Equal(1, options.Limits.SidebarSearchMinCharacters);
+    }
+
+    [Fact]
+    public async Task GetEditorStateColorOptionsMatchIconColorsApiOrder()
+    {
+        var webRoot = CreateIconWebRoot();
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var editorController = BuildController(db, webRoot);
+        var iconsController = new IconsController(db, Mock.Of<ILogger<IconsController>>(), BuildEnvironment(webRoot), new IconColorProvider(BuildEnvironment(webRoot)));
+        ConfigureControllerWithUserRole(editorController, "owner-user");
+
+        var editorResult = await editorController.GetEditorState(trip.Id, CancellationToken.None);
+        var iconsResult = iconsController.GetAvailableColors();
+
+        var options = Assert.IsType<EditorTripStateDto>(Assert.IsType<OkObjectResult>(editorResult).Value).Options;
+        var apiColors = Assert.IsType<OkObjectResult>(iconsResult).Value!;
+        var backgrounds = Assert.IsAssignableFrom<IReadOnlyList<string>>(apiColors.GetType().GetProperty("backgrounds")?.GetValue(apiColors));
+        var glyphs = Assert.IsAssignableFrom<IReadOnlyList<string>>(apiColors.GetType().GetProperty("glyphs")?.GetValue(apiColors));
+        Assert.Equal(backgrounds, options.MarkerColorClasses);
+        Assert.Equal(glyphs, options.GlyphColorClasses);
     }
 
     [Fact]
@@ -212,9 +278,11 @@ public sealed class TripEditorControllerTests : TestBase
 
     private static TripEditorController BuildController(ApplicationDbContext db, string? webRoot = null)
     {
+        var environment = BuildEnvironment(webRoot);
         var controller = new TripEditorController(
             db,
-            BuildEnvironment(webRoot),
+            environment,
+            new IconColorProvider(environment),
             Mock.Of<ILogger<TripEditorController>>());
 
         var url = new Mock<IUrlHelper>();
@@ -247,11 +315,11 @@ public sealed class TripEditorControllerTests : TestBase
         File.WriteAllText(Path.Combine(markerDir, "alpha.svg"), "<svg />");
         File.WriteAllText(
             Path.Combine(root, "icons", "wayfarer-map-icons", "dist", "wayfarer-map-icons.css"),
-            ".bg-red{}\n.bg-blue{}\n.color-yellow{}\n.color-white{}");
+            ".bg-red{}\n.bg-blue{}\n.bg-red{}\n.color-yellow{}\n.color-white{}");
         return root;
     }
 
-    private static Trip SeedTrip(ApplicationDbContext db, string userId)
+    private static Trip SeedTrip(ApplicationDbContext db, string userId, bool isPublic = false, bool shareProgressEnabled = false)
     {
         var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
         var trip = new Trip
@@ -260,8 +328,8 @@ public sealed class TripEditorControllerTests : TestBase
             UserId = userId,
             Name = "Test Trip",
             UpdatedAt = DateTime.UtcNow,
-            IsPublic = false,
-            ShareProgressEnabled = false,
+            IsPublic = isPublic,
+            ShareProgressEnabled = shareProgressEnabled,
             Tags = new List<Tag> { new() { Id = Guid.NewGuid(), Name = "Museum", Slug = "museum" } }
         };
         var shadowRegion = new Region

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -1,12 +1,15 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NetTopologySuite;
 using NetTopologySuite.Geometries;
 using Wayfarer.Areas.Api.Controllers;
 using Wayfarer.Models;
 using Wayfarer.Models.Dtos.Editor;
+using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
 using Xunit;
 
@@ -21,7 +24,7 @@ public sealed class TripEditorControllerTests : TestBase
     public async Task GetEditorStateWithoutUserReturnsUnauthorized()
     {
         using var db = CreateDbContext();
-        var controller = new TripEditorController(db, BuildEnvironment());
+        var controller = BuildController(db);
 
         var result = await controller.GetEditorState(Guid.NewGuid(), CancellationToken.None);
 
@@ -33,7 +36,7 @@ public sealed class TripEditorControllerTests : TestBase
     {
         using var db = CreateDbContext();
         var trip = SeedTrip(db, "owner-user");
-        var controller = new TripEditorController(db, BuildEnvironment());
+        var controller = BuildController(db);
         ConfigureControllerWithUserRole(controller, "other-user");
 
         var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
@@ -46,7 +49,7 @@ public sealed class TripEditorControllerTests : TestBase
     {
         using var db = CreateDbContext();
         var trip = SeedTrip(db, "owner-user");
-        var controller = new TripEditorController(db, BuildEnvironment());
+        var controller = BuildController(db);
         ConfigureControllerWithUserRole(controller, "owner-user", "Manager");
 
         var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
@@ -58,7 +61,7 @@ public sealed class TripEditorControllerTests : TestBase
     public async Task GetEditorStateForMissingOwnedScopeTripReturnsNotFound()
     {
         using var db = CreateDbContext();
-        var controller = new TripEditorController(db, BuildEnvironment());
+        var controller = BuildController(db);
         ConfigureControllerWithUserRole(controller, "owner-user");
 
         var result = await controller.GetEditorState(Guid.NewGuid(), CancellationToken.None);
@@ -67,11 +70,11 @@ public sealed class TripEditorControllerTests : TestBase
     }
 
     [Fact]
-    public async Task GetEditorStateForOwnerReturnsNormalizedMinimumShape()
+    public async Task GetEditorStateForOwnerReturnsCompleteReadState()
     {
         using var db = CreateDbContext();
         var trip = SeedTrip(db, "owner-user");
-        var controller = new TripEditorController(db, BuildEnvironment());
+        var controller = BuildController(db);
         ConfigureControllerWithUserRole(controller, "owner-user");
 
         var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
@@ -80,18 +83,117 @@ public sealed class TripEditorControllerTests : TestBase
         var state = Assert.IsType<EditorTripStateDto>(ok.Value);
         Assert.Equal(trip.Id, state.TripId);
         Assert.Equal(trip.Name, state.Metadata.Name);
-        Assert.Single(state.RegionOrder);
-        Assert.Single(state.RegionsById);
+        Assert.Equal("https://example.test/Public/Trips/" + trip.Id, state.Metadata.PublicUrl);
+        Assert.Equal("https://example.test/Public/Trips/" + trip.Id + "?progress=1", state.Metadata.ProgressPublicUrl);
+        Assert.Equal(2, state.RegionOrder.Count);
+        Assert.Equal(2, state.RegionsById.Count);
         Assert.Single(state.PlacesById);
         Assert.Single(state.AreasById);
         Assert.Single(state.SegmentsById);
         Assert.Single(state.TagsBySlug);
         Assert.Equal(1, state.VisitProgress.TotalPlaces);
         Assert.Equal(1, state.VisitProgress.VisitedPlaces);
-        Assert.NotNull(state.AreasById.Values.Single().Geometry);
+        Assert.Equal(100, state.VisitProgress.PercentVisited);
+        Assert.Equal(3, state.VisitProgress.HistoryRows.Count);
+        Assert.Equal(30, state.VisitProgress.HistoryRows[0].DurationMinutes);
+        Assert.Null(state.VisitProgress.HistoryRows[1].DurationMinutes);
+        Assert.True(state.VisitProgress.HistoryRows[0].VisitId.CompareTo(state.VisitProgress.HistoryRows[1].VisitId) < 0);
+        Assert.Equal("Polygon", state.AreasById.Values.Single().Geometry.GetProperty("type").GetString());
         Assert.NotNull(state.SegmentsById.Values.Single().Route);
         Assert.NotNull(state.Options);
         Assert.True(state.Permissions.CanEditTrip);
+        Assert.True(state.Permissions.CanToggleShareProgress);
+        Assert.All(state.Permissions.GetType().GetProperties(), property => Assert.True((bool)property.GetValue(state.Permissions)!));
+    }
+
+    [Fact]
+    public async Task GetEditorStateMapsCoordinatesAndGeoJsonWithExpectedShapes()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
+
+        var state = Assert.IsType<EditorTripStateDto>(Assert.IsType<OkObjectResult>(result).Value);
+        var place = state.PlacesById.Values.Single();
+        Assert.Equal(37.9715, place.Location!.Latitude, 4);
+        Assert.Equal(23.7261, place.Location.Longitude, 4);
+
+        var areaCoordinates = state.AreasById.Values.Single().Geometry.GetProperty("coordinates")[0][0];
+        Assert.Equal(23.72, areaCoordinates[0].GetDouble(), 2);
+        Assert.Equal(37.97, areaCoordinates[1].GetDouble(), 2);
+
+        var route = state.SegmentsById.Values.Single().Route!.Value;
+        Assert.Equal("LineString", route.GetProperty("type").GetString());
+        var routeCoordinates = route.GetProperty("coordinates")[0];
+        Assert.Equal(23.7261, routeCoordinates[0].GetDouble(), 4);
+        Assert.Equal(37.9715, routeCoordinates[1].GetDouble(), 4);
+    }
+
+    [Fact]
+    public async Task GetEditorStateReturnsShadowRegionCapabilitiesWithoutNameInferenceInFrontendState()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
+
+        var state = Assert.IsType<EditorTripStateDto>(Assert.IsType<OkObjectResult>(result).Value);
+        var shadow = Assert.Single(state.RegionsById.Values, r => r.IsShadow);
+        Assert.Equal(0, shadow.DisplayOrder);
+        Assert.False(shadow.Capabilities.CanRename);
+        Assert.False(shadow.Capabilities.CanDelete);
+        Assert.False(shadow.Capabilities.CanReorder);
+        Assert.False(shadow.Capabilities.CanAddChildren);
+        Assert.True(shadow.Capabilities.CanTargetForSearchAdd);
+    }
+
+    [Fact]
+    public async Task GetEditorStateReturnsDeterministicOptions()
+    {
+        var webRoot = CreateIconWebRoot();
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db, webRoot);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
+
+        var options = Assert.IsType<EditorTripStateDto>(Assert.IsType<OkObjectResult>(result).Value).Options;
+        Assert.Equal(new[] { "alpha", "zulu" }, options.IconNames);
+        Assert.Equal(new[] { "bg-red", "bg-blue" }, options.MarkerColorClasses);
+        Assert.Equal(new[] { "color-yellow", "color-white" }, options.GlyphColorClasses);
+        Assert.Equal(SegmentTransportModes.Options.Select(m => m.Value), options.TransportModes.Select(m => m.Value));
+        Assert.Equal(25, options.Tag.MaxTags);
+        Assert.Equal(8, options.Tag.SuggestionTake);
+        Assert.Equal(6, options.Limits.NominatimSearchLimit);
+        Assert.Equal(1, options.Limits.SidebarSearchMinCharacters);
+    }
+
+    [Fact]
+    public async Task GetEditorStateWithMissingAreaGeometryReturnsProblemDetails()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var area = trip.Regions.SelectMany(r => r.Areas).Single();
+        area.Geometry = null!;
+        db.SaveChanges();
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
+        Assert.Contains("application/problem+json", objectResult.ContentTypes);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal("https://wayfarer/errors/editor-invalid-area-geometry", problem.Type);
+        Assert.Equal(area.Id, problem.Extensions["areaId"]);
+        Assert.Equal(trip.Id, problem.Extensions["tripId"]);
     }
 
     private static void ConfigureControllerWithUserRole(ControllerBase controller, string userId, string role = "User")
@@ -108,11 +210,45 @@ public sealed class TripEditorControllerTests : TestBase
         Assert.Equal(StatusCodes.Status403Forbidden, status.StatusCode);
     }
 
-    private static IWebHostEnvironment BuildEnvironment()
+    private static TripEditorController BuildController(ApplicationDbContext db, string? webRoot = null)
+    {
+        var controller = new TripEditorController(
+            db,
+            BuildEnvironment(webRoot),
+            Mock.Of<ILogger<TripEditorController>>());
+
+        var url = new Mock<IUrlHelper>();
+        url.Setup(u => u.Action(It.IsAny<UrlActionContext>()))
+            .Returns((UrlActionContext context) =>
+            {
+                var id = context.Values?.GetType().GetProperty("id")?.GetValue(context.Values);
+                var progress = context.Values?.GetType().GetProperty("progress")?.GetValue(context.Values);
+                return progress == null
+                    ? $"https://example.test/Public/Trips/{id}"
+                    : $"https://example.test/Public/Trips/{id}?progress={progress}";
+            });
+        controller.Url = url.Object;
+        return controller;
+    }
+
+    private static IWebHostEnvironment BuildEnvironment(string? webRoot = null)
     {
         var mock = new Mock<IWebHostEnvironment>();
-        mock.SetupGet(e => e.WebRootPath).Returns(Path.GetTempPath());
+        mock.SetupGet(e => e.WebRootPath).Returns(webRoot ?? Path.GetTempPath());
         return mock.Object;
+    }
+
+    private static string CreateIconWebRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var markerDir = Path.Combine(root, "icons", "wayfarer-map-icons", "dist", "marker");
+        Directory.CreateDirectory(markerDir);
+        File.WriteAllText(Path.Combine(markerDir, "zulu.svg"), "<svg />");
+        File.WriteAllText(Path.Combine(markerDir, "alpha.svg"), "<svg />");
+        File.WriteAllText(
+            Path.Combine(root, "icons", "wayfarer-map-icons", "dist", "wayfarer-map-icons.css"),
+            ".bg-red{}\n.bg-blue{}\n.color-yellow{}\n.color-white{}");
+        return root;
     }
 
     private static Trip SeedTrip(ApplicationDbContext db, string userId)
@@ -127,6 +263,14 @@ public sealed class TripEditorControllerTests : TestBase
             IsPublic = false,
             ShareProgressEnabled = false,
             Tags = new List<Tag> { new() { Id = Guid.NewGuid(), Name = "Museum", Slug = "museum" } }
+        };
+        var shadowRegion = new Region
+        {
+            Id = Guid.NewGuid(),
+            TripId = trip.Id,
+            UserId = userId,
+            Name = "Unassigned Places",
+            DisplayOrder = 0
         };
         var region = new Region
         {
@@ -180,13 +324,30 @@ public sealed class TripEditorControllerTests : TestBase
         };
         var visit = new PlaceVisitEvent
         {
-            Id = Guid.NewGuid(),
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000003"),
             UserId = userId,
             PlaceId = place.Id,
-            ArrivedAtUtc = DateTime.UtcNow.AddHours(-1),
-            EndedAtUtc = DateTime.UtcNow
+            ArrivedAtUtc = new DateTime(2026, 1, 1, 8, 0, 0, DateTimeKind.Utc),
+            EndedAtUtc = new DateTime(2026, 1, 1, 8, 45, 0, DateTimeKind.Utc)
+        };
+        var latestVisit = new PlaceVisitEvent
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            UserId = userId,
+            PlaceId = place.Id,
+            ArrivedAtUtc = new DateTime(2026, 1, 2, 9, 0, 0, DateTimeKind.Utc),
+            EndedAtUtc = new DateTime(2026, 1, 2, 9, 30, 59, DateTimeKind.Utc)
+        };
+        var latestTieVisit = new PlaceVisitEvent
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000002"),
+            UserId = userId,
+            PlaceId = place.Id,
+            ArrivedAtUtc = new DateTime(2026, 1, 2, 9, 0, 0, DateTimeKind.Utc),
+            EndedAtUtc = null
         };
 
+        trip.Regions.Add(shadowRegion);
         trip.Regions.Add(region);
         trip.Segments.Add(segment);
         region.Places.Add(place);
@@ -194,6 +355,8 @@ public sealed class TripEditorControllerTests : TestBase
 
         db.Trips.Add(trip);
         db.PlaceVisitEvents.Add(visit);
+        db.PlaceVisitEvents.Add(latestVisit);
+        db.PlaceVisitEvents.Add(latestTieVisit);
         db.SaveChanges();
         return trip;
     }


### PR DESCRIPTION
Closes #237.

## Summary
- Completed the Trip Editor read-state API foundation with richer metadata, permissions, region/place/area/segment dictionaries, deterministic ordering, typed visit progress/history rows, and editor option payloads.
- Added visibility-gated public URL metadata using `Url.Action(...)`: private trips expose `null` URLs, public trips expose `publicUrl`, and `progressPublicUrl` is present only when `ShareProgressEnabled` is true.
- Shared icon color discovery through `IIconColorProvider` so `IconsController` and `TripEditorController` return the same sorted/deduped background and glyph color order.
- Centralized legacy segment transport mode options/speeds for read-state options and segment duration behavior.
- Updated the Trip Editor TypeScript read-state types to match the API contract.

## #230 Read-State Coverage Matrix

| #230 section | Field / behavior | Status | Coverage |
| --- | --- | --- | --- |
| Metadata | `id` | implemented | Complete read-state test |
| Metadata | `name` | implemented | Complete read-state test |
| Metadata | `notesHtml` | implemented | Mapper contract coverage |
| Metadata | `isPublic` | implemented | URL visibility tests |
| Metadata | `shareProgressEnabled` | implemented | URL visibility tests |
| Metadata | `center` | implemented | Coordinate shape test |
| Metadata | `zoom` | implemented | Mapper contract coverage |
| Metadata | `coverImage` | implemented | Mapper contract coverage |
| Metadata | `updatedAt` | implemented | Mapper contract coverage |
| Metadata | `publicUrl` | implemented | Private/public URL visibility tests |
| Metadata | `progressPublicUrl` | implemented | Private/public/progress URL visibility tests |
| Regions | `regionsById` | implemented | Complete read-state test |
| Regions | `regionOrder` | implemented | Complete read-state test |
| Regions | `id`, `tripId`, `name`, `notesHtml`, `coverImage`, `center`, `displayOrder`, `isShadow`, `capabilities` | implemented | Complete read-state and shadow capability tests |
| Regions | Shadow region `displayOrder = 0` and restricted capabilities | implemented | Shadow capability test |
| Places | `placesById` | implemented | Complete read-state test |
| Places | `placeOrderByRegionId` | implemented | Mapper contract coverage |
| Places | `id`, `tripId`, `regionId`, `name`, `notesHtml`, `address`, `location`, `iconName`, `markerColor`, `displayOrder`, `visitSummary`, `capabilities` | implemented | Complete read-state and coordinate tests |
| Areas | `areasById` | implemented | Complete read-state test |
| Areas | `areaOrderByRegionId` | implemented | Mapper contract coverage |
| Areas | `id`, `tripId`, `regionId`, `name`, `notesHtml`, `fillHex`, `geometry`, `displayOrder`, `capabilities` | implemented | Complete read-state and GeoJSON tests |
| Areas | Non-null GeoJSON `Polygon` object for returned persisted areas | implemented | GeoJSON shape test |
| Areas | Invalid/missing geometry returns `application/problem+json` 500 with `areaId` and `tripId` | implemented | Invalid geometry test |
| Segments | `segmentsById` | implemented | Complete read-state test |
| Segments | `segmentOrder` | implemented | Complete read-state test |
| Segments | `id`, `tripId`, `fromPlaceId`, `toPlaceId`, `mode`, `estimatedDistanceKm`, `estimatedDurationMinutes`, `notesHtml`, `route`, `displayOrder`, `capabilities` | implemented | Complete read-state and route tests |
| Segments | `route` as GeoJSON `LineString` object or `null` | implemented | GeoJSON route test |
| Tags | `tagsBySlug` | implemented | Complete read-state test |
| Tags | `tagOrder` | implemented | Complete read-state test |
| Tags | Server-authoritative slug/name ordering | implemented | Mapper contract coverage |
| Visit progress | `totalPlaces`, `visitedPlaces`, `percentVisited` | implemented | Complete read-state test |
| Visit progress | `placeSummariesByPlaceId` | implemented | Complete read-state test |
| Visit progress | Summary `placeId`, `visitCount`, `isVisited`, `firstVisitAt`, `lastVisitAt` | implemented | Complete read-state test |
| Visit progress | `historyRows` | implemented | Complete read-state test |
| Visit progress | History `visitId`, `placeId`, `regionId`, `startedAt`, `endedAt`, `durationMinutes` | implemented | Complete read-state test |
| Visit progress | History sort by `startedAt` descending then `visitId` ascending | implemented | Complete read-state test |
| Visit progress | `durationMinutes` null for open visits, otherwise floor elapsed minutes | implemented | Complete read-state test |
| Options | `iconNames` from marker icon source, sorted | implemented | Deterministic options test |
| Options | `markerColorClasses` preserving shared provider/API order | implemented | Deterministic options and icon parity tests |
| Options | `glyphColorClasses` preserving shared provider/API order | implemented | Deterministic options and icon parity tests |
| Options | `transportModes` exact legacy mode set and speeds | implemented | Deterministic options test; shared `SegmentTransportModes` |
| Options | `areaDefaults` `{ name: "Area", fillHex: "#ff6600" }` | implemented | Deterministic options test |
| Options | `tag.maxTags = 25` | implemented | Deterministic options test |
| Options | `tag.suggestionTake = 8` | implemented | Deterministic options test |
| Options | `limits.nominatimSearchLimit = 6` | implemented | Deterministic options test |
| Options | `limits.sidebarSearchMinCharacters = 1` | implemented | Deterministic options test |
| Permissions | All owner editor permissions true | implemented | Complete read-state test |
| Capabilities | Normal region capabilities deterministic | implemented | Mapper contract coverage |
| Capabilities | Place/area/segment capabilities deterministic | implemented | Complete read-state test |
| Capabilities | Shadow region capabilities deterministic | implemented | Shadow capability test |
| Geometry / coordinates | GeoJSON values are JSON objects, not strings | implemented | GeoJSON shape test |
| Geometry / coordinates | GeoJSON coordinates use `[longitude, latitude]` | implemented | GeoJSON shape test |
| Geometry / coordinates | Non-GeoJSON points use named `latitude` / `longitude` | implemented | Coordinate shape test |
| Client read model | TypeScript read-state types mirror metadata, non-null area geometry, and typed history rows | implemented | `npm run build` |

No #230 read-state fields are intentionally deferred or marked not applicable in this PR.

No mutations, editing commands, cutover behavior, or UI parity features were added in this PR.

## Final Review Fixes Included
- URL visibility semantics were tightened: private trips return `metadata.publicUrl == null` and `metadata.progressPublicUrl == null`; public trips return `publicUrl`; `progressPublicUrl` appears only when `ShareProgressEnabled` is true.
- Icon color discovery was moved to a shared minimal/stateless provider while preserving sorted/deduped `{ backgrounds, glyphs }` behavior.

## Validation
- `dotnet build --no-restore` passed locally: 0 warnings, 0 errors in the current run. The ASP0000 warning previously observed in `Program.cs` is pre-existing and unrelated to this branch.
- `dotnet test --no-build --filter "FullyQualifiedName~TripEditorControllerTests|FullyQualifiedName~ApiIconsControllerTests|FullyQualifiedName~StartupTests"` passed locally: 27 passed, 0 failed, 0 skipped.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` passed locally with no warnings.
- `npm run build` was run because `ClientApps/trip-editor/src/types.ts` changed; it passed locally with Vite building 18 modules. No package files or committed `wwwroot` assets are changed by this branch.
