### PR TITLE
[Trip Editor] Add region CRUD and reorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 [Oo]bj/
 
 .claude/
-.local/
 nul
 debug_console.txt
 # Logs

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 [Oo]bj/
 
 .claude/
+.local/
 nul
 debug_console.txt
 # Logs

--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -262,20 +262,10 @@ public sealed class TripEditorController : ControllerBase
 
         var state = await LoadEditorStateForOwnedTrip(tripId, userId!, cancellationToken);
         var dto = state.RegionsById[region.Id];
-        var affected = new EditorAffectedSlicesDto(
-            null,
-            new[] { dto },
-            state.RegionOrder,
-            Array.Empty<EditorPlaceDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>> { [region.Id] = Array.Empty<Guid>() },
-            Array.Empty<EditorAreaDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>> { [region.Id] = Array.Empty<Guid>() },
-            Array.Empty<EditorSegmentDto>(),
-            null,
-            Array.Empty<EditorTagDto>(),
-            null,
-            null,
-            null);
+        var affected = new EditorAffectedSlicesDto(null, new[] { dto }, state.RegionOrder, Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>> { [region.Id] = Array.Empty<Guid>() }, Array.Empty<EditorAreaDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>> { [region.Id] = Array.Empty<Guid>() }, Array.Empty<EditorSegmentDto>(),
+            null, Array.Empty<EditorTagDto>(), null, null, null);
 
         return Ok(new EditorMutationResult<EditorRegionDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
     }
@@ -331,20 +321,9 @@ public sealed class TripEditorController : ControllerBase
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         var dto = EditorTripStateMapper.ToRegion(region);
-        var affected = new EditorAffectedSlicesDto(
-            null,
-            new[] { dto },
-            null,
-            Array.Empty<EditorPlaceDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>>(),
-            Array.Empty<EditorAreaDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>>(),
-            Array.Empty<EditorSegmentDto>(),
-            null,
-            Array.Empty<EditorTagDto>(),
-            null,
-            null,
-            null);
+        var affected = new EditorAffectedSlicesDto(null, new[] { dto }, null, Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(), Array.Empty<EditorAreaDto>(), new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorSegmentDto>(), null, Array.Empty<EditorTagDto>(), null, null, null);
 
         return Ok(new EditorMutationResult<EditorRegionDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
     }
@@ -404,20 +383,9 @@ public sealed class TripEditorController : ControllerBase
         await NormalizeSegmentOrders(tripId, userId!, cancellationToken);
 
         var state = await LoadEditorStateForOwnedTrip(tripId, userId!, cancellationToken);
-        var affected = new EditorAffectedSlicesDto(
-            null,
-            Array.Empty<EditorRegionDto>(),
-            state.RegionOrder,
-            Array.Empty<EditorPlaceDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>>(),
-            Array.Empty<EditorAreaDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>>(),
-            Array.Empty<EditorSegmentDto>(),
-            state.SegmentOrder,
-            Array.Empty<EditorTagDto>(),
-            null,
-            state.VisitProgress,
-            null);
+        var affected = new EditorAffectedSlicesDto(null, Array.Empty<EditorRegionDto>(), state.RegionOrder, Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(), Array.Empty<EditorAreaDto>(), new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorSegmentDto>(), state.SegmentOrder, Array.Empty<EditorTagDto>(), null, state.VisitProgress, null);
         var deletedIds = new EditorDeletedIdsDto(
             new[] { regionId },
             deletedPlaceIds,
@@ -493,20 +461,9 @@ public sealed class TripEditorController : ControllerBase
 
         var state = await LoadEditorStateForOwnedTrip(tripId, userId!, cancellationToken);
         var updatedRegions = orderRequest.RegionIds.Select(id => state.RegionsById[id]).ToList();
-        var affected = new EditorAffectedSlicesDto(
-            null,
-            updatedRegions,
-            state.RegionOrder,
-            Array.Empty<EditorPlaceDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>>(),
-            Array.Empty<EditorAreaDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>>(),
-            Array.Empty<EditorSegmentDto>(),
-            null,
-            Array.Empty<EditorTagDto>(),
-            null,
-            null,
-            null);
+        var affected = new EditorAffectedSlicesDto(null, updatedRegions, state.RegionOrder, Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(), Array.Empty<EditorAreaDto>(), new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorSegmentDto>(), null, Array.Empty<EditorTagDto>(), null, null, null);
         var data = new EditorRegionOrderResult(state.RegionOrder);
 
         return Ok(new EditorMutationResult<EditorRegionOrderResult>(true, data, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));

--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -26,6 +26,7 @@ public sealed class TripEditorController : ControllerBase
     private readonly IIconColorProvider _iconColorProvider;
     private readonly ITripMapThumbnailGenerator _thumbnailGenerator;
     private readonly ICacheWarmupScheduler _warmupScheduler;
+    private readonly TripEditorRegionMutationService _regionMutations;
     private readonly ILogger<TripEditorController> _logger;
 
     /// <summary>
@@ -37,6 +38,7 @@ public sealed class TripEditorController : ControllerBase
         IIconColorProvider iconColorProvider,
         ITripMapThumbnailGenerator thumbnailGenerator,
         ICacheWarmupScheduler warmupScheduler,
+        TripEditorRegionMutationService regionMutations,
         ILogger<TripEditorController> logger)
     {
         _dbContext = dbContext;
@@ -44,6 +46,7 @@ public sealed class TripEditorController : ControllerBase
         _iconColorProvider = iconColorProvider;
         _thumbnailGenerator = thumbnailGenerator;
         _warmupScheduler = warmupScheduler;
+        _regionMutations = regionMutations;
         _logger = logger;
     }
 
@@ -224,50 +227,8 @@ public sealed class TripEditorController : ControllerBase
             return authFailure;
         }
 
-        var trip = await _dbContext.Trips
-            .Include(t => t.Regions)
-            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
-        if (trip == null)
-        {
-            return NotFound();
-        }
-
-        var request = await ParseJsonBody(cancellationToken);
-        if (request == null)
-        {
-            return ValidationError(new Dictionary<string, string[]> { ["request"] = new[] { "Region save request must be valid JSON." } });
-        }
-
-        if (!EditorRegionRequestParser.TryParseSave(request.Value, out var update, out var errors))
-        {
-            return ValidationError(errors);
-        }
-
-        var normalRegions = trip.Regions.Where(r => !IsShadowRegion(r)).ToList();
-        var region = new Region
-        {
-            Id = Guid.NewGuid(),
-            TripId = trip.Id,
-            Trip = trip,
-            UserId = userId!,
-            Name = update.Name.Trim(),
-            Notes = update.NotesHtml ?? string.Empty,
-            CoverImageUrl = NormalizeOptionalUrl(update.CoverImage?.RawUrl),
-            Center = ToPoint(update.Center),
-            DisplayOrder = normalRegions.Count == 0 ? 1 : normalRegions.Max(r => r.DisplayOrder) + 1
-        };
-
-        _dbContext.Regions.Add(region);
-        await _dbContext.SaveChangesAsync(cancellationToken);
-
-        var state = await LoadEditorStateForOwnedTrip(tripId, userId!, cancellationToken);
-        var dto = state.RegionsById[region.Id];
-        var affected = new EditorAffectedSlicesDto(null, new[] { dto }, state.RegionOrder, Array.Empty<EditorPlaceDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>> { [region.Id] = Array.Empty<Guid>() }, Array.Empty<EditorAreaDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>> { [region.Id] = Array.Empty<Guid>() }, Array.Empty<EditorSegmentDto>(),
-            null, Array.Empty<EditorTagDto>(), null, null, null);
-
-        return Ok(new EditorMutationResult<EditorRegionDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+        var outcome = await _regionMutations.CreateRegionAsync(tripId, userId!, Request.Body, cancellationToken);
+        return ToActionResult(outcome);
     }
 
     /// <summary>
@@ -283,49 +244,8 @@ public sealed class TripEditorController : ControllerBase
             return authFailure;
         }
 
-        var trip = await _dbContext.Trips
-            .Include(t => t.Regions)
-            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
-        if (trip == null)
-        {
-            return NotFound();
-        }
-
-        var region = trip.Regions.FirstOrDefault(r => r.Id == regionId);
-        if (region == null)
-        {
-            return NotFound();
-        }
-
-        if (IsShadowRegion(region))
-        {
-            return ForbiddenProblem("The shadow region cannot be updated.");
-        }
-
-        var request = await ParseJsonBody(cancellationToken);
-        if (request == null)
-        {
-            return ValidationError(new Dictionary<string, string[]> { ["request"] = new[] { "Region save request must be valid JSON." } });
-        }
-
-        if (!EditorRegionRequestParser.TryParseSave(request.Value, out var update, out var errors))
-        {
-            return ValidationError(errors);
-        }
-
-        region.Name = update.Name.Trim();
-        region.Notes = update.NotesHtml ?? string.Empty;
-        region.CoverImageUrl = NormalizeOptionalUrl(update.CoverImage?.RawUrl);
-        region.Center = ToPoint(update.Center);
-
-        await _dbContext.SaveChangesAsync(cancellationToken);
-
-        var dto = EditorTripStateMapper.ToRegion(region);
-        var affected = new EditorAffectedSlicesDto(null, new[] { dto }, null, Array.Empty<EditorPlaceDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>>(), Array.Empty<EditorAreaDto>(), new Dictionary<Guid, IReadOnlyList<Guid>>(),
-            Array.Empty<EditorSegmentDto>(), null, Array.Empty<EditorTagDto>(), null, null, null);
-
-        return Ok(new EditorMutationResult<EditorRegionDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+        var outcome = await _regionMutations.UpdateRegionAsync(tripId, regionId, userId!, Request.Body, cancellationToken);
+        return ToActionResult(outcome);
     }
 
     /// <summary>
@@ -341,59 +261,8 @@ public sealed class TripEditorController : ControllerBase
             return authFailure;
         }
 
-        var trip = await _dbContext.Trips
-            .Include(t => t.Regions).ThenInclude(r => r.Places)
-            .Include(t => t.Regions).ThenInclude(r => r.Areas)
-            .Include(t => t.Segments)
-            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
-        if (trip == null)
-        {
-            return NotFound();
-        }
-
-        var region = trip.Regions.FirstOrDefault(r => r.Id == regionId);
-        if (region == null)
-        {
-            return NotFound();
-        }
-
-        if (IsShadowRegion(region))
-        {
-            return ForbiddenProblem("The shadow region cannot be deleted.");
-        }
-
-        var deletedPlaceIds = region.Places.OrderBy(p => p.DisplayOrder).ThenBy(p => p.Id).Select(p => p.Id).ToList();
-        var deletedAreaIds = region.Areas.OrderBy(a => a.DisplayOrder).ThenBy(a => a.Id).Select(a => a.Id).ToList();
-        var deletedSegmentIds = trip.Segments
-            .Where(s => (s.FromPlaceId.HasValue && deletedPlaceIds.Contains(s.FromPlaceId.Value))
-                || (s.ToPlaceId.HasValue && deletedPlaceIds.Contains(s.ToPlaceId.Value)))
-            .OrderBy(s => s.DisplayOrder)
-            .ThenBy(s => s.Id)
-            .Select(s => s.Id)
-            .ToList();
-
-        var deletedSegments = trip.Segments.Where(s => deletedSegmentIds.Contains(s.Id)).ToList();
-        _dbContext.Segments.RemoveRange(deletedSegments);
-        _dbContext.Areas.RemoveRange(region.Areas);
-        _dbContext.Places.RemoveRange(region.Places);
-        _dbContext.Regions.Remove(region);
-        await _dbContext.SaveChangesAsync(cancellationToken);
-
-        await NormalizeRegionOrders(tripId, userId!, cancellationToken);
-        await NormalizeSegmentOrders(tripId, userId!, cancellationToken);
-
-        var state = await LoadEditorStateForOwnedTrip(tripId, userId!, cancellationToken);
-        var affected = new EditorAffectedSlicesDto(null, Array.Empty<EditorRegionDto>(), state.RegionOrder, Array.Empty<EditorPlaceDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>>(), Array.Empty<EditorAreaDto>(), new Dictionary<Guid, IReadOnlyList<Guid>>(),
-            Array.Empty<EditorSegmentDto>(), state.SegmentOrder, Array.Empty<EditorTagDto>(), null, state.VisitProgress, null);
-        var deletedIds = new EditorDeletedIdsDto(
-            new[] { regionId },
-            deletedPlaceIds,
-            deletedAreaIds,
-            deletedSegmentIds,
-            Array.Empty<string>());
-
-        return Ok(new EditorMutationResult<EditorRegionDto?>(true, null, affected, deletedIds, Array.Empty<EditorWarningDto>()));
+        var outcome = await _regionMutations.DeleteRegionAsync(tripId, regionId, userId!, cancellationToken);
+        return ToActionResult(outcome);
     }
 
     /// <summary>
@@ -409,64 +278,8 @@ public sealed class TripEditorController : ControllerBase
             return authFailure;
         }
 
-        var trip = await _dbContext.Trips
-            .Include(t => t.Regions)
-            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
-        if (trip == null)
-        {
-            return NotFound();
-        }
-
-        var request = await ParseJsonBody(cancellationToken);
-        if (request == null)
-        {
-            return ValidationError(new Dictionary<string, string[]> { ["request"] = new[] { "Region order request must be valid JSON." } });
-        }
-
-        if (!EditorRegionRequestParser.TryParseOrder(request.Value, out var orderRequest, out var errors))
-        {
-            return ValidationError(errors);
-        }
-
-        var shadow = trip.Regions.FirstOrDefault(IsShadowRegion);
-        if (shadow != null && orderRequest.RegionIds.Contains(shadow.Id))
-        {
-            return ForbiddenProblem("The shadow region cannot be reordered.");
-        }
-
-        var normalRegions = trip.Regions.Where(r => !IsShadowRegion(r)).OrderBy(r => r.DisplayOrder).ThenBy(r => r.Name).ToList();
-        var normalIds = normalRegions.Select(r => r.Id).ToList();
-        if (orderRequest.RegionIds.Count != normalIds.Count
-            || orderRequest.RegionIds.Distinct().Count() != orderRequest.RegionIds.Count
-            || orderRequest.RegionIds.Any(id => !normalIds.Contains(id)))
-        {
-            return ValidationError(new Dictionary<string, string[]>
-            {
-                ["regionIds"] = new[] { "Region IDs must include every normal region in this trip exactly once." }
-            });
-        }
-
-        if (shadow != null)
-        {
-            shadow.DisplayOrder = 0;
-        }
-
-        var byId = normalRegions.ToDictionary(r => r.Id);
-        for (var i = 0; i < orderRequest.RegionIds.Count; i++)
-        {
-            byId[orderRequest.RegionIds[i]].DisplayOrder = i + 1;
-        }
-
-        await _dbContext.SaveChangesAsync(cancellationToken);
-
-        var state = await LoadEditorStateForOwnedTrip(tripId, userId!, cancellationToken);
-        var updatedRegions = orderRequest.RegionIds.Select(id => state.RegionsById[id]).ToList();
-        var affected = new EditorAffectedSlicesDto(null, updatedRegions, state.RegionOrder, Array.Empty<EditorPlaceDto>(),
-            new Dictionary<Guid, IReadOnlyList<Guid>>(), Array.Empty<EditorAreaDto>(), new Dictionary<Guid, IReadOnlyList<Guid>>(),
-            Array.Empty<EditorSegmentDto>(), null, Array.Empty<EditorTagDto>(), null, null, null);
-        var data = new EditorRegionOrderResult(state.RegionOrder);
-
-        return Ok(new EditorMutationResult<EditorRegionOrderResult>(true, data, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+        var outcome = await _regionMutations.OrderRegionsAsync(tripId, userId!, Request.Body, cancellationToken);
+        return ToActionResult(outcome);
     }
 
     private EditorOptionsDto BuildOptions()
@@ -532,43 +345,6 @@ public sealed class TripEditorController : ControllerBase
             trip.IsPublic && trip.ShareProgressEnabled ? GenerateProgressPublicTripUrl(trip.Id) : null);
     }
 
-    private async Task NormalizeRegionOrders(Guid tripId, string userId, CancellationToken cancellationToken)
-    {
-        var regions = await _dbContext.Regions
-            .Where(r => r.TripId == tripId && r.UserId == userId)
-            .OrderBy(r => r.DisplayOrder)
-            .ThenBy(r => r.Name)
-            .ToListAsync(cancellationToken);
-        var shadow = regions.FirstOrDefault(IsShadowRegion);
-        if (shadow != null)
-        {
-            shadow.DisplayOrder = 0;
-        }
-
-        var order = 1;
-        foreach (var region in regions.Where(r => !IsShadowRegion(r)))
-        {
-            region.DisplayOrder = order++;
-        }
-
-        await _dbContext.SaveChangesAsync(cancellationToken);
-    }
-
-    private async Task NormalizeSegmentOrders(Guid tripId, string userId, CancellationToken cancellationToken)
-    {
-        var segments = await _dbContext.Segments
-            .Where(s => s.TripId == tripId && s.UserId == userId)
-            .OrderBy(s => s.DisplayOrder)
-            .ThenBy(s => s.Id)
-            .ToListAsync(cancellationToken);
-        for (var i = 0; i < segments.Count; i++)
-        {
-            segments[i].DisplayOrder = i;
-        }
-
-        await _dbContext.SaveChangesAsync(cancellationToken);
-    }
-
     private async Task<JsonElement?> ParseJsonBody(CancellationToken cancellationToken)
     {
         try
@@ -630,9 +406,15 @@ public sealed class TripEditorController : ControllerBase
     private static Point? ToPoint(EditorCoordinateDto? coordinate) =>
         coordinate == null ? null : new Point(coordinate.Longitude, coordinate.Latitude) { SRID = 4326 };
 
-    private static bool IsShadowRegion(Region region) =>
-        region.DisplayOrder == 0
-        && string.Equals(region.Name, EditorRegionRequestParser.ShadowRegionName, StringComparison.Ordinal);
+    private IActionResult ToActionResult<T>(EditorRegionMutationOutcome<T> outcome) =>
+        outcome.Status switch
+        {
+            EditorRegionMutationStatus.Success => Ok(outcome.Result),
+            EditorRegionMutationStatus.NotFound => NotFound(),
+            EditorRegionMutationStatus.Forbidden => ForbiddenProblem(outcome.ForbiddenDetail ?? "The operation is forbidden."),
+            EditorRegionMutationStatus.ValidationFailed => ValidationError(outcome.ValidationErrors ?? new Dictionary<string, string[]>()),
+            _ => StatusCode(StatusCodes.Status500InternalServerError)
+        };
 
     private static IActionResult ForbiddenProblem(string detail)
     {

--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Geometries;
 using Wayfarer.Models;
 using Wayfarer.Models.Dtos.Editor;
 using Wayfarer.Services;
@@ -210,6 +211,307 @@ public sealed class TripEditorController : ControllerBase
             warnings));
     }
 
+    /// <summary>
+    /// Creates a normal region for an owned trip.
+    /// </summary>
+    [HttpPost("regions")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CreateRegion(Guid tripId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var trip = await _dbContext.Trips
+            .Include(t => t.Regions)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+        if (trip == null)
+        {
+            return NotFound();
+        }
+
+        var request = await ParseJsonBody(cancellationToken);
+        if (request == null)
+        {
+            return ValidationError(new Dictionary<string, string[]> { ["request"] = new[] { "Region save request must be valid JSON." } });
+        }
+
+        if (!EditorRegionRequestParser.TryParseSave(request.Value, out var update, out var errors))
+        {
+            return ValidationError(errors);
+        }
+
+        var normalRegions = trip.Regions.Where(r => !IsShadowRegion(r)).ToList();
+        var region = new Region
+        {
+            Id = Guid.NewGuid(),
+            TripId = trip.Id,
+            Trip = trip,
+            UserId = userId!,
+            Name = update.Name.Trim(),
+            Notes = update.NotesHtml ?? string.Empty,
+            CoverImageUrl = NormalizeOptionalUrl(update.CoverImage?.RawUrl),
+            Center = ToPoint(update.Center),
+            DisplayOrder = normalRegions.Count == 0 ? 1 : normalRegions.Max(r => r.DisplayOrder) + 1
+        };
+
+        _dbContext.Regions.Add(region);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var state = await LoadEditorStateForOwnedTrip(tripId, userId!, cancellationToken);
+        var dto = state.RegionsById[region.Id];
+        var affected = new EditorAffectedSlicesDto(
+            null,
+            new[] { dto },
+            state.RegionOrder,
+            Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>> { [region.Id] = Array.Empty<Guid>() },
+            Array.Empty<EditorAreaDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>> { [region.Id] = Array.Empty<Guid>() },
+            Array.Empty<EditorSegmentDto>(),
+            null,
+            Array.Empty<EditorTagDto>(),
+            null,
+            null,
+            null);
+
+        return Ok(new EditorMutationResult<EditorRegionDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Updates a normal region for an owned trip.
+    /// </summary>
+    [HttpPut("regions/{regionId:guid}")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateRegion(Guid tripId, Guid regionId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var trip = await _dbContext.Trips
+            .Include(t => t.Regions)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+        if (trip == null)
+        {
+            return NotFound();
+        }
+
+        var region = trip.Regions.FirstOrDefault(r => r.Id == regionId);
+        if (region == null)
+        {
+            return NotFound();
+        }
+
+        if (IsShadowRegion(region))
+        {
+            return ForbiddenProblem("The shadow region cannot be updated.");
+        }
+
+        var request = await ParseJsonBody(cancellationToken);
+        if (request == null)
+        {
+            return ValidationError(new Dictionary<string, string[]> { ["request"] = new[] { "Region save request must be valid JSON." } });
+        }
+
+        if (!EditorRegionRequestParser.TryParseSave(request.Value, out var update, out var errors))
+        {
+            return ValidationError(errors);
+        }
+
+        region.Name = update.Name.Trim();
+        region.Notes = update.NotesHtml ?? string.Empty;
+        region.CoverImageUrl = NormalizeOptionalUrl(update.CoverImage?.RawUrl);
+        region.Center = ToPoint(update.Center);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var dto = EditorTripStateMapper.ToRegion(region);
+        var affected = new EditorAffectedSlicesDto(
+            null,
+            new[] { dto },
+            null,
+            Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorAreaDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorSegmentDto>(),
+            null,
+            Array.Empty<EditorTagDto>(),
+            null,
+            null,
+            null);
+
+        return Ok(new EditorMutationResult<EditorRegionDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Deletes a normal region and returns authoritative deleted IDs and affected slices.
+    /// </summary>
+    [HttpDelete("regions/{regionId:guid}")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteRegion(Guid tripId, Guid regionId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var trip = await _dbContext.Trips
+            .Include(t => t.Regions).ThenInclude(r => r.Places)
+            .Include(t => t.Regions).ThenInclude(r => r.Areas)
+            .Include(t => t.Segments)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+        if (trip == null)
+        {
+            return NotFound();
+        }
+
+        var region = trip.Regions.FirstOrDefault(r => r.Id == regionId);
+        if (region == null)
+        {
+            return NotFound();
+        }
+
+        if (IsShadowRegion(region))
+        {
+            return ForbiddenProblem("The shadow region cannot be deleted.");
+        }
+
+        var deletedPlaceIds = region.Places.OrderBy(p => p.DisplayOrder).ThenBy(p => p.Id).Select(p => p.Id).ToList();
+        var deletedAreaIds = region.Areas.OrderBy(a => a.DisplayOrder).ThenBy(a => a.Id).Select(a => a.Id).ToList();
+        var deletedSegmentIds = trip.Segments
+            .Where(s => (s.FromPlaceId.HasValue && deletedPlaceIds.Contains(s.FromPlaceId.Value))
+                || (s.ToPlaceId.HasValue && deletedPlaceIds.Contains(s.ToPlaceId.Value)))
+            .OrderBy(s => s.DisplayOrder)
+            .ThenBy(s => s.Id)
+            .Select(s => s.Id)
+            .ToList();
+
+        var deletedSegments = trip.Segments.Where(s => deletedSegmentIds.Contains(s.Id)).ToList();
+        _dbContext.Segments.RemoveRange(deletedSegments);
+        _dbContext.Areas.RemoveRange(region.Areas);
+        _dbContext.Places.RemoveRange(region.Places);
+        _dbContext.Regions.Remove(region);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await NormalizeRegionOrders(tripId, userId!, cancellationToken);
+        await NormalizeSegmentOrders(tripId, userId!, cancellationToken);
+
+        var state = await LoadEditorStateForOwnedTrip(tripId, userId!, cancellationToken);
+        var affected = new EditorAffectedSlicesDto(
+            null,
+            Array.Empty<EditorRegionDto>(),
+            state.RegionOrder,
+            Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorAreaDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorSegmentDto>(),
+            state.SegmentOrder,
+            Array.Empty<EditorTagDto>(),
+            null,
+            state.VisitProgress,
+            null);
+        var deletedIds = new EditorDeletedIdsDto(
+            new[] { regionId },
+            deletedPlaceIds,
+            deletedAreaIds,
+            deletedSegmentIds,
+            Array.Empty<string>());
+
+        return Ok(new EditorMutationResult<EditorRegionDto?>(true, null, affected, deletedIds, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Persists the complete desired order for normal regions.
+    /// </summary>
+    [HttpPut("regions/order")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> OrderRegions(Guid tripId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var trip = await _dbContext.Trips
+            .Include(t => t.Regions)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+        if (trip == null)
+        {
+            return NotFound();
+        }
+
+        var request = await ParseJsonBody(cancellationToken);
+        if (request == null)
+        {
+            return ValidationError(new Dictionary<string, string[]> { ["request"] = new[] { "Region order request must be valid JSON." } });
+        }
+
+        if (!EditorRegionRequestParser.TryParseOrder(request.Value, out var orderRequest, out var errors))
+        {
+            return ValidationError(errors);
+        }
+
+        var shadow = trip.Regions.FirstOrDefault(IsShadowRegion);
+        if (shadow != null && orderRequest.RegionIds.Contains(shadow.Id))
+        {
+            return ForbiddenProblem("The shadow region cannot be reordered.");
+        }
+
+        var normalRegions = trip.Regions.Where(r => !IsShadowRegion(r)).OrderBy(r => r.DisplayOrder).ThenBy(r => r.Name).ToList();
+        var normalIds = normalRegions.Select(r => r.Id).ToList();
+        if (orderRequest.RegionIds.Count != normalIds.Count
+            || orderRequest.RegionIds.Distinct().Count() != orderRequest.RegionIds.Count
+            || orderRequest.RegionIds.Any(id => !normalIds.Contains(id)))
+        {
+            return ValidationError(new Dictionary<string, string[]>
+            {
+                ["regionIds"] = new[] { "Region IDs must include every normal region in this trip exactly once." }
+            });
+        }
+
+        if (shadow != null)
+        {
+            shadow.DisplayOrder = 0;
+        }
+
+        var byId = normalRegions.ToDictionary(r => r.Id);
+        for (var i = 0; i < orderRequest.RegionIds.Count; i++)
+        {
+            byId[orderRequest.RegionIds[i]].DisplayOrder = i + 1;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var state = await LoadEditorStateForOwnedTrip(tripId, userId!, cancellationToken);
+        var updatedRegions = orderRequest.RegionIds.Select(id => state.RegionsById[id]).ToList();
+        var affected = new EditorAffectedSlicesDto(
+            null,
+            updatedRegions,
+            state.RegionOrder,
+            Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorAreaDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorSegmentDto>(),
+            null,
+            Array.Empty<EditorTagDto>(),
+            null,
+            null,
+            null);
+        var data = new EditorRegionOrderResult(state.RegionOrder);
+
+        return Ok(new EditorMutationResult<EditorRegionOrderResult>(true, data, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
     private EditorOptionsDto BuildOptions()
     {
         var colors = _iconColorProvider.GetAvailableColors();
@@ -229,6 +531,99 @@ public sealed class TripEditorController : ControllerBase
 
     private string? GenerateProgressPublicTripUrl(Guid tripId) =>
         Url.Action("View", "TripViewer", new { area = "Public", id = tripId, progress = 1 }, Request.Scheme);
+
+    private IActionResult? RequireEditorUser(out string? userId)
+    {
+        userId = User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrWhiteSpace(userId) || User?.Identity?.IsAuthenticated != true)
+        {
+            return Unauthorized();
+        }
+
+        if (User?.IsInRole("User") != true)
+        {
+            return StatusCode(StatusCodes.Status403Forbidden);
+        }
+
+        return null;
+    }
+
+    private async Task<EditorTripStateDto> LoadEditorStateForOwnedTrip(Guid tripId, string userId, CancellationToken cancellationToken)
+    {
+        var trip = await _dbContext.Trips
+            .AsNoTracking()
+            .Include(t => t.Regions).ThenInclude(r => r.Places)
+            .Include(t => t.Regions).ThenInclude(r => r.Areas)
+            .Include(t => t.Segments)
+            .Include(t => t.Tags)
+            .SingleAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+
+        var placeIds = trip.Regions.SelectMany(r => r.Places).Select(p => p.Id).ToArray();
+        var visits = await _dbContext.PlaceVisitEvents
+            .AsNoTracking()
+            .Where(v => v.UserId == userId && v.PlaceId != null && placeIds.Contains(v.PlaceId.Value))
+            .ToListAsync(cancellationToken);
+        var visitsByPlaceId = visits
+            .GroupBy(v => v.PlaceId!.Value)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<PlaceVisitEvent>)g.ToList());
+
+        return EditorTripStateMapper.ToEditorState(
+            trip,
+            visitsByPlaceId,
+            BuildOptions(),
+            trip.IsPublic ? GeneratePublicTripUrl(trip.Id) : null,
+            trip.IsPublic && trip.ShareProgressEnabled ? GenerateProgressPublicTripUrl(trip.Id) : null);
+    }
+
+    private async Task NormalizeRegionOrders(Guid tripId, string userId, CancellationToken cancellationToken)
+    {
+        var regions = await _dbContext.Regions
+            .Where(r => r.TripId == tripId && r.UserId == userId)
+            .OrderBy(r => r.DisplayOrder)
+            .ThenBy(r => r.Name)
+            .ToListAsync(cancellationToken);
+        var shadow = regions.FirstOrDefault(IsShadowRegion);
+        if (shadow != null)
+        {
+            shadow.DisplayOrder = 0;
+        }
+
+        var order = 1;
+        foreach (var region in regions.Where(r => !IsShadowRegion(r)))
+        {
+            region.DisplayOrder = order++;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task NormalizeSegmentOrders(Guid tripId, string userId, CancellationToken cancellationToken)
+    {
+        var segments = await _dbContext.Segments
+            .Where(s => s.TripId == tripId && s.UserId == userId)
+            .OrderBy(s => s.DisplayOrder)
+            .ThenBy(s => s.Id)
+            .ToListAsync(cancellationToken);
+        for (var i = 0; i < segments.Count; i++)
+        {
+            segments[i].DisplayOrder = i;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task<JsonElement?> ParseJsonBody(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var document = await JsonDocument.ParseAsync(Request.Body, cancellationToken: cancellationToken);
+            return document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
 
     private static ObjectResult InvalidAreaGeometryProblem(EditorInvalidAreaGeometryException exception)
     {
@@ -274,6 +669,30 @@ public sealed class TripEditorController : ControllerBase
 
     private static string? NormalizeOptionalUrl(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static Point? ToPoint(EditorCoordinateDto? coordinate) =>
+        coordinate == null ? null : new Point(coordinate.Longitude, coordinate.Latitude) { SRID = 4326 };
+
+    private static bool IsShadowRegion(Region region) =>
+        region.DisplayOrder == 0
+        && string.Equals(region.Name, EditorRegionRequestParser.ShadowRegionName, StringComparison.Ordinal);
+
+    private static IActionResult ForbiddenProblem(string detail)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = StatusCodes.Status403Forbidden,
+            Type = "https://wayfarer/errors/forbidden",
+            Title = "Forbidden.",
+            Detail = detail
+        };
+
+        return new ObjectResult(problem)
+        {
+            StatusCode = StatusCodes.Status403Forbidden,
+            ContentTypes = { "application/problem+json" }
+        };
+    }
 
     private static IActionResult ValidationError(Dictionary<string, string[]> errors)
     {

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { loadEditorState } from './api/tripEditorApi';
 import TripSidebar from './components/TripSidebar.vue';
 import { createTripEditorMap } from './map/leafletAdapter';
-import type { BootstrapConfig, EditorTripMetadata, EditorTripState } from './types';
+import type { BootstrapConfig, EditorMutationResult, EditorTripMetadata, EditorTripState } from './types';
 
 const props = defineProps<{ config: BootstrapConfig }>();
 
@@ -43,6 +43,83 @@ const applyMetadata = (metadata: EditorTripMetadata): void => {
   state.value = { ...state.value, metadata };
   mapAdapter?.render(state.value);
 };
+
+/// Applies mutation affected slices and authoritative deleted IDs to normalized editor state.
+const applyMutation = (result: EditorMutationResult<unknown>): void => {
+  if (!state.value) {
+    return;
+  }
+
+  const next: EditorTripState = {
+    ...state.value,
+    metadata: result.affected.metadata ?? state.value.metadata,
+    regionsById: { ...state.value.regionsById },
+    regionOrder: result.affected.regionOrder ?? [...state.value.regionOrder],
+    placesById: { ...state.value.placesById },
+    placeOrderByRegionId: { ...state.value.placeOrderByRegionId },
+    areasById: { ...state.value.areasById },
+    areaOrderByRegionId: { ...state.value.areaOrderByRegionId },
+    segmentsById: { ...state.value.segmentsById },
+    segmentOrder: result.affected.segmentOrder ?? [...state.value.segmentOrder],
+    tagsBySlug: { ...state.value.tagsBySlug },
+    tagOrder: result.affected.tagOrder ?? [...state.value.tagOrder],
+    visitProgress: result.affected.visitProgress ?? state.value.visitProgress,
+    options: result.affected.options ?? state.value.options
+  };
+
+  result.deletedIds.regions.forEach(id => {
+    delete next.regionsById[id];
+    delete next.placeOrderByRegionId[id];
+    delete next.areaOrderByRegionId[id];
+  });
+  result.deletedIds.places.forEach(id => {
+    delete next.placesById[id];
+  });
+  result.deletedIds.areas.forEach(id => {
+    delete next.areasById[id];
+  });
+  result.deletedIds.segments.forEach(id => {
+    delete next.segmentsById[id];
+  });
+  result.deletedIds.tags.forEach(slug => {
+    delete next.tagsBySlug[slug];
+  });
+
+  result.affected.regions.forEach(region => {
+    next.regionsById[region.id] = region;
+  });
+  result.affected.places.forEach(place => {
+    next.placesById[place.id] = place;
+  });
+  result.affected.areas.forEach(area => {
+    next.areasById[area.id] = area;
+  });
+  result.affected.segments.forEach(segment => {
+    next.segmentsById[segment.id] = segment;
+  });
+  result.affected.tags.forEach(tag => {
+    next.tagsBySlug[tag.slug] = tag;
+  });
+  Object.entries(result.affected.placeOrdersByRegionId).forEach(([regionId, order]) => {
+    next.placeOrderByRegionId[regionId] = order;
+  });
+  Object.entries(result.affected.areaOrdersByRegionId).forEach(([regionId, order]) => {
+    next.areaOrderByRegionId[regionId] = order;
+  });
+
+  next.regionOrder = next.regionOrder.filter(id => next.regionsById[id]);
+  next.segmentOrder = next.segmentOrder.filter(id => next.segmentsById[id]);
+  next.tagOrder = next.tagOrder.filter(slug => next.tagsBySlug[slug]);
+  Object.keys(next.placeOrderByRegionId).forEach(regionId => {
+    next.placeOrderByRegionId[regionId] = next.placeOrderByRegionId[regionId].filter(id => next.placesById[id]);
+  });
+  Object.keys(next.areaOrderByRegionId).forEach(regionId => {
+    next.areaOrderByRegionId[regionId] = next.areaOrderByRegionId[regionId].filter(id => next.areasById[id]);
+  });
+
+  state.value = next;
+  mapAdapter?.render(next);
+};
 </script>
 
 <template>
@@ -64,6 +141,7 @@ const applyMetadata = (metadata: EditorTripMetadata): void => {
         :antiforgery-token="props.config.antiforgeryToken"
         :trip-index-url="props.config.tripIndexUrl"
         @metadata-saved="applyMetadata"
+        @mutation-applied="applyMutation"
       />
       <main class="trip-editor-map-shell">
         <header class="trip-editor-toolbar">

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -10,6 +10,7 @@ const props = defineProps<{ config: BootstrapConfig }>();
 const state = ref<EditorTripState | null>(null);
 const error = ref<string | null>(null);
 const isLoading = ref(true);
+const hasRegionDraftChanges = ref(false);
 const mapElement = ref<HTMLElement | null>(null);
 let mapAdapter: ReturnType<typeof createTripEditorMap> | null = null;
 
@@ -42,6 +43,11 @@ const applyMetadata = (metadata: EditorTripMetadata): void => {
 
   state.value = { ...state.value, metadata };
   mapAdapter?.render(state.value);
+};
+
+/// Tracks region draft changes that live inside the sidebar child component.
+const setRegionDraftChanges = (isDirty: boolean): void => {
+  hasRegionDraftChanges.value = isDirty;
 };
 
 /// Applies mutation affected slices and authoritative deleted IDs to normalized editor state.
@@ -140,8 +146,10 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
         :editor-endpoint="props.config.editorEndpoint"
         :antiforgery-token="props.config.antiforgeryToken"
         :trip-index-url="props.config.tripIndexUrl"
+        :has-region-draft-changes="hasRegionDraftChanges"
         @metadata-saved="applyMetadata"
         @mutation-applied="applyMutation"
+        @region-draft-dirty-changed="setRegionDraftChanges"
       />
       <main class="trip-editor-map-shell">
         <header class="trip-editor-toolbar">

--- a/ClientApps/trip-editor/src/api/tripEditorApi.ts
+++ b/ClientApps/trip-editor/src/api/tripEditorApi.ts
@@ -1,5 +1,9 @@
 import type {
   EditorMutationResult,
+  EditorRegion,
+  EditorRegionOrderRequest,
+  EditorRegionOrderResult,
+  EditorRegionSaveRequest,
   EditorTripMetadata,
   EditorTripMetadataUpdateRequest,
   EditorTripState,
@@ -54,4 +58,67 @@ export const patchMetadata = async (
   }
 
   return (await response.json()) as EditorMutationResult<EditorTripMetadata>;
+};
+
+/// Creates a region through the same-origin editor API.
+export const createRegion = async (
+  endpoint: string,
+  antiforgeryToken: string,
+  request: EditorRegionSaveRequest
+): Promise<EditorMutationResult<EditorRegion>> => sendMutation(`${endpoint}/regions`, 'POST', antiforgeryToken, request, 'region create');
+
+/// Updates a region through the same-origin editor API.
+export const updateRegion = async (
+  endpoint: string,
+  regionId: string,
+  antiforgeryToken: string,
+  request: EditorRegionSaveRequest
+): Promise<EditorMutationResult<EditorRegion>> => sendMutation(`${endpoint}/regions/${regionId}`, 'PUT', antiforgeryToken, request, 'region update');
+
+/// Deletes a region through the same-origin editor API.
+export const deleteRegion = async (
+  endpoint: string,
+  regionId: string,
+  antiforgeryToken: string
+): Promise<EditorMutationResult<EditorRegion | null>> => sendMutation(`${endpoint}/regions/${regionId}`, 'DELETE', antiforgeryToken, null, 'region delete');
+
+/// Persists the complete normal-region order through the same-origin editor API.
+export const orderRegions = async (
+  endpoint: string,
+  antiforgeryToken: string,
+  request: EditorRegionOrderRequest
+): Promise<EditorMutationResult<EditorRegionOrderResult>> => sendMutation(`${endpoint}/regions/order`, 'PUT', antiforgeryToken, request, 'region order');
+
+const sendMutation = async <TData>(
+  url: string,
+  method: string,
+  antiforgeryToken: string,
+  request: unknown,
+  label: string
+): Promise<EditorMutationResult<TData>> => {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    RequestVerificationToken: antiforgeryToken
+  };
+  const init: RequestInit = {
+    method,
+    headers,
+    credentials: 'same-origin'
+  };
+
+  if (request !== null) {
+    headers['Content-Type'] = 'application/json';
+    init.body = JSON.stringify(request);
+  }
+
+  const response = await fetch(url, init);
+  if (response.status === 400) {
+    throw new EditorValidationError((await response.json()) as ValidationProblemDetails);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Trip Editor ${label} returned ${response.status}`);
+  }
+
+  return (await response.json()) as EditorMutationResult<TData>;
 };

--- a/ClientApps/trip-editor/src/components/MetadataEditor.vue
+++ b/ClientApps/trip-editor/src/components/MetadataEditor.vue
@@ -76,6 +76,14 @@ const resetDraft = (): void => {
   warnings.value = [];
 };
 
+const saveAndExit = async (): Promise<void> => {
+  if (hasUnsavedNonMetadataEditorChanges() && !window.confirm('Discard unsaved trip editor changes and return to Trips?')) {
+    return;
+  }
+
+  await save(true);
+};
+
 const save = async (exitAfterSave: boolean): Promise<void> => {
   isSaving.value = true;
   savedExitInProgress.value = false;
@@ -130,6 +138,11 @@ function confirmUnload(event: BeforeUnloadEvent): void {
 /// Combines metadata changes with the active region draft dirty state owned by RegionManager.
 function hasUnsavedEditorChanges(): boolean {
   return isDirty.value || props.hasRegionDraftChanges;
+}
+
+/// Tracks editor-owned drafts that Save & Exit cannot persist through the metadata endpoint.
+function hasUnsavedNonMetadataEditorChanges(): boolean {
+  return props.hasRegionDraftChanges;
 }
 
 function toDraft(metadata: EditorTripMetadata): MetadataDraft {
@@ -228,7 +241,7 @@ const fieldErrors = (key: string): string[] => validationErrors.value[key] ?? []
 
     <div class="trip-editor-actions">
       <button type="button" class="btn btn-primary btn-sm" :disabled="isSaving" @click="save(false)">Save &amp; Continue</button>
-      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="save(true)">Save &amp; Exit</button>
+      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="saveAndExit">Save &amp; Exit</button>
       <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="isSaving || !isDirty" @click="resetDraft">Cancel / Reset</button>
       <button type="button" class="btn btn-link btn-sm" :disabled="isSaving" @click="backToTrips">Back to Trips</button>
     </div>

--- a/ClientApps/trip-editor/src/components/MetadataEditor.vue
+++ b/ClientApps/trip-editor/src/components/MetadataEditor.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
   editorEndpoint: string;
   antiforgeryToken: string;
   tripIndexUrl: string;
+  hasRegionDraftChanges: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -108,7 +109,7 @@ const save = async (exitAfterSave: boolean): Promise<void> => {
 };
 
 const backToTrips = (): void => {
-  if (!isDirty.value || window.confirm('Discard unsaved metadata changes and return to Trips?')) {
+  if (!hasUnsavedEditorChanges() || window.confirm('Discard unsaved trip editor changes and return to Trips?')) {
     window.location.assign(props.tripIndexUrl);
   }
 };
@@ -118,12 +119,17 @@ function confirmUnload(event: BeforeUnloadEvent): void {
     return;
   }
 
-  if (!isDirty.value) {
+  if (!hasUnsavedEditorChanges()) {
     return;
   }
 
   event.preventDefault();
   event.returnValue = '';
+}
+
+/// Combines metadata changes with the active region draft dirty state owned by RegionManager.
+function hasUnsavedEditorChanges(): boolean {
+  return isDirty.value || props.hasRegionDraftChanges;
 }
 
 function toDraft(metadata: EditorTripMetadata): MetadataDraft {

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -27,8 +27,8 @@ type RegionDraft = {
   name: string;
   notesHtml: string;
   coverImageRawUrl: string;
-  centerLatitude: string;
-  centerLongitude: string;
+  centerLatitude: string | number;
+  centerLongitude: string | number;
 };
 
 const fields = ['name', 'notesHtml', 'coverImage.rawUrl', 'center.latitude', 'center.longitude'];
@@ -248,9 +248,9 @@ function toDraft(region: EditorRegion | null): RegionDraft {
 }
 
 function buildRequest(value: RegionDraft): EditorRegionSaveRequest {
-  const latitude = value.centerLatitude.trim();
-  const longitude = value.centerLongitude.trim();
-  const coverImageRawUrl = value.coverImageRawUrl.trim();
+  const latitude = draftText(value.centerLatitude);
+  const longitude = draftText(value.centerLongitude);
+  const coverImageRawUrl = draftText(value.coverImageRawUrl);
   const hasPartialCenter = Boolean(latitude || longitude);
 
   return {
@@ -259,6 +259,11 @@ function buildRequest(value: RegionDraft): EditorRegionSaveRequest {
     coverImage: coverImageRawUrl ? { rawUrl: coverImageRawUrl } : null,
     center: hasPartialCenter ? { latitude: latitude ? Number(latitude) : Number.NaN, longitude: longitude ? Number(longitude) : Number.NaN } : null
   };
+}
+
+/// Normalizes Vue number-input values before validation and API serialization.
+function draftText(value: string | number): string {
+  return String(value ?? '').trim();
 }
 
 function confirmDiscard(): boolean {

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   mutationApplied: [result: EditorMutationResult<unknown>];
+  dirtyStateChanged: [isDirty: boolean];
 }>();
 
 type RegionDraft = {
@@ -33,6 +34,7 @@ type RegionDraft = {
 
 const fields = ['name', 'notesHtml', 'coverImage.rawUrl', 'center.latitude', 'center.longitude'];
 const regionList = ref<HTMLElement | null>(null);
+const regionListKey = ref(0);
 const draft = reactive<RegionDraft>(emptyDraft());
 const isSaving = ref(false);
 const isOrdering = ref(false);
@@ -40,6 +42,7 @@ const saveError = ref<string | null>(null);
 const validationErrors = ref<Record<string, string[]>>({});
 const lastSavedAt = ref<string | null>(null);
 let sortable: { destroy: () => void } | null = null;
+let reorderSnapshotIds: string[] | null = null;
 
 const orderedRegions = computed(() =>
   props.state.regionOrder
@@ -83,6 +86,12 @@ watch(
   }
 );
 
+watch(
+  isDirty,
+  value => emit('dirtyStateChanged', value),
+  { immediate: true }
+);
+
 onMounted(() => {
   attachSortable();
   window.addEventListener('beforeunload', confirmUnload);
@@ -90,6 +99,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   sortable?.destroy();
+  emit('dirtyStateChanged', false);
   window.removeEventListener('beforeunload', confirmUnload);
 });
 
@@ -150,6 +160,10 @@ const deleteDraftRegion = async (): Promise<void> => {
     return;
   }
 
+  if (!confirmDiscard('Discard unsaved region draft changes before deleting?')) {
+    return;
+  }
+
   if (!window.confirm('Delete this region, its child places and areas, and any segments connected to deleted places?')) {
     return;
   }
@@ -168,20 +182,29 @@ const deleteDraftRegion = async (): Promise<void> => {
   }
 };
 
+const onSortStart = (): void => {
+  reorderSnapshotIds = [...normalRegionIds.value];
+};
+
 const onSortEnd = async (): Promise<void> => {
   if (!regionList.value) {
     return;
   }
 
+  const previousIds = reorderSnapshotIds ?? [...normalRegionIds.value];
+  reorderSnapshotIds = null;
   const ids = Array.from(regionList.value.querySelectorAll<HTMLElement>('[data-region-id][data-reorderable="true"]')).map(element => element.dataset.regionId!);
-  if (ids.join('|') === normalRegionIds.value.join('|')) {
+  if (ids.join('|') === previousIds.join('|')) {
     return;
   }
 
   if (isDirty.value && !window.confirm('Discard unsaved region draft changes before reordering?')) {
-    await nextTick();
-    attachSortable();
+    await restoreRegionOrder(previousIds);
     return;
+  }
+
+  if (isDirty.value) {
+    Object.assign(draft, emptyDraft());
   }
 
   isOrdering.value = true;
@@ -193,6 +216,7 @@ const onSortEnd = async (): Promise<void> => {
     lastSavedAt.value = new Intl.DateTimeFormat(undefined, { timeStyle: 'short' }).format(new Date());
   } catch (error) {
     applyError(error, 'Region reorder failed.');
+    await restoreRegionOrder(previousIds);
   } finally {
     isOrdering.value = false;
   }
@@ -212,8 +236,16 @@ function attachSortable(): void {
     animation: 150,
     draggable: '.trip-editor-region-card--normal',
     handle: '.trip-editor-drag-handle',
+    onStart: onSortStart,
     onEnd: onSortEnd
   });
+}
+
+/// Rebuilds the Sortable-mutated list from persisted Vue state after canceled or failed reorder.
+async function restoreRegionOrder(_previousIds: string[]): Promise<void> {
+  regionListKey.value += 1;
+  await nextTick();
+  attachSortable();
 }
 
 function orderedPlaces(regionId: string): EditorPlace[] {
@@ -266,8 +298,8 @@ function draftText(value: string | number): string {
   return String(value ?? '').trim();
 }
 
-function confirmDiscard(): boolean {
-  return !isDirty.value || window.confirm('Discard unsaved region changes?');
+function confirmDiscard(message = 'Discard unsaved region changes?'): boolean {
+  return !isDirty.value || window.confirm(message);
 }
 
 function resetFeedback(): void {
@@ -306,7 +338,7 @@ const fieldErrors = (key: string): string[] => validationErrors.value[key] ?? []
 
     <div v-if="saveError" class="trip-editor-form-error" role="alert">{{ saveError }}</div>
 
-    <div ref="regionList" class="trip-editor-region-list">
+    <div :key="regionListKey" ref="regionList" class="trip-editor-region-list">
       <article
         v-for="region in orderedRegions"
         :key="region.id"

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -1,0 +1,396 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
+import { createRegion, deleteRegion, orderRegions, updateRegion } from '../api/tripEditorApi';
+import { EditorValidationError } from '../api/tripEditorApi';
+import type { EditorArea, EditorMutationResult, EditorPlace, EditorRegion, EditorRegionSaveRequest, EditorTripState } from '../types';
+
+declare global {
+  interface Window {
+    Sortable?: {
+      create: (element: HTMLElement, options: Record<string, unknown>) => { destroy: () => void };
+    };
+  }
+}
+
+const props = defineProps<{
+  state: EditorTripState;
+  editorEndpoint: string;
+  antiforgeryToken: string;
+}>();
+
+const emit = defineEmits<{
+  mutationApplied: [result: EditorMutationResult<unknown>];
+}>();
+
+type RegionDraft = {
+  id: string | null;
+  name: string;
+  notesHtml: string;
+  coverImageRawUrl: string;
+  centerLatitude: string;
+  centerLongitude: string;
+};
+
+const fields = ['name', 'notesHtml', 'coverImage.rawUrl', 'center.latitude', 'center.longitude'];
+const regionList = ref<HTMLElement | null>(null);
+const draft = reactive<RegionDraft>(emptyDraft());
+const isSaving = ref(false);
+const isOrdering = ref(false);
+const saveError = ref<string | null>(null);
+const validationErrors = ref<Record<string, string[]>>({});
+const lastSavedAt = ref<string | null>(null);
+let sortable: { destroy: () => void } | null = null;
+
+const orderedRegions = computed(() =>
+  props.state.regionOrder
+    .map(id => props.state.regionsById[id])
+    .filter(region => region && (!region.isShadow || hasRegionChildren(region))) as EditorRegion[]
+);
+const normalRegionIds = computed(() => orderedRegions.value.filter(region => !region.isShadow).map(region => region.id));
+const activeRegion = computed(() => (draft.id ? props.state.regionsById[draft.id] ?? null : null));
+const isDraftOpen = computed(() => draft.id !== null || Boolean(draft.name || draft.notesHtml || draft.coverImageRawUrl || draft.centerLatitude || draft.centerLongitude));
+const isDirty = computed(() => JSON.stringify(buildRequest(draft)) !== JSON.stringify(buildRequest(toDraft(activeRegion.value))));
+const statusText = computed(() => {
+  if (isSaving.value) {
+    return 'Saving...';
+  }
+
+  if (isOrdering.value) {
+    return 'Saving order...';
+  }
+
+  if (saveError.value) {
+    return 'Save failed';
+  }
+
+  if (isDirty.value) {
+    return 'Unsaved changes';
+  }
+
+  return lastSavedAt.value ? `Saved ${lastSavedAt.value}` : 'Saved';
+});
+const formSummaryErrors = computed(() =>
+  Object.entries(validationErrors.value)
+    .filter(([key]) => !fields.includes(key))
+    .flatMap(([, messages]) => messages)
+);
+
+watch(
+  () => props.state.regionOrder.join('|'),
+  async () => {
+    await nextTick();
+    attachSortable();
+  }
+);
+
+onMounted(() => {
+  attachSortable();
+  window.addEventListener('beforeunload', confirmUnload);
+});
+
+onUnmounted(() => {
+  sortable?.destroy();
+  window.removeEventListener('beforeunload', confirmUnload);
+});
+
+const openCreate = (): void => {
+  if (!confirmDiscard()) {
+    return;
+  }
+
+  Object.assign(draft, emptyDraft());
+  draft.name = 'New Region';
+  resetFeedback();
+};
+
+const openEdit = (region: EditorRegion): void => {
+  if (!region.capabilities.canEdit || !confirmDiscard()) {
+    return;
+  }
+
+  Object.assign(draft, toDraft(region));
+  resetFeedback();
+};
+
+const resetDraft = (): void => {
+  Object.assign(draft, toDraft(activeRegion.value));
+  resetFeedback();
+};
+
+const cancelDraft = (): void => {
+  if (!confirmDiscard()) {
+    return;
+  }
+
+  Object.assign(draft, emptyDraft());
+  resetFeedback();
+};
+
+const saveDraft = async (): Promise<void> => {
+  isSaving.value = true;
+  resetFeedback();
+
+  try {
+    const request = buildRequest(draft);
+    const result = draft.id
+      ? await updateRegion(props.editorEndpoint, draft.id, props.antiforgeryToken, request)
+      : await createRegion(props.editorEndpoint, props.antiforgeryToken, request);
+    emit('mutationApplied', result as EditorMutationResult<unknown>);
+    Object.assign(draft, toDraft(result.data));
+    lastSavedAt.value = new Intl.DateTimeFormat(undefined, { timeStyle: 'short' }).format(new Date());
+  } catch (error) {
+    applyError(error, 'Region save failed.');
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const deleteDraftRegion = async (): Promise<void> => {
+  if (!activeRegion.value || !activeRegion.value.capabilities.canDelete) {
+    return;
+  }
+
+  if (!window.confirm('Delete this region, its child places and areas, and any segments connected to deleted places?')) {
+    return;
+  }
+
+  isSaving.value = true;
+  resetFeedback();
+  try {
+    const result = await deleteRegion(props.editorEndpoint, activeRegion.value.id, props.antiforgeryToken);
+    emit('mutationApplied', result as EditorMutationResult<unknown>);
+    Object.assign(draft, emptyDraft());
+    lastSavedAt.value = new Intl.DateTimeFormat(undefined, { timeStyle: 'short' }).format(new Date());
+  } catch (error) {
+    applyError(error, 'Region delete failed.');
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const onSortEnd = async (): Promise<void> => {
+  if (!regionList.value) {
+    return;
+  }
+
+  const ids = Array.from(regionList.value.querySelectorAll<HTMLElement>('[data-region-id][data-reorderable="true"]')).map(element => element.dataset.regionId!);
+  if (ids.join('|') === normalRegionIds.value.join('|')) {
+    return;
+  }
+
+  if (isDirty.value && !window.confirm('Discard unsaved region draft changes before reordering?')) {
+    await nextTick();
+    attachSortable();
+    return;
+  }
+
+  isOrdering.value = true;
+  resetFeedback();
+  try {
+    const result = await orderRegions(props.editorEndpoint, props.antiforgeryToken, { regionIds: ids });
+    emit('mutationApplied', result as EditorMutationResult<unknown>);
+    Object.assign(draft, emptyDraft());
+    lastSavedAt.value = new Intl.DateTimeFormat(undefined, { timeStyle: 'short' }).format(new Date());
+  } catch (error) {
+    applyError(error, 'Region reorder failed.');
+  } finally {
+    isOrdering.value = false;
+  }
+};
+
+function attachSortable(): void {
+  sortable?.destroy();
+  sortable = null;
+  if (!regionList.value || !window.Sortable) {
+    if (!window.Sortable) {
+      saveError.value = 'Region reorder is unavailable because SortableJS is not loaded.';
+    }
+    return;
+  }
+
+  sortable = window.Sortable.create(regionList.value, {
+    animation: 150,
+    draggable: '.trip-editor-region-card--normal',
+    handle: '.trip-editor-drag-handle',
+    onEnd: onSortEnd
+  });
+}
+
+function orderedPlaces(regionId: string): EditorPlace[] {
+  return (props.state.placeOrderByRegionId[regionId] ?? []).map(id => props.state.placesById[id]).filter(Boolean) as EditorPlace[];
+}
+
+function orderedAreas(regionId: string): EditorArea[] {
+  return (props.state.areaOrderByRegionId[regionId] ?? []).map(id => props.state.areasById[id]).filter(Boolean) as EditorArea[];
+}
+
+function hasRegionChildren(region: EditorRegion): boolean {
+  return (props.state.placeOrderByRegionId[region.id]?.length ?? 0) > 0 || (props.state.areaOrderByRegionId[region.id]?.length ?? 0) > 0;
+}
+
+function emptyDraft(): RegionDraft {
+  return { id: null, name: '', notesHtml: '', coverImageRawUrl: '', centerLatitude: '', centerLongitude: '' };
+}
+
+function toDraft(region: EditorRegion | null): RegionDraft {
+  if (!region) {
+    return emptyDraft();
+  }
+
+  return {
+    id: region.id,
+    name: region.name,
+    notesHtml: region.notesHtml,
+    coverImageRawUrl: region.coverImage?.rawUrl ?? '',
+    centerLatitude: region.center ? String(region.center.latitude) : '',
+    centerLongitude: region.center ? String(region.center.longitude) : ''
+  };
+}
+
+function buildRequest(value: RegionDraft): EditorRegionSaveRequest {
+  const latitude = value.centerLatitude.trim();
+  const longitude = value.centerLongitude.trim();
+  const coverImageRawUrl = value.coverImageRawUrl.trim();
+  const hasPartialCenter = Boolean(latitude || longitude);
+
+  return {
+    name: value.name,
+    notesHtml: value.notesHtml,
+    coverImage: coverImageRawUrl ? { rawUrl: coverImageRawUrl } : null,
+    center: hasPartialCenter ? { latitude: latitude ? Number(latitude) : Number.NaN, longitude: longitude ? Number(longitude) : Number.NaN } : null
+  };
+}
+
+function confirmDiscard(): boolean {
+  return !isDirty.value || window.confirm('Discard unsaved region changes?');
+}
+
+function resetFeedback(): void {
+  saveError.value = null;
+  validationErrors.value = {};
+}
+
+function applyError(error: unknown, fallback: string): void {
+  if (error instanceof EditorValidationError) {
+    validationErrors.value = error.errors;
+    saveError.value = error.message;
+    return;
+  }
+
+  saveError.value = error instanceof Error ? error.message : fallback;
+}
+
+function confirmUnload(event: BeforeUnloadEvent): void {
+  if (!isDirty.value) {
+    return;
+  }
+
+  event.preventDefault();
+  event.returnValue = '';
+}
+
+const fieldErrors = (key: string): string[] => validationErrors.value[key] ?? [];
+</script>
+
+<template>
+  <section class="trip-editor-panel trip-editor-regions">
+    <div class="trip-editor-panel__line">
+      <h2>Regions &amp; Places</h2>
+      <span class="trip-editor-save-state">{{ statusText }}</span>
+    </div>
+
+    <div v-if="saveError" class="trip-editor-form-error" role="alert">{{ saveError }}</div>
+
+    <div ref="regionList" class="trip-editor-region-list">
+      <article
+        v-for="region in orderedRegions"
+        :key="region.id"
+        class="trip-editor-region-card"
+        :class="{ 'trip-editor-region-card--normal': !region.isShadow, 'trip-editor-region-card--shadow': region.isShadow }"
+        :data-region-id="region.id"
+        :data-reorderable="!region.isShadow"
+      >
+        <header class="trip-editor-region-card__header">
+          <button
+            v-if="!region.isShadow"
+            type="button"
+            class="trip-editor-icon-button trip-editor-drag-handle"
+            title="Drag to reorder region"
+            aria-label="Drag to reorder region"
+          >
+            <span aria-hidden="true">::</span>
+          </button>
+          <div>
+            <h3>{{ region.name }}</h3>
+            <small v-if="region.isShadow">Shadow region</small>
+          </div>
+          <button v-if="!region.isShadow" type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="openEdit(region)">Edit</button>
+        </header>
+
+        <ul>
+          <li v-for="place in orderedPlaces(region.id)" :key="place.id">
+            <span>{{ place.name }}</span>
+            <small v-if="place.visitSummary.isVisited">{{ place.visitSummary.visitCount }} visit(s)</small>
+          </li>
+          <li v-for="area in orderedAreas(region.id)" :key="area.id">
+            <span>{{ area.name }}</span>
+            <small>Area</small>
+          </li>
+        </ul>
+      </article>
+    </div>
+
+    <button type="button" class="btn btn-primary btn-sm trip-editor-add-button" :disabled="isSaving || isOrdering" @click="openCreate">Add Region</button>
+
+    <form v-if="isDraftOpen" class="trip-editor-region-form" @submit.prevent="saveDraft">
+      <div class="trip-editor-panel__line">
+        <h3>{{ draft.id ? 'Edit Region' : 'Add Region' }}</h3>
+        <span class="trip-editor-save-state">{{ statusText }}</span>
+      </div>
+
+      <div v-if="formSummaryErrors.length > 0" class="trip-editor-form-error" role="alert">
+        <p v-for="message in formSummaryErrors" :key="message">{{ message }}</p>
+      </div>
+
+      <label class="trip-editor-field">
+        <span>Name</span>
+        <input v-model="draft.name" type="text" autocomplete="off" />
+        <small v-for="message in fieldErrors('name')" :key="message">{{ message }}</small>
+      </label>
+
+      <label class="trip-editor-field">
+        <span>Notes HTML</span>
+        <textarea v-model="draft.notesHtml" rows="6"></textarea>
+        <small v-for="message in fieldErrors('notesHtml')" :key="message">{{ message }}</small>
+      </label>
+
+      <label class="trip-editor-field">
+        <span>Cover Image URL</span>
+        <input v-model="draft.coverImageRawUrl" type="url" autocomplete="off" />
+        <small v-for="message in fieldErrors('coverImage.rawUrl')" :key="message">{{ message }}</small>
+      </label>
+
+      <div class="trip-editor-grid">
+        <label class="trip-editor-field">
+          <span>Center Latitude</span>
+          <input v-model="draft.centerLatitude" type="number" step="any" />
+          <small v-for="message in fieldErrors('center.latitude')" :key="message">{{ message }}</small>
+        </label>
+        <label class="trip-editor-field">
+          <span>Center Longitude</span>
+          <input v-model="draft.centerLongitude" type="number" step="any" />
+          <small v-for="message in fieldErrors('center.longitude')" :key="message">{{ message }}</small>
+        </label>
+      </div>
+
+      <div class="trip-editor-actions">
+        <button type="submit" class="btn btn-primary btn-sm" :disabled="isSaving">Save Region</button>
+        <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="isSaving || !isDirty" @click="resetDraft">Reset</button>
+        <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="cancelDraft">Cancel</button>
+        <button v-if="activeRegion?.capabilities.canDelete" type="button" class="btn btn-outline-danger btn-sm" :disabled="isSaving" @click="deleteDraftRegion">
+          Delete
+        </button>
+      </div>
+    </form>
+  </section>
+</template>

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import type { EditorArea, EditorPlace, EditorRegion, EditorSegment, EditorTripState } from '../types';
+import type { EditorMutationResult, EditorSegment, EditorTripState } from '../types';
 import MetadataEditor from './MetadataEditor.vue';
+import RegionManager from './RegionManager.vue';
 
 defineProps<{
   state: EditorTripState;
@@ -11,24 +12,11 @@ defineProps<{
 
 const emit = defineEmits<{
   metadataSaved: [metadata: EditorTripState['metadata']];
+  mutationApplied: [result: EditorMutationResult<unknown>];
 }>();
-
-const orderedRegions = (state: EditorTripState): EditorRegion[] =>
-  state.regionOrder
-    .map(id => state.regionsById[id])
-    .filter(region => region && (!region.isShadow || hasRegionChildren(state, region))) as EditorRegion[];
-
-const orderedPlaces = (state: EditorTripState, regionId: string): EditorPlace[] =>
-  (state.placeOrderByRegionId[regionId] ?? []).map(id => state.placesById[id]).filter(Boolean) as EditorPlace[];
-
-const orderedAreas = (state: EditorTripState, regionId: string): EditorArea[] =>
-  (state.areaOrderByRegionId[regionId] ?? []).map(id => state.areasById[id]).filter(Boolean) as EditorArea[];
 
 const orderedSegments = (state: EditorTripState): EditorSegment[] =>
   state.segmentOrder.map(id => state.segmentsById[id]).filter(Boolean) as EditorSegment[];
-
-const hasRegionChildren = (state: EditorTripState, region: EditorRegion): boolean =>
-  (state.placeOrderByRegionId[region.id]?.length ?? 0) > 0 || (state.areaOrderByRegionId[region.id]?.length ?? 0) > 0;
 
 const segmentLabel = (state: EditorTripState, segment: EditorSegment): string => {
   const from = segment.fromPlaceId ? state.placesById[segment.fromPlaceId]?.name : null;
@@ -73,22 +61,12 @@ const segmentLabel = (state: EditorTripState, segment: EditorSegment): string =>
       </div>
     </section>
 
-    <section class="trip-editor-panel">
-      <h2>Regions & Places</h2>
-      <article v-for="region in orderedRegions(state)" :key="region.id" class="trip-editor-region">
-        <h3>{{ region.name }}</h3>
-        <ul>
-          <li v-for="place in orderedPlaces(state, region.id)" :key="place.id">
-            <span>{{ place.name }}</span>
-            <small v-if="place.visitSummary.isVisited">{{ place.visitSummary.visitCount }} visit(s)</small>
-          </li>
-          <li v-for="area in orderedAreas(state, region.id)" :key="area.id">
-            <span>{{ area.name }}</span>
-            <small>Area</small>
-          </li>
-        </ul>
-      </article>
-    </section>
+    <RegionManager
+      :state="state"
+      :editor-endpoint="editorEndpoint"
+      :antiforgery-token="antiforgeryToken"
+      @mutation-applied="result => emit('mutationApplied', result)"
+    />
 
     <section v-if="state.segmentOrder.length > 0" class="trip-editor-panel">
       <h2>Segments</h2>

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -8,11 +8,13 @@ defineProps<{
   editorEndpoint: string;
   antiforgeryToken: string;
   tripIndexUrl: string;
+  hasRegionDraftChanges: boolean;
 }>();
 
 const emit = defineEmits<{
   metadataSaved: [metadata: EditorTripState['metadata']];
   mutationApplied: [result: EditorMutationResult<unknown>];
+  regionDraftDirtyChanged: [isDirty: boolean];
 }>();
 
 const orderedSegments = (state: EditorTripState): EditorSegment[] =>
@@ -40,6 +42,7 @@ const segmentLabel = (state: EditorTripState, segment: EditorSegment): string =>
       :editor-endpoint="editorEndpoint"
       :antiforgery-token="antiforgeryToken"
       :trip-index-url="tripIndexUrl"
+      :has-region-draft-changes="hasRegionDraftChanges"
       @saved="metadata => emit('metadataSaved', metadata)"
     />
 
@@ -66,6 +69,7 @@ const segmentLabel = (state: EditorTripState, segment: EditorSegment): string =>
       :editor-endpoint="editorEndpoint"
       :antiforgery-token="antiforgeryToken"
       @mutation-applied="result => emit('mutationApplied', result)"
+      @dirty-state-changed="isDirty => emit('regionDraftDirtyChanged', isDirty)"
     />
 
     <section v-if="state.segmentOrder.length > 0" class="trip-editor-panel">

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -72,7 +72,7 @@ body {
 }
 
 .trip-editor-panel__line,
-.trip-editor-region li,
+.trip-editor-region-card li,
 .trip-editor-segments li {
   align-items: center;
   display: flex;
@@ -184,16 +184,72 @@ body {
   gap: 0.4rem;
 }
 
-.trip-editor-region {
+.trip-editor-region-list,
+.trip-editor-region-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.trip-editor-region-card {
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
   margin-bottom: 1rem;
+  padding: 0.65rem;
 }
 
-.trip-editor-region h3 {
+.trip-editor-region-card--shadow {
+  border-style: dashed;
+}
+
+.trip-editor-region-card__header {
+  align-items: center;
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  margin-bottom: 0.5rem;
+}
+
+.trip-editor-region-card__header h3,
+.trip-editor-region-form h3 {
   font-size: 1rem;
-  margin: 0 0 0.5rem;
+  margin: 0;
 }
 
-.trip-editor-region ul,
+.trip-editor-region-card__header small {
+  color: #9ca3af;
+}
+
+.trip-editor-icon-button {
+  align-items: center;
+  background: #0f172a;
+  border: 1px solid #475569;
+  border-radius: 6px;
+  color: #cbd5e1;
+  cursor: grab;
+  display: inline-flex;
+  height: 2rem;
+  justify-content: center;
+  width: 2rem;
+}
+
+.trip-editor-icon-button:active {
+  cursor: grabbing;
+}
+
+.trip-editor-add-button {
+  width: fit-content;
+}
+
+.trip-editor-region-form {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(147, 197, 253, 0.25);
+  border-radius: 6px;
+  margin-top: 0.9rem;
+  padding: 0.75rem;
+}
+
+.trip-editor-region-card ul,
 .trip-editor-segments {
   display: grid;
   gap: 0.4rem;
@@ -202,7 +258,7 @@ body {
   padding: 0;
 }
 
-.trip-editor-region li,
+.trip-editor-region-card li,
 .trip-editor-segments li {
   background: rgba(255, 255, 255, 0.06);
   border-radius: 6px;

--- a/ClientApps/trip-editor/src/types.ts
+++ b/ClientApps/trip-editor/src/types.ts
@@ -167,6 +167,21 @@ export interface EditorTripMetadataUpdateRequest {
   zoom: number | null;
 }
 
+export interface EditorRegionSaveRequest {
+  name: string;
+  notesHtml: string | null;
+  coverImage: { rawUrl: string | null } | null;
+  center: EditorCoordinate | null;
+}
+
+export interface EditorRegionOrderRequest {
+  regionIds: Guid[];
+}
+
+export interface EditorRegionOrderResult {
+  regionOrder: Guid[];
+}
+
 export interface EditorMutationResult<TData> {
   success: true;
   data: TData;

--- a/Models/Dtos/Editor/EditorMutationDtos.cs
+++ b/Models/Dtos/Editor/EditorMutationDtos.cs
@@ -17,6 +17,25 @@ public sealed record EditorTripMetadataUpdateRequest(
 public sealed record EditorImageUpdateRequest(string? RawUrl);
 
 /// <summary>
+/// Complete-draft request for creating or updating a region from the same-origin editor.
+/// </summary>
+public sealed record EditorRegionSaveRequest(
+    string Name,
+    string? NotesHtml,
+    EditorImageUpdateRequest? CoverImage,
+    EditorCoordinateDto? Center);
+
+/// <summary>
+/// Complete desired order for normal editor regions.
+/// </summary>
+public sealed record EditorRegionOrderRequest(IReadOnlyList<Guid> RegionIds);
+
+/// <summary>
+/// Region order data returned by the region order endpoint.
+/// </summary>
+public sealed record EditorRegionOrderResult(IReadOnlyList<Guid> RegionOrder);
+
+/// <summary>
 /// Standard success envelope returned by editor mutation endpoints.
 /// </summary>
 public sealed record EditorMutationResult<TData>(

--- a/Models/Dtos/Editor/EditorRegionRequestParser.cs
+++ b/Models/Dtos/Editor/EditorRegionRequestParser.cs
@@ -1,0 +1,284 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Wayfarer.Models.Dtos.Editor;
+
+/// <summary>
+/// Parses and validates region mutation JSON while preserving ownership-first request handling.
+/// </summary>
+internal static class EditorRegionRequestParser
+{
+    /// <summary>Reserved display name used by the shadow region.</summary>
+    public const string ShadowRegionName = "Unassigned Places";
+
+    private static readonly string[] ServerOwnedFields =
+    {
+        "id",
+        "tripId",
+        "displayOrder",
+        "isShadow",
+        "capabilities"
+    };
+
+    private static readonly Regex DataImageSourceRegex = new(
+        @"<img\b[^>]*?\bsrc\s*=\s*[""']?\s*data:image/",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Attempts to parse a complete-draft region save request.
+    /// </summary>
+    public static bool TryParseSave(
+        JsonElement request,
+        out EditorRegionSaveRequest update,
+        out Dictionary<string, string[]> errors)
+    {
+        errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        update = new EditorRegionSaveRequest(string.Empty, null, null, null);
+
+        if (request.ValueKind != JsonValueKind.Object)
+        {
+            errors["request"] = new[] { "Region save request must be a JSON object." };
+            return false;
+        }
+
+        RejectServerOwnedFields(request, errors);
+
+        var name = ReadRequiredString(request, "name", errors);
+        var notesHtml = ReadRequiredNullableString(request, "notesHtml", errors);
+        var coverImage = ReadRequiredCoverImage(request, errors);
+        var center = ReadRequiredCenter(request, errors);
+
+        ValidateName(name, errors);
+        ValidateCoverImage(coverImage?.RawUrl, errors);
+        ValidateNotesHtml(notesHtml, errors);
+
+        if (errors.Count > 0)
+        {
+            return false;
+        }
+
+        update = new EditorRegionSaveRequest(name!, notesHtml, coverImage, center);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to parse a region order request.
+    /// </summary>
+    public static bool TryParseOrder(
+        JsonElement request,
+        out EditorRegionOrderRequest update,
+        out Dictionary<string, string[]> errors)
+    {
+        errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        update = new EditorRegionOrderRequest(Array.Empty<Guid>());
+
+        if (request.ValueKind != JsonValueKind.Object)
+        {
+            errors["request"] = new[] { "Region order request must be a JSON object." };
+            return false;
+        }
+
+        if (!request.TryGetProperty("regionIds", out var regionIdsProperty))
+        {
+            errors["regionIds"] = new[] { "The field is required." };
+            return false;
+        }
+
+        if (regionIdsProperty.ValueKind != JsonValueKind.Array)
+        {
+            errors["regionIds"] = new[] { "Region IDs must be an array." };
+            return false;
+        }
+
+        var regionIds = new List<Guid>();
+        foreach (var item in regionIdsProperty.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String || !Guid.TryParse(item.GetString(), out var id))
+            {
+                errors["regionIds"] = new[] { "Every region ID must be a GUID string." };
+                return false;
+            }
+
+            regionIds.Add(id);
+        }
+
+        update = new EditorRegionOrderRequest(regionIds);
+        return true;
+    }
+
+    private static void RejectServerOwnedFields(JsonElement request, Dictionary<string, string[]> errors)
+    {
+        foreach (var field in ServerOwnedFields)
+        {
+            if (request.TryGetProperty(field, out _))
+            {
+                errors[field] = new[] { "The field is server-owned and cannot be updated." };
+            }
+        }
+    }
+
+    private static string? ReadRequiredString(JsonElement request, string name, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty(name, out var property))
+        {
+            errors[name] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.String)
+        {
+            errors[name] = new[] { "The field must be a string." };
+            return null;
+        }
+
+        return property.GetString();
+    }
+
+    private static string? ReadRequiredNullableString(JsonElement request, string name, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty(name, out var property))
+        {
+            errors[name] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.String)
+        {
+            errors[name] = new[] { "The field must be a string or null." };
+            return null;
+        }
+
+        return property.GetString();
+    }
+
+    private static EditorImageUpdateRequest? ReadRequiredCoverImage(JsonElement request, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty("coverImage", out var property))
+        {
+            errors["coverImage"] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.Object)
+        {
+            errors["coverImage"] = new[] { "The field must be an object or null." };
+            return null;
+        }
+
+        if (!property.TryGetProperty("rawUrl", out var rawUrlProperty))
+        {
+            errors["coverImage.rawUrl"] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (rawUrlProperty.ValueKind == JsonValueKind.Null)
+        {
+            return new EditorImageUpdateRequest(null);
+        }
+
+        if (rawUrlProperty.ValueKind != JsonValueKind.String)
+        {
+            errors["coverImage.rawUrl"] = new[] { "The field must be a string or null." };
+            return null;
+        }
+
+        return new EditorImageUpdateRequest(rawUrlProperty.GetString());
+    }
+
+    private static EditorCoordinateDto? ReadRequiredCenter(JsonElement request, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty("center", out var property))
+        {
+            errors["center"] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.Object)
+        {
+            errors["center"] = new[] { "The field must be an object or null." };
+            return null;
+        }
+
+        var latitude = ReadRequiredDouble(property, "latitude", "center.latitude", errors);
+        var longitude = ReadRequiredDouble(property, "longitude", "center.longitude", errors);
+        if (latitude is < -90 or > 90)
+        {
+            errors["center.latitude"] = new[] { "Latitude must be between -90 and 90." };
+        }
+
+        if (longitude is < -180 or > 180)
+        {
+            errors["center.longitude"] = new[] { "Longitude must be between -180 and 180." };
+        }
+
+        return latitude.HasValue && longitude.HasValue ? new EditorCoordinateDto(latitude.Value, longitude.Value) : null;
+    }
+
+    private static double? ReadRequiredDouble(JsonElement request, string propertyName, string fieldKey, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty(propertyName, out var property))
+        {
+            errors[fieldKey] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.Number || !property.TryGetDouble(out var value) || double.IsNaN(value) || double.IsInfinity(value))
+        {
+            errors[fieldKey] = new[] { "The field must be a finite number." };
+            return null;
+        }
+
+        return value;
+    }
+
+    private static void ValidateName(string? name, Dictionary<string, string[]> errors)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            errors["name"] = new[] { "Name is required." };
+            return;
+        }
+
+        if (string.Equals(name.Trim(), ShadowRegionName, StringComparison.OrdinalIgnoreCase))
+        {
+            errors["name"] = new[] { "The reserved shadow region name cannot be used." };
+        }
+    }
+
+    private static void ValidateCoverImage(string? rawUrl, Dictionary<string, string[]> errors)
+    {
+        if (string.IsNullOrWhiteSpace(rawUrl))
+        {
+            return;
+        }
+
+        if (!Uri.TryCreate(rawUrl.Trim(), UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            errors["coverImage.rawUrl"] = new[] { "Cover image URL must be an absolute HTTP or HTTPS URL." };
+        }
+    }
+
+    private static void ValidateNotesHtml(string? notesHtml, Dictionary<string, string[]> errors)
+    {
+        if (!string.IsNullOrEmpty(notesHtml) && DataImageSourceRegex.IsMatch(notesHtml))
+        {
+            errors["notesHtml"] = new[] { "Notes images must use external image URLs, not data:image sources." };
+        }
+    }
+}

--- a/Models/Dtos/Editor/EditorTripStateMapper.cs
+++ b/Models/Dtos/Editor/EditorTripStateMapper.cs
@@ -10,7 +10,6 @@ namespace Wayfarer.Models.Dtos.Editor;
 /// </summary>
 public static class EditorTripStateMapper
 {
-    private const string ShadowRegionName = "Unassigned Places";
     private static readonly GeoJsonWriter GeoJsonWriter = new();
 
     /// <summary>
@@ -35,35 +34,20 @@ public static class EditorTripStateMapper
         {
             TripId = trip.Id,
             Metadata = ToMetadata(trip, publicUrl, progressPublicUrl),
-            RegionsById = regions.ToDictionary(r => r.Id, MapRegion),
+            RegionsById = regions.ToDictionary(r => r.Id, ToRegion),
             RegionOrder = regions.Select(r => r.Id).ToList(),
-            PlacesById = places.ToDictionary(p => p.Place.Id, p => MapPlace(trip.Id, p.Region.Id, p.Place, visitSummaries[p.Place.Id])),
+            PlacesById = places.ToDictionary(p => p.Place.Id, p => ToPlace(trip.Id, p.Region.Id, p.Place, visitSummaries[p.Place.Id])),
             PlaceOrderByRegionId = regions.ToDictionary(r => r.Id, r => (IReadOnlyList<Guid>)r.Places.OrderBy(p => p.DisplayOrder).ThenBy(p => p.Name).Select(p => p.Id).ToList()),
-            AreasById = areas.ToDictionary(a => a.Area.Id, a => MapArea(trip.Id, a.Region.Id, a.Area)),
+            AreasById = areas.ToDictionary(a => a.Area.Id, a => ToArea(trip.Id, a.Region.Id, a.Area)),
             AreaOrderByRegionId = regions.ToDictionary(r => r.Id, r => (IReadOnlyList<Guid>)r.Areas.OrderBy(a => a.DisplayOrder).ThenBy(a => a.Name).Select(a => a.Id).ToList()),
-            SegmentsById = segments.ToDictionary(s => s.Id, s => MapSegment(trip.Id, s)),
+            SegmentsById = segments.ToDictionary(s => s.Id, s => ToSegment(trip.Id, s)),
             SegmentOrder = segments.Select(s => s.Id).ToList(),
             TagsBySlug = trip.Tags.OrderBy(t => t.Name).ToDictionary(t => t.Slug, t => new EditorTagDto(t.Id, t.Name, t.Slug)),
             TagOrder = trip.Tags.OrderBy(t => t.Name).Select(t => t.Slug).ToList(),
-            VisitProgress = BuildVisitProgress(places, visitSummaries, visitsByPlaceId),
+            VisitProgress = ToVisitProgress(places, visitSummaries, visitsByPlaceId),
             Options = options,
             Permissions = new EditorPermissionsDto(true, true, true, true, true, true, true, true, true)
         };
-
-        EditorRegionDto MapRegion(Region region)
-        {
-            var isShadow = IsShadowRegion(region);
-            return new EditorRegionDto(
-                region.Id,
-                region.TripId,
-                region.Name,
-                region.Notes ?? string.Empty,
-                ToImageReference(region.CoverImageUrl),
-                ToCoordinate(region.Center),
-                region.DisplayOrder,
-                isShadow,
-                isShadow ? ShadowCapabilities() : EditableRegionCapabilities());
-        }
     }
 
     /// <summary>
@@ -85,7 +69,59 @@ public static class EditorTripStateMapper
             publicUrl,
             progressPublicUrl);
 
-    private static EditorPlaceDto MapPlace(
+    /// <summary>
+    /// Maps a region into the editor region contract.
+    /// </summary>
+    public static EditorRegionDto ToRegion(Region region)
+    {
+        var isShadow = IsShadowRegion(region);
+        return new EditorRegionDto(
+            region.Id,
+            region.TripId,
+            region.Name,
+            region.Notes ?? string.Empty,
+            ToImageReference(region.CoverImageUrl),
+            ToCoordinate(region.Center),
+            region.DisplayOrder,
+            isShadow,
+            isShadow ? ShadowCapabilities() : EditableRegionCapabilities());
+    }
+
+    /// <summary>
+    /// Maps remaining places and visits into the editor visit progress contract.
+    /// </summary>
+    public static EditorVisitProgressDto ToVisitProgress(
+        IReadOnlyList<(Region Region, Place Place)> places,
+        IReadOnlyDictionary<Guid, EditorPlaceVisitSummaryDto> summaries,
+        IReadOnlyDictionary<Guid, IReadOnlyList<PlaceVisitEvent>> visitsByPlaceId) =>
+        BuildVisitProgress(places, summaries, visitsByPlaceId);
+
+    /// <summary>
+    /// Builds editor visit summaries for the supplied places.
+    /// </summary>
+    public static IReadOnlyDictionary<Guid, EditorPlaceVisitSummaryDto> ToVisitSummaries(
+        IEnumerable<Place> places,
+        IReadOnlyDictionary<Guid, IReadOnlyList<PlaceVisitEvent>> visitsByPlaceId) =>
+        BuildVisitSummaries(places, visitsByPlaceId);
+
+    /// <summary>
+    /// Maps a segment into the editor segment contract.
+    /// </summary>
+    public static EditorSegmentDto ToSegment(Guid tripId, Segment segment) =>
+        new(
+            segment.Id,
+            tripId,
+            segment.FromPlaceId,
+            segment.ToPlaceId,
+            segment.Mode ?? string.Empty,
+            segment.EstimatedDistanceKm,
+            segment.EstimatedDuration?.TotalMinutes,
+            segment.Notes ?? string.Empty,
+            ToGeoJson(segment.RouteGeometry),
+            segment.DisplayOrder,
+            EditableLeafCapabilities());
+
+    private static EditorPlaceDto ToPlace(
         Guid tripId,
         Guid regionId,
         Place place,
@@ -104,7 +140,7 @@ public static class EditorTripStateMapper
             visitSummary,
             EditableLeafCapabilities());
 
-    private static EditorAreaDto MapArea(Guid tripId, Guid regionId, Area area) =>
+    private static EditorAreaDto ToArea(Guid tripId, Guid regionId, Area area) =>
         new(
             area.Id,
             tripId,
@@ -114,20 +150,6 @@ public static class EditorTripStateMapper
             string.IsNullOrWhiteSpace(area.FillHex) ? "#ff6600" : area.FillHex,
             ToAreaPolygonGeoJson(tripId, area),
             area.DisplayOrder ?? 0,
-            EditableLeafCapabilities());
-
-    private static EditorSegmentDto MapSegment(Guid tripId, Segment segment) =>
-        new(
-            segment.Id,
-            tripId,
-            segment.FromPlaceId,
-            segment.ToPlaceId,
-            segment.Mode ?? string.Empty,
-            segment.EstimatedDistanceKm,
-            segment.EstimatedDuration?.TotalMinutes,
-            segment.Notes ?? string.Empty,
-            ToGeoJson(segment.RouteGeometry),
-            segment.DisplayOrder,
             EditableLeafCapabilities());
 
     private static EditorVisitProgressDto BuildVisitProgress(
@@ -220,7 +242,7 @@ public static class EditorTripStateMapper
     }
 
     private static bool IsShadowRegion(Region region) =>
-        region.DisplayOrder == 0 && string.Equals(region.Name, ShadowRegionName, StringComparison.Ordinal);
+        region.DisplayOrder == 0 && string.Equals(region.Name, EditorRegionRequestParser.ShadowRegionName, StringComparison.Ordinal);
 
     private static EditorEntityCapabilitiesDto ShadowCapabilities() =>
         new(false, false, false, false, false, false, true);

--- a/Program.cs
+++ b/Program.cs
@@ -596,7 +596,6 @@ static void ConfigureServices(WebApplicationBuilder builder)
     builder.Services.AddSingleton<MapSnapshotService>();
     builder.Services.AddScoped<TripEditorRegionMutationService>();
 
-    // Trip thumbnail services for public trips index
     builder.Services.AddScoped<ITripThumbnailService, TripThumbnailService>();
     builder.Services.AddSingleton<ITripMapThumbnailGenerator, TripMapThumbnailGenerator>();
 

--- a/Program.cs
+++ b/Program.cs
@@ -594,6 +594,7 @@ static void ConfigureServices(WebApplicationBuilder builder)
 
     builder.Services.AddScoped<IRazorViewRenderer, RazorViewRenderer>();
     builder.Services.AddSingleton<MapSnapshotService>();
+    builder.Services.AddScoped<TripEditorRegionMutationService>();
 
     // Trip thumbnail services for public trips index
     builder.Services.AddScoped<ITripThumbnailService, TripThumbnailService>();

--- a/Services/EditorRegionMutationOutcome.cs
+++ b/Services/EditorRegionMutationOutcome.cs
@@ -1,0 +1,45 @@
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Service-level outcome that lets the controller keep HTTP status orchestration.
+/// </summary>
+public sealed record EditorRegionMutationOutcome<T>(
+    EditorRegionMutationStatus Status,
+    T? Result,
+    Dictionary<string, string[]>? ValidationErrors,
+    string? ForbiddenDetail)
+{
+    /// <summary>Creates a successful mutation outcome.</summary>
+    public static EditorRegionMutationOutcome<T> Succeeded(T result) =>
+        new(EditorRegionMutationStatus.Success, result, null, null);
+
+    /// <summary>Creates a not-found outcome for hidden or missing trips/entities.</summary>
+    public static EditorRegionMutationOutcome<T> NotFound() =>
+        new(EditorRegionMutationStatus.NotFound, default, null, null);
+
+    /// <summary>Creates a forbidden outcome for valid but blocked region operations.</summary>
+    public static EditorRegionMutationOutcome<T> Forbidden(string detail) =>
+        new(EditorRegionMutationStatus.Forbidden, default, null, detail);
+
+    /// <summary>Creates a validation-failed outcome with field-keyed errors.</summary>
+    public static EditorRegionMutationOutcome<T> ValidationFailed(Dictionary<string, string[]> errors) =>
+        new(EditorRegionMutationStatus.ValidationFailed, default, errors, null);
+}
+
+/// <summary>
+/// Non-success service outcomes for Trip Editor region mutations.
+/// </summary>
+public enum EditorRegionMutationStatus
+{
+    /// <summary>The mutation succeeded and produced a result envelope.</summary>
+    Success,
+
+    /// <summary>The ownership-filtered trip or target entity was not found.</summary>
+    NotFound,
+
+    /// <summary>The target exists but the operation is forbidden.</summary>
+    Forbidden,
+
+    /// <summary>The request payload failed deterministic validation.</summary>
+    ValidationFailed
+}

--- a/Services/TripEditorRegionMutationService.cs
+++ b/Services/TripEditorRegionMutationService.cs
@@ -1,0 +1,425 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Geometries;
+using Wayfarer.Models;
+using Wayfarer.Models.Dtos.Editor;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Executes Trip Editor region mutations and builds their mutation result envelopes.
+/// </summary>
+public sealed class TripEditorRegionMutationService
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    /// <summary>
+    /// Initializes a new region mutation service for the editor API.
+    /// </summary>
+    public TripEditorRegionMutationService(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    /// <summary>
+    /// Creates a normal region for an owned trip.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>> CreateRegionAsync(
+        Guid tripId,
+        string userId,
+        Stream requestBody,
+        CancellationToken cancellationToken)
+    {
+        var trip = await _dbContext.Trips
+            .Include(t => t.Regions)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+        if (trip == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>.NotFound();
+        }
+
+        var request = await ParseJsonBodyAsync(requestBody, "Region save request must be valid JSON.", cancellationToken);
+        if (request.ValidationErrors != null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>.ValidationFailed(request.ValidationErrors);
+        }
+
+        if (!EditorRegionRequestParser.TryParseSave(request.Value!.Value, out var update, out var errors))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>.ValidationFailed(errors);
+        }
+
+        var normalRegions = trip.Regions.Where(r => !IsShadowRegion(r)).ToList();
+        var region = new Region
+        {
+            Id = Guid.NewGuid(),
+            TripId = trip.Id,
+            Trip = trip,
+            UserId = userId,
+            Name = update.Name.Trim(),
+            Notes = update.NotesHtml ?? string.Empty,
+            CoverImageUrl = NormalizeOptionalUrl(update.CoverImage?.RawUrl),
+            Center = ToPoint(update.Center),
+            DisplayOrder = normalRegions.Count == 0 ? 1 : normalRegions.Max(r => r.DisplayOrder) + 1
+        };
+
+        _dbContext.Regions.Add(region);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var regionOrder = await LoadRegionOrderAsync(tripId, userId, cancellationToken);
+        var dto = EditorTripStateMapper.ToRegion(region);
+        var affected = new EditorAffectedSlicesDto(
+            null,
+            new[] { dto },
+            regionOrder,
+            Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>> { [region.Id] = Array.Empty<Guid>() },
+            Array.Empty<EditorAreaDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>> { [region.Id] = Array.Empty<Guid>() },
+            Array.Empty<EditorSegmentDto>(),
+            null,
+            Array.Empty<EditorTagDto>(),
+            null,
+            null,
+            null);
+
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>.Succeeded(
+            new EditorMutationResult<EditorRegionDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Updates a normal region for an owned trip.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>> UpdateRegionAsync(
+        Guid tripId,
+        Guid regionId,
+        string userId,
+        Stream requestBody,
+        CancellationToken cancellationToken)
+    {
+        var trip = await _dbContext.Trips
+            .Include(t => t.Regions)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+        if (trip == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>.NotFound();
+        }
+
+        var region = trip.Regions.FirstOrDefault(r => r.Id == regionId);
+        if (region == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>.NotFound();
+        }
+
+        if (IsShadowRegion(region))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>.Forbidden("The shadow region cannot be updated.");
+        }
+
+        var request = await ParseJsonBodyAsync(requestBody, "Region save request must be valid JSON.", cancellationToken);
+        if (request.ValidationErrors != null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>.ValidationFailed(request.ValidationErrors);
+        }
+
+        if (!EditorRegionRequestParser.TryParseSave(request.Value!.Value, out var update, out var errors))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>.ValidationFailed(errors);
+        }
+
+        region.Name = update.Name.Trim();
+        region.Notes = update.NotesHtml ?? string.Empty;
+        region.CoverImageUrl = NormalizeOptionalUrl(update.CoverImage?.RawUrl);
+        region.Center = ToPoint(update.Center);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var dto = EditorTripStateMapper.ToRegion(region);
+        var affected = new EditorAffectedSlicesDto(
+            null,
+            new[] { dto },
+            null,
+            Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorAreaDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorSegmentDto>(),
+            null,
+            Array.Empty<EditorTagDto>(),
+            null,
+            null,
+            null);
+
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto>>.Succeeded(
+            new EditorMutationResult<EditorRegionDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Deletes a normal region and returns authoritative deleted IDs and affected slices.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto?>>> DeleteRegionAsync(
+        Guid tripId,
+        Guid regionId,
+        string userId,
+        CancellationToken cancellationToken)
+    {
+        var trip = await _dbContext.Trips
+            .Include(t => t.Regions).ThenInclude(r => r.Places)
+            .Include(t => t.Regions).ThenInclude(r => r.Areas)
+            .Include(t => t.Segments)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+        if (trip == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto?>>.NotFound();
+        }
+
+        var region = trip.Regions.FirstOrDefault(r => r.Id == regionId);
+        if (region == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto?>>.NotFound();
+        }
+
+        if (IsShadowRegion(region))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto?>>.Forbidden("The shadow region cannot be deleted.");
+        }
+
+        var deletedPlaceIds = region.Places.OrderBy(p => p.DisplayOrder).ThenBy(p => p.Id).Select(p => p.Id).ToList();
+        var deletedAreaIds = region.Areas.OrderBy(a => a.DisplayOrder).ThenBy(a => a.Id).Select(a => a.Id).ToList();
+        var deletedSegmentIds = trip.Segments
+            .Where(s => (s.FromPlaceId.HasValue && deletedPlaceIds.Contains(s.FromPlaceId.Value))
+                || (s.ToPlaceId.HasValue && deletedPlaceIds.Contains(s.ToPlaceId.Value)))
+            .OrderBy(s => s.DisplayOrder)
+            .ThenBy(s => s.Id)
+            .Select(s => s.Id)
+            .ToList();
+
+        var deletedSegments = trip.Segments.Where(s => deletedSegmentIds.Contains(s.Id)).ToList();
+        _dbContext.Segments.RemoveRange(deletedSegments);
+        _dbContext.Areas.RemoveRange(region.Areas);
+        _dbContext.Places.RemoveRange(region.Places);
+        _dbContext.Regions.Remove(region);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await NormalizeRegionOrdersAsync(tripId, userId, cancellationToken);
+        await NormalizeSegmentOrdersAsync(tripId, userId, cancellationToken);
+
+        var regionOrder = await LoadRegionOrderAsync(tripId, userId, cancellationToken);
+        var segmentOrder = await LoadSegmentOrderAsync(tripId, userId, cancellationToken);
+        var visitProgress = await LoadVisitProgressAsync(tripId, userId, cancellationToken);
+        var affected = new EditorAffectedSlicesDto(
+            null,
+            Array.Empty<EditorRegionDto>(),
+            regionOrder,
+            Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorAreaDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorSegmentDto>(),
+            segmentOrder,
+            Array.Empty<EditorTagDto>(),
+            null,
+            visitProgress,
+            null);
+        var deletedIds = new EditorDeletedIdsDto(new[] { regionId }, deletedPlaceIds, deletedAreaIds, deletedSegmentIds, Array.Empty<string>());
+
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionDto?>>.Succeeded(
+            new EditorMutationResult<EditorRegionDto?>(true, null, affected, deletedIds, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Persists the complete desired order for normal regions.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorRegionOrderResult>>> OrderRegionsAsync(
+        Guid tripId,
+        string userId,
+        Stream requestBody,
+        CancellationToken cancellationToken)
+    {
+        var trip = await _dbContext.Trips
+            .Include(t => t.Regions)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+        if (trip == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionOrderResult>>.NotFound();
+        }
+
+        var request = await ParseJsonBodyAsync(requestBody, "Region order request must be valid JSON.", cancellationToken);
+        if (request.ValidationErrors != null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionOrderResult>>.ValidationFailed(request.ValidationErrors);
+        }
+
+        if (!EditorRegionRequestParser.TryParseOrder(request.Value!.Value, out var orderRequest, out var errors))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionOrderResult>>.ValidationFailed(errors);
+        }
+
+        var shadow = trip.Regions.FirstOrDefault(IsShadowRegion);
+        if (shadow != null && orderRequest.RegionIds.Contains(shadow.Id))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionOrderResult>>.Forbidden("The shadow region cannot be reordered.");
+        }
+
+        var normalRegions = trip.Regions.Where(r => !IsShadowRegion(r)).OrderBy(r => r.DisplayOrder).ThenBy(r => r.Name).ToList();
+        var normalIds = normalRegions.Select(r => r.Id).ToList();
+        if (orderRequest.RegionIds.Count != normalIds.Count
+            || orderRequest.RegionIds.Distinct().Count() != orderRequest.RegionIds.Count
+            || orderRequest.RegionIds.Any(id => !normalIds.Contains(id)))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionOrderResult>>.ValidationFailed(new Dictionary<string, string[]>
+            {
+                ["regionIds"] = new[] { "Region IDs must include every normal region in this trip exactly once." }
+            });
+        }
+
+        if (shadow != null)
+        {
+            shadow.DisplayOrder = 0;
+        }
+
+        var byId = normalRegions.ToDictionary(r => r.Id);
+        for (var i = 0; i < orderRequest.RegionIds.Count; i++)
+        {
+            byId[orderRequest.RegionIds[i]].DisplayOrder = i + 1;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var regionOrder = await LoadRegionOrderAsync(tripId, userId, cancellationToken);
+        var updatedRegions = await LoadRegionsByIdsAsync(orderRequest.RegionIds, cancellationToken);
+        var affected = new EditorAffectedSlicesDto(
+            null,
+            updatedRegions,
+            regionOrder,
+            Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorAreaDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorSegmentDto>(),
+            null,
+            Array.Empty<EditorTagDto>(),
+            null,
+            null,
+            null);
+        var data = new EditorRegionOrderResult(regionOrder);
+
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionOrderResult>>.Succeeded(
+            new EditorMutationResult<EditorRegionOrderResult>(true, data, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    private async Task<IReadOnlyList<Guid>> LoadRegionOrderAsync(Guid tripId, string userId, CancellationToken cancellationToken) =>
+        await _dbContext.Regions
+            .AsNoTracking()
+            .Where(r => r.TripId == tripId && r.UserId == userId)
+            .OrderBy(r => r.DisplayOrder)
+            .ThenBy(r => r.Name)
+            .Select(r => r.Id)
+            .ToListAsync(cancellationToken);
+
+    private static async Task<(JsonElement? Value, Dictionary<string, string[]>? ValidationErrors)> ParseJsonBodyAsync(
+        Stream requestBody,
+        string invalidJsonMessage,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var document = await JsonDocument.ParseAsync(requestBody, cancellationToken: cancellationToken);
+            return (document.RootElement.Clone(), null);
+        }
+        catch (JsonException)
+        {
+            return (null, new Dictionary<string, string[]> { ["request"] = new[] { invalidJsonMessage } });
+        }
+    }
+
+    private async Task<IReadOnlyList<Guid>> LoadSegmentOrderAsync(Guid tripId, string userId, CancellationToken cancellationToken) =>
+        await _dbContext.Segments
+            .AsNoTracking()
+            .Where(s => s.TripId == tripId && s.UserId == userId)
+            .OrderBy(s => s.DisplayOrder)
+            .ThenBy(s => s.Id)
+            .Select(s => s.Id)
+            .ToListAsync(cancellationToken);
+
+    private async Task<IReadOnlyList<EditorRegionDto>> LoadRegionsByIdsAsync(IReadOnlyList<Guid> regionIds, CancellationToken cancellationToken)
+    {
+        var regions = await _dbContext.Regions
+            .AsNoTracking()
+            .Where(r => regionIds.Contains(r.Id))
+            .ToListAsync(cancellationToken);
+        var byId = regions.ToDictionary(r => r.Id);
+
+        return regionIds.Select(id => EditorTripStateMapper.ToRegion(byId[id])).ToList();
+    }
+
+    private async Task<EditorVisitProgressDto> LoadVisitProgressAsync(Guid tripId, string userId, CancellationToken cancellationToken)
+    {
+        var regions = await _dbContext.Regions
+            .AsNoTracking()
+            .Include(r => r.Places)
+            .Where(r => r.TripId == tripId && r.UserId == userId)
+            .OrderBy(r => r.DisplayOrder)
+            .ThenBy(r => r.Name)
+            .ToListAsync(cancellationToken);
+        var places = regions.SelectMany(r => r.Places.Select(p => (Region: r, Place: p))).ToList();
+        var placeIds = places.Select(p => p.Place.Id).ToArray();
+        var visits = await _dbContext.PlaceVisitEvents
+            .AsNoTracking()
+            .Where(v => v.UserId == userId && v.PlaceId != null && placeIds.Contains(v.PlaceId.Value))
+            .ToListAsync(cancellationToken);
+        var visitsByPlaceId = visits
+            .GroupBy(v => v.PlaceId!.Value)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<PlaceVisitEvent>)g.ToList());
+        var summaries = EditorTripStateMapper.ToVisitSummaries(places.Select(p => p.Place), visitsByPlaceId);
+
+        return EditorTripStateMapper.ToVisitProgress(places, summaries, visitsByPlaceId);
+    }
+
+    private async Task NormalizeRegionOrdersAsync(Guid tripId, string userId, CancellationToken cancellationToken)
+    {
+        var regions = await _dbContext.Regions
+            .Where(r => r.TripId == tripId && r.UserId == userId)
+            .OrderBy(r => r.DisplayOrder)
+            .ThenBy(r => r.Name)
+            .ToListAsync(cancellationToken);
+        var shadow = regions.FirstOrDefault(IsShadowRegion);
+        if (shadow != null)
+        {
+            shadow.DisplayOrder = 0;
+        }
+
+        var order = 1;
+        foreach (var region in regions.Where(r => !IsShadowRegion(r)))
+        {
+            region.DisplayOrder = order++;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task NormalizeSegmentOrdersAsync(Guid tripId, string userId, CancellationToken cancellationToken)
+    {
+        var segments = await _dbContext.Segments
+            .Where(s => s.TripId == tripId && s.UserId == userId)
+            .OrderBy(s => s.DisplayOrder)
+            .ThenBy(s => s.Id)
+            .ToListAsync(cancellationToken);
+        for (var i = 0; i < segments.Count; i++)
+        {
+            segments[i].DisplayOrder = i;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static string? NormalizeOptionalUrl(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static Point? ToPoint(EditorCoordinateDto? coordinate) =>
+        coordinate == null ? null : new Point(coordinate.Longitude, coordinate.Latitude) { SRID = 4326 };
+
+    private static bool IsShadowRegion(Region region) =>
+        region.DisplayOrder == 0
+        && string.Equals(region.Name, EditorRegionRequestParser.ShadowRegionName, StringComparison.Ordinal);
+}

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -289,6 +289,7 @@ public sealed class TripEditorControllerTests : TestBase
             new IconColorProvider(environment),
             thumbnailMock?.Object ?? Mock.Of<ITripMapThumbnailGenerator>(),
             warmupMock?.Object ?? Mock.Of<ICacheWarmupScheduler>(),
+            new TripEditorRegionMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
         var url = new Mock<IUrlHelper>();

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
@@ -204,6 +204,7 @@ public sealed class TripEditorMetadataControllerTests : TestBase
             new IconColorProvider(environment),
             thumbnailMock?.Object ?? Mock.Of<ITripMapThumbnailGenerator>(),
             warmupMock?.Object ?? Mock.Of<ICacheWarmupScheduler>(),
+            new TripEditorRegionMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
         var url = new Mock<IUrlHelper>();

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataValidationControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataValidationControllerTests.cs
@@ -252,6 +252,7 @@ public sealed class TripEditorMetadataValidationControllerTests : TestBase
             new IconColorProvider(environment),
             Mock.Of<ITripMapThumbnailGenerator>(),
             Mock.Of<ICacheWarmupScheduler>(),
+            new TripEditorRegionMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
     }
 

--- a/tests/Wayfarer.Tests/Controllers/TripEditorRegionControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorRegionControllerTests.cs
@@ -322,6 +322,7 @@ public sealed class TripEditorRegionControllerTests : TestBase
             new IconColorProvider(environment),
             Mock.Of<ITripMapThumbnailGenerator>(),
             Mock.Of<ICacheWarmupScheduler>(),
+            new TripEditorRegionMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
     }
 

--- a/tests/Wayfarer.Tests/Controllers/TripEditorRegionControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorRegionControllerTests.cs
@@ -1,0 +1,361 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NetTopologySuite.Geometries;
+using Wayfarer.Areas.Api.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Models.Dtos.Editor;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Controllers;
+
+/// <summary>
+/// Focused tests for Trip Editor region mutations.
+/// </summary>
+public sealed class TripEditorRegionControllerTests : TestBase
+{
+    [Fact]
+    public async Task CreateRegionForOwnerAppendsNormalRegionAndReturnsAffectedSlices()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripWithRegions(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.CreateRegion(trip.Id, CancellationToken.None), ValidRegionBody("Created Region"));
+
+        var envelope = AssertMutation<EditorRegionDto>(result);
+        Assert.True(envelope.Success);
+        Assert.Equal("Created Region", envelope.Data.Name);
+        Assert.Equal("<p>Notes</p>", envelope.Data.NotesHtml);
+        Assert.Equal("https://cdn.example.test/cover.jpg", envelope.Data.CoverImage!.RawUrl);
+        Assert.Equal(10, envelope.Data.Center!.Latitude);
+        Assert.Equal(20, envelope.Data.Center.Longitude);
+        Assert.Equal(new[] { envelope.Data.Id }, envelope.Affected.Regions.Select(r => r.Id));
+        Assert.Equal(Array.Empty<Guid>(), envelope.Affected.PlaceOrdersByRegionId[envelope.Data.Id]);
+        Assert.Equal(Array.Empty<Guid>(), envelope.Affected.AreaOrdersByRegionId[envelope.Data.Id]);
+        Assert.Contains(envelope.Data.Id, envelope.Affected.RegionOrder!);
+        Assert.Empty(envelope.DeletedIds.Regions);
+        Assert.Equal(3, db.Regions.Single(r => r.Id == envelope.Data.Id).DisplayOrder);
+    }
+
+    [Fact]
+    public async Task UpdateRegionForOwnerSavesCompleteDraftAndReturnsRegionOnlySlice()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripWithRegions(db, "owner-user");
+        var region = trip.Regions.Single(r => r.Name == "Athens");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.UpdateRegion(trip.Id, region.Id, CancellationToken.None), ValidRegionBody("Updated Region"));
+
+        var envelope = AssertMutation<EditorRegionDto>(result);
+        Assert.Equal(region.Id, envelope.Data.Id);
+        Assert.Equal("Updated Region", envelope.Data.Name);
+        Assert.Single(envelope.Affected.Regions);
+        Assert.Null(envelope.Affected.RegionOrder);
+        Assert.Empty(envelope.DeletedIds.Regions);
+        Assert.Equal("Updated Region", db.Regions.Single(r => r.Id == region.Id).Name);
+    }
+
+    [Fact]
+    public async Task DeleteRegionRemovesChildrenEndpointSegmentsAndReturnsExplicitAffectedSlices()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripWithDeleteGraph(db, "owner-user");
+        var deletedRegion = trip.Regions.Single(r => r.Name == "Delete Me");
+        var keptRegion = trip.Regions.Single(r => r.Name == "Keep Me");
+        var deletedPlaceIds = deletedRegion.Places.Select(p => p.Id).OrderBy(id => id).ToArray();
+        var deletedAreaIds = deletedRegion.Areas.Select(a => a.Id).OrderBy(id => id).ToArray();
+        var deletedSegmentIds = trip.Segments
+            .Where(s => deletedPlaceIds.Contains(s.FromPlaceId!.Value) || deletedPlaceIds.Contains(s.ToPlaceId!.Value))
+            .Select(s => s.Id)
+            .OrderBy(id => id)
+            .ToArray();
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.DeleteRegion(trip.Id, deletedRegion.Id, CancellationToken.None);
+
+        var envelope = AssertMutation<EditorRegionDto?>(result);
+        Assert.Null(envelope.Data);
+        Assert.Equal(new[] { deletedRegion.Id }, envelope.DeletedIds.Regions);
+        Assert.Equal(deletedPlaceIds, envelope.DeletedIds.Places.OrderBy(id => id));
+        Assert.Equal(deletedAreaIds, envelope.DeletedIds.Areas.OrderBy(id => id));
+        Assert.Equal(deletedSegmentIds, envelope.DeletedIds.Segments.OrderBy(id => id));
+        Assert.Empty(envelope.Affected.Regions);
+        Assert.Equal(new[] { trip.Regions.Single(r => r.Name == "Unassigned Places").Id, keptRegion.Id }, envelope.Affected.RegionOrder);
+        Assert.Single(envelope.Affected.SegmentOrder!);
+        Assert.NotNull(envelope.Affected.VisitProgress);
+        Assert.Equal(1, envelope.Affected.VisitProgress!.TotalPlaces);
+        Assert.Empty(db.Places.Where(p => deletedPlaceIds.Contains(p.Id)));
+        Assert.Empty(db.Areas.Where(a => deletedAreaIds.Contains(a.Id)));
+        Assert.Empty(db.Segments.Where(s => deletedSegmentIds.Contains(s.Id)));
+    }
+
+    [Fact]
+    public async Task OrderRegionsForOwnerPersistsShadowAtZeroAndNormalRegionsFromOne()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripWithRegions(db, "owner-user");
+        var first = trip.Regions.Single(r => r.Name == "Athens");
+        var second = trip.Regions.Single(r => r.Name == "Thessaloniki");
+        var shadow = trip.Regions.Single(r => r.Name == "Unassigned Places");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.OrderRegions(trip.Id, CancellationToken.None), $$"""
+        { "regionIds": [ "{{second.Id}}", "{{first.Id}}" ] }
+        """);
+
+        var envelope = AssertMutation<EditorRegionOrderResult>(result);
+        Assert.Equal(new[] { shadow.Id, second.Id, first.Id }, envelope.Data.RegionOrder);
+        Assert.Equal(envelope.Data.RegionOrder, envelope.Affected.RegionOrder);
+        Assert.Equal(0, db.Regions.Single(r => r.Id == shadow.Id).DisplayOrder);
+        Assert.Equal(1, db.Regions.Single(r => r.Id == second.Id).DisplayOrder);
+        Assert.Equal(2, db.Regions.Single(r => r.Id == first.Id).DisplayOrder);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("{")]
+    [InlineData("[]")]
+    public async Task OwnedRegionMutationsWithInvalidBodyReturnRequestValidationProblem(string body)
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripWithRegions(db, "owner-user");
+        var region = trip.Regions.Single(r => r.Name == "Athens");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var create = await SendJson(controller, c => c.CreateRegion(trip.Id, CancellationToken.None), body);
+        var update = await SendJson(controller, c => c.UpdateRegion(trip.Id, region.Id, CancellationToken.None), body);
+        var order = await SendJson(controller, c => c.OrderRegions(trip.Id, CancellationToken.None), body);
+
+        Assert.Contains("request", AssertValidationProblem(create).Errors.Keys);
+        Assert.Contains("request", AssertValidationProblem(update).Errors.Keys);
+        Assert.Contains("request", AssertValidationProblem(order).Errors.Keys);
+    }
+
+    [Fact]
+    public async Task MissingTripOrRegionReturnsNotFoundBeforeBodyParsing()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripWithRegions(db, "owner-user");
+        var region = trip.Regions.Single(r => r.Name == "Athens");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "other-user");
+
+        var nonOwnerTrip = await SendJson(controller, c => c.CreateRegion(trip.Id, CancellationToken.None), "{");
+        var nonOwnerRegion = await SendJson(controller, c => c.UpdateRegion(trip.Id, region.Id, CancellationToken.None), "{");
+        ConfigureControllerWithUserRole(controller, "owner-user");
+        var missingRegion = await SendJson(controller, c => c.UpdateRegion(trip.Id, Guid.NewGuid(), CancellationToken.None), "{");
+
+        Assert.IsType<NotFoundResult>(nonOwnerTrip);
+        Assert.IsType<NotFoundResult>(nonOwnerRegion);
+        Assert.IsType<NotFoundResult>(missingRegion);
+    }
+
+    [Fact]
+    public async Task RegionMutationAuthFailuresReturnExpectedStatus()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripWithRegions(db, "owner-user");
+        var controller = BuildController(db);
+
+        var anonymous = await SendJson(controller, c => c.CreateRegion(trip.Id, CancellationToken.None), ValidRegionBody("Blocked"));
+        ConfigureControllerWithUserRole(controller, "owner-user", "Manager");
+        var wrongRole = await SendJson(controller, c => c.CreateRegion(trip.Id, CancellationToken.None), ValidRegionBody("Blocked"));
+
+        Assert.IsType<UnauthorizedResult>(anonymous);
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<StatusCodeResult>(wrongRole).StatusCode);
+    }
+
+    [Fact]
+    public async Task ShadowRegionCannotBeUpdatedDeletedReorderedOrRenamed()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripWithRegions(db, "owner-user");
+        var shadow = trip.Regions.Single(r => r.Name == "Unassigned Places");
+        var normal = trip.Regions.Single(r => r.Name == "Athens");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var updateShadow = await SendJson(controller, c => c.UpdateRegion(trip.Id, shadow.Id, CancellationToken.None), ValidRegionBody("Updated"));
+        var deleteShadow = await controller.DeleteRegion(trip.Id, shadow.Id, CancellationToken.None);
+        var orderShadow = await SendJson(controller, c => c.OrderRegions(trip.Id, CancellationToken.None), $$"""
+        { "regionIds": [ "{{shadow.Id}}", "{{normal.Id}}" ] }
+        """);
+        var reservedName = await SendJson(controller, c => c.UpdateRegion(trip.Id, normal.Id, CancellationToken.None), ValidRegionBody(" unassigned places "));
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ObjectResult>(updateShadow).StatusCode);
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ObjectResult>(deleteShadow).StatusCode);
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ObjectResult>(orderShadow).StatusCode);
+        Assert.Contains("name", AssertValidationProblem(reservedName).Errors.Keys);
+    }
+
+    [Fact]
+    public async Task RegionSaveValidationRejectsInvalidFieldsAndServerOwnedFields()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripWithRegions(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.CreateRegion(trip.Id, CancellationToken.None), """
+        {
+          "id": "00000000-0000-0000-0000-000000000001",
+          "tripId": "00000000-0000-0000-0000-000000000002",
+          "displayOrder": 99,
+          "isShadow": true,
+          "capabilities": {},
+          "name": " ",
+          "notesHtml": "<img src=\"   DATA:image/png;base64,abc\">",
+          "coverImage": { "rawUrl": "ftp://example.test/a.jpg" },
+          "center": { "latitude": 91, "longitude": -181 }
+        }
+        """);
+
+        var problem = AssertValidationProblem(result);
+        Assert.Contains("id", problem.Errors.Keys);
+        Assert.Contains("tripId", problem.Errors.Keys);
+        Assert.Contains("displayOrder", problem.Errors.Keys);
+        Assert.Contains("isShadow", problem.Errors.Keys);
+        Assert.Contains("capabilities", problem.Errors.Keys);
+        Assert.Contains("name", problem.Errors.Keys);
+        Assert.Contains("notesHtml", problem.Errors.Keys);
+        Assert.Contains("coverImage.rawUrl", problem.Errors.Keys);
+        Assert.Contains("center.latitude", problem.Errors.Keys);
+        Assert.Contains("center.longitude", problem.Errors.Keys);
+    }
+
+    [Theory]
+    [InlineData("""{ "regionIds": [] }""")]
+    [InlineData("""{ "regionIds": [ "00000000-0000-0000-0000-000000000001" ] }""")]
+    public async Task OrderRegionsRejectsIncompleteOrUnknownIds(string body)
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripWithRegions(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.OrderRegions(trip.Id, CancellationToken.None), body);
+
+        Assert.Contains("regionIds", AssertValidationProblem(result).Errors.Keys);
+    }
+
+    private static Trip SeedTripWithRegions(ApplicationDbContext db, string userId)
+    {
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = userId, Name = "Trip", UpdatedAt = DateTime.UtcNow };
+        trip.Regions.Add(new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, Name = "Unassigned Places", DisplayOrder = 0 });
+        trip.Regions.Add(new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, Name = "Athens", DisplayOrder = 1 });
+        trip.Regions.Add(new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, Name = "Thessaloniki", DisplayOrder = 2 });
+        db.Trips.Add(trip);
+        db.SaveChanges();
+        return trip;
+    }
+
+    private static Trip SeedTripWithDeleteGraph(ApplicationDbContext db, string userId)
+    {
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = userId, Name = "Trip", UpdatedAt = DateTime.UtcNow };
+        var shadow = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, Name = "Unassigned Places", DisplayOrder = 0 };
+        var deleteRegion = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, Name = "Delete Me", DisplayOrder = 3 };
+        var keepRegion = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, Name = "Keep Me", DisplayOrder = 4 };
+        trip.Regions.Add(shadow);
+        trip.Regions.Add(deleteRegion);
+        trip.Regions.Add(keepRegion);
+        var deletePlace = new Place { Id = Guid.NewGuid(), Region = deleteRegion, RegionId = deleteRegion.Id, UserId = userId, Name = "Delete Place", DisplayOrder = 1 };
+        var keepPlace = new Place { Id = Guid.NewGuid(), Region = keepRegion, RegionId = keepRegion.Id, UserId = userId, Name = "Keep Place", DisplayOrder = 1 };
+        deleteRegion.Places.Add(deletePlace);
+        keepRegion.Places.Add(keepPlace);
+        deleteRegion.Areas.Add(new Area { Id = Guid.NewGuid(), Region = deleteRegion, RegionId = deleteRegion.Id, Name = "Delete Area", DisplayOrder = 1, Geometry = Square() });
+        trip.Segments.Add(new Segment { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, FromPlaceId = deletePlace.Id, ToPlaceId = keepPlace.Id, DisplayOrder = 1 });
+        trip.Segments.Add(new Segment { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, FromPlaceId = keepPlace.Id, ToPlaceId = keepPlace.Id, DisplayOrder = 2 });
+        db.Trips.Add(trip);
+        db.SaveChanges();
+        return trip;
+    }
+
+    private static Polygon Square()
+    {
+        var coordinates = new[]
+        {
+            new Coordinate(0, 0),
+            new Coordinate(1, 0),
+            new Coordinate(1, 1),
+            new Coordinate(0, 0)
+        };
+        return new Polygon(new LinearRing(coordinates)) { SRID = 4326 };
+    }
+
+    private static string ValidRegionBody(string name) =>
+        $$"""
+        {
+          "name": "{{name}}",
+          "notesHtml": "<p>Notes</p>",
+          "coverImage": { "rawUrl": "https://cdn.example.test/cover.jpg" },
+          "center": { "latitude": 10, "longitude": 20 }
+        }
+        """;
+
+    private static void ConfigureControllerWithUserRole(ControllerBase controller, string userId, string role = "User")
+    {
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = BuildHttpContextWithUser(userId, role)
+        };
+    }
+
+    private static TripEditorController BuildController(ApplicationDbContext db)
+    {
+        var environment = BuildEnvironment();
+        return new TripEditorController(
+            db,
+            environment,
+            new IconColorProvider(environment),
+            Mock.Of<ITripMapThumbnailGenerator>(),
+            Mock.Of<ICacheWarmupScheduler>(),
+            Mock.Of<ILogger<TripEditorController>>());
+    }
+
+    private static IWebHostEnvironment BuildEnvironment()
+    {
+        var mock = new Mock<IWebHostEnvironment>();
+        mock.SetupGet(e => e.WebRootPath).Returns(Path.GetTempPath());
+        return mock.Object;
+    }
+
+    private static async Task<IActionResult> SendJson(
+        TripEditorController controller,
+        Func<TripEditorController, Task<IActionResult>> action,
+        string requestBody)
+    {
+        var httpContext = controller.ControllerContext.HttpContext ?? new DefaultHttpContext();
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        var body = Encoding.UTF8.GetBytes(requestBody);
+        httpContext.Request.Body = new MemoryStream(body);
+        httpContext.Request.ContentLength = body.Length;
+        httpContext.Request.ContentType = "application/json";
+        return await action(controller);
+    }
+
+    private static ValidationProblemDetails AssertValidationProblem(IActionResult result)
+    {
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("application/problem+json", badRequest.ContentTypes);
+        return Assert.IsType<ValidationProblemDetails>(badRequest.Value);
+    }
+
+    private static EditorMutationResult<T> AssertMutation<T>(IActionResult result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result);
+        return Assert.IsType<EditorMutationResult<T>>(ok.Value);
+    }
+}


### PR DESCRIPTION
Closes #241.

## Summary

- Adds Trip Editor region mutation endpoints for create, update, delete, and reorder:
  - `POST /api/trips/{tripId}/editor/regions`
  - `PUT /api/trips/{tripId}/editor/regions/{regionId}`
  - `DELETE /api/trips/{tripId}/editor/regions/{regionId}`
  - `PUT /api/trips/{tripId}/editor/regions/order`
- Returns authoritative `EditorMutationResult<T>` envelopes with affected region/order/place/area/segment slices, deleted IDs, and validation/forbidden/not-found handling for normal vs. shadow regions.
- Adds Vue Trip Editor region management for add/edit/save/delete, validation display, dirty-state cancel prompts, destructive delete confirmation, SortableJS drag-handle reorder, and visible-order restore on reorder cancel/failure.

## Scope exclusions confirmed

- No place/area/segment CRUD.
- No share-progress toggle.
- No expanded rich text/Quill toolbar.
- No map edit modes, search-add, mobile cutover, or legacy cleanup.

## Validation

- `dotnet build` passed: 0 warnings, 0 errors.
- TripEditor tests passed: `dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --filter FullyQualifiedName~TripEditor` passed, 53 total.
- Full `dotnet test` passed, 1483 total.
- `npm run build` passed.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` passed with no warnings.
- `git diff --check main...HEAD` passed.

## Manual UI / #231 conformance notes

- Workspace loads.
- Add/edit/save/delete region flows verified.
- Validation errors verified.
- Delete dirty prompt appears before destructive confirmation.
- Drag-handle reorder succeeds.
- Reorder cancel/failure restores the visible order.
- Shadow controls are absent.
- No temporary up/down controls are present.
- Legacy `/User/Trip/Edit/{id}` loads.
- Runbook user/trip preserved and temporary data cleaned up.

## Residual risks

- No known residual risks beyond normal review attention to the destructive delete cascade and browser-only reorder behavior.