### PR TITLE
[Trip Editor] Add shared confirmation dialog

### DIFF
--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { loadEditorState } from './api/tripEditorApi';
 import ConfirmDialog from './components/ConfirmDialog.vue';
 import TripSidebar from './components/TripSidebar.vue';
-import { setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
+import { disposeConfirmDialogHost, setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
 import { createTripEditorMap } from './map/leafletAdapter';
 import type { BootstrapConfig, EditorMutationResult, EditorTripMetadata, EditorTripState } from './types';
 
@@ -38,6 +38,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  disposeConfirmDialogHost();
   setConfirmDialogFocusFallback(null);
   mapAdapter?.dispose();
 });

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { loadEditorState } from './api/tripEditorApi';
+import ConfirmDialog from './components/ConfirmDialog.vue';
 import TripSidebar from './components/TripSidebar.vue';
+import { setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
 import { createTripEditorMap } from './map/leafletAdapter';
 import type { BootstrapConfig, EditorMutationResult, EditorTripMetadata, EditorTripState } from './types';
 
@@ -11,6 +13,7 @@ const state = ref<EditorTripState | null>(null);
 const error = ref<string | null>(null);
 const isLoading = ref(true);
 const hasRegionDraftChanges = ref(false);
+const workspaceElement = ref<HTMLElement | null>(null);
 const mapElement = ref<HTMLElement | null>(null);
 let mapAdapter: ReturnType<typeof createTripEditorMap> | null = null;
 
@@ -19,6 +22,8 @@ const updatedLabel = computed(() =>
 );
 
 onMounted(async () => {
+  setConfirmDialogFocusFallback(workspaceElement.value);
+
   try {
     state.value = await loadEditorState(props.config.editorEndpoint);
     if (mapElement.value) {
@@ -33,6 +38,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  setConfirmDialogFocusFallback(null);
   mapAdapter?.dispose();
 });
 
@@ -129,7 +135,7 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
 </script>
 
 <template>
-  <div class="trip-editor-workspace">
+  <div ref="workspaceElement" class="trip-editor-workspace" tabindex="-1">
     <div v-if="isLoading" class="trip-editor-state trip-editor-state--loading">
       <div class="spinner-border" role="status" aria-label="Loading"></div>
       <span>Loading trip editor workspace...</span>
@@ -162,5 +168,7 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
         <div ref="mapElement" class="trip-editor-map" aria-label="Read-only trip map"></div>
       </main>
     </template>
+
+    <ConfirmDialog />
   </div>
 </template>

--- a/ClientApps/trip-editor/src/components/ConfirmDialog.vue
+++ b/ClientApps/trip-editor/src/components/ConfirmDialog.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue';
+import { confirmDialogState, settleConfirmDialog } from '../composables/useConfirmDialog';
+
+const dialogElement = ref<HTMLElement | null>(null);
+const confirmButton = ref<HTMLButtonElement | null>(null);
+const cancelButton = ref<HTMLButtonElement | null>(null);
+
+const dialog = computed(() => confirmDialogState.value);
+const titleId = computed(() => (dialog.value ? `trip-editor-confirm-title-${dialog.value.id}` : undefined));
+const bodyId = computed(() => (dialog.value ? `trip-editor-confirm-body-${dialog.value.id}` : undefined));
+const confirmClass = computed(() => {
+  if (dialog.value?.variant === 'danger') {
+    return 'btn-danger';
+  }
+
+  if (dialog.value?.variant === 'warning') {
+    return 'btn-warning';
+  }
+
+  return 'btn-primary';
+});
+const variantClass = computed(() => (dialog.value ? `trip-editor-confirm-dialog--${dialog.value.variant}` : ''));
+
+watch(
+  () => dialog.value?.id,
+  async id => {
+    if (!id) {
+      return;
+    }
+
+    await nextTick();
+    const initialButton = dialog.value?.variant === 'default' ? confirmButton.value : cancelButton.value;
+    initialButton?.focus();
+  }
+);
+
+const cancel = (): void => {
+  settleConfirmDialog(false);
+};
+
+const confirmChoice = (): void => {
+  settleConfirmDialog(true);
+};
+
+const onDialogKeydown = (event: KeyboardEvent): void => {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    cancel();
+    return;
+  }
+
+  if (event.key !== 'Tab') {
+    return;
+  }
+
+  const focusable = getFocusableElements();
+  if (focusable.length === 0) {
+    event.preventDefault();
+    return;
+  }
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+
+  if (event.shiftKey && active === first) {
+    event.preventDefault();
+    last.focus();
+    return;
+  }
+
+  if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+};
+
+/// Finds controls currently reachable inside this confirmation dialog for keyboard trapping.
+function getFocusableElements(): HTMLElement[] {
+  if (!dialogElement.value) {
+    return [];
+  }
+
+  return Array.from(
+    dialogElement.value.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter(element => element.offsetParent !== null);
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="dialog" class="trip-editor-confirm">
+      <div class="modal-backdrop fade show trip-editor-confirm__backdrop" aria-hidden="true"></div>
+      <div class="modal fade show trip-editor-confirm__modal" tabindex="-1" @keydown="onDialogKeydown">
+        <div
+          ref="dialogElement"
+          class="modal-dialog modal-dialog-centered trip-editor-confirm-dialog"
+          :class="variantClass"
+          role="dialog"
+          aria-modal="true"
+          :aria-labelledby="titleId"
+          :aria-describedby="bodyId"
+        >
+          <div class="modal-content trip-editor-confirm-dialog__content">
+            <div class="modal-header trip-editor-confirm-dialog__header">
+              <h2 :id="titleId" class="modal-title trip-editor-confirm-dialog__title">{{ dialog.title }}</h2>
+            </div>
+            <div :id="bodyId" class="modal-body trip-editor-confirm-dialog__body">
+              <p>{{ dialog.message }}</p>
+            </div>
+            <div class="modal-footer trip-editor-confirm-dialog__footer">
+              <button ref="cancelButton" type="button" class="btn btn-secondary" @click="cancel">{{ dialog.cancelLabel }}</button>
+              <button ref="confirmButton" type="button" class="btn" :class="confirmClass" @click="confirmChoice">{{ dialog.confirmLabel }}</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/ClientApps/trip-editor/src/components/MetadataEditor.vue
+++ b/ClientApps/trip-editor/src/components/MetadataEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
 import { EditorValidationError, patchMetadata } from '../api/tripEditorApi';
+import { confirm } from '../composables/useConfirmDialog';
 import type { EditorTripMetadata, EditorTripMetadataUpdateRequest, EditorWarning } from '../types';
 
 const props = defineProps<{
@@ -77,7 +78,7 @@ const resetDraft = (): void => {
 };
 
 const saveAndExit = async (): Promise<void> => {
-  if (hasUnsavedNonMetadataEditorChanges() && !window.confirm('Discard unsaved trip editor changes and return to Trips?')) {
+  if (hasUnsavedNonMetadataEditorChanges() && !(await confirmDiscardTripEditorChanges())) {
     return;
   }
 
@@ -116,8 +117,8 @@ const save = async (exitAfterSave: boolean): Promise<void> => {
   }
 };
 
-const backToTrips = (): void => {
-  if (!hasUnsavedEditorChanges() || window.confirm('Discard unsaved trip editor changes and return to Trips?')) {
+const backToTrips = async (): Promise<void> => {
+  if (!hasUnsavedEditorChanges() || (await confirmDiscardTripEditorChanges())) {
     window.location.assign(props.tripIndexUrl);
   }
 };
@@ -143,6 +144,17 @@ function hasUnsavedEditorChanges(): boolean {
 /// Tracks editor-owned drafts that Save & Exit cannot persist through the metadata endpoint.
 function hasUnsavedNonMetadataEditorChanges(): boolean {
   return props.hasRegionDraftChanges;
+}
+
+/// Confirms before discarding Trip Editor drafts that are not saved by the current action.
+function confirmDiscardTripEditorChanges(): Promise<boolean> {
+  return confirm({
+    title: 'Discard changes?',
+    message: 'Discard unsaved trip editor changes and return to Trips?',
+    confirmLabel: 'Discard',
+    cancelLabel: 'Stay',
+    variant: 'warning'
+  });
 }
 
 function toDraft(metadata: EditorTripMetadata): MetadataDraft {

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -2,6 +2,7 @@
 import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
 import { createRegion, deleteRegion, orderRegions, updateRegion } from '../api/tripEditorApi';
 import { EditorValidationError } from '../api/tripEditorApi';
+import { confirm } from '../composables/useConfirmDialog';
 import type { EditorArea, EditorMutationResult, EditorPlace, EditorRegion, EditorRegionSaveRequest, EditorTripState } from '../types';
 
 declare global {
@@ -103,8 +104,8 @@ onUnmounted(() => {
   window.removeEventListener('beforeunload', confirmUnload);
 });
 
-const openCreate = (): void => {
-  if (!confirmDiscard()) {
+const openCreate = async (): Promise<void> => {
+  if (!(await confirmDiscard())) {
     return;
   }
 
@@ -113,8 +114,8 @@ const openCreate = (): void => {
   resetFeedback();
 };
 
-const openEdit = (region: EditorRegion): void => {
-  if (!region.capabilities.canEdit || !confirmDiscard()) {
+const openEdit = async (region: EditorRegion): Promise<void> => {
+  if (!region.capabilities.canEdit || !(await confirmDiscard())) {
     return;
   }
 
@@ -127,8 +128,8 @@ const resetDraft = (): void => {
   resetFeedback();
 };
 
-const cancelDraft = (): void => {
-  if (!confirmDiscard()) {
+const cancelDraft = async (): Promise<void> => {
+  if (!(await confirmDiscard())) {
     return;
   }
 
@@ -160,11 +161,17 @@ const deleteDraftRegion = async (): Promise<void> => {
     return;
   }
 
-  if (!confirmDiscard('Discard unsaved region draft changes before deleting?')) {
+  if (!(await confirmDiscard('Discard unsaved region draft changes before deleting?'))) {
     return;
   }
 
-  if (!window.confirm('Delete this region, its child places and areas, and any segments connected to deleted places?')) {
+  if (!(await confirm({
+    title: 'Delete region?',
+    message: 'Delete this region, its child places and areas, and any segments connected to deleted places?',
+    confirmLabel: 'Delete',
+    cancelLabel: 'Keep region',
+    variant: 'danger'
+  }))) {
     return;
   }
 
@@ -198,7 +205,7 @@ const onSortEnd = async (): Promise<void> => {
     return;
   }
 
-  if (isDirty.value && !window.confirm('Discard unsaved region draft changes before reordering?')) {
+  if (isDirty.value && !(await confirmDiscard('Discard unsaved region draft changes before reordering?'))) {
     await restoreRegionOrder(previousIds);
     return;
   }
@@ -298,8 +305,18 @@ function draftText(value: string | number): string {
   return String(value ?? '').trim();
 }
 
-function confirmDiscard(message = 'Discard unsaved region changes?'): boolean {
-  return !isDirty.value || window.confirm(message);
+function confirmDiscard(message = 'Discard unsaved region changes?'): Promise<boolean> {
+  if (!isDirty.value) {
+    return Promise.resolve(true);
+  }
+
+  return confirm({
+    title: 'Discard region changes?',
+    message,
+    confirmLabel: 'Discard',
+    cancelLabel: 'Keep editing',
+    variant: 'warning'
+  });
 }
 
 function resetFeedback(): void {

--- a/ClientApps/trip-editor/src/composables/useConfirmDialog.ts
+++ b/ClientApps/trip-editor/src/composables/useConfirmDialog.ts
@@ -1,0 +1,89 @@
+import { readonly, ref } from 'vue';
+
+export type ConfirmDialogVariant = 'default' | 'warning' | 'danger';
+
+export type ConfirmDialogOptions = {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: ConfirmDialogVariant;
+};
+
+export type ActiveConfirmDialog = Required<ConfirmDialogOptions> & {
+  id: number;
+  returnFocusTarget: HTMLElement | null;
+};
+
+const activeDialog = ref<ActiveConfirmDialog | null>(null);
+const focusFallback = ref<HTMLElement | null>(null);
+let nextDialogId = 0;
+let activeResolver: ((confirmed: boolean) => void) | null = null;
+let activeSettled = false;
+
+/// Identifies accidental overlapping confirmation requests without replacing the active dialog.
+export class ConfirmDialogAlreadyOpenError extends Error {
+  constructor() {
+    super('A Trip Editor confirmation dialog is already open.');
+    this.name = 'ConfirmDialogAlreadyOpenError';
+  }
+}
+
+export const confirmDialogState = readonly(activeDialog);
+
+/// Registers the stable Trip Editor focus target used when the triggering control no longer exists.
+export const setConfirmDialogFocusFallback = (element: HTMLElement | null): void => {
+  focusFallback.value = element;
+};
+
+/// Opens one Trip Editor confirmation dialog and resolves to the user's yes/no choice.
+export const confirm = (options: ConfirmDialogOptions): Promise<boolean> => {
+  if (activeDialog.value || activeResolver) {
+    return Promise.reject(new ConfirmDialogAlreadyOpenError());
+  }
+
+  const returnFocusTarget = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const dialog: ActiveConfirmDialog = {
+    id: ++nextDialogId,
+    title: options.title,
+    message: options.message,
+    confirmLabel: options.confirmLabel ?? 'Confirm',
+    cancelLabel: options.cancelLabel ?? 'Cancel',
+    variant: options.variant ?? 'default',
+    returnFocusTarget
+  };
+
+  activeDialog.value = dialog;
+  activeSettled = false;
+
+  return new Promise<boolean>(resolve => {
+    activeResolver = resolve;
+  });
+};
+
+/// Settles the active confirmation once, then clears dialog state and resolver references.
+export const settleConfirmDialog = (confirmed: boolean): void => {
+  if (!activeResolver || activeSettled) {
+    return;
+  }
+
+  const resolver = activeResolver;
+  const returnFocusTarget = activeDialog.value?.returnFocusTarget ?? null;
+  activeSettled = true;
+  activeResolver = null;
+  activeDialog.value = null;
+
+  resolver(confirmed);
+  window.setTimeout(() => restoreFocus(returnFocusTarget), 0);
+};
+
+function restoreFocus(returnFocusTarget: HTMLElement | null): void {
+  if (returnFocusTarget && document.contains(returnFocusTarget)) {
+    returnFocusTarget.focus();
+    return;
+  }
+
+  if (focusFallback.value && document.contains(focusFallback.value)) {
+    focusFallback.value.focus();
+  }
+}

--- a/ClientApps/trip-editor/src/composables/useConfirmDialog.ts
+++ b/ClientApps/trip-editor/src/composables/useConfirmDialog.ts
@@ -69,21 +69,75 @@ export const settleConfirmDialog = (confirmed: boolean): void => {
 
   const resolver = activeResolver;
   const returnFocusTarget = activeDialog.value?.returnFocusTarget ?? null;
-  activeSettled = true;
-  activeResolver = null;
-  activeDialog.value = null;
+  clearActiveDialog();
 
   resolver(confirmed);
   window.setTimeout(() => restoreFocus(returnFocusTarget), 0);
 };
 
-function restoreFocus(returnFocusTarget: HTMLElement | null): void {
-  if (returnFocusTarget && document.contains(returnFocusTarget)) {
-    returnFocusTarget.focus();
+/// Disposes the Trip Editor confirm host and cancels any pending confirmation owned by it.
+export const disposeConfirmDialogHost = (): void => {
+  if (!activeResolver || activeSettled) {
+    clearActiveDialog();
     return;
   }
 
-  if (focusFallback.value && document.contains(focusFallback.value)) {
-    focusFallback.value.focus();
+  const resolver = activeResolver;
+  clearActiveDialog();
+  resolver(false);
+};
+
+function clearActiveDialog(): void {
+  activeSettled = true;
+  activeResolver = null;
+  activeDialog.value = null;
+}
+
+function restoreFocus(returnFocusTarget: HTMLElement | null): void {
+  if (returnFocusTarget && tryFocus(returnFocusTarget)) {
+    return;
   }
+
+  if (focusFallback.value) {
+    tryFocus(focusFallback.value);
+  }
+}
+
+function tryFocus(element: HTMLElement): boolean {
+  if (!isFocusable(element)) {
+    return false;
+  }
+
+  try {
+    element.focus();
+  } catch {
+    return false;
+  }
+
+  return document.activeElement === element || element.contains(document.activeElement);
+}
+
+function isFocusable(element: HTMLElement): boolean {
+  if (!document.contains(element) || element.closest('[inert]')) {
+    return false;
+  }
+
+  if ('disabled' in element && element.disabled === true) {
+    return false;
+  }
+
+  if (element.closest('[hidden]')) {
+    return false;
+  }
+
+  const style = window.getComputedStyle(element);
+  if (style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse') {
+    return false;
+  }
+
+  if (element.getClientRects().length === 0) {
+    return false;
+  }
+
+  return element.tabIndex >= -1 || element.isContentEditable;
 }

--- a/ClientApps/trip-editor/src/composables/useConfirmDialog.ts
+++ b/ClientApps/trip-editor/src/composables/useConfirmDialog.ts
@@ -68,11 +68,19 @@ export const settleConfirmDialog = (confirmed: boolean): void => {
   }
 
   const resolver = activeResolver;
+  const settledDialogId = activeDialog.value?.id ?? nextDialogId;
   const returnFocusTarget = activeDialog.value?.returnFocusTarget ?? null;
   clearActiveDialog();
 
   resolver(confirmed);
-  window.setTimeout(() => restoreFocus(returnFocusTarget), 0);
+  window.setTimeout(() => {
+    // A chained dialog owns focus; stale restoration would move focus behind it.
+    if (activeDialog.value || nextDialogId !== settledDialogId) {
+      return;
+    }
+
+    restoreFocus(returnFocusTarget);
+  }, 0);
 };
 
 /// Disposes the Trip Editor confirm host and cancels any pending confirmation owned by it.

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -301,6 +301,61 @@ body {
   justify-content: center;
 }
 
+.trip-editor-confirm__backdrop {
+  background-color: #020617;
+  opacity: 0.72;
+  z-index: 1070;
+}
+
+.modal.trip-editor-confirm__modal {
+  display: block;
+  z-index: 1080;
+}
+
+.trip-editor-confirm-dialog {
+  max-width: min(420px, calc(100vw - 2rem));
+}
+
+.trip-editor-confirm-dialog__content {
+  background: #172033;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 8px;
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.45);
+  color: #e5e7eb;
+}
+
+.trip-editor-confirm-dialog__header,
+.trip-editor-confirm-dialog__footer {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.trip-editor-confirm-dialog__title {
+  font-size: 1.05rem;
+  line-height: 1.3;
+}
+
+.trip-editor-confirm-dialog__body p {
+  color: #cbd5e1;
+  margin: 0;
+}
+
+.trip-editor-confirm-dialog__footer {
+  gap: 0.5rem;
+}
+
+.trip-editor-confirm-dialog--warning .trip-editor-confirm-dialog__content {
+  border-color: rgba(245, 158, 11, 0.5);
+}
+
+.trip-editor-confirm-dialog--danger .trip-editor-confirm-dialog__content {
+  border-color: rgba(239, 68, 68, 0.55);
+}
+
+.trip-editor-confirm-dialog .btn:focus-visible {
+  box-shadow: 0 0 0 0.22rem rgba(147, 197, 253, 0.45);
+  outline: 0;
+}
+
 @media (max-width: 900px) {
   .trip-editor-workspace {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Closes #243.

## Summary
- Added a shared Trip Editor confirmation composable.
- Added a ConfirmDialog Vue host.
- Added Bootstrap-based compact dialog styling.
- Migrated metadata and region in-app confirms to the shared dialog.
- Preserved native beforeunload behavior.

## Scope exclusions
- No generic modal framework.
- No expanded editor, image dialog, visit modal, mobile sheet, or toast work.
- No place, area, or segment CRUD.
- No map editing, share progress, cutover, or legacy cleanup.

## Validation
- `npm run build`: passed.
- LOC checker: passed.
- `rg "window\\.confirm" ClientApps/trip-editor/src`: no matches.
- `rg "\\bconfirm\\(" ClientApps/trip-editor/src`: only shared dialog API calls.
- `git diff --check main...HEAD`: passed.

## Manual UI/#231 notes
- Metadata Back to Trips warning dialog: Vue warning dialog shown; cancel/Escape preserves draft and prevents navigation; confirm proceeds.
- Metadata Save & Exit region-draft warning dialog: Vue warning dialog shown; cancel preserves region draft and prevents action.
- Region dirty cancel/switch/create warning dialog: Vue warning dialog shown; cancel preserves draft/prevents action; confirm discards and proceeds.
- Region delete danger dialog: Vue danger dialog shown; cancel prevents delete; confirm proceeds.
- Region delete with dirty draft: warning dialog appears first, then danger dialog appears second after confirming discard.
- Region reorder dirty-discard warning: Vue warning dialog shown; cancel restores order and preserves draft; confirm proceeds.
- Browser reload/tab close remains native beforeunload behavior.
- Local screenshots/notes exist under `.local/confirm-dialog-screenshots/` and are intentionally untracked.

## Residual risk
- No automated frontend test harness for unmount/focus behavior; reviewed by code inspection and manual verification.