### PR TITLE
test(trip-editor): add Playwright UI verification harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,11 @@ wwwroot/frontend.manifest.json
 # npm/Vite generated files
 node_modules/
 wwwroot/vite/trip-editor/
+
+# Playwright dev-test artifacts
+playwright-report/
+test-results/
+.local/manual-verification.md
+.local/playwright/
+.local/test-results/
+.local/browser-profiles/

--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ dev server side-by-side:
 npm run dev
 ```
 
+Trip Editor browser verification is dev-only tooling. After the ASP.NET Core app
+and Vite are already running, configure local credentials with `WAYFARER_E2E_*`
+environment variables or ignored `.local/manual-verification.md`, then run:
+
+```bash
+npm run test:e2e:trip-editor
+```
+
+See `docs/22-Testing.md` for the required variables, local file format, and
+browser install command. Do not reset passwords or create users for this harness
+unless that is explicitly approved.
+
 Production and deployment builds still use `npm ci` and `npm run build` to emit
 static Trip Editor assets served by ASP.NET Core.
 

--- a/docs/22-Testing.md
+++ b/docs/22-Testing.md
@@ -6,6 +6,43 @@ Approach
 
 Running Tests
 - `dotnet test`
+- Trip Editor E2E: `npm run test:e2e:trip-editor`
+
+Trip Editor Playwright Verification
+- This is dev-only tooling for the Vue Trip Editor. It is not part of production deployment, and `npm run build` does not run Playwright.
+- Start the ASP.NET Core app first:
+
+```powershell
+dotnet run --urls http://localhost:5012
+```
+
+- Start Vite in a second terminal:
+
+```powershell
+npm run dev
+```
+
+- Configure credentials in the test terminal with environment variables:
+
+```powershell
+$env:WAYFARER_E2E_BASE_URL='http://localhost:5012'
+$env:WAYFARER_E2E_USERNAME='user'
+$env:WAYFARER_E2E_PASSWORD='local-password'
+$env:WAYFARER_E2E_TRIP_ID='15993426-552d-40e5-bd74-86dea34a3bf8'
+npm run test:e2e:trip-editor
+```
+
+- As an alternative, put the same keys in ignored `.local/manual-verification.md` as simple `KEY=value` lines or PowerShell `$env:KEY='value'` lines. Environment variables win when both sources are present.
+- Required keys are `WAYFARER_E2E_BASE_URL`, `WAYFARER_E2E_USERNAME`, `WAYFARER_E2E_PASSWORD`, and `WAYFARER_E2E_TRIP_ID`.
+- Do not commit credentials, screenshots, traces, videos, browser profiles, or Playwright reports.
+- Do not reset passwords or create users for E2E verification unless that action is explicitly approved.
+- Install browser binaries locally when needed:
+
+```powershell
+npx playwright install
+```
+
+- If browser verification cannot run, report the exact reason, such as missing `WAYFARER_E2E_*` settings, ASP.NET not running, Vite not running, or missing Playwright browser binaries. Do not describe skipped browser checks as passed.
 
 Coverage
 - Install tools and generate HTML: `dotnet tool restore` then `.\tools\coverage-report.ps1`

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "vite": "7.3.3",
         "vue": "3.5.34"
       },
-      "devDependencies": {}
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      }
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -484,6 +486,22 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
@@ -1137,6 +1155,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -5,15 +5,18 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173",
-    "build": "vite build"
+    "build": "vite build",
+    "test:e2e:trip-editor": "playwright test --config=playwright.config.ts"
   },
   "dependencies": {
+    "@types/leaflet": "1.9.21",
     "@vitejs/plugin-vue": "6.0.3",
-    "vite": "7.3.3",
-    "typescript": "5.9.3",
-    "vue": "3.5.34",
     "leaflet": "1.9.4",
-    "@types/leaflet": "1.9.21"
+    "typescript": "5.9.3",
+    "vite": "7.3.3",
+    "vue": "3.5.34"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
+  }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseUrl = process.env.WAYFARER_E2E_BASE_URL ?? 'http://localhost:5012';
+
+export default defineConfig({
+  testDir: './tests/e2e/trip-editor',
+  outputDir: '.local/playwright/test-output',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  use: {
+    baseURL: baseUrl,
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { loadTripEditorConfig } from './tripEditorConfig';
+
+const config = loadTripEditorConfig();
+const workspacePath = `/User/Trip/Workspace/${config.tripId}`;
+const legacyEditPath = `/User/Trip/Edit/${config.tripId}`;
+const editorApiPath = `/api/trips/${config.tripId}/editor`;
+
+test.describe('Trip Editor dev verification', () => {
+  test('login succeeds', async ({ page }) => {
+    await signIn(page);
+
+    await expect(page).toHaveURL(pathRegex(workspacePath));
+    await expect(page.getByRole('heading', { name: 'Trip Settings' })).toBeVisible();
+  });
+
+  test('workspace loads and Vue app mounts', async ({ page }) => {
+    await signIn(page);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+  });
+
+  test('editor API returns authenticated JSON', async ({ page }) => {
+    await signIn(page);
+
+    const response = await page.request.get(absoluteUrl(editorApiPath), {
+      headers: { Accept: 'application/json' }
+    });
+    expect(response.ok(), `GET ${editorApiPath} returned ${response.status()}`).toBeTruthy();
+    await expect(response).toHaveHeader('content-type', /application\/json/i);
+
+    const payload = await response.json();
+    expect(String(payload.tripId).toLowerCase()).toBe(config.tripId.toLowerCase());
+  });
+
+  test('legacy trip edit page loads', async ({ page }) => {
+    await signIn(page);
+    const response = await page.goto(absoluteUrl(legacyEditPath));
+
+    expect(response?.ok(), `GET ${legacyEditPath} returned ${response?.status() ?? 'no response'}`).toBeTruthy();
+    await expect(page).toHaveURL(pathRegex(legacyEditPath));
+    await expect(page.locator('body')).not.toContainText(/not found|unauthorized|forbidden/i);
+  });
+
+  test('current editor surface keeps metadata docked and excludes mockup-only place controls', async ({ page }) => {
+    await signIn(page);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    await expect(page.locator('.trip-editor-sidebar')).toContainText('Trip Settings');
+    await expect(page.locator('.trip-editor-metadata')).toBeVisible();
+    await expectTripLevelTagsOnly(page);
+    await expectMockupOnlyPlaceControlsAbsent(page);
+    await expectAddPlaceButtonsAreRegionScoped(page);
+    await expectUnimplementedAreaAndSegmentActionsAbsent(page);
+  });
+});
+
+// Signs in through the real Identity page without logging credential values.
+async function signIn(page: Page): Promise<void> {
+  await page.goto(absoluteUrl(`/Identity/Account/Login?ReturnUrl=${encodeURIComponent(workspacePath)}`));
+  await page.getByLabel('Username').fill(config.username);
+  await page.getByLabel('Password').fill(config.password);
+  await Promise.all([
+    page.waitForURL(url => !url.pathname.includes('/Identity/Account/Login')),
+    page.getByRole('button', { name: 'Log in' }).click()
+  ]);
+}
+
+// Waits for the Vue workspace to replace the Razor loading shell.
+async function expectMountedWorkspace(page: Page): Promise<void> {
+  const app = page.locator('#trip-editor-app');
+  await expect(app).toBeVisible();
+  await expect(app.locator('.trip-editor-workspace')).toBeVisible();
+  await expect(app).not.toContainText('Trip Editor development server is not available');
+  await expect(page.getByRole('heading', { name: 'Trip Settings' })).toBeVisible();
+  await expect(page.getByLabel('Read-only trip map')).toBeVisible();
+}
+
+// Confirms tags appear in the Trip-level panel and not inside the place editor form.
+async function expectTripLevelTagsOnly(page: Page): Promise<void> {
+  const tagsHeading = page.getByRole('heading', { name: 'Tags' });
+  if (await tagsHeading.isVisible()) {
+    await expect(tagsHeading.locator('xpath=ancestor::section[contains(@class, "trip-editor-panel")]')).toBeVisible();
+  }
+
+  const placeForm = await openFirstPlaceFormIfAvailable(page);
+  if (placeForm) {
+    await expect(placeForm.getByText(/^Tags$/i)).toHaveCount(0);
+    await expect(placeForm.getByLabel(/tags/i)).toHaveCount(0);
+  }
+}
+
+// Guards against fields from the design mockups that are not implemented on main.
+async function expectMockupOnlyPlaceControlsAbsent(page: Page): Promise<void> {
+  await expect(page.getByRole('tab', { name: /visit progress/i })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /visit progress/i })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /photos?/i })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /links?|official site/i })).toHaveCount(0);
+
+  const placeForm = await openFirstPlaceFormIfAvailable(page);
+  if (!placeForm) {
+    return;
+  }
+
+  await expect(placeForm.getByLabel(/photos?/i)).toHaveCount(0);
+  await expect(placeForm.getByLabel(/official site|links?/i)).toHaveCount(0);
+  await expect(placeForm.getByLabel(/^type$/i)).toHaveCount(0);
+  await expect(placeForm.getByLabel(/tags/i)).toHaveCount(0);
+  await expect(placeForm.getByText(/visit-progress|visit progress/i)).toHaveCount(0);
+}
+
+// Uses the existing region cards to ensure Add Place remains attached to a region surface.
+async function expectAddPlaceButtonsAreRegionScoped(page: Page): Promise<void> {
+  const addPlaceButtons = page.getByRole('button', { name: 'Add Place' });
+  const count = await addPlaceButtons.count();
+  for (let index = 0; index < count; index += 1) {
+    await expect(addPlaceButtons.nth(index).locator('xpath=ancestor::article[contains(@class, "trip-editor-region-card")]')).toHaveCount(1);
+  }
+}
+
+// Keeps future Add Area/Add Segment work from appearing as inert controls in this tooling baseline.
+async function expectUnimplementedAreaAndSegmentActionsAbsent(page: Page): Promise<void> {
+  await expect(page.getByRole('button', { name: /add area/i })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /add segment/i })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /add area/i })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /add segment/i })).toHaveCount(0);
+}
+
+async function openFirstPlaceFormIfAvailable(page: Page): Promise<Locator | null> {
+  const form = page.locator('form').filter({ has: page.getByRole('heading', { name: /^(Add|Edit) Place$/ }) });
+  if (await form.isVisible()) {
+    return form;
+  }
+
+  const addPlace = page.getByRole('button', { name: 'Add Place' }).first();
+  if ((await addPlace.count()) === 0 || !(await addPlace.isVisible()) || !(await addPlace.isEnabled())) {
+    return null;
+  }
+
+  await addPlace.click();
+  await expect(page.getByRole('heading', { name: 'Add Place' })).toBeVisible();
+  return form;
+}
+
+function pathRegex(path: string): RegExp {
+  return new RegExp(`${path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/?$`, 'i');
+}
+
+function absoluteUrl(path: string): string {
+  return `${config.baseUrl}${path}`;
+}

--- a/tests/e2e/trip-editor/tripEditorConfig.ts
+++ b/tests/e2e/trip-editor/tripEditorConfig.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type TripEditorE2EConfig = {
+  baseUrl: string;
+  username: string;
+  password: string;
+  tripId: string;
+};
+
+const configKeys = [
+  'WAYFARER_E2E_BASE_URL',
+  'WAYFARER_E2E_USERNAME',
+  'WAYFARER_E2E_PASSWORD',
+  'WAYFARER_E2E_TRIP_ID'
+] as const;
+
+type ConfigKey = (typeof configKeys)[number];
+
+// Loads Trip Editor E2E settings from environment variables, then the ignored local runbook.
+export function loadTripEditorConfig(): TripEditorE2EConfig {
+  const localConfig = readLocalManualVerification();
+  const values = Object.fromEntries(configKeys.map(key => [key, process.env[key] || localConfig[key] || ''])) as Record<ConfigKey, string>;
+  const missing = configKeys.filter(key => !values[key].trim());
+
+  if (missing.length > 0) {
+    throw new Error(
+      [
+        `Missing Trip Editor E2E configuration: ${missing.join(', ')}.`,
+        'Set the WAYFARER_E2E_* environment variables or add simple KEY=value lines to .local/manual-verification.md.',
+        'The password value is required but is never printed by this harness.'
+      ].join(' ')
+    );
+  }
+
+  return {
+    baseUrl: values.WAYFARER_E2E_BASE_URL.trim().replace(/\/+$/, ''),
+    username: values.WAYFARER_E2E_USERNAME.trim(),
+    password: values.WAYFARER_E2E_PASSWORD,
+    tripId: values.WAYFARER_E2E_TRIP_ID.trim()
+  };
+}
+
+// Parses only explicit KEY=value or PowerShell $env:KEY='value' lines from the ignored local runbook.
+function readLocalManualVerification(): Partial<Record<ConfigKey, string>> {
+  const filePath = path.resolve(process.cwd(), '.local', 'manual-verification.md');
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+
+  const result: Partial<Record<ConfigKey, string>> = {};
+  const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+  for (const line of lines) {
+    const match = line.match(/^\s*(?:\$env:)?(WAYFARER_E2E_[A-Z_]+)\s*=\s*['"`]?([^'"`\r\n]+)['"`]?\s*$/);
+    if (!match || !configKeys.includes(match[1] as ConfigKey)) {
+      continue;
+    }
+
+    result[match[1] as ConfigKey] = match[2].trim();
+  }
+
+  return result;
+}


### PR DESCRIPTION
Summary:
- Adds dev-only Playwright harness for Trip Editor UI verification.
- Adds npm script npm run test:e2e:trip-editor.
- Adds env/local runbook configuration support without committing secrets.
- Adds initial Trip Editor smoke/UI checks.
- Documents ASP.NET + Vite + Playwright local workflow.
- Keeps production build/deployment unaffected.

Validation:
- npm run build passed.
- npx playwright test --config=playwright.config.ts --list with dummy non-secret env values passed and discovered tests.
- npm run test:e2e:trip-editor with missing config failed clearly with missing WAYFARER_E2E_* keys and did not print password.
- LOC checker passed with no warnings.
- git diff --check main...HEAD passed.
- git status --short --untracked-files=all clean.
- dotnet build not run because no C#/Razor/backend/deployment files changed.

Notes:
- Browser execution against a live app requires ASP.NET + Vite running and local credentials via env vars or .local/manual-verification.md.
- This is dev-only tooling; production deployment is not changed.
