### PR TITLE
feat(trip-editor): add sidebar search filter

### DIFF
--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -16,6 +16,10 @@ const props = defineProps<{
   editorSurface: EditorSurfaceController;
   editorEndpoint: string;
   antiforgeryToken: string;
+  searchActive: boolean;
+  searchRegions: EditorRegion[];
+  searchPlaceIdsByRegionId: Record<Guid, Guid[]>;
+  searchAreaIdsByRegionId: Record<Guid, Guid[]>;
 }>();
 
 const emit = defineEmits<{
@@ -46,6 +50,33 @@ const regionDirty = computed(() => JSON.stringify(buildRegionRequest(draft)) !==
 const placeDirty = computed(() => JSON.stringify(buildPlaceRequest(placeDraft)) !== JSON.stringify(placeBaselineRequest.value));
 const isDirty = computed(() => regionDirty.value || placeDirty.value);
 const normalRegions = computed(() => orderedRegions.value.filter(region => !region.isShadow));
+const renderedRegions = computed(() => {
+  const regions = props.searchActive ? [...props.searchRegions] : [...orderedRegions.value];
+  const included = new Set(regions.map(region => region.id));
+
+  for (const region of activeContextRegions()) {
+    if (!included.has(region.id)) {
+      regions.push(region);
+      included.add(region.id);
+    }
+  }
+
+  return regions;
+});
+const renderedPlaceIdsByRegionId = computed(() => {
+  if (!props.searchActive) {
+    return props.state.placeOrderByRegionId;
+  }
+
+  const result = cloneIdRecord(props.searchPlaceIdsByRegionId);
+  if (activePlace.value) {
+    pushUnique(result, activePlace.value.regionId, activePlace.value.id);
+  }
+
+  return result;
+});
+const renderedAreaIdsByRegionId = computed(() => (props.searchActive ? props.searchAreaIdsByRegionId : props.state.areaOrderByRegionId));
+const forcedExpandedRegionIds = computed(() => new Set(props.searchActive ? renderedRegions.value.map(region => region.id) : []));
 const regionBaselineRequest = computed(() => draft.id ? buildRegionRequest(toRegionDraft(activeRegion.value)) : regionCreateBaselineRequest.value ?? buildRegionRequest(emptyRegionDraft()));
 const placeBaselineRequest = computed(() => placeDraft.id ? buildPlaceRequest(toPlaceDraft(activePlace.value, placeDraft.regionId)) : placeCreateBaselineRequest.value ?? buildPlaceRequest(emptyPlaceDraft(placeDraft.regionId)));
 const activeRegionTarget = computed<EditorTarget>(() => ({
@@ -372,6 +403,34 @@ function hasRegionChildren(region: EditorRegion): boolean {
   return (props.state.placeOrderByRegionId[region.id]?.length ?? 0) > 0 || (props.state.areaOrderByRegionId[region.id]?.length ?? 0) > 0;
 }
 
+function activeContextRegions(): EditorRegion[] {
+  const regions: EditorRegion[] = [];
+  if (activeRegion.value) {
+    regions.push(activeRegion.value);
+  }
+
+  const activePlaceRegionId = activePlace.value?.regionId ?? placeDraft.regionId;
+  if (activePlaceRegionId) {
+    const region = props.state.regionsById[activePlaceRegionId];
+    if (region) {
+      regions.push(region);
+    }
+  }
+
+  return regions;
+}
+
+function cloneIdRecord(record: Record<Guid, Guid[]>): Record<Guid, Guid[]> {
+  return Object.fromEntries(Object.entries(record).map(([regionId, ids]) => [regionId, [...ids]]));
+}
+
+function pushUnique(record: Record<Guid, Guid[]>, regionId: Guid, id: Guid): void {
+  record[regionId] = record[regionId] ?? [];
+  if (!record[regionId].includes(id)) {
+    record[regionId].push(id);
+  }
+}
+
 function confirmDiscard(message = 'Discard unsaved changes?'): Promise<boolean> {
   if (!isDirty.value) {
     return Promise.resolve(true);
@@ -434,7 +493,7 @@ function isPlaceCreateOpen(region: EditorRegion): boolean {
 
     <RegionEditorSurface v-if="isDraftOpen && !draft.id" :active-region="activeRegion" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="regionFormId" :form-summary-errors="formSummaryErrors" :is-dirty="regionDirty" :is-saving="isSaving" :status-text="statusText" :target="activeRegionTarget" @cancel="cancelDraft" @delete="deleteDraftRegion" @reset="resetDraft" @save="saveDraft" />
 
-    <RegionPlaceList :key="regionListKey" :active-place-id="activePlace?.id ?? null" :active-region-id="activeRegion?.id ?? null" :is-ordering="isOrdering" :is-saving="isSaving" :regions="orderedRegions" :state="state" @add-place="openPlaceCreate" @edit-place="openPlaceEdit" @edit-region="openEdit" @place-reorder="reorderPlaces" @region-reorder="reorderRegions">
+    <RegionPlaceList :key="regionListKey" :active-place-id="activePlace?.id ?? null" :active-region-id="activeRegion?.id ?? null" :force-expanded-region-ids="forcedExpandedRegionIds" :is-ordering="isOrdering" :is-saving="isSaving" :place-ids-by-region-id="renderedPlaceIdsByRegionId" :area-ids-by-region-id="renderedAreaIdsByRegionId" :regions="renderedRegions" :search-active="searchActive" :state="state" @add-place="openPlaceCreate" @edit-place="openPlaceEdit" @edit-region="openEdit" @place-reorder="reorderPlaces" @region-reorder="reorderRegions">
       <template #region-editor="{ region }">
         <RegionEditorSurface v-if="isRegionEditOpen(region)" :active-region="activeRegion" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="regionFormId" :form-summary-errors="formSummaryErrors" :is-dirty="regionDirty" :is-saving="isSaving" :status-text="statusText" :target="activeRegionTarget" @cancel="cancelDraft" @delete="deleteDraftRegion" @reset="resetDraft" @save="saveDraft" />
       </template>

--- a/ClientApps/trip-editor/src/components/RegionPlaceList.vue
+++ b/ClientApps/trip-editor/src/components/RegionPlaceList.vue
@@ -13,9 +13,13 @@ declare global {
 const props = defineProps<{
   activePlaceId: Guid | null;
   activeRegionId: Guid | null;
+  areaIdsByRegionId: Record<Guid, Guid[]>;
+  forceExpandedRegionIds: Set<Guid>;
   isOrdering: boolean;
   isSaving: boolean;
+  placeIdsByRegionId: Record<Guid, Guid[]>;
   regions: EditorRegion[];
+  searchActive: boolean;
   state: EditorTripState;
 }>();
 
@@ -29,16 +33,32 @@ const emit = defineEmits<{
 
 const regionList = ref<HTMLElement | null>(null);
 const collapsedRegionIds = ref<Set<Guid>>(new Set());
+const searchCollapsedSnapshot = ref<Set<Guid> | null>(null);
 const placeSortables = new Map<string, { destroy: () => void }>();
 let sortable: { destroy: () => void } | null = null;
 let reorderSnapshotIds: Guid[] | null = null;
 let placeReorderSnapshot: { regionId: Guid; ids: Guid[] } | null = null;
 
 watch(
-  () => `${props.regions.map(region => region.id).join('|')}|${Object.entries(props.state.placeOrderByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}`,
+  () => `${props.searchActive}|${props.regions.map(region => region.id).join('|')}|${Object.entries(props.placeIdsByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}`,
   async () => {
     await nextTick();
     attachSortables();
+  }
+);
+
+watch(
+  () => props.searchActive,
+  value => {
+    if (value) {
+      searchCollapsedSnapshot.value = new Set(collapsedRegionIds.value);
+      return;
+    }
+
+    if (searchCollapsedSnapshot.value) {
+      collapsedRegionIds.value = new Set(searchCollapsedSnapshot.value);
+      searchCollapsedSnapshot.value = null;
+    }
   }
 );
 
@@ -57,7 +77,7 @@ function attachSortables(): void {
 function attachRegionSortable(): void {
   sortable?.destroy();
   sortable = null;
-  if (!regionList.value || !window.Sortable) {
+  if (props.searchActive || !regionList.value || !window.Sortable) {
     return;
   }
 
@@ -85,7 +105,7 @@ function attachRegionSortable(): void {
 
 function attachPlaceSortables(): void {
   destroyPlaceSortables();
-  if (!window.Sortable) {
+  if (props.searchActive || !window.Sortable) {
     return;
   }
 
@@ -120,18 +140,26 @@ function normalRegionIds(): Guid[] {
 }
 
 function orderedPlaces(regionId: Guid): EditorPlace[] {
-  return (props.state.placeOrderByRegionId[regionId] ?? []).map(id => props.state.placesById[id]).filter(Boolean) as EditorPlace[];
+  return (props.placeIdsByRegionId[regionId] ?? []).map(id => props.state.placesById[id]).filter(Boolean) as EditorPlace[];
 }
 
 function orderedAreas(regionId: Guid): EditorArea[] {
-  return (props.state.areaOrderByRegionId[regionId] ?? []).map(id => props.state.areasById[id]).filter(Boolean) as EditorArea[];
+  return (props.areaIdsByRegionId[regionId] ?? []).map(id => props.state.areasById[id]).filter(Boolean) as EditorArea[];
 }
 
 function isCollapsed(regionId: Guid): boolean {
+  if (props.forceExpandedRegionIds.has(regionId)) {
+    return false;
+  }
+
   return collapsedRegionIds.value.has(regionId);
 }
 
 function toggleRegion(regionId: Guid): void {
+  if (props.searchActive) {
+    return;
+  }
+
   const next = new Set(collapsedRegionIds.value);
   if (next.has(regionId)) {
     next.delete(regionId);
@@ -164,6 +192,7 @@ function toggleRegion(regionId: Guid): void {
           class="trip-editor-icon-button trip-editor-drag-handle"
           title="Drag to reorder region"
           aria-label="Drag to reorder region"
+          :disabled="props.searchActive"
         >
           <span aria-hidden="true">::</span>
         </button>
@@ -177,6 +206,7 @@ function toggleRegion(regionId: Guid): void {
             class="btn btn-outline-light btn-sm"
             :aria-expanded="!isCollapsed(region.id)"
             :aria-controls="`trip-editor-region-children-${region.id}`"
+            :disabled="props.searchActive"
             @click="toggleRegion(region.id)"
           >
             {{ isCollapsed(region.id) ? 'Expand' : 'Collapse' }}
@@ -200,6 +230,7 @@ function toggleRegion(regionId: Guid): void {
               class="trip-editor-icon-button trip-editor-place-drag-handle"
               title="Drag to reorder place"
               aria-label="Drag to reorder place"
+              :disabled="props.searchActive"
             >
               <span aria-hidden="true">::</span>
             </button>

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
-import type { EditorMutationResult, EditorSegment, EditorTripState } from '../types';
+import { computed, ref } from 'vue';
+import type { EditorArea, EditorMutationResult, EditorPlace, EditorRegion, EditorSegment, EditorTripState, Guid } from '../types';
 import type { EditorSurfaceController } from '../composables/useEditorSurface';
 import MetadataEditor from './MetadataEditor.vue';
 import RegionManager from './RegionManager.vue';
 
-defineProps<{
+type SidebarSearchResult = {
+  hasMatches: boolean;
+  regions: EditorRegion[];
+  placesByRegionId: Record<Guid, Guid[]>;
+  areasByRegionId: Record<Guid, Guid[]>;
+};
+
+const props = defineProps<{
   state: EditorTripState;
   editorSurface: EditorSurfaceController;
   editorEndpoint: string;
@@ -19,14 +27,95 @@ const emit = defineEmits<{
   regionDraftDirtyChanged: [isDirty: boolean];
 }>();
 
-const orderedSegments = (state: EditorTripState): EditorSegment[] =>
-  state.segmentOrder.map(id => state.segmentsById[id]).filter(Boolean) as EditorSegment[];
+const searchQuery = ref('');
+const normalizedSearchQuery = computed(() => normalize(searchQuery.value));
+const searchMinimumCharacters = computed(() => props.state.options.limits.sidebarSearchMinCharacters ?? 1);
+const isSearchActive = computed(() => normalizedSearchQuery.value.length >= searchMinimumCharacters.value);
+const orderedSegments = computed(() => props.state.segmentOrder.map(id => props.state.segmentsById[id]).filter(Boolean) as EditorSegment[]);
+const filteredSegments = computed(() => (isSearchActive.value ? orderedSegments.value.filter(segment => matchesSegment(props.state, segment, normalizedSearchQuery.value)) : orderedSegments.value));
+const sidebarSearch = computed<SidebarSearchResult>(() => {
+  if (!isSearchActive.value) {
+    return {
+      hasMatches: true,
+      regions: orderedVisibleRegions(props.state),
+      placesByRegionId: props.state.placeOrderByRegionId,
+      areasByRegionId: props.state.areaOrderByRegionId
+    };
+  }
+
+  const result: SidebarSearchResult = {
+    hasMatches: false,
+    regions: [],
+    placesByRegionId: {},
+    areasByRegionId: {}
+  };
+
+  for (const region of orderedVisibleRegions(props.state)) {
+    const regionMatches = includesSearch(region.name, normalizedSearchQuery.value);
+    const places = orderedPlaces(props.state, region.id);
+    const areas = orderedAreas(props.state, region.id);
+    const matchingPlaces = regionMatches ? places : places.filter(place => matchesPlace(place, normalizedSearchQuery.value));
+    const matchingAreas = regionMatches ? areas : areas.filter(area => includesSearch(area.name, normalizedSearchQuery.value));
+
+    if (!regionMatches && matchingPlaces.length === 0 && matchingAreas.length === 0) {
+      continue;
+    }
+
+    result.hasMatches = true;
+    result.regions.push(region);
+    result.placesByRegionId[region.id] = matchingPlaces.map(place => place.id);
+    result.areasByRegionId[region.id] = matchingAreas.map(area => area.id);
+  }
+
+  return result;
+});
+const hasSidebarSearchMatches = computed(() => sidebarSearch.value.hasMatches || filteredSegments.value.length > 0);
 
 const segmentLabel = (state: EditorTripState, segment: EditorSegment): string => {
   const from = segment.fromPlaceId ? state.placesById[segment.fromPlaceId]?.name : null;
   const to = segment.toPlaceId ? state.placesById[segment.toPlaceId]?.name : null;
   return [from, to].filter(Boolean).join(' to ') || segment.mode || 'Segment';
 };
+
+const transportModeLabel = (state: EditorTripState, mode: string): string | null =>
+  state.options.transportModes.find(option => option.value === mode)?.label ?? null;
+
+const segmentModeText = (state: EditorTripState, segment: EditorSegment): string =>
+  (transportModeLabel(state, segment.mode) ?? segment.mode) || 'mode unset';
+
+function orderedVisibleRegions(state: EditorTripState): EditorRegion[] {
+  return state.regionOrder.map(id => state.regionsById[id]).filter(region => region && (!region.isShadow || hasRegionChildren(state, region))) as EditorRegion[];
+}
+
+function orderedPlaces(state: EditorTripState, regionId: Guid): EditorPlace[] {
+  return (state.placeOrderByRegionId[regionId] ?? []).map(id => state.placesById[id]).filter(Boolean) as EditorPlace[];
+}
+
+function orderedAreas(state: EditorTripState, regionId: Guid): EditorArea[] {
+  return (state.areaOrderByRegionId[regionId] ?? []).map(id => state.areasById[id]).filter(Boolean) as EditorArea[];
+}
+
+function hasRegionChildren(state: EditorTripState, region: EditorRegion): boolean {
+  return orderedPlaces(state, region.id).length > 0 || orderedAreas(state, region.id).length > 0;
+}
+
+function matchesPlace(place: EditorPlace, query: string): boolean {
+  return includesSearch(place.name, query) || includesSearch(place.address, query);
+}
+
+function matchesSegment(state: EditorTripState, segment: EditorSegment, query: string): boolean {
+  const from = segment.fromPlaceId ? state.placesById[segment.fromPlaceId]?.name : null;
+  const to = segment.toPlaceId ? state.placesById[segment.toPlaceId]?.name : null;
+  return [segmentLabel(state, segment), segment.mode, transportModeLabel(state, segment.mode), from, to].some(value => includesSearch(value, query));
+}
+
+function includesSearch(value: string | null | undefined, query: string): boolean {
+  return normalize(value ?? '').includes(query);
+}
+
+function normalize(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
 </script>
 
 <template>
@@ -67,21 +156,33 @@ const segmentLabel = (state: EditorTripState, segment: EditorSegment): string =>
       </div>
     </section>
 
+    <section class="trip-editor-panel trip-editor-sidebar-search">
+      <label class="trip-editor-field">
+        <span>Sidebar search</span>
+        <input v-model="searchQuery" type="search" autocomplete="off" :placeholder="`Search regions, places, areas, segments`" />
+      </label>
+      <p v-if="isSearchActive && !hasSidebarSearchMatches" class="trip-editor-empty-state">No matching regions, places, areas, or segments.</p>
+    </section>
+
     <RegionManager
       :state="state"
       :editor-surface="editorSurface"
       :editor-endpoint="editorEndpoint"
       :antiforgery-token="antiforgeryToken"
+      :search-active="isSearchActive"
+      :search-regions="sidebarSearch.regions"
+      :search-place-ids-by-region-id="sidebarSearch.placesByRegionId"
+      :search-area-ids-by-region-id="sidebarSearch.areasByRegionId"
       @mutation-applied="result => emit('mutationApplied', result)"
       @dirty-state-changed="isDirty => emit('regionDraftDirtyChanged', isDirty)"
     />
 
-    <section v-if="state.segmentOrder.length > 0" class="trip-editor-panel">
+    <section v-if="state.segmentOrder.length > 0 && (!isSearchActive || filteredSegments.length > 0)" class="trip-editor-panel">
       <h2>Segments</h2>
       <ul class="trip-editor-segments">
-        <li v-for="segment in orderedSegments(state)" :key="segment.id">
+        <li v-for="segment in filteredSegments" :key="segment.id">
           <span>{{ segmentLabel(state, segment) }}</span>
-          <small>{{ segment.mode || 'mode unset' }}</small>
+          <small>{{ segmentModeText(state, segment) }}</small>
         </li>
       </ul>
     </section>

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -29,7 +29,7 @@ const emit = defineEmits<{
 
 const searchQuery = ref('');
 const normalizedSearchQuery = computed(() => normalize(searchQuery.value));
-const searchMinimumCharacters = computed(() => props.state.options.limits.sidebarSearchMinCharacters ?? 1);
+const searchMinimumCharacters = computed(() => props.state.options.limits?.sidebarSearchMinCharacters ?? 1);
 const isSearchActive = computed(() => normalizedSearchQuery.value.length >= searchMinimumCharacters.value);
 const orderedSegments = computed(() => props.state.segmentOrder.map(id => props.state.segmentsById[id]).filter(Boolean) as EditorSegment[]);
 const filteredSegments = computed(() => (isSearchActive.value ? orderedSegments.value.filter(segment => matchesSegment(props.state, segment, normalizedSearchQuery.value)) : orderedSegments.value));

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -267,6 +267,18 @@ body {
   gap: 0.4rem;
 }
 
+.trip-editor-sidebar-search {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.trip-editor-empty-state {
+  background: var(--trip-editor-surface-muted);
+  border: 1px solid var(--trip-editor-border);
+  border-radius: 6px;
+  padding: 0.55rem 0.65rem;
+}
+
 .trip-editor-region-list,
 .trip-editor-region-form {
   display: grid;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
   testDir: './tests/e2e/trip-editor',
   outputDir: '.local/playwright/test-output',
   fullyParallel: false,
+  // Keep shared runbook trip checks serialized across split spec files.
+  workers: 1,
   forbidOnly: Boolean(process.env.CI),
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
   use: {

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -349,4 +349,3 @@ async function setTheme(page: Page, theme: 'dark' | 'light'): Promise<void> {
 async function capture(page: Page, testInfo: TestInfo, name: string): Promise<void> {
   await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
 }
-

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -5,6 +5,28 @@ const config = loadTripEditorConfig();
 const workspacePath = `/User/Trip/Workspace/${config.tripId}`;
 const legacyEditPath = `/User/Trip/Edit/${config.tripId}`;
 const editorApiPath = `/api/trips/${config.tripId}/editor`;
+const forbiddenSidebarSearchRequest = /nominatim|geosearch|search-add|searchadd|\/search(?:[/?#]|$)/i;
+
+type EditorTripFixture = {
+  regionsById: Record<string, { id: string; name: string; isShadow: boolean }>;
+  regionOrder: string[];
+  placesById: Record<string, { id: string; name: string; address: string; regionId: string }>;
+  placeOrderByRegionId: Record<string, string[]>;
+  areasById: Record<string, { id: string; name: string; regionId: string }>;
+  areaOrderByRegionId: Record<string, string[]>;
+  segmentsById: Record<string, { id: string; mode: string; fromPlaceId: string | null; toPlaceId: string | null }>;
+  segmentOrder: string[];
+  tagOrder: string[];
+  tagsBySlug: Record<string, { name: string }>;
+  options: { transportModes: Array<{ value: string; label: string }> };
+};
+
+type SidebarSearchFixture = {
+  region: { name: string };
+  place: { name: string; regionName: string };
+  area: { name: string; regionName: string } | null;
+  segment: { query: string; label: string } | null;
+};
 
 test.describe.serial('Trip Editor dev verification', () => {
   test('login succeeds', async ({ page }) => {
@@ -178,6 +200,110 @@ test.describe.serial('Trip Editor dev verification', () => {
     await expect(children).toBeVisible();
   });
 
+  test('sidebar search filters regions and places without network search or draft loss', async ({ page }) => {
+    await signIn(page);
+    const state = await loadEditorStateFixture(page);
+    const fixture = sidebarSearchFixture(state);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    const requests = collectForbiddenSidebarSearchRequests(page);
+    const search = page.getByLabel('Sidebar search');
+    await expect(search).toBeVisible();
+
+    const tagsPanel = page.getByRole('heading', { name: 'Tags' }).locator('xpath=ancestor::section[contains(@class, "trip-editor-panel")]');
+    const tagsText = (await tagsPanel.count()) > 0 && await tagsPanel.isVisible() ? await tagsPanel.innerText() : null;
+
+    await search.fill(fixture.region.name);
+    await expect(regionCard(page, fixture.region.name)).toBeVisible();
+    await expect(tagsPanel).toHaveCount(tagsText ? 1 : 0);
+    if (tagsText) {
+      expect(await tagsPanel.innerText()).toBe(tagsText);
+    }
+
+    const placeRegion = regionCard(page, fixture.place.regionName);
+    await search.fill(fixture.place.name);
+    await expect(placeRegion).toBeVisible();
+    await expect(placeRegion).toContainText(fixture.place.name);
+    await expectNoSearchAddUi(page);
+    expect(requests(), 'Sidebar search should not call Nominatim, geosearch, search-add, or search endpoints.').toEqual([]);
+
+    const children = placeRegion.locator('ul');
+    await search.fill('');
+    await expect(regionCard(page, fixture.region.name)).toBeVisible();
+    await expect(children).toBeVisible();
+
+    await regionEditButton(regionCard(page, fixture.region.name)).click();
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Region - ${escapeRegex(fixture.region.name)}`) })).toBeVisible();
+    await search.fill(uniqueName('no matching region draft query'));
+    await expect(regionCard(page, fixture.region.name)).toBeVisible();
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Region - ${escapeRegex(fixture.region.name)}`) })).toBeVisible();
+    await closeDraftWithDiscard(page);
+    await search.fill('');
+
+    await placeRegion.getByText(fixture.place.name).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(fixture.place.name)}`) })).toBeVisible();
+    await search.fill(uniqueName('no matching place draft query'));
+    await expect(placeRegion).toBeVisible();
+    await expect(placeRegion).toContainText(fixture.place.name);
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(fixture.place.name)}`) })).toBeVisible();
+    await closeDraftWithDiscard(page);
+  });
+
+  test('sidebar search restores collapsed hierarchy after clear', async ({ page }) => {
+    await signIn(page);
+    const state = await loadEditorStateFixture(page);
+    const fixture = sidebarSearchFixture(state);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    const card = regionCard(page, fixture.place.regionName);
+    const children = card.locator('ul');
+    const toggle = card.getByRole('button', { name: 'Collapse' });
+    await expect(children).toBeVisible();
+    await toggle.click();
+    await expect(children).toBeHidden();
+
+    await page.getByLabel('Sidebar search').fill(fixture.place.name);
+    await expect(children).toBeVisible();
+    await expect(card.getByRole('button', { name: 'Collapse' })).toBeDisabled();
+    await page.getByLabel('Sidebar search').fill(`${fixture.place.name} unmatched suffix`);
+    await expect(children).toBeHidden();
+    await page.getByLabel('Sidebar search').fill(fixture.place.name);
+    await expect(children).toBeVisible();
+
+    await page.getByLabel('Sidebar search').fill('');
+    await expect(children).toBeHidden();
+    await expect(card.getByRole('button', { name: 'Expand' })).toBeEnabled();
+  });
+
+  test('sidebar search filters areas when the configured trip has area fixture data', async ({ page }) => {
+    await signIn(page);
+    const state = await loadEditorStateFixture(page);
+    const fixture = sidebarSearchFixture(state);
+    test.skip(!fixture.area, 'Configured Trip Editor fixture has no loaded area rows to verify sidebar area search.');
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    await page.getByLabel('Sidebar search').fill(fixture.area!.name);
+    const card = regionCard(page, fixture.area!.regionName);
+    await expect(card).toBeVisible();
+    await expect(card).toContainText(fixture.area!.name);
+  });
+
+  test('sidebar search filters segments when the configured trip has segment fixture data', async ({ page }) => {
+    await signIn(page);
+    const state = await loadEditorStateFixture(page);
+    const fixture = sidebarSearchFixture(state);
+    test.skip(!fixture.segment, 'Configured Trip Editor fixture has no loaded segment rows to verify sidebar segment search.');
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    await page.getByLabel('Sidebar search').fill(fixture.segment!.query);
+    await expect(page.getByRole('heading', { name: 'Segments' })).toBeVisible();
+    await expect(page.locator('.trip-editor-segments')).toContainText(fixture.segment!.label);
+  });
+
   test('responsive narrow workspace remains usable', async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 900 });
     await signIn(page);
@@ -305,6 +431,61 @@ async function expectUnimplementedAreaAndSegmentActionsAbsent(page: Page): Promi
   await expect(page.getByRole('button', { name: /add segment/i })).toHaveCount(0);
   await expect(page.getByRole('link', { name: /add area/i })).toHaveCount(0);
   await expect(page.getByRole('link', { name: /add segment/i })).toHaveCount(0);
+}
+
+async function loadEditorStateFixture(page: Page): Promise<EditorTripFixture> {
+  const response = await page.request.get(absoluteUrl(editorApiPath), {
+    headers: { Accept: 'application/json' }
+  });
+  expect(response.ok(), `GET ${editorApiPath} returned ${response.status()}`).toBeTruthy();
+  return (await response.json()) as EditorTripFixture;
+}
+
+function sidebarSearchFixture(state: EditorTripFixture): SidebarSearchFixture {
+  const place = Object.values(state.placesById)[0];
+  if (!place) {
+    throw new Error('Configured Trip Editor fixture must contain at least one loaded place for sidebar search coverage.');
+  }
+
+  const placeRegion = state.regionsById[place.regionId];
+  if (!placeRegion) {
+    throw new Error(`Configured Trip Editor fixture place ${place.id} references a missing parent region.`);
+  }
+
+  const area = Object.values(state.areasById)[0] ?? null;
+  const areaRegion = area ? state.regionsById[area.regionId] : null;
+  const segment = state.segmentOrder.map(id => state.segmentsById[id]).find(Boolean) ?? null;
+
+  return {
+    region: { name: placeRegion.name },
+    place: { name: place.name, regionName: placeRegion.name },
+    area: area && areaRegion ? { name: area.name, regionName: areaRegion.name } : null,
+    segment: segment ? segmentSearchFixture(state, segment) : null
+  };
+}
+
+function segmentSearchFixture(state: EditorTripFixture, segment: EditorTripFixture['segmentsById'][string]): { query: string; label: string } {
+  const from = segment.fromPlaceId ? state.placesById[segment.fromPlaceId]?.name : null;
+  const to = segment.toPlaceId ? state.placesById[segment.toPlaceId]?.name : null;
+  const label = [from, to].filter(Boolean).join(' to ') || segment.mode || 'Segment';
+  const modeLabel = state.options.transportModes.find(mode => mode.value === segment.mode)?.label;
+  return { query: modeLabel || segment.mode || label, label };
+}
+
+function collectForbiddenSidebarSearchRequests(page: Page): () => string[] {
+  const urls: string[] = [];
+  page.on('request', request => {
+    if (forbiddenSidebarSearchRequest.test(request.url())) {
+      urls.push(request.url());
+    }
+  });
+
+  return () => urls;
+}
+
+async function expectNoSearchAddUi(page: Page): Promise<void> {
+  await expect(page.getByRole('button', { name: /search.?add|add from search/i })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /search.?add|add from search/i })).toHaveCount(0);
 }
 
 async function openFirstPlaceFormIfAvailable(page: Page): Promise<Locator | null> {

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -1,32 +1,22 @@
 import { expect, test, type Locator, type Page, type TestInfo } from '@playwright/test';
-import { loadTripEditorConfig } from './tripEditorConfig';
-
-const config = loadTripEditorConfig();
-const workspacePath = `/User/Trip/Workspace/${config.tripId}`;
-const legacyEditPath = `/User/Trip/Edit/${config.tripId}`;
-const editorApiPath = `/api/trips/${config.tripId}/editor`;
-const forbiddenSidebarSearchRequest = /nominatim|geosearch|search-add|searchadd|\/search(?:[/?#]|$)/i;
-
-type EditorTripFixture = {
-  regionsById: Record<string, { id: string; name: string; isShadow: boolean }>;
-  regionOrder: string[];
-  placesById: Record<string, { id: string; name: string; address: string; regionId: string }>;
-  placeOrderByRegionId: Record<string, string[]>;
-  areasById: Record<string, { id: string; name: string; regionId: string }>;
-  areaOrderByRegionId: Record<string, string[]>;
-  segmentsById: Record<string, { id: string; mode: string; fromPlaceId: string | null; toPlaceId: string | null }>;
-  segmentOrder: string[];
-  tagOrder: string[];
-  tagsBySlug: Record<string, { name: string }>;
-  options: { transportModes: Array<{ value: string; label: string }> };
-};
-
-type SidebarSearchFixture = {
-  region: { name: string };
-  place: { name: string; regionName: string };
-  area: { name: string; regionName: string } | null;
-  segment: { query: string; label: string } | null;
-};
+import {
+  absoluteUrl,
+  closeDraftWithDiscard,
+  config,
+  editorApiPath,
+  escapeRegex,
+  expectActiveMetadataSurface,
+  expectMountedWorkspace,
+  firstRegionWithChildren,
+  firstVisibleAddPlace,
+  legacyEditPath,
+  pathRegex,
+  regionCard,
+  regionEditButton,
+  signIn,
+  uniqueName,
+  workspacePath
+} from './tripEditorTestUtils';
 
 test.describe.serial('Trip Editor dev verification', () => {
   test('login succeeds', async ({ page }) => {
@@ -200,110 +190,6 @@ test.describe.serial('Trip Editor dev verification', () => {
     await expect(children).toBeVisible();
   });
 
-  test('sidebar search filters regions and places without network search or draft loss', async ({ page }) => {
-    await signIn(page);
-    const state = await loadEditorStateFixture(page);
-    const fixture = sidebarSearchFixture(state);
-    await page.goto(absoluteUrl(workspacePath));
-    await expectMountedWorkspace(page);
-
-    const requests = collectForbiddenSidebarSearchRequests(page);
-    const search = page.getByLabel('Sidebar search');
-    await expect(search).toBeVisible();
-
-    const tagsPanel = page.getByRole('heading', { name: 'Tags' }).locator('xpath=ancestor::section[contains(@class, "trip-editor-panel")]');
-    const tagsText = (await tagsPanel.count()) > 0 && await tagsPanel.isVisible() ? await tagsPanel.innerText() : null;
-
-    await search.fill(fixture.region.name);
-    await expect(regionCard(page, fixture.region.name)).toBeVisible();
-    await expect(tagsPanel).toHaveCount(tagsText ? 1 : 0);
-    if (tagsText) {
-      expect(await tagsPanel.innerText()).toBe(tagsText);
-    }
-
-    const placeRegion = regionCard(page, fixture.place.regionName);
-    await search.fill(fixture.place.name);
-    await expect(placeRegion).toBeVisible();
-    await expect(placeRegion).toContainText(fixture.place.name);
-    await expectNoSearchAddUi(page);
-    expect(requests(), 'Sidebar search should not call Nominatim, geosearch, search-add, or search endpoints.').toEqual([]);
-
-    const children = placeRegion.locator('ul');
-    await search.fill('');
-    await expect(regionCard(page, fixture.region.name)).toBeVisible();
-    await expect(children).toBeVisible();
-
-    await regionEditButton(regionCard(page, fixture.region.name)).click();
-    await expect(page.getByRole('heading', { name: new RegExp(`Edit Region - ${escapeRegex(fixture.region.name)}`) })).toBeVisible();
-    await search.fill(uniqueName('no matching region draft query'));
-    await expect(regionCard(page, fixture.region.name)).toBeVisible();
-    await expect(page.getByRole('heading', { name: new RegExp(`Edit Region - ${escapeRegex(fixture.region.name)}`) })).toBeVisible();
-    await closeDraftWithDiscard(page);
-    await search.fill('');
-
-    await placeRegion.getByText(fixture.place.name).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
-    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(fixture.place.name)}`) })).toBeVisible();
-    await search.fill(uniqueName('no matching place draft query'));
-    await expect(placeRegion).toBeVisible();
-    await expect(placeRegion).toContainText(fixture.place.name);
-    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(fixture.place.name)}`) })).toBeVisible();
-    await closeDraftWithDiscard(page);
-  });
-
-  test('sidebar search restores collapsed hierarchy after clear', async ({ page }) => {
-    await signIn(page);
-    const state = await loadEditorStateFixture(page);
-    const fixture = sidebarSearchFixture(state);
-    await page.goto(absoluteUrl(workspacePath));
-    await expectMountedWorkspace(page);
-
-    const card = regionCard(page, fixture.place.regionName);
-    const children = card.locator('ul');
-    const toggle = card.getByRole('button', { name: 'Collapse' });
-    await expect(children).toBeVisible();
-    await toggle.click();
-    await expect(children).toBeHidden();
-
-    await page.getByLabel('Sidebar search').fill(fixture.place.name);
-    await expect(children).toBeVisible();
-    await expect(card.getByRole('button', { name: 'Collapse' })).toBeDisabled();
-    await page.getByLabel('Sidebar search').fill(`${fixture.place.name} unmatched suffix`);
-    await expect(children).toBeHidden();
-    await page.getByLabel('Sidebar search').fill(fixture.place.name);
-    await expect(children).toBeVisible();
-
-    await page.getByLabel('Sidebar search').fill('');
-    await expect(children).toBeHidden();
-    await expect(card.getByRole('button', { name: 'Expand' })).toBeEnabled();
-  });
-
-  test('sidebar search filters areas when the configured trip has area fixture data', async ({ page }) => {
-    await signIn(page);
-    const state = await loadEditorStateFixture(page);
-    const fixture = sidebarSearchFixture(state);
-    test.skip(!fixture.area, 'Configured Trip Editor fixture has no loaded area rows to verify sidebar area search.');
-    await page.goto(absoluteUrl(workspacePath));
-    await expectMountedWorkspace(page);
-
-    await page.getByLabel('Sidebar search').fill(fixture.area!.name);
-    const card = regionCard(page, fixture.area!.regionName);
-    await expect(card).toBeVisible();
-    await expect(card).toContainText(fixture.area!.name);
-  });
-
-  test('sidebar search filters segments when the configured trip has segment fixture data', async ({ page }) => {
-    await signIn(page);
-    const state = await loadEditorStateFixture(page);
-    const fixture = sidebarSearchFixture(state);
-    test.skip(!fixture.segment, 'Configured Trip Editor fixture has no loaded segment rows to verify sidebar segment search.');
-    await page.goto(absoluteUrl(workspacePath));
-    await expectMountedWorkspace(page);
-
-    await page.getByLabel('Sidebar search').fill(fixture.segment!.query);
-    await expect(page.getByRole('heading', { name: 'Segments' })).toBeVisible();
-    await expect(page.locator('.trip-editor-segments')).toContainText(fixture.segment!.label);
-  });
-
   test('responsive narrow workspace remains usable', async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 900 });
     await signIn(page);
@@ -332,48 +218,6 @@ test.describe.serial('Trip Editor dev verification', () => {
     await expect(regionHandles.first()).toBeVisible();
   });
 });
-
-// Signs in through the real Identity page without logging credential values.
-async function signIn(page: Page): Promise<void> {
-  await page.goto(absoluteUrl(`/Identity/Account/Login?ReturnUrl=${encodeURIComponent(workspacePath)}`));
-  await page.getByLabel('Username').fill(config.username);
-  await page.getByLabel('Password').fill(config.password);
-  await Promise.all([
-    page.waitForURL(url => !url.pathname.includes('/Identity/Account/Login')),
-    page.getByRole('button', { name: 'Log in' }).click()
-  ]);
-}
-
-// Waits for the Vue workspace to replace the Razor loading shell.
-async function expectMountedWorkspace(page: Page): Promise<void> {
-  const app = page.locator('#trip-editor-app');
-  await expect(app).toBeVisible();
-  await expect(app.locator('.trip-editor-workspace')).toBeVisible();
-  await expect(app).not.toContainText('Trip Editor development server is not available');
-  await expectActiveMetadataSurface(page);
-  await expectInitializedTripMap(page);
-}
-
-// Confirms the #252 shared surface hosts the active trip metadata editor.
-async function expectActiveMetadataSurface(page: Page): Promise<void> {
-  await expect(page.locator('.trip-editor-surface--docked .trip-editor-metadata')).toBeVisible();
-  await expect(page.locator('.trip-editor-surface--docked')).toContainText(/Edit Trip -/i);
-}
-
-// Confirms Leaflet mounted into a real map box after Vue rendered the workspace.
-async function expectInitializedTripMap(page: Page): Promise<void> {
-  const map = page.getByLabel('Read-only trip map');
-  await expect(map).toBeVisible();
-  await expect(map).toHaveClass(/leaflet-container/);
-  await expect(map.locator('.leaflet-pane')).not.toHaveCount(0);
-  await expect(map.locator('.leaflet-tile-pane')).toHaveCount(1);
-  await expect(map.locator('.leaflet-overlay-pane')).toHaveCount(1);
-
-  const box = await map.boundingBox();
-  expect(box, 'Trip Editor map should have a rendered bounding box.').not.toBeNull();
-  expect(box!.width, 'Trip Editor map should have usable width.').toBeGreaterThan(300);
-  expect(box!.height, 'Trip Editor map should have usable height.').toBeGreaterThan(300);
-}
 
 // Confirms the selected place editor docks as a usable full-width row under the place.
 async function expectUsableDockedPlaceEditor(page: Page): Promise<void> {
@@ -433,61 +277,6 @@ async function expectUnimplementedAreaAndSegmentActionsAbsent(page: Page): Promi
   await expect(page.getByRole('link', { name: /add segment/i })).toHaveCount(0);
 }
 
-async function loadEditorStateFixture(page: Page): Promise<EditorTripFixture> {
-  const response = await page.request.get(absoluteUrl(editorApiPath), {
-    headers: { Accept: 'application/json' }
-  });
-  expect(response.ok(), `GET ${editorApiPath} returned ${response.status()}`).toBeTruthy();
-  return (await response.json()) as EditorTripFixture;
-}
-
-function sidebarSearchFixture(state: EditorTripFixture): SidebarSearchFixture {
-  const place = Object.values(state.placesById)[0];
-  if (!place) {
-    throw new Error('Configured Trip Editor fixture must contain at least one loaded place for sidebar search coverage.');
-  }
-
-  const placeRegion = state.regionsById[place.regionId];
-  if (!placeRegion) {
-    throw new Error(`Configured Trip Editor fixture place ${place.id} references a missing parent region.`);
-  }
-
-  const area = Object.values(state.areasById)[0] ?? null;
-  const areaRegion = area ? state.regionsById[area.regionId] : null;
-  const segment = state.segmentOrder.map(id => state.segmentsById[id]).find(Boolean) ?? null;
-
-  return {
-    region: { name: placeRegion.name },
-    place: { name: place.name, regionName: placeRegion.name },
-    area: area && areaRegion ? { name: area.name, regionName: areaRegion.name } : null,
-    segment: segment ? segmentSearchFixture(state, segment) : null
-  };
-}
-
-function segmentSearchFixture(state: EditorTripFixture, segment: EditorTripFixture['segmentsById'][string]): { query: string; label: string } {
-  const from = segment.fromPlaceId ? state.placesById[segment.fromPlaceId]?.name : null;
-  const to = segment.toPlaceId ? state.placesById[segment.toPlaceId]?.name : null;
-  const label = [from, to].filter(Boolean).join(' to ') || segment.mode || 'Segment';
-  const modeLabel = state.options.transportModes.find(mode => mode.value === segment.mode)?.label;
-  return { query: modeLabel || segment.mode || label, label };
-}
-
-function collectForbiddenSidebarSearchRequests(page: Page): () => string[] {
-  const urls: string[] = [];
-  page.on('request', request => {
-    if (forbiddenSidebarSearchRequest.test(request.url())) {
-      urls.push(request.url());
-    }
-  });
-
-  return () => urls;
-}
-
-async function expectNoSearchAddUi(page: Page): Promise<void> {
-  await expect(page.getByRole('button', { name: /search.?add|add from search/i })).toHaveCount(0);
-  await expect(page.getByRole('link', { name: /search.?add|add from search/i })).toHaveCount(0);
-}
-
 async function openFirstPlaceFormIfAvailable(page: Page): Promise<Locator | null> {
   const form = page.locator('form').filter({ has: page.getByRole('heading', { name: /^(Add|Edit) Place$/ }) });
   if (await form.isVisible()) {
@@ -504,18 +293,6 @@ async function openFirstPlaceFormIfAvailable(page: Page): Promise<Locator | null
   return form;
 }
 
-function firstVisibleAddPlace(page: Page): Locator {
-  return page.getByRole('button', { name: 'Add Place' }).filter({ visible: true }).first();
-}
-
-function firstRegionWithChildren(page: Page): Locator {
-  return page.locator('.trip-editor-region-card').filter({ has: page.locator('ul li') }).first();
-}
-
-function regionCard(page: Page, name: string): Locator {
-  return page.locator('.trip-editor-region-card').filter({ has: page.getByRole('heading', { name }) });
-}
-
 async function cleanupTemporaryPlace(page: Page, name: string, shouldCleanup: boolean): Promise<void> {
   if (!shouldCleanup || (await page.getByText(name).count()) === 0) {
     return;
@@ -525,30 +302,6 @@ async function cleanupTemporaryPlace(page: Page, name: string, shouldCleanup: bo
   await page.getByRole('button', { name: 'Delete' }).click();
   await page.getByRole('dialog', { name: 'Delete place?' }).getByRole('button', { name: 'Delete' }).click();
   await expect(page.getByText(name)).toHaveCount(0);
-}
-
-async function closeDraftWithDiscard(page: Page): Promise<void> {
-  await page.getByRole('button', { name: 'Cancel' }).click();
-  const dialog = page.getByRole('dialog', { name: 'Discard changes?' });
-  if (await dialog.isVisible({ timeout: 1000 }).catch(() => false)) {
-    await dialog.getByRole('button', { name: 'Discard' }).click();
-  }
-  await expect(page.getByRole('dialog', { name: 'Discard changes?' })).toHaveCount(0);
-}
-
-async function cleanupTemporaryRegion(page: Page, name: string, shouldCleanup: boolean): Promise<void> {
-  if (!shouldCleanup || (await regionCard(page, name).count()) === 0) {
-    return;
-  }
-
-  await regionEditButton(regionCard(page, name)).click();
-  await page.getByRole('button', { name: 'Delete' }).click();
-  await page.getByRole('dialog', { name: 'Delete region?' }).getByRole('button', { name: 'Delete' }).click();
-  await expect(regionCard(page, name)).toHaveCount(0);
-}
-
-function regionEditButton(card: Locator): Locator {
-  return card.locator('.trip-editor-region-card__header').getByRole('button', { name: 'Edit' });
 }
 
 async function expectSaved(page: Page): Promise<void> {
@@ -597,18 +350,3 @@ async function capture(page: Page, testInfo: TestInfo, name: string): Promise<vo
   await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
 }
 
-function uniqueName(prefix: string): string {
-  return `${prefix} ${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
-}
-
-function pathRegex(path: string): RegExp {
-  return new RegExp(`${path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/?$`, 'i');
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function absoluteUrl(path: string): string {
-  return `${config.baseUrl}${path}`;
-}

--- a/tests/e2e/trip-editor/tripEditorSidebarSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSidebarSearch.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from '@playwright/test';
+import {
+  absoluteUrl,
+  closeDraftWithDiscard,
+  collectForbiddenSidebarSearchRequests,
+  escapeRegex,
+  expectMountedWorkspace,
+  expectNoSearchAddUi,
+  loadEditorStateFixture,
+  regionCard,
+  regionEditButton,
+  shadowChildFixture,
+  sidebarSearchFixture,
+  signIn,
+  uniqueName,
+  workspacePath
+} from './tripEditorTestUtils';
+
+test.describe.serial('Trip Editor sidebar search verification', () => {
+  test('filters regions and places without network search or draft loss', async ({ page }) => {
+    await signIn(page);
+    const state = await loadEditorStateFixture(page);
+    const fixture = sidebarSearchFixture(state);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    const requests = collectForbiddenSidebarSearchRequests(page);
+    const search = page.getByLabel('Sidebar search');
+    await expect(search).toBeVisible();
+
+    const tagsPanel = page.getByRole('heading', { name: 'Tags' }).locator('xpath=ancestor::section[contains(@class, "trip-editor-panel")]');
+    const tagsText = (await tagsPanel.count()) > 0 && await tagsPanel.isVisible() ? await tagsPanel.innerText() : null;
+
+    await search.fill(fixture.region.name);
+    await expect(regionCard(page, fixture.region.name)).toBeVisible();
+    await expect(tagsPanel).toHaveCount(tagsText ? 1 : 0);
+    if (tagsText) {
+      expect(await tagsPanel.innerText()).toBe(tagsText);
+    }
+
+    const placeRegion = regionCard(page, fixture.place.regionName);
+    await search.fill(fixture.place.name);
+    await expect(placeRegion).toBeVisible();
+    await expect(placeRegion).toContainText(fixture.place.name);
+    await expectNoSearchAddUi(page);
+    expect(requests(), 'Sidebar search should not call Nominatim, geosearch, search-add, or search endpoints.').toEqual([]);
+
+    const children = placeRegion.locator('ul');
+    await search.fill('');
+    await expect(regionCard(page, fixture.region.name)).toBeVisible();
+    await expect(children).toBeVisible();
+
+    await regionEditButton(regionCard(page, fixture.region.name)).click();
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Region - ${escapeRegex(fixture.region.name)}`) })).toBeVisible();
+    await search.fill(uniqueName('no matching region draft query'));
+    await expect(regionCard(page, fixture.region.name)).toBeVisible();
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Region - ${escapeRegex(fixture.region.name)}`) })).toBeVisible();
+    await closeDraftWithDiscard(page);
+    await search.fill('');
+
+    await placeRegion.getByText(fixture.place.name).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(fixture.place.name)}`) })).toBeVisible();
+    await search.fill(uniqueName('no matching place draft query'));
+    await expect(placeRegion).toBeVisible();
+    await expect(placeRegion).toContainText(fixture.place.name);
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(fixture.place.name)}`) })).toBeVisible();
+    await closeDraftWithDiscard(page);
+  });
+
+  test('restores collapsed hierarchy after clear', async ({ page }) => {
+    await signIn(page);
+    const state = await loadEditorStateFixture(page);
+    const fixture = sidebarSearchFixture(state);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    const card = regionCard(page, fixture.place.regionName);
+    const children = card.locator('ul');
+    const toggle = card.getByRole('button', { name: 'Collapse' });
+    await expect(children).toBeVisible();
+    await toggle.click();
+    await expect(children).toBeHidden();
+
+    await page.getByLabel('Sidebar search').fill(fixture.place.name);
+    await expect(children).toBeVisible();
+    await expect(card.getByRole('button', { name: 'Collapse' })).toBeDisabled();
+    await page.getByLabel('Sidebar search').fill(`${fixture.place.name} unmatched suffix`);
+    await expect(children).toBeHidden();
+    await page.getByLabel('Sidebar search').fill(fixture.place.name);
+    await expect(children).toBeVisible();
+
+    await page.getByLabel('Sidebar search').fill('');
+    await expect(children).toBeHidden();
+    await expect(card.getByRole('button', { name: 'Expand' })).toBeEnabled();
+  });
+
+  test('filters areas when the configured trip has area fixture data', async ({ page }) => {
+    await signIn(page);
+    const state = await loadEditorStateFixture(page);
+    const fixture = sidebarSearchFixture(state);
+    test.skip(!fixture.area, 'Configured Trip Editor fixture has no loaded area rows to verify sidebar area search.');
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    await page.getByLabel('Sidebar search').fill(fixture.area!.name);
+    const card = regionCard(page, fixture.area!.regionName);
+    await expect(card).toBeVisible();
+    await expect(card).toContainText(fixture.area!.name);
+  });
+
+  test('filters segments when the configured trip has segment fixture data', async ({ page }) => {
+    await signIn(page);
+    const state = await loadEditorStateFixture(page);
+    const fixture = sidebarSearchFixture(state);
+    test.skip(!fixture.segment, 'Configured Trip Editor fixture has no loaded segment rows to verify sidebar segment search.');
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    await page.getByLabel('Sidebar search').fill(fixture.segment!.query);
+    await expect(page.getByRole('heading', { name: 'Segments' })).toBeVisible();
+    await expect(page.locator('.trip-editor-segments')).toContainText(fixture.segment!.label);
+  });
+
+  test('shows shadow parents for matching shadow children without mutation controls', async ({ page }) => {
+    await signIn(page);
+    const state = await loadEditorStateFixture(page);
+    const fixture = shadowChildFixture(state);
+    test.skip(!fixture, 'Configured Trip Editor fixture has no loaded shadow-region child row to verify shadow search behavior.');
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    await page.getByLabel('Sidebar search').fill(fixture!.childName);
+    const shadowCard = regionCard(page, fixture!.regionName);
+    await expect(shadowCard).toBeVisible();
+    await expect(shadowCard.getByText(fixture!.childName, { exact: true })).toBeVisible();
+    await expect(shadowCard.getByRole('button', { name: 'Add Place' })).toHaveCount(0);
+    await expect(shadowCard.getByRole('button', { name: /add area/i })).toHaveCount(0);
+    await expect(regionEditButton(shadowCard)).toHaveCount(0);
+    await expect(shadowCard.getByRole('button', { name: /drag to reorder/i })).toHaveCount(0);
+  });
+});

--- a/tests/e2e/trip-editor/tripEditorTestUtils.ts
+++ b/tests/e2e/trip-editor/tripEditorTestUtils.ts
@@ -1,0 +1,207 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { loadTripEditorConfig } from './tripEditorConfig';
+
+export const config = loadTripEditorConfig();
+export const workspacePath = `/User/Trip/Workspace/${config.tripId}`;
+export const legacyEditPath = `/User/Trip/Edit/${config.tripId}`;
+export const editorApiPath = `/api/trips/${config.tripId}/editor`;
+
+const forbiddenSidebarSearchRequest = /nominatim|geosearch|search-add|searchadd|\/search(?:[/?#]|$)/i;
+
+export type EditorTripFixture = {
+  regionsById: Record<string, { id: string; name: string; isShadow: boolean }>;
+  regionOrder: string[];
+  placesById: Record<string, { id: string; name: string; address: string; regionId: string }>;
+  placeOrderByRegionId: Record<string, string[]>;
+  areasById: Record<string, { id: string; name: string; regionId: string }>;
+  areaOrderByRegionId: Record<string, string[]>;
+  segmentsById: Record<string, { id: string; mode: string; fromPlaceId: string | null; toPlaceId: string | null }>;
+  segmentOrder: string[];
+  tagOrder: string[];
+  tagsBySlug: Record<string, { name: string }>;
+  options: { transportModes: Array<{ value: string; label: string }> };
+};
+
+export type SidebarSearchFixture = {
+  region: { name: string };
+  place: { name: string; regionName: string };
+  area: { name: string; regionName: string } | null;
+  segment: { query: string; label: string } | null;
+};
+
+export type ShadowChildFixture = {
+  regionName: string;
+  childName: string;
+  childKind: 'place' | 'area';
+};
+
+// Builds a local URL against the configured ASP.NET dev server.
+export function absoluteUrl(path: string): string {
+  return `${config.baseUrl}${path}`;
+}
+
+// Escapes dynamic fixture text before using it in a regular expression.
+export function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Builds a URL matcher that tolerates the trailing slash added by routing.
+export function pathRegex(path: string): RegExp {
+  return new RegExp(`${path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/?$`, 'i');
+}
+
+// Creates deterministic-enough run labels for temporary UI data.
+export function uniqueName(prefix: string): string {
+  return `${prefix} ${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+// Signs in through the real Identity page without logging credential values.
+export async function signIn(page: Page): Promise<void> {
+  await page.goto(absoluteUrl(`/Identity/Account/Login?ReturnUrl=${encodeURIComponent(workspacePath)}`));
+  await page.getByLabel('Username').fill(config.username);
+  await page.getByLabel('Password').fill(config.password);
+  await Promise.all([
+    page.waitForURL(url => !url.pathname.includes('/Identity/Account/Login')),
+    page.getByRole('button', { name: 'Log in' }).click()
+  ]);
+}
+
+// Waits for the Vue workspace to replace the Razor loading shell.
+export async function expectMountedWorkspace(page: Page): Promise<void> {
+  const app = page.locator('#trip-editor-app');
+  await expect(app).toBeVisible();
+  await expect(app.locator('.trip-editor-workspace')).toBeVisible();
+  await expect(app).not.toContainText('Trip Editor development server is not available');
+  await expectActiveMetadataSurface(page);
+  await expectInitializedTripMap(page);
+}
+
+// Confirms the #252 shared surface hosts the active trip metadata editor.
+export async function expectActiveMetadataSurface(page: Page): Promise<void> {
+  await expect(page.locator('.trip-editor-surface--docked .trip-editor-metadata')).toBeVisible();
+  await expect(page.locator('.trip-editor-surface--docked')).toContainText(/Edit Trip -/i);
+}
+
+// Confirms Leaflet mounted into a real map box after Vue rendered the workspace.
+export async function expectInitializedTripMap(page: Page): Promise<void> {
+  const map = page.getByLabel('Read-only trip map');
+  await expect(map).toBeVisible();
+  await expect(map).toHaveClass(/leaflet-container/);
+  await expect(map.locator('.leaflet-pane')).not.toHaveCount(0);
+  await expect(map.locator('.leaflet-tile-pane')).toHaveCount(1);
+  await expect(map.locator('.leaflet-overlay-pane')).toHaveCount(1);
+
+  const box = await map.boundingBox();
+  expect(box, 'Trip Editor map should have a rendered bounding box.').not.toBeNull();
+  expect(box!.width, 'Trip Editor map should have usable width.').toBeGreaterThan(300);
+  expect(box!.height, 'Trip Editor map should have usable height.').toBeGreaterThan(300);
+}
+
+// Loads the editor API state used to derive runbook-specific E2E fixtures.
+export async function loadEditorStateFixture(page: Page): Promise<EditorTripFixture> {
+  const response = await page.request.get(absoluteUrl(editorApiPath), {
+    headers: { Accept: 'application/json' }
+  });
+  expect(response.ok(), `GET ${editorApiPath} returned ${response.status()}`).toBeTruthy();
+  return (await response.json()) as EditorTripFixture;
+}
+
+// Derives stable sidebar search examples from the configured trip fixture.
+export function sidebarSearchFixture(state: EditorTripFixture): SidebarSearchFixture {
+  const place = Object.values(state.placesById)[0];
+  if (!place) {
+    throw new Error('Configured Trip Editor fixture must contain at least one loaded place for sidebar search coverage.');
+  }
+
+  const placeRegion = state.regionsById[place.regionId];
+  if (!placeRegion) {
+    throw new Error(`Configured Trip Editor fixture place ${place.id} references a missing parent region.`);
+  }
+
+  const area = Object.values(state.areasById)[0] ?? null;
+  const areaRegion = area ? state.regionsById[area.regionId] : null;
+  const segment = state.segmentOrder.map(id => state.segmentsById[id]).find(Boolean) ?? null;
+
+  return {
+    region: { name: placeRegion.name },
+    place: { name: place.name, regionName: placeRegion.name },
+    area: area && areaRegion ? { name: area.name, regionName: areaRegion.name } : null,
+    segment: segment ? segmentSearchFixture(state, segment) : null
+  };
+}
+
+// Finds a child under the shadow region, or returns null so the spec can skip explicitly.
+export function shadowChildFixture(state: EditorTripFixture): ShadowChildFixture | null {
+  const shadow = Object.values(state.regionsById).find(region => region.isShadow);
+  if (!shadow) {
+    return null;
+  }
+
+  const shadowPlaceId = state.placeOrderByRegionId[shadow.id]?.find(id => state.placesById[id]);
+  if (shadowPlaceId) {
+    return { regionName: shadow.name, childName: state.placesById[shadowPlaceId].name, childKind: 'place' };
+  }
+
+  const shadowAreaId = state.areaOrderByRegionId[shadow.id]?.find(id => state.areasById[id]);
+  if (shadowAreaId) {
+    return { regionName: shadow.name, childName: state.areasById[shadowAreaId].name, childKind: 'area' };
+  }
+
+  return null;
+}
+
+// Collects disallowed network calls caused by sidebar-only filtering.
+export function collectForbiddenSidebarSearchRequests(page: Page): () => string[] {
+  const urls: string[] = [];
+  page.on('request', request => {
+    if (forbiddenSidebarSearchRequest.test(request.url())) {
+      urls.push(request.url());
+    }
+  });
+
+  return () => urls;
+}
+
+// Locates a rendered region card by its heading.
+export function regionCard(page: Page, name: string): Locator {
+  return page.locator('.trip-editor-region-card').filter({ has: page.getByRole('heading', { name }) });
+}
+
+// Locates the region header edit action when the current region allows it.
+export function regionEditButton(card: Locator): Locator {
+  return card.locator('.trip-editor-region-card__header').getByRole('button', { name: 'Edit' });
+}
+
+// Locates the first currently visible Add Place action.
+export function firstVisibleAddPlace(page: Page): Locator {
+  return page.getByRole('button', { name: 'Add Place' }).filter({ visible: true }).first();
+}
+
+// Locates the first region that currently renders child rows.
+export function firstRegionWithChildren(page: Page): Locator {
+  return page.locator('.trip-editor-region-card').filter({ has: page.locator('ul li') }).first();
+}
+
+// Closes the active editor, accepting the shared discard dialog when dirty.
+export async function closeDraftWithDiscard(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Cancel' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Discard changes?' });
+  if (await dialog.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await dialog.getByRole('button', { name: 'Discard' }).click();
+  }
+  await expect(page.getByRole('dialog', { name: 'Discard changes?' })).toHaveCount(0);
+}
+
+// Confirms search-add UI is not exposed by sidebar filtering.
+export async function expectNoSearchAddUi(page: Page): Promise<void> {
+  await expect(page.getByRole('button', { name: /search.?add|add from search/i })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /search.?add|add from search/i })).toHaveCount(0);
+}
+
+function segmentSearchFixture(state: EditorTripFixture, segment: EditorTripFixture['segmentsById'][string]): { query: string; label: string } {
+  const from = segment.fromPlaceId ? state.placesById[segment.fromPlaceId]?.name : null;
+  const to = segment.toPlaceId ? state.placesById[segment.toPlaceId]?.name : null;
+  const label = [from, to].filter(Boolean).join(' to ') || segment.mode || 'Segment';
+  const modeLabel = state.options.transportModes.find(mode => mode.value === segment.mode)?.label;
+  return { query: modeLabel || segment.mode || label, label };
+}


### PR DESCRIPTION
Summary:
- Adds client-only sidebar search/filter over loaded editor state.
- Searches regions, places, areas, and segments.
- Preserves hierarchy and active draft context.
- Snapshots/restores collapse state.
- Keeps tags unaffected.
- Does not add backend/geosearch/search-add behavior.

Validation:
- npm run build passed.
- npm run test:e2e:trip-editor passed: 13 passed, 1 skipped; shadow-region search test skipped because the configured runbook trip has no loaded shadow child.
- LOC checker passed with accepted warnings:
  - RegionManager.vue 446 LOC, accepted because cohesive and not worsened by this PR.
  - styles.css 406 LOC, accepted because cohesive and small style addition.
- rg "window\\.confirm" no matches.
- rg "\\bconfirm\\(" manually reviewed.
- git diff --check main...HEAD passed.

Notes:
- Shadow-region search test skips explicitly if the configured runbook trip has no loaded shadow child.
- No backend/C#/Razor files changed.
- No .local, Playwright reports, test-results, screenshots, traces, browser profiles, or generated Vite assets tracked.