### PR TITLE
feat(trip-editor): add trip tags and share-progress editing

### DIFF
--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -25,6 +25,7 @@ public sealed partial class TripEditorController : ControllerBase
     private readonly IIconColorProvider _iconColorProvider;
     private readonly ITripMapThumbnailGenerator _thumbnailGenerator;
     private readonly ICacheWarmupScheduler _warmupScheduler;
+    private readonly ITripTagService _tripTagService;
     private readonly TripEditorRegionMutationService _regionMutations;
     private readonly TripEditorPlaceMutationService _placeMutations;
     private readonly ILogger<TripEditorController> _logger;
@@ -38,6 +39,7 @@ public sealed partial class TripEditorController : ControllerBase
         IIconColorProvider iconColorProvider,
         ITripMapThumbnailGenerator thumbnailGenerator,
         ICacheWarmupScheduler warmupScheduler,
+        ITripTagService tripTagService,
         TripEditorRegionMutationService regionMutations,
         TripEditorPlaceMutationService placeMutations,
         ILogger<TripEditorController> logger)
@@ -47,6 +49,7 @@ public sealed partial class TripEditorController : ControllerBase
         _iconColorProvider = iconColorProvider;
         _thumbnailGenerator = thumbnailGenerator;
         _warmupScheduler = warmupScheduler;
+        _tripTagService = tripTagService;
         _regionMutations = regionMutations;
         _placeMutations = placeMutations;
         _logger = logger;

--- a/Areas/Api/Controllers/TripEditorTagShareProgressController.cs
+++ b/Areas/Api/Controllers/TripEditorTagShareProgressController.cs
@@ -1,0 +1,235 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Wayfarer.Models.Dtos;
+using Wayfarer.Models.Dtos.Editor;
+using Wayfarer.Services;
+
+namespace Wayfarer.Areas.Api.Controllers;
+
+/// <summary>
+/// Trip-level tags and share-progress mutations for the private Vue Trip Editor.
+/// </summary>
+public sealed partial class TripEditorController
+{
+    /// <summary>
+    /// Replaces the complete trip-level tag set for an owned trip.
+    /// </summary>
+    [HttpPut("tags")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> PutTags(Guid tripId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        if (!await _dbContext.Trips.AnyAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken))
+        {
+            return NotFound();
+        }
+
+        var request = await TryReadJsonRequestAsync(cancellationToken);
+        if (!request.HasValue)
+        {
+            return ValidationError(new Dictionary<string, string[]> { ["request"] = new[] { "Tag update request must be valid JSON." } });
+        }
+
+        if (!TryParseTagsRequest(request.Value, BuildOptions().Tag.MaxTags, out var update, out var errors))
+        {
+            return ValidationError(errors);
+        }
+
+        try
+        {
+            var replacement = await _tripTagService.ReplaceTagsAsync(tripId, update.Tags, userId!, cancellationToken);
+            var tags = replacement.Tags.Select(ToEditorTag).ToList();
+            var affected = new EditorAffectedSlicesDto(
+                null,
+                Array.Empty<EditorRegionDto>(),
+                null,
+                Array.Empty<EditorPlaceDto>(),
+                new Dictionary<Guid, IReadOnlyList<Guid>>(),
+                Array.Empty<EditorAreaDto>(),
+                new Dictionary<Guid, IReadOnlyList<Guid>>(),
+                Array.Empty<EditorSegmentDto>(),
+                null,
+                tags,
+                tags.Select(t => t.Slug).ToList(),
+                null,
+                null);
+            var deletedIds = new EditorDeletedIdsDto(Array.Empty<Guid>(), Array.Empty<Guid>(), Array.Empty<Guid>(), Array.Empty<Guid>(), replacement.DeletedSlugs);
+
+            return Ok(new EditorMutationResult<IReadOnlyList<EditorTagDto>>(true, tags, affected, deletedIds, Array.Empty<EditorWarningDto>()));
+        }
+        catch (ValidationException)
+        {
+            return ValidationError(new Dictionary<string, string[]> { ["tags"] = new[] { "One or more tags are invalid." } });
+        }
+    }
+
+    /// <summary>
+    /// Toggles public visit-progress sharing for an owned trip.
+    /// </summary>
+    [HttpPatch("share-progress")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> PatchShareProgress(Guid tripId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var trip = await _dbContext.Trips.FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+        if (trip == null)
+        {
+            return NotFound();
+        }
+
+        var request = await TryReadJsonRequestAsync(cancellationToken);
+        if (!request.HasValue)
+        {
+            return ValidationError(new Dictionary<string, string[]> { ["request"] = new[] { "Share-progress update request must be valid JSON." } });
+        }
+
+        if (!TryParseShareProgressRequest(request.Value, out var update, out var errors))
+        {
+            return ValidationError(errors);
+        }
+
+        if (update.Enabled && !trip.IsPublic)
+        {
+            return ValidationError(new Dictionary<string, string[]>
+            {
+                ["shareProgressEnabled"] = new[] { "Share progress can only be enabled for public trips." }
+            });
+        }
+
+        trip.ShareProgressEnabled = update.Enabled;
+        trip.UpdatedAt = DateTime.UtcNow;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var metadata = EditorTripStateMapper.ToMetadata(
+            trip,
+            trip.IsPublic ? GeneratePublicTripUrl(trip.Id) : null,
+            trip.IsPublic && trip.ShareProgressEnabled ? GenerateProgressPublicTripUrl(trip.Id) : null);
+
+        return Ok(new EditorMutationResult<EditorTripMetadataDto>(
+            true,
+            metadata,
+            EditorAffectedSlicesDto.MetadataOnly(metadata),
+            EditorDeletedIdsDto.Empty,
+            Array.Empty<EditorWarningDto>()));
+    }
+
+    private async Task<JsonElement?> TryReadJsonRequestAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var document = await JsonDocument.ParseAsync(Request.Body, cancellationToken: cancellationToken);
+            return document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static bool TryParseTagsRequest(
+        JsonElement request,
+        int maxTags,
+        out EditorTripTagsUpdateRequest update,
+        out Dictionary<string, string[]> errors)
+    {
+        update = new EditorTripTagsUpdateRequest(Array.Empty<string>());
+        errors = new Dictionary<string, string[]>();
+        if (request.ValueKind != JsonValueKind.Object)
+        {
+            errors["request"] = new[] { "Tag update request must be a JSON object." };
+            return false;
+        }
+
+        if (!request.TryGetProperty("tags", out var tagsElement) || tagsElement.ValueKind != JsonValueKind.Array)
+        {
+            errors["tags"] = new[] { "Tags must be provided as an array." };
+            return false;
+        }
+
+        var tags = new List<string>();
+        var slugs = new HashSet<string>(StringComparer.Ordinal);
+        var index = 0;
+        foreach (var tagElement in tagsElement.EnumerateArray())
+        {
+            if (tagElement.ValueKind != JsonValueKind.String)
+            {
+                errors[$"tags[{index}]"] = new[] { "Tag value must be a string." };
+                index++;
+                continue;
+            }
+
+            var tag = tagElement.GetString()?.Trim() ?? string.Empty;
+            if (tag.Length == 0)
+            {
+                errors[$"tags[{index}]"] = new[] { "Tag value cannot be blank." };
+                index++;
+                continue;
+            }
+
+            if (!TripTagService.IsValidTagName(tag))
+            {
+                errors[$"tags[{index}]"] = new[] { "Tag uses unsupported characters or is too long." };
+                index++;
+                continue;
+            }
+
+            if (slugs.Add(TripTagService.NormalizeSlug(tag)))
+            {
+                tags.Add(tag);
+            }
+
+            index++;
+        }
+
+        if (tags.Count > maxTags)
+        {
+            errors["tags"] = new[] { $"A trip can have up to {maxTags} tags." };
+        }
+
+        update = new EditorTripTagsUpdateRequest(tags);
+        return errors.Count == 0;
+    }
+
+    private static bool TryParseShareProgressRequest(
+        JsonElement request,
+        out EditorShareProgressUpdateRequest update,
+        out Dictionary<string, string[]> errors)
+    {
+        update = new EditorShareProgressUpdateRequest(false);
+        errors = new Dictionary<string, string[]>();
+        if (request.ValueKind != JsonValueKind.Object)
+        {
+            errors["request"] = new[] { "Share-progress update request must be a JSON object." };
+            return false;
+        }
+
+        if (!request.TryGetProperty("enabled", out var enabledElement))
+        {
+            errors["enabled"] = new[] { "Enabled is required." };
+            return false;
+        }
+
+        if (enabledElement.ValueKind != JsonValueKind.True && enabledElement.ValueKind != JsonValueKind.False)
+        {
+            errors["enabled"] = new[] { "Enabled must be a boolean." };
+            return false;
+        }
+
+        update = new EditorShareProgressUpdateRequest(enabledElement.GetBoolean());
+        return true;
+    }
+
+    private static EditorTagDto ToEditorTag(TripTagDto tag) => new(tag.Id, tag.Name, tag.Slug);
+}

--- a/ClientApps/trip-editor/src/api/tripEditorApi.ts
+++ b/ClientApps/trip-editor/src/api/tripEditorApi.ts
@@ -9,9 +9,13 @@ import type {
   EditorRegionOrderRequest,
   EditorRegionOrderResult,
   EditorRegionSaveRequest,
+  EditorShareProgressUpdateRequest,
+  EditorTag,
+  EditorTripTagsUpdateRequest,
   EditorTripMetadata,
   EditorTripMetadataUpdateRequest,
   EditorTripState,
+  TagSuggestion,
   ValidationProblemDetails
 } from '../types';
 
@@ -63,6 +67,36 @@ export const patchMetadata = async (
   }
 
   return (await response.json()) as EditorMutationResult<EditorTripMetadata>;
+};
+
+/// Replaces the complete trip-level tag set through the same-origin editor API.
+export const putTags = async (
+  endpoint: string,
+  antiforgeryToken: string,
+  request: EditorTripTagsUpdateRequest
+): Promise<EditorMutationResult<EditorTag[]>> => sendMutation(`${endpoint}/tags`, 'PUT', antiforgeryToken, request, 'tag save');
+
+/// Toggles public progress sharing through the same-origin editor API.
+export const patchShareProgress = async (
+  endpoint: string,
+  antiforgeryToken: string,
+  request: EditorShareProgressUpdateRequest
+): Promise<EditorMutationResult<EditorTripMetadata>> =>
+  sendMutation(`${endpoint}/share-progress`, 'PATCH', antiforgeryToken, request, 'share-progress save');
+
+/// Loads existing public tag suggestions without mutating editor state.
+export const suggestTags = async (query: string, take: number): Promise<TagSuggestion[]> => {
+  const url = `/api/tags/suggest?q=${encodeURIComponent(query)}&take=${encodeURIComponent(String(take))}`;
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json' },
+    credentials: 'same-origin'
+  });
+
+  if (!response.ok) {
+    throw new Error(`Tag suggestions returned ${response.status}`);
+  }
+
+  return (await response.json()) as TagSuggestion[];
 };
 
 /// Creates a region through the same-origin editor API.

--- a/ClientApps/trip-editor/src/components/MetadataEditor.vue
+++ b/ClientApps/trip-editor/src/components/MetadataEditor.vue
@@ -1,13 +1,24 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
-import { EditorValidationError, patchMetadata } from '../api/tripEditorApi';
+import { EditorValidationError, patchMetadata, patchShareProgress, putTags, suggestTags } from '../api/tripEditorApi';
 import { confirm } from '../composables/useConfirmDialog';
 import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
 import EditorSurface from './EditorSurface.vue';
-import type { EditorTripMetadata, EditorTripMetadataUpdateRequest, EditorWarning } from '../types';
+import type {
+  EditorMutationResult,
+  EditorOptions,
+  EditorTag,
+  EditorTripMetadata,
+  EditorTripMetadataUpdateRequest,
+  EditorWarning,
+  TagSuggestion
+} from '../types';
 
 const props = defineProps<{
   metadata: EditorTripMetadata;
+  tagsBySlug: Record<string, EditorTag>;
+  tagOrder: string[];
+  tagOptions: EditorOptions['tag'];
   editorSurface: EditorSurfaceController;
   editorEndpoint: string;
   antiforgeryToken: string;
@@ -17,29 +28,47 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   saved: [metadata: EditorTripMetadata];
+  mutationApplied: [result: EditorMutationResult<unknown>];
 }>();
 
 type MetadataDraft = {
   name: string;
   isPublic: boolean;
+  shareProgressEnabled: boolean;
   notesHtml: string;
   coverImageRawUrl: string;
   centerLatitude: string;
   centerLongitude: string;
   zoom: string;
+  tags: string[];
 };
 
-const draft = reactive<MetadataDraft>(toDraft(props.metadata));
+const draft = reactive<MetadataDraft>(toDraft(props.metadata, props.tagOrder, props.tagsBySlug));
 const isSaving = ref(false);
 const lastSavedAt = ref<string | null>(null);
 const saveError = ref<string | null>(null);
 const validationErrors = ref<Record<string, string[]>>({});
 const warnings = ref<EditorWarning[]>([]);
 const savedExitInProgress = ref(false);
+const tagInput = ref('');
+const tagSuggestions = ref<TagSuggestion[]>([]);
+const tagSuggestionError = ref<string | null>(null);
 let unregisterSurfaceHandler: (() => void) | null = null;
+let suggestionRequestId = 0;
 
-const persistedDraft = computed(() => toDraft(props.metadata));
-const isDirty = computed(() => JSON.stringify(normalizeDraft(draft)) !== JSON.stringify(normalizeDraft(persistedDraft.value)));
+const persistedDraft = computed(() => toDraft(props.metadata, props.tagOrder, props.tagsBySlug));
+const isMetadataDirty = computed(() => JSON.stringify(normalizeMetadataDraft(draft)) !== JSON.stringify(normalizeMetadataDraft(persistedDraft.value)));
+const isTagsDirty = computed(() => JSON.stringify(normalizeTagNames(draft.tags)) !== JSON.stringify(normalizeTagNames(persistedDraft.value.tags)));
+const isShareProgressDirty = computed(() => normalizeShareProgress(draft) !== normalizeShareProgress(persistedDraft.value));
+const isDirty = computed(() => isMetadataDirty.value || isTagsDirty.value || isShareProgressDirty.value);
+const shareProgressUnavailable = computed(() => !draft.isPublic || !props.metadata.isPublic);
+const visibleShareProgressEnabled = computed({
+  get: () => !shareProgressUnavailable.value && draft.shareProgressEnabled,
+  set: value => {
+    draft.shareProgressEnabled = value;
+  }
+});
+const progressUrl = computed(() => (!shareProgressUnavailable.value && draft.shareProgressEnabled ? props.metadata.progressPublicUrl : null));
 const target = computed<EditorTarget>(() => ({
   key: 'metadata',
   identity: 'metadata',
@@ -67,11 +96,28 @@ const statusText = computed(() => {
 });
 
 watch(
-  () => props.metadata,
-  metadata => {
-    Object.assign(draft, toDraft(metadata));
+  () => [props.metadata, props.tagOrder, props.tagsBySlug] as const,
+  () => {
+    if (isSaving.value) {
+      return;
+    }
+
+    Object.assign(draft, toDraft(props.metadata, props.tagOrder, props.tagsBySlug));
     validationErrors.value = {};
     saveError.value = null;
+  }
+);
+
+watch(tagInput, () => {
+  void loadTagSuggestions();
+});
+
+watch(
+  () => draft.isPublic,
+  isPublic => {
+    if (!isPublic) {
+      draft.shareProgressEnabled = false;
+    }
   }
 );
 
@@ -90,7 +136,10 @@ onUnmounted(() => {
 });
 
 const resetDraft = (): void => {
-  Object.assign(draft, toDraft(props.metadata));
+  Object.assign(draft, toDraft(props.metadata, props.tagOrder, props.tagsBySlug));
+  tagInput.value = '';
+  tagSuggestions.value = [];
+  tagSuggestionError.value = null;
   validationErrors.value = {};
   saveError.value = null;
   warnings.value = [];
@@ -111,28 +160,50 @@ const save = async (exitAfterSave: boolean): Promise<void> => {
   validationErrors.value = {};
   warnings.value = [];
 
+  let savedMetadata = props.metadata;
+  let failed = false;
+
   try {
-    const result = await patchMetadata(props.editorEndpoint, props.antiforgeryToken, buildRequest(draft));
-    const metadata = result.affected.metadata ?? result.data;
-    warnings.value = result.warnings;
-    if (exitAfterSave) {
-      savedExitInProgress.value = true;
+    if (isMetadataDirty.value) {
+      const result = await patchMetadata(props.editorEndpoint, props.antiforgeryToken, buildMetadataRequest(draft));
+      savedMetadata = result.affected.metadata ?? result.data;
+      warnings.value = result.warnings;
+      Object.assign(draft, { ...draft, ...toMetadataDraft(savedMetadata) });
+      emit('saved', savedMetadata);
+      emit('mutationApplied', result as EditorMutationResult<unknown>);
     }
 
-    emit('saved', metadata);
-    lastSavedAt.value = new Intl.DateTimeFormat(undefined, { timeStyle: 'short' }).format(new Date());
-    if (exitAfterSave) {
-      window.location.assign(props.tripIndexUrl);
+    if (isTagsDirty.value) {
+      const result = await putTags(props.editorEndpoint, props.antiforgeryToken, { tags: normalizeTagNames(draft.tags) });
+      draft.tags = result.data.map(tag => tag.name);
+      emit('mutationApplied', result as EditorMutationResult<unknown>);
+    }
+
+    if (isShareProgressDirty.value && savedMetadata.isPublic) {
+      const result = await patchShareProgress(props.editorEndpoint, props.antiforgeryToken, { enabled: draft.shareProgressEnabled });
+      savedMetadata = result.affected.metadata ?? result.data;
+      draft.shareProgressEnabled = savedMetadata.shareProgressEnabled;
+      emit('saved', savedMetadata);
+      emit('mutationApplied', result as EditorMutationResult<unknown>);
     }
   } catch (error) {
+    failed = true;
     if (error instanceof EditorValidationError) {
       validationErrors.value = error.errors;
       saveError.value = error.message;
     } else {
-      saveError.value = error instanceof Error ? error.message : 'Metadata save failed.';
+      saveError.value = error instanceof Error ? error.message : 'Trip settings save failed.';
     }
   } finally {
     isSaving.value = false;
+  }
+
+  if (!failed) {
+    lastSavedAt.value = new Intl.DateTimeFormat(undefined, { timeStyle: 'short' }).format(new Date());
+    if (exitAfterSave) {
+      savedExitInProgress.value = true;
+      window.location.assign(props.tripIndexUrl);
+    }
   }
 };
 
@@ -155,12 +226,12 @@ function confirmUnload(event: BeforeUnloadEvent): void {
   event.returnValue = '';
 }
 
-/// Combines metadata changes with the active region draft dirty state owned by RegionManager.
+/// Combines metadata, tag, share-progress, and child-region drafts for navigation prompts.
 function hasUnsavedEditorChanges(): boolean {
   return isDirty.value || props.hasRegionDraftChanges;
 }
 
-/// Tracks editor-owned drafts that Save & Exit cannot persist through the metadata endpoint.
+/// Tracks editor-owned drafts that Save & Exit cannot persist through the metadata surface.
 function hasUnsavedNonMetadataEditorChanges(): boolean {
   return props.hasRegionDraftChanges;
 }
@@ -180,10 +251,61 @@ async function openMetadata(): Promise<void> {
   await props.editorSurface.activateTarget(target.value);
 }
 
-function toDraft(metadata: EditorTripMetadata): MetadataDraft {
+async function loadTagSuggestions(): Promise<void> {
+  const query = tagInput.value.trim();
+  const requestId = ++suggestionRequestId;
+  tagSuggestionError.value = null;
+
+  if (!query) {
+    tagSuggestions.value = [];
+    return;
+  }
+
+  try {
+    const items = await suggestTags(query, props.tagOptions.suggestionTake);
+    if (requestId === suggestionRequestId) {
+      const existing = new Set(normalizeTagNames(draft.tags).map(normalizeTagSlug));
+      tagSuggestions.value = items.filter(item => !existing.has(item.slug));
+    }
+  } catch {
+    if (requestId === suggestionRequestId) {
+      tagSuggestions.value = [];
+      tagSuggestionError.value = 'Suggestions unavailable.';
+    }
+  }
+}
+
+function addTag(value: string): void {
+  const name = value.trim();
+  if (!name || draft.tags.length >= props.tagOptions.maxTags) {
+    return;
+  }
+
+  const existing = new Set(normalizeTagNames(draft.tags).map(normalizeTagSlug));
+  if (!existing.has(normalizeTagSlug(name))) {
+    draft.tags.push(name);
+  }
+
+  tagInput.value = '';
+  tagSuggestions.value = [];
+}
+
+function removeTag(index: number): void {
+  draft.tags.splice(index, 1);
+}
+
+function toDraft(metadata: EditorTripMetadata, tagOrder: string[], tagsBySlug: Record<string, EditorTag>): MetadataDraft {
+  return {
+    ...toMetadataDraft(metadata),
+    tags: tagOrder.map(slug => tagsBySlug[slug]?.name).filter(Boolean) as string[]
+  };
+}
+
+function toMetadataDraft(metadata: EditorTripMetadata): Omit<MetadataDraft, 'tags'> {
   return {
     name: metadata.name,
     isPublic: metadata.isPublic,
+    shareProgressEnabled: metadata.isPublic && metadata.shareProgressEnabled,
     notesHtml: metadata.notesHtml,
     coverImageRawUrl: metadata.coverImage?.rawUrl ?? '',
     centerLatitude: metadata.center ? String(metadata.center.latitude) : '',
@@ -192,11 +314,15 @@ function toDraft(metadata: EditorTripMetadata): MetadataDraft {
   };
 }
 
-function normalizeDraft(value: MetadataDraft): EditorTripMetadataUpdateRequest {
-  return buildRequest(value);
+function normalizeMetadataDraft(value: MetadataDraft): EditorTripMetadataUpdateRequest {
+  return buildMetadataRequest(value);
 }
 
-function buildRequest(value: MetadataDraft): EditorTripMetadataUpdateRequest {
+function normalizeShareProgress(value: MetadataDraft): boolean {
+  return value.isPublic && props.metadata.isPublic && value.shareProgressEnabled;
+}
+
+function buildMetadataRequest(value: MetadataDraft): EditorTripMetadataUpdateRequest {
   const centerLatitude = value.centerLatitude.trim();
   const centerLongitude = value.centerLongitude.trim();
   const zoom = value.zoom.trim();
@@ -213,6 +339,30 @@ function buildRequest(value: MetadataDraft): EditorTripMetadataUpdateRequest {
       : null,
     zoom: zoom ? Number(zoom) : null
   };
+}
+
+function normalizeTagNames(values: string[]): string[] {
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  values.forEach(value => {
+    const tag = value.trim();
+    const slug = normalizeTagSlug(tag);
+    if (tag && slug && !seen.has(slug)) {
+      seen.add(slug);
+      tags.push(tag);
+    }
+  });
+  return tags;
+}
+
+function normalizeTagSlug(value: string): string {
+  return value
+    .trim()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLocaleLowerCase();
 }
 
 const fieldErrors = (key: string): string[] => validationErrors.value[key] ?? [];
@@ -246,6 +396,50 @@ const fieldErrors = (key: string): string[] => validationErrors.value[key] ?? []
           <input v-model="draft.isPublic" type="checkbox" />
           <span>Public trip</span>
         </label>
+
+        <section class="trip-editor-settings-group" aria-labelledby="trip-editor-share-progress-heading">
+          <h3 id="trip-editor-share-progress-heading">Share Progress</h3>
+          <label class="trip-editor-toggle">
+            <input v-model="visibleShareProgressEnabled" type="checkbox" :disabled="shareProgressUnavailable" />
+            <span>Show visit progress on public trip</span>
+          </label>
+          <a v-if="progressUrl" :href="progressUrl" target="_blank" rel="noopener">Open progress URL</a>
+          <small v-for="message in fieldErrors('enabled')" :key="message">{{ message }}</small>
+          <small v-for="message in fieldErrors('shareProgressEnabled')" :key="message">{{ message }}</small>
+        </section>
+
+        <section class="trip-editor-settings-group" aria-labelledby="trip-editor-tags-heading">
+          <h3 id="trip-editor-tags-heading">Tags</h3>
+          <div class="trip-editor-tags trip-editor-tags--editable">
+            <span v-for="(tag, index) in draft.tags" :key="`${normalizeTagSlug(tag)}-${index}`">
+              {{ tag }}
+              <button type="button" :aria-label="`Remove tag ${tag}`" @click="removeTag(index)">Remove</button>
+            </span>
+          </div>
+          <div class="trip-editor-tag-entry">
+            <label class="trip-editor-field">
+              <span>Add tag</span>
+              <input
+                v-model="tagInput"
+                type="text"
+                autocomplete="off"
+                :aria-describedby="tagSuggestionError ? 'trip-editor-tag-suggestion-error' : undefined"
+                @keydown.enter.prevent="addTag(tagInput)"
+              />
+            </label>
+            <button type="button" class="btn btn-outline-light btn-sm" :disabled="!tagInput.trim() || draft.tags.length >= tagOptions.maxTags" @click="addTag(tagInput)">Add</button>
+          </div>
+          <div v-if="tagSuggestions.length > 0" class="trip-editor-tag-suggestions">
+            <button v-for="suggestion in tagSuggestions" :key="suggestion.slug" type="button" @click="addTag(suggestion.name)">
+              {{ suggestion.name }}
+            </button>
+          </div>
+          <small id="trip-editor-tag-suggestion-error" v-if="tagSuggestionError">{{ tagSuggestionError }}</small>
+          <small v-for="message in fieldErrors('tags')" :key="message">{{ message }}</small>
+          <template v-for="(_, index) in draft.tags" :key="`tag-error-${index}`">
+            <small v-for="message in fieldErrors(`tags[${index}]`)" :key="message">{{ message }}</small>
+          </template>
+        </section>
 
         <label class="trip-editor-field">
           <span>Notes HTML</span>

--- a/ClientApps/trip-editor/src/components/MetadataEditor.vue
+++ b/ClientApps/trip-editor/src/components/MetadataEditor.vue
@@ -264,8 +264,8 @@ async function loadTagSuggestions(): Promise<void> {
   try {
     const items = await suggestTags(query, props.tagOptions.suggestionTake);
     if (requestId === suggestionRequestId) {
-      const existing = new Set(normalizeTagNames(draft.tags).map(normalizeTagSlug));
-      tagSuggestions.value = items.filter(item => !existing.has(item.slug));
+      const existingNames = new Set(normalizeTagNames(draft.tags).map(normalizeTagNameKey));
+      tagSuggestions.value = items.filter(item => !existingNames.has(normalizeTagNameKey(item.name)));
     }
   } catch {
     if (requestId === suggestionRequestId) {
@@ -281,8 +281,8 @@ function addTag(value: string): void {
     return;
   }
 
-  const existing = new Set(normalizeTagNames(draft.tags).map(normalizeTagSlug));
-  if (!existing.has(normalizeTagSlug(name))) {
+  const existing = new Set(normalizeTagNames(draft.tags).map(normalizeTagNameKey));
+  if (!existing.has(normalizeTagNameKey(name))) {
     draft.tags.push(name);
   }
 
@@ -346,23 +346,17 @@ function normalizeTagNames(values: string[]): string[] {
   const tags: string[] = [];
   values.forEach(value => {
     const tag = value.trim();
-    const slug = normalizeTagSlug(tag);
-    if (tag && slug && !seen.has(slug)) {
-      seen.add(slug);
+    const key = normalizeTagNameKey(tag);
+    if (tag && !seen.has(key)) {
+      seen.add(key);
       tags.push(tag);
     }
   });
   return tags;
 }
 
-function normalizeTagSlug(value: string): string {
-  return value
-    .trim()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-zA-Z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .toLocaleLowerCase();
+function normalizeTagNameKey(value: string): string {
+  return value.trim().toLocaleLowerCase();
 }
 
 const fieldErrors = (key: string): string[] => validationErrors.value[key] ?? [];
@@ -411,7 +405,7 @@ const fieldErrors = (key: string): string[] => validationErrors.value[key] ?? []
         <section class="trip-editor-settings-group" aria-labelledby="trip-editor-tags-heading">
           <h3 id="trip-editor-tags-heading">Tags</h3>
           <div class="trip-editor-tags trip-editor-tags--editable">
-            <span v-for="(tag, index) in draft.tags" :key="`${normalizeTagSlug(tag)}-${index}`">
+            <span v-for="(tag, index) in draft.tags" :key="`${normalizeTagNameKey(tag)}-${index}`">
               {{ tag }}
               <button type="button" :aria-label="`Remove tag ${tag}`" @click="removeTag(index)">Remove</button>
             </span>

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -130,12 +130,16 @@ function normalize(value: string): string {
 
     <MetadataEditor
       :metadata="state.metadata"
+      :tags-by-slug="state.tagsBySlug"
+      :tag-order="state.tagOrder"
+      :tag-options="state.options.tag"
       :editor-surface="editorSurface"
       :editor-endpoint="editorEndpoint"
       :antiforgery-token="antiforgeryToken"
       :trip-index-url="tripIndexUrl"
       :has-region-draft-changes="hasRegionDraftChanges"
       @saved="metadata => emit('metadataSaved', metadata)"
+      @mutation-applied="result => emit('mutationApplied', result)"
     />
 
     <section v-if="state.visitProgress.totalPlaces > 0" class="trip-editor-panel">

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -267,6 +267,59 @@ body {
   gap: 0.4rem;
 }
 
+.trip-editor-settings-group {
+  border: 1px solid var(--trip-editor-border);
+  border-radius: 6px;
+  display: grid;
+  gap: 0.6rem;
+  padding: 0.7rem;
+}
+
+.trip-editor-settings-group h3 {
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.trip-editor-settings-group small {
+  color: #fecaca;
+}
+
+.trip-editor-tags--editable span {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.trip-editor-tags--editable button,
+.trip-editor-tag-suggestions button {
+  background: transparent;
+  border: 0;
+  color: var(--trip-editor-accent);
+  font: inherit;
+  padding: 0;
+}
+
+.trip-editor-tag-entry {
+  align-items: end;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.trip-editor-tag-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.trip-editor-tag-suggestions button {
+  background: var(--trip-editor-surface-muted);
+  border: 1px solid var(--trip-editor-field-border);
+  border-radius: 999px;
+  color: var(--trip-editor-text);
+  padding: 0.25rem 0.55rem;
+}
+
 .trip-editor-sidebar-search {
   display: grid;
   gap: 0.6rem;

--- a/ClientApps/trip-editor/src/types.ts
+++ b/ClientApps/trip-editor/src/types.ts
@@ -167,6 +167,20 @@ export interface EditorTripMetadataUpdateRequest {
   zoom: number | null;
 }
 
+export interface EditorTripTagsUpdateRequest {
+  tags: string[];
+}
+
+export interface EditorShareProgressUpdateRequest {
+  enabled: boolean;
+}
+
+export interface TagSuggestion {
+  name: string;
+  slug: string;
+  count: number;
+}
+
 export interface EditorRegionSaveRequest {
   name: string;
   notesHtml: string | null;

--- a/Models/Dtos/Editor/EditorMutationDtos.cs
+++ b/Models/Dtos/Editor/EditorMutationDtos.cs
@@ -12,6 +12,16 @@ public sealed record EditorTripMetadataUpdateRequest(
     int? Zoom);
 
 /// <summary>
+/// Complete-draft request for replacing all trip-level tags from the same-origin editor.
+/// </summary>
+public sealed record EditorTripTagsUpdateRequest(IReadOnlyList<string> Tags);
+
+/// <summary>
+/// Request for toggling trip share-progress from the same-origin editor.
+/// </summary>
+public sealed record EditorShareProgressUpdateRequest(bool Enabled);
+
+/// <summary>
 /// Cover image update payload containing the raw external URL or a clear instruction.
 /// </summary>
 public sealed record EditorImageUpdateRequest(string? RawUrl);

--- a/Services/ITripTagService.cs
+++ b/Services/ITripTagService.cs
@@ -12,6 +12,8 @@ public interface ITripTagService
 
     Task<IReadOnlyList<TripTagDto>> AttachTagsAsync(Guid tripId, IEnumerable<string> names, string userId, CancellationToken cancellationToken = default);
 
+    Task<TripTagReplacementResult> ReplaceTagsAsync(Guid tripId, IReadOnlyList<string> names, string userId, CancellationToken cancellationToken = default);
+
     Task<bool> DetachTagAsync(Guid tripId, string slug, string userId, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<TagSuggestionDto>> GetSuggestionsAsync(string? query, int limit = 10, CancellationToken cancellationToken = default);
@@ -22,3 +24,10 @@ public interface ITripTagService
 
     Task RemoveOrphanTagsAsync(CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Result of replacing the complete tag set attached to a trip.
+/// </summary>
+public sealed record TripTagReplacementResult(
+    IReadOnlyList<TripTagDto> Tags,
+    IReadOnlyList<string> DeletedSlugs);

--- a/Services/TripTagService.cs
+++ b/Services/TripTagService.cs
@@ -94,6 +94,51 @@ public sealed class TripTagService(ApplicationDbContext dbContext, ILogger<TripT
             .ToList();
     }
 
+    public async Task<TripTagReplacementResult> ReplaceTagsAsync(Guid tripId, IReadOnlyList<string> names, string userId, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(names);
+
+        var desired = names
+            .Select(name => new { Name = name.Trim().Normalize(NormalizationForm.FormC), Slug = ToSlug(name) })
+            .DistinctBy(tag => tag.Slug)
+            .ToList();
+
+        await using var tx = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        var trip = await _dbContext.Trips
+            .Include(t => t.Tags)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+
+        if (trip == null)
+        {
+            throw new KeyNotFoundException("Trip not found or access denied.");
+        }
+
+        var previousSlugs = trip.Tags.Select(t => t.Slug).ToHashSet(StringComparer.Ordinal);
+        var desiredSlugs = desired.Select(t => t.Slug).ToHashSet(StringComparer.Ordinal);
+        var deletedSlugs = previousSlugs.Except(desiredSlugs, StringComparer.Ordinal).OrderBy(slug => slug).ToList();
+        var nextTags = new List<Tag>();
+
+        foreach (var desiredTag in desired)
+        {
+            ValidateTagName(desiredTag.Name);
+            nextTags.Add(await GetOrCreateTagBySlugAsync(desiredTag.Name, desiredTag.Slug, cancellationToken));
+        }
+
+        trip.Tags.Clear();
+        foreach (var tag in nextTags)
+        {
+            trip.Tags.Add(tag);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await RemoveUnusedTagsAsync(deletedSlugs, cancellationToken);
+        await tx.CommitAsync(cancellationToken);
+
+        var tags = await GetTagsForTripAsync(tripId, userId, cancellationToken);
+        return new TripTagReplacementResult(tags, deletedSlugs);
+    }
+
     public async Task<bool> DetachTagAsync(Guid tripId, string slug, string userId, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(slug))
@@ -244,7 +289,14 @@ WHERE NOT EXISTS (
 );", cancellationToken);
     }
 
-    private void ValidateTagName(string name)
+    public static string NormalizeSlug(string name) => ToSlug(name);
+
+    public static bool IsValidTagName(string name) =>
+        !string.IsNullOrWhiteSpace(name)
+        && name.Length <= 64
+        && NameRegex.IsMatch(name);
+
+    private static void ValidateTagName(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -289,6 +341,54 @@ WHERE NOT EXISTS (
             _logger.LogWarning(ex, "Race while creating tag {Tag}", normalized);
             return await _dbContext.Tags.FirstAsync(t => t.Name == normalized, cancellationToken);
         }
+    }
+
+    private async Task<Tag> GetOrCreateTagBySlugAsync(string name, string slug, CancellationToken cancellationToken)
+    {
+        var existing = await _dbContext.Tags.FirstOrDefaultAsync(t => t.Slug == slug, cancellationToken);
+        if (existing != null)
+        {
+            return existing;
+        }
+
+        var tag = new Tag
+        {
+            Name = name,
+            Slug = slug
+        };
+
+        _dbContext.Tags.Add(tag);
+
+        try
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return tag;
+        }
+        catch (DbUpdateException ex)
+        {
+            _logger.LogWarning(ex, "Race while creating tag slug {TagSlug}", slug);
+            return await _dbContext.Tags.FirstAsync(t => t.Slug == slug, cancellationToken);
+        }
+    }
+
+    private async Task RemoveUnusedTagsAsync(IReadOnlyList<string> slugs, CancellationToken cancellationToken)
+    {
+        if (slugs.Count == 0)
+        {
+            return;
+        }
+
+        var candidates = await _dbContext.Tags
+            .Include(t => t.Trips)
+            .Where(t => slugs.Contains(t.Slug))
+            .ToListAsync(cancellationToken);
+
+        foreach (var tag in candidates.Where(t => t.Trips.Count == 0))
+        {
+            _dbContext.Tags.Remove(tag);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
     }
 
     private static TripTagDto MapToDto(Tag tag) => new(tag.Id, tag.Name, tag.Slug);

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -290,6 +290,7 @@ public sealed class TripEditorControllerTests : TestBase
             new IconColorProvider(environment),
             thumbnailMock?.Object ?? Mock.Of<ITripMapThumbnailGenerator>(),
             warmupMock?.Object ?? Mock.Of<ICacheWarmupScheduler>(),
+            Mock.Of<ITripTagService>(),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             Mock.Of<ILogger<TripEditorController>>());

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
@@ -205,6 +205,7 @@ public sealed class TripEditorMetadataControllerTests : TestBase
             new IconColorProvider(environment),
             thumbnailMock?.Object ?? Mock.Of<ITripMapThumbnailGenerator>(),
             warmupMock?.Object ?? Mock.Of<ICacheWarmupScheduler>(),
+            Mock.Of<ITripTagService>(),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             Mock.Of<ILogger<TripEditorController>>());

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataValidationControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataValidationControllerTests.cs
@@ -253,6 +253,7 @@ public sealed class TripEditorMetadataValidationControllerTests : TestBase
             new IconColorProvider(environment),
             Mock.Of<ITripMapThumbnailGenerator>(),
             Mock.Of<ICacheWarmupScheduler>(),
+            Mock.Of<ITripTagService>(),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             Mock.Of<ILogger<TripEditorController>>());

--- a/tests/Wayfarer.Tests/Controllers/TripEditorPlaceControllerTestBase.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorPlaceControllerTestBase.cs
@@ -100,6 +100,7 @@ public abstract class TripEditorPlaceControllerTestBase : TestBase
             iconColorProvider,
             Mock.Of<ITripMapThumbnailGenerator>(),
             Mock.Of<ICacheWarmupScheduler>(),
+            Mock.Of<ITripTagService>(),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, iconColorProvider, reverseGeocodingService ?? new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             Mock.Of<ILogger<TripEditorController>>());

--- a/tests/Wayfarer.Tests/Controllers/TripEditorRegionControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorRegionControllerTests.cs
@@ -323,6 +323,7 @@ public sealed class TripEditorRegionControllerTests : TestBase
             new IconColorProvider(environment),
             Mock.Of<ITripMapThumbnailGenerator>(),
             Mock.Of<ICacheWarmupScheduler>(),
+            Mock.Of<ITripTagService>(),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             Mock.Of<ILogger<TripEditorController>>());

--- a/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
@@ -93,6 +93,21 @@ public sealed class TripEditorTagsShareProgressControllerTests : TestBase
     }
 
     [Fact]
+    public async Task PutTagsReturnsTagsValidationKeyWhenTagCountExceedsOptionsLimit()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+        var tags = Enumerable.Range(1, 26).Select(index => $"Tag {index}");
+        var body = "{ \"tags\": [ " + string.Join(", ", tags.Select(tag => $"\"{tag}\"")) + " ] }";
+
+        var result = await SendJson(controller, c => c.PutTags(trip.Id, CancellationToken.None), body);
+
+        Assert.Contains("tags", AssertValidationProblem(result).Errors.Keys);
+    }
+
+    [Fact]
     public async Task PutTagsChecksOwnershipBeforeBodyParsing()
     {
         using var db = CreateDbContext();

--- a/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
@@ -1,0 +1,284 @@
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Wayfarer.Areas.Api.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Models.Dtos.Editor;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Controllers;
+
+/// <summary>
+/// Covers Trip Editor tag replacement and share-progress mutation contracts.
+/// </summary>
+public sealed class TripEditorTagsShareProgressControllerTests : TestBase
+{
+    [Fact]
+    public async Task PutTagsReplacesCompleteSetAndReturnsAffectedTags()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        AddTag(db, trip, "Beta", "beta");
+        AddTag(db, trip, "Old", "old");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.PutTags(trip.Id, CancellationToken.None), """{ "tags": [ "Alpha", "Beta" ] }""");
+
+        var envelope = AssertMutation<IReadOnlyList<EditorTagDto>>(result);
+        Assert.Equal(new[] { "Alpha", "Beta" }, envelope.Data.Select(t => t.Name));
+        Assert.Equal(new[] { "alpha", "beta" }, envelope.Affected.TagOrder);
+        Assert.Equal(new[] { "old" }, envelope.DeletedIds.Tags);
+        Assert.Equal(new[] { "alpha", "beta" }, db.Trips.Single(t => t.Id == trip.Id).Tags.OrderBy(t => t.Name).Select(t => t.Slug));
+    }
+
+    [Fact]
+    public async Task PutTagsClearsAllTags()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        AddTag(db, trip, "Old", "old");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.PutTags(trip.Id, CancellationToken.None), """{ "tags": [] }""");
+
+        var envelope = AssertMutation<IReadOnlyList<EditorTagDto>>(result);
+        Assert.Empty(envelope.Data);
+        Assert.Empty(envelope.Affected.Tags);
+        Assert.Empty(envelope.Affected.TagOrder!);
+        Assert.Equal(new[] { "old" }, envelope.DeletedIds.Tags);
+    }
+
+    [Fact]
+    public async Task PutTagsCollapsesDuplicateNormalizedSlugsWithFirstDisplayName()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.PutTags(trip.Id, CancellationToken.None), """{ "tags": [ "Cafe", "Café", "Trail" ] }""");
+
+        var envelope = AssertMutation<IReadOnlyList<EditorTagDto>>(result);
+        Assert.Equal(new[] { "Cafe", "Trail" }, envelope.Data.Select(t => t.Name));
+        Assert.Equal(new[] { "cafe", "trail" }, envelope.Affected.TagOrder);
+    }
+
+    [Theory]
+    [InlineData("""{ "tags": [ "" ] }""", "tags[0]")]
+    [InlineData("""{ "tags": [ 3 ] }""", "tags[0]")]
+    [InlineData("""{ "tags": [ "bad/tag" ] }""", "tags[0]")]
+    [InlineData("""{ "tags": null }""", "tags")]
+    [InlineData("""{ "name": "missing" }""", "tags")]
+    [InlineData("""[]""", "request")]
+    public async Task PutTagsReturnsValidationKeys(string body, string key)
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.PutTags(trip.Id, CancellationToken.None), body);
+
+        Assert.Contains(key, AssertValidationProblem(result).Errors.Keys);
+    }
+
+    [Fact]
+    public async Task PutTagsChecksOwnershipBeforeBodyParsing()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "other-user");
+
+        var result = await SendJson(controller, c => c.PutTags(trip.Id, CancellationToken.None), "{");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task PatchShareProgressEnablesForPublicTrip()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user", isPublic: true);
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.PatchShareProgress(trip.Id, CancellationToken.None), """{ "enabled": true }""");
+
+        var envelope = AssertMutation<EditorTripMetadataDto>(result);
+        Assert.True(envelope.Data.ShareProgressEnabled);
+        Assert.NotNull(envelope.Data.ProgressPublicUrl);
+        Assert.Same(envelope.Data, envelope.Affected.Metadata);
+        Assert.True(db.Trips.Single(t => t.Id == trip.Id).ShareProgressEnabled);
+    }
+
+    [Fact]
+    public async Task PatchShareProgressDisablesForPrivateTrip()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user", isPublic: false, shareProgressEnabled: true);
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.PatchShareProgress(trip.Id, CancellationToken.None), """{ "enabled": false }""");
+
+        var envelope = AssertMutation<EditorTripMetadataDto>(result);
+        Assert.False(envelope.Data.ShareProgressEnabled);
+        Assert.Null(envelope.Data.ProgressPublicUrl);
+    }
+
+    [Fact]
+    public async Task PatchShareProgressRejectsEnableForPrivateTrip()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user", isPublic: false);
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.PatchShareProgress(trip.Id, CancellationToken.None), """{ "enabled": true }""");
+
+        Assert.Contains("shareProgressEnabled", AssertValidationProblem(result).Errors.Keys);
+        Assert.False(db.Trips.Single(t => t.Id == trip.Id).ShareProgressEnabled);
+    }
+
+    [Theory]
+    [InlineData("", "request")]
+    [InlineData("{", "request")]
+    [InlineData("[]", "request")]
+    [InlineData("""{ "enabled": null }""", "enabled")]
+    [InlineData("""{ "name": "missing" }""", "enabled")]
+    public async Task PatchShareProgressReturnsValidationKeys(string body, string key)
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.PatchShareProgress(trip.Id, CancellationToken.None), body);
+
+        Assert.Contains(key, AssertValidationProblem(result).Errors.Keys);
+    }
+
+    [Fact]
+    public async Task PatchShareProgressChecksOwnershipBeforeBodyParsing()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "other-user");
+
+        var result = await SendJson(controller, c => c.PatchShareProgress(trip.Id, CancellationToken.None), "{");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    private static TripEditorController BuildController(ApplicationDbContext db)
+    {
+        var environment = BuildEnvironment();
+        var controller = new TripEditorController(
+            db,
+            environment,
+            new IconColorProvider(environment),
+            Mock.Of<ITripMapThumbnailGenerator>(),
+            Mock.Of<ICacheWarmupScheduler>(),
+            new TripTagService(db, NullLogger<TripTagService>.Instance),
+            new TripEditorRegionMutationService(db),
+            new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
+            Mock.Of<ILogger<TripEditorController>>());
+
+        var url = new Mock<IUrlHelper>();
+        url.Setup(u => u.Action(It.IsAny<UrlActionContext>()))
+            .Returns((UrlActionContext context) =>
+            {
+                var id = context.Values?.GetType().GetProperty("id")?.GetValue(context.Values);
+                var progress = context.Values?.GetType().GetProperty("progress")?.GetValue(context.Values);
+                return progress == null
+                    ? $"https://example.test/Public/Trips/{id}"
+                    : $"https://example.test/Public/Trips/{id}?progress={progress}";
+            });
+        controller.Url = url.Object;
+        return controller;
+    }
+
+    private static async Task<IActionResult> SendJson(
+        TripEditorController controller,
+        Func<TripEditorController, Task<IActionResult>> action,
+        string requestBody)
+    {
+        var httpContext = controller.ControllerContext.HttpContext ?? new DefaultHttpContext();
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        var body = Encoding.UTF8.GetBytes(requestBody);
+        httpContext.Request.Body = new MemoryStream(body);
+        httpContext.Request.ContentLength = body.Length;
+        httpContext.Request.ContentType = "application/json";
+        return await action(controller);
+    }
+
+    private static void ConfigureControllerWithUserRole(ControllerBase controller, string userId, string role = "User")
+    {
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = BuildHttpContextWithUser(userId, role)
+        };
+    }
+
+    private static EditorMutationResult<T> AssertMutation<T>(IActionResult result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result);
+        return Assert.IsType<EditorMutationResult<T>>(ok.Value);
+    }
+
+    private static ValidationProblemDetails AssertValidationProblem(IActionResult result)
+    {
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("application/problem+json", badRequest.ContentTypes);
+        return Assert.IsType<ValidationProblemDetails>(badRequest.Value);
+    }
+
+    private static void AddTag(ApplicationDbContext db, Trip trip, string name, string slug)
+    {
+        var tag = new Tag { Id = Guid.NewGuid(), Name = name, Slug = slug };
+        trip.Tags.Add(tag);
+        db.Tags.Add(tag);
+        db.SaveChanges();
+    }
+
+    private static Trip SeedTrip(
+        ApplicationDbContext db,
+        string userId,
+        bool isPublic = false,
+        bool shareProgressEnabled = false)
+    {
+        var trip = new Trip
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Name = "Test Trip",
+            Notes = "Old notes",
+            UpdatedAt = DateTime.UtcNow,
+            IsPublic = isPublic,
+            ShareProgressEnabled = shareProgressEnabled
+        };
+
+        db.Trips.Add(trip);
+        db.SaveChanges();
+        return trip;
+    }
+
+    private static IWebHostEnvironment BuildEnvironment()
+    {
+        var mock = new Mock<IWebHostEnvironment>();
+        mock.SetupGet(e => e.WebRootPath).Returns(Path.GetTempPath());
+        return mock.Object;
+    }
+}

--- a/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
@@ -73,6 +73,26 @@ public sealed class TripEditorTagsShareProgressControllerTests : TestBase
         Assert.Equal(new[] { "cafe", "trail" }, envelope.Affected.TagOrder);
     }
 
+    [Fact]
+    public async Task PutTagsPreservesExistingUnicodeTagByDisplayName()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var unicodeSlug = TripTagService.NormalizeSlug("Αθήνα");
+        AddTag(db, trip, "Αθήνα", unicodeSlug);
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.PutTags(trip.Id, CancellationToken.None), """{ "tags": [ "Αθήνα" ] }""");
+
+        var envelope = AssertMutation<IReadOnlyList<EditorTagDto>>(result);
+        Assert.Equal(new[] { "Αθήνα" }, envelope.Data.Select(t => t.Name));
+        Assert.Equal(new[] { "Αθήνα" }, envelope.Affected.Tags.Select(t => t.Name));
+        Assert.Equal(new[] { unicodeSlug }, envelope.Affected.TagOrder);
+        Assert.Empty(envelope.DeletedIds.Tags);
+        Assert.Equal(new[] { unicodeSlug }, db.Trips.Single(t => t.Id == trip.Id).Tags.Select(t => t.Slug));
+    }
+
     [Theory]
     [InlineData("""{ "tags": [ "" ] }""", "tags[0]")]
     [InlineData("""{ "tags": [ 3 ] }""", "tags[0]")]

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -233,12 +233,11 @@ test.describe.serial('Trip Editor dev verification', () => {
     const shareToggle = surface.getByLabel('Show visit progress on public trip');
     await expect(shareToggle).toBeVisible();
 
-    await surface.getByLabel('Public trip').uncheck();
+    await surface.getByRole('checkbox', { name: 'Public trip', exact: true }).uncheck();
 
     await expect(shareToggle).toBeDisabled();
     await expect(shareToggle).not.toBeChecked();
     await expect(surface.getByRole('link', { name: 'Open progress URL' })).toHaveCount(0);
-    await surface.getByRole('button', { name: 'Cancel / Reset' }).click();
   });
 
   test('Save & Exit stays on workspace when tag save fails', async ({ page }) => {
@@ -309,10 +308,12 @@ async function expectUsableDockedPlaceEditor(page: Page): Promise<void> {
 
 // Confirms tags appear in the Trip-level panel and not inside the place editor form.
 async function expectTripLevelTagsOnly(page: Page): Promise<void> {
-  const tagsHeading = page.getByRole('heading', { name: 'Tags' });
-  if (await tagsHeading.isVisible()) {
-    await expect(tagsHeading.locator('xpath=ancestor::section[contains(@class, "trip-editor-panel")]')).toBeVisible();
+  const sidebarPanel = sidebarTagsPanel(page);
+  if (await sidebarPanel.isVisible().catch(() => false)) {
+    await expect(sidebarPanel).toBeVisible();
   }
+
+  await expect(page.locator('#trip-editor-metadata-form').getByRole('heading', { name: 'Tags' })).toBeVisible();
 }
 
 // Guards against fields from the design mockups that are not implemented on main.

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -190,6 +190,81 @@ test.describe.serial('Trip Editor dev verification', () => {
     await expect(children).toBeVisible();
   });
 
+  test('trip tags are editable in docked settings and update the sidebar', async ({ page }) => {
+    await signIn(page);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    const tagName = uniqueName('pw-docked-tag');
+    try {
+      await addTagInActiveSettings(page, tagName);
+      await page.getByRole('button', { name: 'Save & Continue' }).click();
+      await expectSaved(page);
+      await expect(sidebarTagsPanel(page)).toContainText(tagName);
+    } finally {
+      await removeTagIfPresent(page, tagName);
+    }
+  });
+
+  test('trip tags are editable in expanded settings', async ({ page }) => {
+    await signIn(page);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    const tagName = uniqueName('pw-expanded-tag');
+    try {
+      await page.getByRole('button', { name: 'Expand Editor' }).click();
+      const dialog = page.getByRole('dialog', { name: /Edit Trip -/i });
+      await addTagInSurface(dialog, tagName);
+      await dialog.getByRole('button', { name: 'Save & Continue' }).click();
+      await expectSaved(page);
+      await expect(sidebarTagsPanel(page)).toContainText(tagName);
+    } finally {
+      await removeTagIfPresent(page, tagName);
+    }
+  });
+
+  test('share progress toggle is visible and private draft disables it', async ({ page }) => {
+    await signIn(page);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    const surface = page.locator('.trip-editor-surface--docked');
+    const shareToggle = surface.getByLabel('Show visit progress on public trip');
+    await expect(shareToggle).toBeVisible();
+
+    await surface.getByLabel('Public trip').uncheck();
+
+    await expect(shareToggle).toBeDisabled();
+    await expect(shareToggle).not.toBeChecked();
+    await expect(surface.getByRole('link', { name: 'Open progress URL' })).toHaveCount(0);
+    await surface.getByRole('button', { name: 'Cancel / Reset' }).click();
+  });
+
+  test('Save & Exit stays on workspace when tag save fails', async ({ page }) => {
+    await signIn(page);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+    await page.route('**/api/trips/*/editor/tags', async route => {
+      await route.fulfill({
+        status: 400,
+        contentType: 'application/problem+json',
+        body: JSON.stringify({
+          title: 'One or more validation errors occurred.',
+          status: 400,
+          errors: { tags: ['Injected tag save failure.'] }
+        })
+      });
+    });
+
+    await addTagInActiveSettings(page, uniqueName('pw-failed-tag'));
+    await page.getByRole('button', { name: 'Save & Exit' }).click();
+
+    await expect(page).toHaveURL(pathRegex(workspacePath));
+    await expect(page.getByRole('alert')).toContainText('One or more validation errors occurred.');
+    await expect(page.locator('.trip-editor-surface--docked')).toContainText('Injected tag save failure.');
+  });
+
   test('responsive narrow workspace remains usable', async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 900 });
     await signIn(page);
@@ -322,6 +397,35 @@ async function expectReverseGeocodeWarningIfPresent(page: Page): Promise<void> {
   await expect(warning).toHaveCSS('color', /rgb\(/);
   await expect(page.locator('.trip-editor-form-error')).toHaveCount(0);
   await expect(page.getByText('Save failed')).toHaveCount(0);
+}
+
+function sidebarTagsPanel(page: Page): Locator {
+  return page.locator('.trip-editor-panel').filter({ has: page.locator('h2', { hasText: 'Tags' }) }).first();
+}
+
+async function addTagInActiveSettings(page: Page, tagName: string): Promise<void> {
+  await addTagInSurface(page.locator('.trip-editor-surface--docked'), tagName);
+}
+
+async function addTagInSurface(surface: Locator, tagName: string): Promise<void> {
+  await surface.getByLabel('Add tag').fill(tagName);
+  await surface.getByRole('button', { name: 'Add' }).click();
+  await expect(surface).toContainText(tagName);
+}
+
+async function removeTagIfPresent(page: Page, tagName: string): Promise<void> {
+  await page.unroute('**/api/trips/*/editor/tags').catch(() => undefined);
+  await page.goto(absoluteUrl(workspacePath));
+  await expectMountedWorkspace(page);
+  const remove = page.locator('.trip-editor-surface--docked').getByRole('button', { name: `Remove tag ${tagName}` });
+  if ((await remove.count()) === 0) {
+    return;
+  }
+
+  await remove.click();
+  await page.getByRole('button', { name: 'Save & Continue' }).click();
+  await expectSaved(page);
+  await expect(page.locator('.trip-editor-sidebar')).not.toContainText(tagName);
 }
 
 async function expectNoObviousOverflow(locator: Locator): Promise<void> {


### PR DESCRIPTION
## Summary
- Adds Trip Editor endpoints for replacing trip-level tags and toggling share-progress sharing: `PUT /api/trips/{tripId}/editor/tags` and `PATCH /api/trips/{tripId}/editor/share-progress`.
- Adds Trip Editor UI controls in the metadata/settings surfaces for tag add/remove workflows and share-progress visibility, with sidebar tag updates after successful saves.
- Uses the existing `GET /api/tags/suggest` endpoint for tag suggestions.
- Keeps the Place editor tag-free.
- Leaves the legacy `TripTagsController` unchanged.

## Validation
- `dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --filter TripEditorTagsShareProgress` passed: 20 passed, 0 failed, 0 skipped.
- `npm run test:e2e:trip-editor` passed with local ASP.NET on `http://localhost:5012` and Vite on `http://localhost:5173`: 17 passed, 1 skipped.
- `npm run build` passed.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` passed with warnings only.
- `git diff --check origin/main...HEAD` passed.

## LOC Warning Decisions
- `ClientApps/trip-editor/src/styles.css` warned at 451 LOC. Warning accepted: the added rules extend the existing Trip Editor stylesheet for the new settings controls without introducing a separate styling responsibility.
- `ClientApps/trip-editor/src/components/RegionManager.vue` warned at 446 LOC. Warning accepted: this branch does not expand that component's responsibility; it remains existing Trip Editor region/place orchestration.
- `ClientApps/trip-editor/src/components/MetadataEditor.vue` warned at 424 LOC. Warning accepted for this slice: the component owns trip-level metadata/settings, and the new tag/share-progress controls are part of that same surface.

## Notes
- No database migration required.
- No merge requested.