### PR TITLE
Add Trip Editor map navigation toolbar

### DIFF
--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -99,7 +99,7 @@ const focusActiveEntity = (): void => {
 
   const target = editorSurface.activeTarget.value;
   const result = mapAdapter.focusActiveEntity(state.value, target);
-  navigationStatus.value = focusStatusText(result, target?.kind ?? null);
+  navigationStatus.value = focusStatusText(result, target);
 };
 
 /// Tracks region draft changes that live inside the sidebar child component.
@@ -184,8 +184,13 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
   mapAdapter?.render(next);
 };
 
-function focusStatusText(result: FocusActiveEntityResult, kind: string | null): string {
+function focusStatusText(result: FocusActiveEntityResult, target: { kind: string; mode: string } | null): string {
   if (result === 'moved') {
+    if (target?.kind === 'place' && target.mode === 'add') {
+      return 'Focused parent region';
+    }
+
+    const kind = target?.kind ?? null;
     if (kind === 'metadata') {
       return 'Focused trip map';
     }

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -6,7 +6,7 @@ import MapWorkToolbar from './components/MapWorkToolbar.vue';
 import TripSidebar from './components/TripSidebar.vue';
 import { disposeConfirmDialogHost, setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
 import { useEditorSurface } from './composables/useEditorSurface';
-import { createTripEditorMap } from './map/leafletAdapter';
+import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type FocusActiveEntityResult } from './map/leafletAdapter';
 import type { BootstrapConfig, EditorMutationResult, EditorTripMetadata, EditorTripState } from './types';
 
 const props = defineProps<{ config: BootstrapConfig }>();
@@ -17,12 +17,24 @@ const isLoading = ref(true);
 const hasRegionDraftChanges = ref(false);
 const workspaceElement = ref<HTMLElement | null>(null);
 const mapElement = ref<HTMLElement | null>(null);
+const navigationStatus = ref<string | null>(null);
 const editorSurface = useEditorSurface();
 let mapAdapter: ReturnType<typeof createTripEditorMap> | null = null;
 
 const updatedLabel = computed(() =>
   state.value ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(state.value.metadata.updatedAt)) : ''
 );
+const isMapWorkActive = computed(() => editorSurface.isMapWorkActive.value);
+const toolbarContext = computed(() => {
+  if (editorSurface.mapWork.value) {
+    return `${editorSurface.mapWork.value.modeName}: ${editorSurface.mapWork.value.statusText}`;
+  }
+
+  return editorSurface.activeTarget.value?.title ?? 'Trip map';
+});
+const canFitAllGeometry = computed(() => Boolean(state.value && hasAnyGeometry(state.value)));
+const canRecenterSavedView = computed(() => Boolean(state.value && hasSavedTripView(state.value.metadata)));
+const canFocusTarget = computed(() => Boolean(state.value && canFocusActiveEntity(state.value, editorSurface.activeTarget.value)));
 
 onMounted(async () => {
   setConfirmDialogFocusFallback(workspaceElement.value);
@@ -57,6 +69,37 @@ const applyMetadata = (metadata: EditorTripMetadata): void => {
 
   state.value = { ...state.value, metadata };
   mapAdapter?.render(state.value);
+};
+
+/// Runs a navigation-only adapter command without mutating editor drafts or metadata.
+const fitAllGeometry = (): void => {
+  if (!state.value || !mapAdapter) {
+    return;
+  }
+
+  const result = mapAdapter.fitAllGeometry(state.value);
+  navigationStatus.value = result === 'moved' ? 'Fit all geometry' : 'No geometry to fit';
+};
+
+/// Recenters to the persisted trip view; it never saves the current map viewport.
+const recenterSavedTripView = (): void => {
+  if (!state.value || !mapAdapter) {
+    return;
+  }
+
+  const result = mapAdapter.focusSavedTripView(state.value.metadata);
+  navigationStatus.value = result === 'moved' ? 'Recentered saved trip view' : 'Saved trip view unavailable';
+};
+
+/// Focuses the active target through the map adapter and reports only local toolbar status.
+const focusActiveEntity = (): void => {
+  if (!state.value || !mapAdapter) {
+    return;
+  }
+
+  const target = editorSurface.activeTarget.value;
+  const result = mapAdapter.focusActiveEntity(state.value, target);
+  navigationStatus.value = focusStatusText(result, target?.kind ?? null);
 };
 
 /// Tracks region draft changes that live inside the sidebar child component.
@@ -140,6 +183,34 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
   state.value = next;
   mapAdapter?.render(next);
 };
+
+function focusStatusText(result: FocusActiveEntityResult, kind: string | null): string {
+  if (result === 'moved') {
+    if (kind === 'metadata') {
+      return 'Focused trip map';
+    }
+
+    if (kind === 'region') {
+      return 'Focused region';
+    }
+
+    if (kind === 'place') {
+      return 'Focused place';
+    }
+
+    return 'Focused active entity';
+  }
+
+  if (result === 'missing-target') {
+    return 'No active target to focus';
+  }
+
+  if (result === 'unsupported-target') {
+    return 'Active target cannot be focused';
+  }
+
+  return 'No geometry to focus';
+}
 </script>
 
 <template>
@@ -168,11 +239,22 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
       />
       <main class="trip-editor-map-shell">
         <header class="trip-editor-toolbar">
-          <div>
+          <div class="trip-editor-toolbar__context">
             <span>{{ state.metadata.isPublic ? 'Public trip' : 'Private trip' }}</span>
             <strong>Updated {{ updatedLabel }}</strong>
+            <small>{{ toolbarContext }}</small>
+            <small v-if="navigationStatus" class="trip-editor-toolbar__status" role="status">{{ navigationStatus }}</small>
           </div>
-          <a class="btn btn-outline-light btn-sm" :href="`/User/Trip/Edit/${state.tripId}`">Legacy editor</a>
+          <div class="trip-editor-toolbar__actions">
+            <template v-if="!isMapWorkActive">
+              <button type="button" class="btn btn-outline-light btn-sm" :disabled="!canFitAllGeometry" @click="fitAllGeometry">Fit All</button>
+              <button type="button" class="btn btn-outline-light btn-sm" :disabled="!canRecenterSavedView" @click="recenterSavedTripView">
+                Recenter Saved Trip View
+              </button>
+              <button type="button" class="btn btn-outline-light btn-sm" :disabled="!canFocusTarget" @click="focusActiveEntity">Focus Active Entity</button>
+            </template>
+            <a class="btn btn-outline-light btn-sm" :href="`/User/Trip/Edit/${state.tripId}`">Legacy editor</a>
+          </div>
         </header>
         <MapWorkToolbar :controller="editorSurface" />
         <div ref="mapElement" class="trip-editor-map" aria-label="Read-only trip map"></div>

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -85,7 +85,8 @@ const activeRegionTarget = computed<EditorTarget>(() => ({
   kind: 'region',
   mode: draft.id ? 'edit' : 'add',
   title: draft.id ? `Edit Region - ${activeRegion.value?.name ?? draft.name}` : 'Add Region',
-  subtitle: draft.id ? 'Region details' : 'New region'
+  subtitle: draft.id ? 'Region details' : 'New region',
+  entityId: draft.id ?? undefined
 }));
 const activePlaceTarget = computed<EditorTarget>(() => ({
   key: placeDraftKey,
@@ -93,7 +94,9 @@ const activePlaceTarget = computed<EditorTarget>(() => ({
   kind: 'place',
   mode: placeDraft.id ? 'edit' : 'add',
   title: placeDraft.id ? `Edit Place - ${activePlace.value?.name ?? placeDraft.name}` : 'Add Place',
-  subtitle: placeDraft.regionId ? props.state.regionsById[placeDraft.regionId]?.name : undefined
+  subtitle: placeDraft.regionId ? props.state.regionsById[placeDraft.regionId]?.name : undefined,
+  entityId: placeDraft.id ?? undefined,
+  parentRegionId: placeDraft.regionId ?? undefined
 }));
 const { applyError, fieldErrors, formSummaryErrors, markSaved, resetFeedback, saveError, saveWarning, statusText } = useEditorMutationFeedback({
   isDirty,

--- a/ClientApps/trip-editor/src/components/regionPlaceEditorTargets.ts
+++ b/ClientApps/trip-editor/src/components/regionPlaceEditorTargets.ts
@@ -22,7 +22,8 @@ export function buildRegionEditTarget(region: EditorRegion): EditorTarget {
     kind: 'region',
     mode: 'edit',
     title: `Edit Region - ${region.name}`,
-    subtitle: 'Region details'
+    subtitle: 'Region details',
+    entityId: region.id
   };
 }
 
@@ -33,7 +34,8 @@ export function buildPlaceCreateTarget(region: EditorRegion): EditorTarget {
     kind: 'place',
     mode: 'add',
     title: 'Add Place',
-    subtitle: region.name
+    subtitle: region.name,
+    parentRegionId: region.id
   };
 }
 
@@ -44,6 +46,8 @@ export function buildPlaceEditTarget(place: EditorPlace, subtitle?: string): Edi
     kind: 'place',
     mode: 'edit',
     title: `Edit Place - ${place.name}`,
-    subtitle
+    subtitle,
+    entityId: place.id,
+    parentRegionId: place.regionId
   };
 }

--- a/ClientApps/trip-editor/src/composables/useEditorSurface.ts
+++ b/ClientApps/trip-editor/src/composables/useEditorSurface.ts
@@ -1,5 +1,6 @@
 import { computed, readonly, ref, type Ref } from 'vue';
 import { confirm } from './useConfirmDialog';
+import type { Guid } from '../types';
 
 export type EditorSurfaceMode = 'docked' | 'expanded' | 'map-work';
 export type EditorTargetKind = 'metadata' | 'region' | 'place';
@@ -12,6 +13,8 @@ export interface EditorTarget {
   mode: EditorTargetMode;
   title: string;
   subtitle?: string;
+  entityId?: Guid;
+  parentRegionId?: Guid;
 }
 
 export interface EditorTargetHandler {

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -1,9 +1,17 @@
 import L, { type LayerGroup, type Map as LeafletMap } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
-import type { EditorArea, EditorPlace, EditorRegion, EditorSegment, EditorTripState } from '../types';
+import type { EditorTarget } from '../composables/useEditorSurface';
+import type { EditorArea, EditorCoordinate, EditorPlace, EditorRegion, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from '../types';
+
+export type FitAllGeometryResult = 'moved' | 'no-geometry';
+export type FocusSavedTripViewResult = 'moved' | 'missing-view';
+export type FocusActiveEntityResult = 'moved' | 'missing-target' | 'no-geometry' | 'unsupported-target';
 
 interface TripEditorMapAdapter {
   render: (state: EditorTripState) => void;
+  fitAllGeometry: (state: EditorTripState) => FitAllGeometryResult;
+  focusSavedTripView: (metadata: EditorTripMetadata) => FocusSavedTripViewResult;
+  focusActiveEntity: (state: EditorTripState, target: EditorTarget | null) => FocusActiveEntityResult;
   dispose: () => void;
 }
 
@@ -29,6 +37,9 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
 
   return {
     render,
+    fitAllGeometry: state => fitAllGeometry(map, state),
+    focusSavedTripView: metadata => focusSavedTripView(map, metadata),
+    focusActiveEntity: (state, target) => focusActiveEntity(map, state, target),
     dispose: () => map.remove()
   };
 };
@@ -93,23 +104,172 @@ const fallbackSegmentCoordinates = (segment: EditorSegment, state: EditorTripSta
   return from && to ? [[from.longitude, from.latitude], [to.longitude, to.latitude]] : null;
 };
 
+// Preserves the existing render-time auto-fit while toolbar commands remain explicit navigation calls.
 const fitMapToState = (map: LeafletMap, state: EditorTripState): void => {
-  const bounds = L.latLngBounds([]);
-
-  Object.values(state.regionsById).forEach(region => region.center && bounds.extend([region.center.latitude, region.center.longitude]));
-  Object.values(state.placesById).forEach(place => place.location && bounds.extend([place.location.latitude, place.location.longitude]));
-  Object.values(state.areasById).forEach(area => area.geometry?.coordinates.flat().forEach(([longitude, latitude]) => bounds.extend([latitude, longitude])));
-  Object.values(state.segmentsById).forEach(segment => (segment.route?.coordinates ?? fallbackSegmentCoordinates(segment, state))?.forEach(([longitude, latitude]) => bounds.extend([latitude, longitude])));
-
-  if (bounds.isValid()) {
-    map.fitBounds(bounds, { padding: [32, 32], maxZoom: 12 });
+  if (fitBounds(map, allGeometryBounds(state)) === 'moved') {
     return;
   }
 
-  if (state.metadata.center) {
-    map.setView([state.metadata.center.latitude, state.metadata.center.longitude], state.metadata.zoom ?? 8);
+  focusSavedTripView(map, state.metadata);
+};
+
+const fitAllGeometry = (map: LeafletMap, state: EditorTripState): FitAllGeometryResult =>
+  fitBounds(map, allGeometryBounds(state));
+
+const focusSavedTripView = (map: LeafletMap, metadata: EditorTripMetadata): FocusSavedTripViewResult => {
+  if (!hasSavedTripView(metadata)) {
+    return 'missing-view';
+  }
+
+  map.setView([metadata.center.latitude, metadata.center.longitude], metadata.zoom);
+  return 'moved';
+};
+
+const focusActiveEntity = (map: LeafletMap, state: EditorTripState, target: EditorTarget | null): FocusActiveEntityResult => {
+  if (!target) {
+    return 'missing-target';
+  }
+
+  if (target.kind === 'metadata') {
+    return focusSavedTripView(map, state.metadata) === 'moved' ? 'moved' : fitAllGeometry(map, state);
+  }
+
+  if (target.kind === 'region') {
+    if (target.mode !== 'edit' || !target.entityId) {
+      return 'no-geometry';
+    }
+
+    return fitBounds(map, regionGeometryBounds(state, target.entityId));
+  }
+
+  if (target.kind === 'place') {
+    if (target.mode === 'add') {
+      return target.parentRegionId ? fitBounds(map, regionGeometryBounds(state, target.parentRegionId)) : 'no-geometry';
+    }
+
+    if (!target.entityId) {
+      return 'missing-target';
+    }
+
+    const place = state.placesById[target.entityId];
+    if (!place) {
+      return 'missing-target';
+    }
+
+    return fitBounds(map, coordinateBounds(place.location));
+  }
+
+  return 'unsupported-target';
+};
+
+export const hasAnyGeometry = (state: EditorTripState): boolean => allGeometryBounds(state).isValid();
+
+export const hasSavedTripView = (metadata: EditorTripMetadata): metadata is EditorTripMetadata & { center: EditorCoordinate; zoom: number } =>
+  metadata.center !== null &&
+  isFiniteCoordinate(metadata.center) &&
+  metadata.zoom !== null &&
+  Number.isFinite(metadata.zoom) &&
+  metadata.zoom >= 0 &&
+  metadata.zoom <= 19;
+
+export const canFocusActiveEntity = (state: EditorTripState, target: EditorTarget | null): boolean => {
+  if (!target) {
+    return false;
+  }
+
+  if (target.kind === 'metadata') {
+    return hasSavedTripView(state.metadata) || hasAnyGeometry(state);
+  }
+
+  if (target.kind === 'region') {
+    return target.mode === 'edit' && Boolean(target.entityId) && regionGeometryBounds(state, target.entityId!).isValid();
+  }
+
+  if (target.kind === 'place') {
+    if (target.mode === 'add') {
+      return Boolean(target.parentRegionId) && regionGeometryBounds(state, target.parentRegionId!).isValid();
+    }
+
+    if (!target.entityId) {
+      return false;
+    }
+
+    return coordinateBounds(state.placesById[target.entityId]?.location ?? null).isValid();
+  }
+
+  return false;
+};
+
+const fitBounds = (map: LeafletMap, bounds: L.LatLngBounds): FitAllGeometryResult => {
+  if (!bounds.isValid()) {
+    return 'no-geometry';
+  }
+
+  map.fitBounds(bounds, { padding: [32, 32], maxZoom: 12 });
+  return 'moved';
+};
+
+const allGeometryBounds = (state: EditorTripState): L.LatLngBounds => {
+  const bounds = L.latLngBounds([]);
+  Object.values(state.regionsById).forEach(region => extendCoordinate(bounds, region.center));
+  Object.values(state.placesById).forEach(place => extendCoordinate(bounds, place.location));
+  Object.values(state.areasById).forEach(area => extendArea(bounds, area));
+  Object.values(state.segmentsById).forEach(segment => extendSegment(bounds, segment, state));
+  return bounds;
+};
+
+const regionGeometryBounds = (state: EditorTripState, regionId: Guid): L.LatLngBounds => {
+  const bounds = L.latLngBounds([]);
+  const regionPlaceIds = new Set<Guid>();
+
+  Object.values(state.placesById).forEach(place => {
+    if (place.regionId === regionId) {
+      regionPlaceIds.add(place.id);
+      extendCoordinate(bounds, place.location);
+    }
+  });
+  Object.values(state.areasById).forEach(area => {
+    if (area.regionId === regionId) {
+      extendArea(bounds, area);
+    }
+  });
+  Object.values(state.segmentsById).forEach(segment => {
+    if ((segment.fromPlaceId && regionPlaceIds.has(segment.fromPlaceId)) || (segment.toPlaceId && regionPlaceIds.has(segment.toPlaceId))) {
+      extendSegment(bounds, segment, state);
+    }
+  });
+  extendCoordinate(bounds, state.regionsById[regionId]?.center ?? null);
+  return bounds;
+};
+
+const coordinateBounds = (coordinate: EditorCoordinate | null): L.LatLngBounds => {
+  const bounds = L.latLngBounds([]);
+  extendCoordinate(bounds, coordinate);
+  return bounds;
+};
+
+const extendCoordinate = (bounds: L.LatLngBounds, coordinate: EditorCoordinate | null | undefined): void => {
+  if (coordinate && isFiniteCoordinate(coordinate)) {
+    bounds.extend([coordinate.latitude, coordinate.longitude]);
   }
 };
+
+const extendArea = (bounds: L.LatLngBounds, area: EditorArea): void => {
+  area.geometry?.coordinates.flat().forEach(coordinate => extendLongitudeLatitude(bounds, coordinate));
+};
+
+const extendSegment = (bounds: L.LatLngBounds, segment: EditorSegment, state: EditorTripState): void => {
+  (segment.route?.coordinates ?? fallbackSegmentCoordinates(segment, state))?.forEach(coordinate => extendLongitudeLatitude(bounds, coordinate));
+};
+
+const extendLongitudeLatitude = (bounds: L.LatLngBounds, [longitude, latitude]: [number, number]): void => {
+  if (Number.isFinite(latitude) && Number.isFinite(longitude)) {
+    bounds.extend([latitude, longitude]);
+  }
+};
+
+const isFiniteCoordinate = (coordinate: EditorCoordinate): boolean =>
+  Number.isFinite(coordinate.latitude) && Number.isFinite(coordinate.longitude);
 
 const segmentLabel = (segment: EditorSegment, state: EditorTripState): string => {
   const fromName = segment.fromPlaceId ? state.placesById[segment.fromPlaceId]?.name : null;

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -110,7 +110,7 @@ const fitMapToState = (map: LeafletMap, state: EditorTripState): void => {
     return;
   }
 
-  focusSavedTripView(map, state.metadata);
+  focusRenderFallbackView(map, state.metadata);
 };
 
 const fitAllGeometry = (map: LeafletMap, state: EditorTripState): FitAllGeometryResult =>
@@ -123,6 +123,14 @@ const focusSavedTripView = (map: LeafletMap, metadata: EditorTripMetadata): Focu
 
   map.setView([metadata.center.latitude, metadata.center.longitude], metadata.zoom);
   return 'moved';
+};
+
+const focusRenderFallbackView = (map: LeafletMap, metadata: EditorTripMetadata): void => {
+  if (!metadata.center || !isFiniteCoordinate(metadata.center)) {
+    return;
+  }
+
+  map.setView([metadata.center.latitude, metadata.center.longitude], metadata.zoom ?? 8);
 };
 
 const focusActiveEntity = (map: LeafletMap, state: EditorTripState, target: EditorTarget | null): FocusActiveEntityResult => {

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -448,19 +448,39 @@ body {
   background: var(--trip-editor-bg);
   border-bottom: 1px solid var(--trip-editor-border);
   display: flex;
+  gap: 1rem;
   justify-content: space-between;
   padding: 0.75rem 1rem;
 }
 
-.trip-editor-toolbar div {
+.trip-editor-toolbar__context {
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
+  min-width: 0;
 }
 
-.trip-editor-toolbar span {
+.trip-editor-toolbar span,
+.trip-editor-toolbar small {
   color: var(--trip-editor-muted);
   font-size: 0.85rem;
+}
+
+.trip-editor-toolbar__context strong,
+.trip-editor-toolbar__context small {
+  overflow-wrap: anywhere;
+}
+
+.trip-editor-toolbar__status {
+  color: var(--trip-editor-text);
+}
+
+.trip-editor-toolbar__actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
 }
 
 .trip-editor-map { min-height: 0; }
@@ -534,6 +554,15 @@ body {
 
   .trip-editor-map {
     min-height: 55vh;
+  }
+
+  .trip-editor-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .trip-editor-toolbar__actions {
+    justify-content: flex-start;
   }
 
 }

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -11,7 +11,6 @@ import {
   firstVisibleAddPlace,
   legacyEditPath,
   pathRegex,
-  regionCard,
   regionEditButton,
   signIn,
   uniqueName,

--- a/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
@@ -131,6 +131,7 @@ async function loadWorkspaceWithEditorState<T>(page: Page, mutate: (state: Mutab
   await page.unroute(`**${editorApiPath}`).catch(() => undefined);
   const state = await loadEditorStateFixture(page) as MutableEditorState;
   const result = mutate(state);
+  // Route only the editor read model so toolbar coverage can vary geometry without mutating runbook data.
   await page.route(`**${editorApiPath}`, async route => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
   });
@@ -243,6 +244,7 @@ async function expectPlaceDraftCoordinateValues(page: Page, values: { latitude: 
 async function enterMapWorkFromE2e(page: Page): Promise<void> {
   await page.evaluate(async () => {
     const moduleUrl = '/ClientApps/trip-editor/src/composables/useEditorSurface.ts';
+    // Use the real surface singleton through Vite so map-work assertions do not add fake UI controls.
     const surface = await import(/* @vite-ignore */ moduleUrl) as {
       enterMapWork: (options: {
         modeName: string;

--- a/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
@@ -1,0 +1,269 @@
+import { expect, test, type Page } from '@playwright/test';
+import {
+  absoluteUrl,
+  editorApiPath,
+  expectInitializedTripMap,
+  expectMountedWorkspace,
+  expectNoSearchAddUi,
+  loadEditorStateFixture,
+  regionCard,
+  regionEditButton,
+  signIn,
+  workspacePath
+} from './tripEditorTestUtils';
+
+type MutableEditorState = Record<string, any>;
+
+test.describe.serial('Trip Editor map navigation toolbar', () => {
+  test('renders real commands without mutating metadata drafts', async ({ page }) => {
+    await signIn(page);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    const toolbar = page.locator('.trip-editor-toolbar');
+    await expect(toolbar).toBeVisible();
+    await expect(toolbar.getByRole('button', { name: 'Fit All' })).toBeVisible();
+    await expect(toolbar.getByRole('button', { name: 'Recenter Saved Trip View' })).toBeVisible();
+    await expect(toolbar.getByRole('button', { name: 'Focus Active Entity' })).toBeVisible();
+    await expectInitializedTripMap(page);
+    await expectNoSearchAddUi(page);
+
+    const before = await metadataMapFieldValues(page);
+    const fitAll = toolbar.getByRole('button', { name: 'Fit All' });
+    if (await fitAll.isEnabled()) {
+      await fitAll.click();
+      await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Fit all geometry');
+    } else {
+      await expect(fitAll).toBeDisabled();
+    }
+
+    const recenter = toolbar.getByRole('button', { name: 'Recenter Saved Trip View' });
+    if (await recenter.isEnabled()) {
+      await recenter.click();
+      await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Recentered saved trip view');
+    } else {
+      await expect(recenter).toBeDisabled();
+    }
+
+    const focus = toolbar.getByRole('button', { name: 'Focus Active Entity' });
+    if (await focus.isEnabled()) {
+      await focus.click();
+      await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Focused trip map');
+    }
+
+    await expectMetadataMapFieldValues(page, before);
+    await expect(page.locator('.trip-editor-surface--docked .trip-editor-save-state').first()).toContainText('Saved');
+
+    await page.locator('.trip-editor-surface--docked').getByRole('button', { name: 'Close' }).click();
+    await expect(toolbar.getByRole('button', { name: 'Focus Active Entity' })).toBeDisabled();
+  });
+
+  test('availability follows saved view and empty geometry state', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithEditorState(page, state => {
+      state.metadata.center = { latitude: 37.9838, longitude: 23.7275 };
+      state.metadata.zoom = 8;
+    });
+
+    await expect(page.locator('.trip-editor-toolbar').getByRole('button', { name: 'Recenter Saved Trip View' })).toBeEnabled();
+
+    await loadWorkspaceWithEditorState(page, state => {
+      clearNavigationGeometry(state);
+      state.metadata.center = null;
+      state.metadata.zoom = null;
+    });
+
+    const toolbar = page.locator('.trip-editor-toolbar');
+    await expect(toolbar.getByRole('button', { name: 'Fit All' })).toBeDisabled();
+    await expect(toolbar.getByRole('button', { name: 'Recenter Saved Trip View' })).toBeDisabled();
+    await expect(toolbar.getByRole('button', { name: 'Focus Active Entity' })).toBeDisabled();
+  });
+
+  test('focuses active region and place targets without inventing coordinates', async ({ page }) => {
+    await signIn(page);
+    const fixture = await loadWorkspaceWithEditorState(page, state => prepareNavigationFocusState(state));
+    const toolbar = page.locator('.trip-editor-toolbar');
+    const focus = toolbar.getByRole('button', { name: 'Focus Active Entity' });
+    const region = regionCard(page, fixture.regionName);
+
+    await regionEditButton(region).click();
+    await expect(focus).toBeEnabled();
+    await focus.click();
+    await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Focused region');
+
+    await region.getByText(fixture.placeName).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
+    await expect(focus).toBeDisabled();
+
+    await region.getByRole('button', { name: 'Add Place' }).click();
+    await expect(page.getByRole('heading', { name: 'Add Place' })).toBeVisible();
+    const before = await placeDraftCoordinateValues(page);
+    await expect(focus).toBeEnabled();
+    await focus.click();
+    await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Focused place');
+    await expectPlaceDraftCoordinateValues(page, before);
+
+    await page.getByRole('button', { name: 'Add Region' }).click();
+    await expect(page.getByRole('heading', { name: 'Add Region' })).toBeVisible();
+    await expect(focus).toBeDisabled();
+  });
+
+  test('defers to map-work toolbar', async ({ page }) => {
+    await signIn(page);
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    await enterMapWorkFromE2e(page);
+
+    const toolbar = page.locator('.trip-editor-toolbar');
+    await expect(toolbar.getByRole('button', { name: 'Fit All' })).toHaveCount(0);
+    await expect(toolbar.getByRole('button', { name: 'Recenter Saved Trip View' })).toHaveCount(0);
+    await expect(toolbar.getByRole('button', { name: 'Focus Active Entity' })).toHaveCount(0);
+
+    const mapWork = page.getByRole('region', { name: 'Map work' });
+    await expect(mapWork.getByRole('button', { name: 'Done' })).toBeVisible();
+    await expect(mapWork.getByRole('button', { name: 'Cancel' })).toBeVisible();
+    await mapWork.getByRole('button', { name: 'Done' }).click();
+    await expect(toolbar.getByRole('button', { name: 'Fit All' })).toBeVisible();
+  });
+});
+
+async function loadWorkspaceWithEditorState<T>(page: Page, mutate: (state: MutableEditorState) => T): Promise<T> {
+  await page.unroute(`**${editorApiPath}`).catch(() => undefined);
+  const state = await loadEditorStateFixture(page) as MutableEditorState;
+  const result = mutate(state);
+  await page.route(`**${editorApiPath}`, async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+  });
+  await page.goto(absoluteUrl(workspacePath));
+  await expectMountedWorkspace(page);
+  return result;
+}
+
+function clearNavigationGeometry(state: MutableEditorState): void {
+  Object.values(state.regionsById).forEach((region: any) => {
+    region.center = null;
+  });
+  Object.values(state.placesById).forEach((place: any) => {
+    place.location = null;
+  });
+  Object.values(state.segmentsById).forEach((segment: any) => {
+    segment.route = null;
+  });
+  state.areasById = {};
+  state.areaOrderByRegionId = Object.fromEntries(Object.keys(state.areaOrderByRegionId ?? {}).map(regionId => [regionId, []]));
+}
+
+function prepareNavigationFocusState(state: MutableEditorState): { placeName: string; regionName: string } {
+  clearNavigationGeometry(state);
+  state.metadata.center = null;
+  state.metadata.zoom = null;
+
+  const region = Object.values(state.regionsById).find((item: any) => !item.isShadow) as any;
+  if (!region) {
+    throw new Error('Configured Trip Editor fixture must contain a normal region for map navigation coverage.');
+  }
+
+  const areaId = '00000000-0000-0000-0000-000000260001';
+  state.areasById[areaId] = {
+    id: areaId,
+    tripId: state.tripId,
+    regionId: region.id,
+    name: 'PW navigation area',
+    notesHtml: '',
+    fillHex: '#22c55e',
+    geometry: { type: 'Polygon', coordinates: [[[23, 37], [24, 37], [24, 38], [23, 38], [23, 37]]] },
+    displayOrder: 1,
+    capabilities: editableCapabilities()
+  };
+  state.areaOrderByRegionId[region.id] = [areaId];
+
+  const placeId = state.placeOrderByRegionId[region.id]?.find((id: string) => state.placesById[id]) ?? '00000000-0000-0000-0000-000000260002';
+  if (!state.placesById[placeId]) {
+    state.placesById[placeId] = {
+      id: placeId,
+      tripId: state.tripId,
+      regionId: region.id,
+      name: 'PW navigation place',
+      notesHtml: '',
+      address: '',
+      location: null,
+      iconName: state.options.iconNames[0] ?? 'marker',
+      markerColor: state.options.markerColorClasses[0] ?? 'bg-blue',
+      displayOrder: 1,
+      visitSummary: { placeId, visitCount: 0, isVisited: false, firstVisitAt: null, lastVisitAt: null },
+      capabilities: editableCapabilities()
+    };
+    state.placeOrderByRegionId[region.id] = [...(state.placeOrderByRegionId[region.id] ?? []), placeId];
+  }
+
+  state.placesById[placeId].location = null;
+  return { placeName: state.placesById[placeId].name, regionName: region.name };
+}
+
+function editableCapabilities(): Record<string, boolean> {
+  return {
+    canEdit: true,
+    canRename: true,
+    canDelete: true,
+    canReorder: true,
+    canMove: true,
+    canAddChildren: true,
+    canTargetForSearchAdd: false
+  };
+}
+
+async function metadataMapFieldValues(page: Page): Promise<{ latitude: string; longitude: string; zoom: string }> {
+  return {
+    latitude: await page.getByLabel('Center Latitude').inputValue(),
+    longitude: await page.getByLabel('Center Longitude').inputValue(),
+    zoom: await page.getByLabel('Zoom').inputValue()
+  };
+}
+
+async function expectMetadataMapFieldValues(page: Page, values: { latitude: string; longitude: string; zoom: string }): Promise<void> {
+  await expect(page.getByLabel('Center Latitude')).toHaveValue(values.latitude);
+  await expect(page.getByLabel('Center Longitude')).toHaveValue(values.longitude);
+  await expect(page.getByLabel('Zoom')).toHaveValue(values.zoom);
+}
+
+async function placeDraftCoordinateValues(page: Page): Promise<{ latitude: string; longitude: string }> {
+  const form = page.locator('#trip-editor-place-form');
+  return {
+    latitude: await form.getByLabel('Latitude').inputValue(),
+    longitude: await form.getByLabel('Longitude').inputValue()
+  };
+}
+
+async function expectPlaceDraftCoordinateValues(page: Page, values: { latitude: string; longitude: string }): Promise<void> {
+  const form = page.locator('#trip-editor-place-form');
+  await expect(form.getByLabel('Latitude')).toHaveValue(values.latitude);
+  await expect(form.getByLabel('Longitude')).toHaveValue(values.longitude);
+}
+
+async function enterMapWorkFromE2e(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const moduleUrl = '/ClientApps/trip-editor/src/composables/useEditorSurface.ts';
+    const surface = await import(/* @vite-ignore */ moduleUrl) as {
+      enterMapWork: (options: {
+        modeName: string;
+        instruction: string;
+        statusText: string;
+        isDirty: () => boolean;
+        snapshot: () => unknown;
+        rollback: (snapshot: unknown) => void;
+        done: () => void;
+        cancel: () => void;
+      }) => boolean;
+    };
+    surface.enterMapWork({
+      modeName: 'Verify map work',
+      instruction: 'Use map-work toolbar actions.',
+      statusText: 'Navigation toolbar deferred',
+      isDirty: () => false,
+      snapshot: () => null,
+      rollback: () => undefined,
+      done: () => undefined,
+      cancel: () => undefined
+    });
+  });
+}

--- a/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
@@ -79,6 +79,27 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
     await expect(toolbar.getByRole('button', { name: 'Focus Active Entity' })).toBeDisabled();
   });
 
+  test('metadata focus falls back to Fit All when saved trip view is missing', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithEditorState(page, state => {
+      clearNavigationGeometry(state);
+      state.metadata.center = null;
+      state.metadata.zoom = null;
+      const region = normalRegion(state);
+      test.skip(!region, 'Configured Trip Editor fixture has no normal region for metadata fallback geometry.');
+      addAreaGeometry(state, region!.id, '00000000-0000-0000-0000-000000260101', 'PW metadata fallback area');
+    });
+
+    const toolbar = page.locator('.trip-editor-toolbar');
+    const focus = toolbar.getByRole('button', { name: 'Focus Active Entity' });
+    await expect(toolbar.getByRole('button', { name: 'Recenter Saved Trip View' })).toBeDisabled();
+    await expect(focus).toBeEnabled();
+
+    await focus.click();
+    await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Focused trip map');
+    await expectUsableMapView(page);
+  });
+
   test('focuses active region and place targets without inventing coordinates', async ({ page }) => {
     await signIn(page);
     const fixture = await loadWorkspaceWithEditorState(page, state => prepareNavigationFocusState(state));
@@ -99,12 +120,69 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
     const before = await placeDraftCoordinateValues(page);
     await expect(focus).toBeEnabled();
     await focus.click();
-    await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Focused place');
+    await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Focused parent region');
     await expectPlaceDraftCoordinateValues(page, before);
 
     await page.getByRole('button', { name: 'Add Region' }).click();
     await expect(page.getByRole('heading', { name: 'Add Region' })).toBeVisible();
     await expect(focus).toBeDisabled();
+  });
+
+  test('focuses a saved place location from the edit surface', async ({ page }) => {
+    await signIn(page);
+    const fixture = await loadWorkspaceWithEditorState(page, state => preparePlaceLocationFocusState(state));
+    const toolbar = page.locator('.trip-editor-toolbar');
+
+    await toolbar.getByRole('button', { name: 'Recenter Saved Trip View' }).click();
+    const before = await readMapView(page);
+
+    const region = regionCard(page, fixture.regionName);
+    await region.getByText(fixture.placeName).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
+    await expect(toolbar.getByRole('button', { name: 'Focus Active Entity' })).toBeEnabled();
+    await toolbar.getByRole('button', { name: 'Focus Active Entity' }).click();
+
+    await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Focused place');
+    await expectMapViewChanged(page, before, 'Place focus should move away from the intentionally distinct saved trip view.');
+    await expectUsableMapView(page);
+  });
+
+  test('fits segment route geometry and endpoint fallback geometry', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithEditorState(page, state => prepareSegmentGeometryState(state, true));
+    const toolbar = page.locator('.trip-editor-toolbar');
+
+    await toolbar.getByRole('button', { name: 'Recenter Saved Trip View' }).click();
+    const routeBefore = await readMapView(page);
+    await toolbar.getByRole('button', { name: 'Fit All' }).click();
+    await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Fit all geometry');
+    await expectMapViewChanged(page, routeBefore, 'Fit All should include explicit segment route geometry.');
+    await expectRenderedRouteGeometry(page);
+
+    await loadWorkspaceWithEditorState(page, state => prepareSegmentGeometryState(state, false));
+    await toolbar.getByRole('button', { name: 'Recenter Saved Trip View' }).click();
+    const fallbackBefore = await readMapView(page);
+    await toolbar.getByRole('button', { name: 'Fit All' }).click();
+    await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Fit all geometry');
+    await expectMapViewChanged(page, fallbackBefore, 'Fit All should include segment endpoint fallback geometry.');
+    await expectRenderedRouteGeometry(page);
+    await expectUsableMapView(page);
+  });
+
+  test('focuses region center when it is the only region geometry', async ({ page }) => {
+    await signIn(page);
+    const fixture = await loadWorkspaceWithEditorState(page, state => prepareRegionCenterOnlyState(state));
+    const toolbar = page.locator('.trip-editor-toolbar');
+
+    await toolbar.getByRole('button', { name: 'Recenter Saved Trip View' }).click();
+    const before = await readMapView(page);
+
+    await regionEditButton(regionCard(page, fixture.regionName)).click();
+    await expect(toolbar.getByRole('button', { name: 'Focus Active Entity' })).toBeEnabled();
+    await toolbar.getByRole('button', { name: 'Focus Active Entity' }).click();
+
+    await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Focused region');
+    await expectMapViewChanged(page, before, 'Region focus should move to the region center-only geometry.');
+    await expectUsableMapView(page);
   });
 
   test('defers to map-work toolbar', async ({ page }) => {
@@ -133,12 +211,18 @@ async function loadWorkspaceWithEditorState<T>(page: Page, mutate: (state: Mutab
   const result = mutate(state);
   // Route only the editor read model so toolbar coverage can vary geometry without mutating runbook data.
   await page.route(`**${editorApiPath}`, async route => {
+    if (route.request().method() !== 'GET') {
+      throw new Error(`Map navigation fixture route blocked unexpected ${route.request().method()} ${route.request().url()}`);
+    }
+
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
   });
   await page.goto(absoluteUrl(workspacePath));
   await expectMountedWorkspace(page);
   return result;
 }
+
+type MapViewSnapshot = { mapPaneTransform: string; markerTransforms: string[]; pathCount: number; tilePaneTransform: string };
 
 function clearNavigationGeometry(state: MutableEditorState): void {
   Object.values(state.regionsById).forEach((region: any) => {
@@ -159,46 +243,116 @@ function prepareNavigationFocusState(state: MutableEditorState): { placeName: st
   state.metadata.center = null;
   state.metadata.zoom = null;
 
-  const region = Object.values(state.regionsById).find((item: any) => !item.isShadow) as any;
+  const region = normalRegion(state);
   if (!region) {
     throw new Error('Configured Trip Editor fixture must contain a normal region for map navigation coverage.');
   }
 
-  const areaId = '00000000-0000-0000-0000-000000260001';
+  addAreaGeometry(state, region.id, '00000000-0000-0000-0000-000000260001', 'PW navigation area');
+
+  const placeId = ensurePlace(state, region.id, '00000000-0000-0000-0000-000000260002', 'PW navigation place');
+  state.placesById[placeId].location = null;
+  return { placeName: state.placesById[placeId].name, regionName: region.name };
+}
+
+function preparePlaceLocationFocusState(state: MutableEditorState): { placeName: string; regionName: string } {
+  clearNavigationGeometry(state);
+  state.metadata.center = { latitude: -33.8688, longitude: 151.2093 };
+  state.metadata.zoom = 4;
+
+  const region = normalRegion(state);
+  test.skip(!region, 'Configured Trip Editor fixture has no normal region for place focus coverage.');
+
+  const placeId = ensurePlace(state, region!.id, '00000000-0000-0000-0000-000000260201', 'PW located place');
+  state.placesById[placeId].location = { latitude: 48.8566, longitude: 2.3522 };
+  return { placeName: state.placesById[placeId].name, regionName: region!.name };
+}
+
+function prepareSegmentGeometryState(state: MutableEditorState, useRoute: boolean): void {
+  clearNavigationGeometry(state);
+  state.metadata.center = { latitude: -33.8688, longitude: 151.2093 };
+  state.metadata.zoom = 4;
+
+  const region = normalRegion(state);
+  test.skip(!region, 'Configured Trip Editor fixture has no normal region for segment geometry coverage.');
+
+  const fromId = ensurePlace(state, region!.id, '00000000-0000-0000-0000-000000260301', 'PW segment from');
+  const toId = ensurePlace(state, region!.id, '00000000-0000-0000-0000-000000260302', 'PW segment to');
+  state.placesById[fromId].location = { latitude: 40.7128, longitude: -74.006 };
+  state.placesById[toId].location = { latitude: 42.3601, longitude: -71.0589 };
+
+  const segmentId = '00000000-0000-0000-0000-000000260303';
+  state.segmentsById = {
+    [segmentId]: {
+      id: segmentId,
+      tripId: state.tripId,
+      fromPlaceId: fromId,
+      toPlaceId: toId,
+      mode: 'car',
+      estimatedDistanceKm: null,
+      estimatedDurationMinutes: null,
+      notesHtml: '',
+      route: useRoute
+        ? { type: 'LineString', coordinates: [[-74.006, 40.7128], [-73, 41.25], [-71.0589, 42.3601]] }
+        : null,
+      displayOrder: 1,
+      capabilities: editableCapabilities()
+    }
+  };
+  state.segmentOrder = [segmentId];
+}
+
+function prepareRegionCenterOnlyState(state: MutableEditorState): { regionName: string } {
+  clearNavigationGeometry(state);
+  state.metadata.center = { latitude: -33.8688, longitude: 151.2093 };
+  state.metadata.zoom = 4;
+
+  const region = normalRegion(state);
+  test.skip(!region, 'Configured Trip Editor fixture has no normal region for region center coverage.');
+  region!.center = { latitude: 64.1466, longitude: -21.9426 };
+  return { regionName: region!.name };
+}
+
+function normalRegion(state: MutableEditorState): any | null {
+  return Object.values(state.regionsById).find((item: any) => !item.isShadow) ?? null;
+}
+
+function addAreaGeometry(state: MutableEditorState, regionId: string, areaId: string, name: string): void {
   state.areasById[areaId] = {
     id: areaId,
     tripId: state.tripId,
-    regionId: region.id,
-    name: 'PW navigation area',
+    regionId,
+    name,
     notesHtml: '',
     fillHex: '#22c55e',
     geometry: { type: 'Polygon', coordinates: [[[23, 37], [24, 37], [24, 38], [23, 38], [23, 37]]] },
     displayOrder: 1,
     capabilities: editableCapabilities()
   };
-  state.areaOrderByRegionId[region.id] = [areaId];
+  state.areaOrderByRegionId[regionId] = [areaId];
+}
 
-  const placeId = state.placeOrderByRegionId[region.id]?.find((id: string) => state.placesById[id]) ?? '00000000-0000-0000-0000-000000260002';
-  if (!state.placesById[placeId]) {
-    state.placesById[placeId] = {
-      id: placeId,
+function ensurePlace(state: MutableEditorState, regionId: string, placeId: string, name: string): string {
+  const existingId = state.placeOrderByRegionId[regionId]?.find((id: string) => state.placesById[id]) ?? placeId;
+  if (!state.placesById[existingId]) {
+    state.placesById[existingId] = {
+      id: existingId,
       tripId: state.tripId,
-      regionId: region.id,
-      name: 'PW navigation place',
+      regionId,
+      name,
       notesHtml: '',
       address: '',
       location: null,
       iconName: state.options.iconNames[0] ?? 'marker',
       markerColor: state.options.markerColorClasses[0] ?? 'bg-blue',
       displayOrder: 1,
-      visitSummary: { placeId, visitCount: 0, isVisited: false, firstVisitAt: null, lastVisitAt: null },
+      visitSummary: { placeId: existingId, visitCount: 0, isVisited: false, firstVisitAt: null, lastVisitAt: null },
       capabilities: editableCapabilities()
     };
-    state.placeOrderByRegionId[region.id] = [...(state.placeOrderByRegionId[region.id] ?? []), placeId];
+    state.placeOrderByRegionId[regionId] = [...(state.placeOrderByRegionId[regionId] ?? []), existingId];
   }
 
-  state.placesById[placeId].location = null;
-  return { placeName: state.placesById[placeId].name, regionName: region.name };
+  return existingId;
 }
 
 function editableCapabilities(): Record<string, boolean> {
@@ -217,14 +371,14 @@ async function metadataMapFieldValues(page: Page): Promise<{ latitude: string; l
   return {
     latitude: await page.getByLabel('Center Latitude').inputValue(),
     longitude: await page.getByLabel('Center Longitude').inputValue(),
-    zoom: await page.getByLabel('Zoom').inputValue()
+    zoom: await page.getByRole('spinbutton', { name: 'Zoom' }).inputValue()
   };
 }
 
 async function expectMetadataMapFieldValues(page: Page, values: { latitude: string; longitude: string; zoom: string }): Promise<void> {
   await expect(page.getByLabel('Center Latitude')).toHaveValue(values.latitude);
   await expect(page.getByLabel('Center Longitude')).toHaveValue(values.longitude);
-  await expect(page.getByLabel('Zoom')).toHaveValue(values.zoom);
+  await expect(page.getByRole('spinbutton', { name: 'Zoom' })).toHaveValue(values.zoom);
 }
 
 async function placeDraftCoordinateValues(page: Page): Promise<{ latitude: string; longitude: string }> {
@@ -241,9 +395,48 @@ async function expectPlaceDraftCoordinateValues(page: Page, values: { latitude: 
   await expect(form.getByLabel('Longitude')).toHaveValue(values.longitude);
 }
 
+async function readMapView(page: Page): Promise<MapViewSnapshot> {
+  await expectUsableMapView(page);
+  return await page.getByLabel('Read-only trip map').evaluate(map => {
+    const readTransform = (selector: string): string => {
+      const element = map.querySelector(selector);
+      return element ? getComputedStyle(element).transform : '';
+    };
+
+    return {
+      mapPaneTransform: readTransform('.leaflet-map-pane'),
+      markerTransforms: Array.from(map.querySelectorAll<HTMLElement>('.leaflet-marker-icon, .leaflet-interactive')).map(element => `${getComputedStyle(element).transform} ${element.getAttribute('d') ?? ''}`),
+      pathCount: map.querySelectorAll('.leaflet-overlay-pane path').length,
+      tilePaneTransform: readTransform('.leaflet-tile-pane')
+    };
+  });
+}
+
+async function expectMapViewChanged(page: Page, before: MapViewSnapshot, message: string): Promise<void> {
+  const after = await readMapView(page);
+  expect(JSON.stringify(after), message).not.toBe(JSON.stringify(before));
+}
+
+async function expectUsableMapView(page: Page): Promise<void> {
+  await expectInitializedTripMap(page);
+  const invalidTokens = await page.getByLabel('Read-only trip map').evaluate(map => {
+    const viewText = [
+      map.getAttribute('class') ?? '',
+      ...Array.from(map.querySelectorAll<HTMLElement>('.leaflet-pane, .leaflet-marker-icon, .leaflet-interactive')).map(element => `${element.getAttribute('style') ?? ''} ${element.getAttribute('d') ?? ''}`)
+    ].join(' ');
+    return /(NaN|Infinity|undefined)/i.test(viewText);
+  });
+  expect(invalidTokens, 'Leaflet map view should not contain invalid coordinate artifacts.').toBeFalsy();
+}
+
+async function expectRenderedRouteGeometry(page: Page): Promise<void> {
+  await expect(page.getByLabel('Read-only trip map').locator('.leaflet-overlay-pane path')).not.toHaveCount(0);
+}
+
 async function enterMapWorkFromE2e(page: Page): Promise<void> {
   await page.evaluate(async () => {
-    const moduleUrl = '/ClientApps/trip-editor/src/composables/useEditorSurface.ts';
+    const entryScript = document.querySelector<HTMLScriptElement>('script[src*="/ClientApps/trip-editor/src/main.ts"]');
+    const moduleUrl = new URL('/ClientApps/trip-editor/src/composables/useEditorSurface.ts', entryScript?.src ?? window.location.origin).href;
     // Use the real surface singleton through Vite so map-work assertions do not add fake UI controls.
     const surface = await import(/* @vite-ignore */ moduleUrl) as {
       enterMapWork: (options: {


### PR DESCRIPTION
Closes #260.

## Summary
- Added Trip Editor map navigation toolbar controls: Fit All, Recenter Saved Trip View, Focus Active Entity.
- Added structured active target IDs for map focus without display-text parsing.
- Added Leaflet adapter navigation commands with deterministic result states.
- Preserved render(state) auto-fit behavior.
- Map navigation is read-only and does not mutate metadata, drafts, coordinates, dirty state, or save state.

## Scope exclusions
- no backend/API changes
- no geocode/Nominatim/search-add
- no coordinate picking
- no area polygon drawing
- no segment editing

## Validation
- npm run build passed
- npx playwright test --config=playwright.config.ts --list passed, 26 tests listed
- npm run test:e2e:trip-editor passed in worker live run: 25 passed, 1 skipped
- focused map-navigation spec passed: 8 passed
- LOC checker passed with accepted existing warnings for styles.css, RegionManager.vue, MetadataEditor.vue
- rg "window\\.confirm" no matches
- rg "\\bconfirm\\(" reviewed shared confirm usages only
- git diff --check main...HEAD passed

Note: the later re-review could not rerun E2E because ASP.NET was unavailable, but reviewed the passing worker E2E result and code.