### PR TITLE
Add place coordinate map work

### DIFF
--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -6,7 +6,7 @@ import MapWorkToolbar from './components/MapWorkToolbar.vue';
 import TripSidebar from './components/TripSidebar.vue';
 import { disposeConfirmDialogHost, setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
 import { useEditorSurface } from './composables/useEditorSurface';
-import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type FocusActiveEntityResult } from './map/leafletAdapter';
+import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type CoordinatePickOptions, type FocusActiveEntityResult } from './map/leafletAdapter';
 import type { BootstrapConfig, EditorMutationResult, EditorTripMetadata, EditorTripState } from './types';
 
 const props = defineProps<{ config: BootstrapConfig }>();
@@ -20,6 +20,9 @@ const mapElement = ref<HTMLElement | null>(null);
 const navigationStatus = ref<string | null>(null);
 const editorSurface = useEditorSurface();
 let mapAdapter: ReturnType<typeof createTripEditorMap> | null = null;
+const coordinatePicker = {
+  startCoordinatePick: (options: CoordinatePickOptions): (() => void) => mapAdapter?.startCoordinatePick(options) ?? (() => undefined)
+};
 
 const updatedLabel = computed(() =>
   state.value ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(state.value.metadata.updatedAt)) : ''
@@ -27,7 +30,8 @@ const updatedLabel = computed(() =>
 const isMapWorkActive = computed(() => editorSurface.isMapWorkActive.value);
 const toolbarContext = computed(() => {
   if (editorSurface.mapWork.value) {
-    return `${editorSurface.mapWork.value.modeName}: ${editorSurface.mapWork.value.statusText}`;
+    const status = editorSurface.mapWork.value.statusText;
+    return `${editorSurface.mapWork.value.modeName}: ${typeof status === 'function' ? status() : status}`;
   }
 
   return editorSurface.activeTarget.value?.title ?? 'Trip map';
@@ -238,6 +242,7 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
         :antiforgery-token="props.config.antiforgeryToken"
         :trip-index-url="props.config.tripIndexUrl"
         :has-region-draft-changes="hasRegionDraftChanges"
+        :coordinate-picker="coordinatePicker"
         @metadata-saved="applyMetadata"
         @mutation-applied="applyMutation"
         @region-draft-dirty-changed="setRegionDraftChanges"

--- a/ClientApps/trip-editor/src/components/MapWorkToolbar.vue
+++ b/ClientApps/trip-editor/src/components/MapWorkToolbar.vue
@@ -8,6 +8,20 @@ const props = defineProps<{
 
 const doneButton = ref<HTMLButtonElement | null>(null);
 const mapWork = computed(() => props.controller.mapWork.value);
+const statusText = computed(() => {
+  const status = mapWork.value?.statusText;
+  return typeof status === 'function' ? status() : status;
+});
+const canFinish = computed(() => mapWork.value?.canFinish() ?? false);
+
+const onKeydown = async (event: KeyboardEvent): Promise<void> => {
+  if (event.key !== 'Escape') {
+    return;
+  }
+
+  event.preventDefault();
+  await props.controller.cancelMapWork();
+};
 
 watch(
   () => props.controller.isMapWorkActive.value,
@@ -23,15 +37,15 @@ watch(
 </script>
 
 <template>
-  <div v-if="mapWork" class="trip-editor-map-work-toolbar" role="region" aria-label="Map work">
+  <div v-if="mapWork" class="trip-editor-map-work-toolbar" role="region" aria-label="Map work" tabindex="-1" @keydown="onKeydown">
     <div>
       <p class="trip-editor-surface__eyebrow">{{ mapWork.target.title }}</p>
       <strong>{{ mapWork.modeName }}</strong>
       <span>{{ mapWork.instruction }}</span>
-      <small>{{ mapWork.statusText }}</small>
+      <small>{{ statusText }}</small>
     </div>
     <div class="trip-editor-map-work-toolbar__actions">
-      <button ref="doneButton" type="button" class="btn btn-primary btn-sm" @click="controller.finishMapWork()">Done</button>
+      <button ref="doneButton" type="button" class="btn btn-primary btn-sm" :disabled="!canFinish" @click="controller.finishMapWork()">Done</button>
       <button type="button" class="btn btn-outline-light btn-sm" @click="controller.cancelMapWork()">Cancel</button>
     </div>
   </div>

--- a/ClientApps/trip-editor/src/components/PlaceEditorSurface.vue
+++ b/ClientApps/trip-editor/src/components/PlaceEditorSurface.vue
@@ -22,6 +22,7 @@ defineProps<{
 defineEmits<{
   cancel: [];
   delete: [];
+  pickCoordinate: [];
   reset: [];
   save: [];
 }>();
@@ -47,6 +48,7 @@ defineEmits<{
       <button v-if="activePlace?.capabilities.canDelete" type="button" class="btn btn-outline-danger btn-sm me-auto" :disabled="isSaving" @click="$emit('delete')">
         Delete
       </button>
+      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="$emit('pickCoordinate')">Pick on map</button>
       <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="$emit('cancel')">Cancel</button>
       <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="isSaving || !isDirty" @click="$emit('reset')">Reset</button>
       <button type="submit" :form="formId" class="btn btn-primary btn-sm" :disabled="isSaving">Save Place</button>

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -9,7 +9,8 @@ import RegionPlaceList from './RegionPlaceList.vue';
 import { buildPlaceCreateTarget, buildPlaceEditTarget, buildRegionCreateTarget, buildRegionEditTarget, placeDraftKey, regionDraftKey } from './regionPlaceEditorTargets';
 import { buildPlaceRequest, buildRegionRequest, emptyPlaceDraft, emptyRegionDraft, toPlaceDraft, toRegionDraft, withoutRegionId } from './regionPlaceDrafts';
 import { useEditorMutationFeedback } from './useEditorMutationFeedback';
-import type { EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
+import type { CoordinatePickOptions } from '../map/leafletAdapter';
+import type { EditorCoordinate, EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
 
 const props = defineProps<{
   state: EditorTripState;
@@ -20,6 +21,7 @@ const props = defineProps<{
   searchRegions: EditorRegion[];
   searchPlaceIdsByRegionId: Record<Guid, Guid[]>;
   searchAreaIdsByRegionId: Record<Guid, Guid[]>;
+  coordinatePicker: { startCoordinatePick: (options: CoordinatePickOptions) => () => void };
 }>();
 
 const emit = defineEmits<{
@@ -40,6 +42,8 @@ const regionCreateBaselineRequest = ref<EditorRegionSaveRequest | null>(null);
 const placeCreateBaselineRequest = ref<EditorPlaceSaveRequest | null>(null);
 let unregisterRegionHandler: (() => void) | null = null;
 let unregisterPlaceHandler: (() => void) | null = null;
+let stopPlaceCoordinatePick: (() => void) | null = null;
+const placeCoordinatePick = ref<EditorCoordinate | null>(null);
 
 const orderedRegions = computed(() => props.state.regionOrder.map(id => props.state.regionsById[id]).filter(region => region && (!region.isShadow || hasRegionChildren(region))) as EditorRegion[]);
 const activeRegion = computed(() => (draft.id ? props.state.regionsById[draft.id] ?? null : null));
@@ -128,6 +132,7 @@ onMounted(() => {
 onUnmounted(() => {
   unregisterRegionHandler?.();
   unregisterPlaceHandler?.();
+  stopActivePlaceCoordinatePick();
   emit('dirtyStateChanged', false);
   window.removeEventListener('beforeunload', confirmUnload);
 });
@@ -334,6 +339,43 @@ const savePlaceDraft = async (): Promise<void> => {
   }
 };
 
+const pickPlaceCoordinate = (): void => {
+  const coordinateSnapshot = snapshotPlaceCoordinate();
+  placeCoordinatePick.value = parsePlaceDraftCoordinate();
+  stopActivePlaceCoordinatePick();
+  stopPlaceCoordinatePick = props.coordinatePicker.startCoordinatePick({
+    initialCoordinate: placeCoordinatePick.value,
+    onPicked: coordinate => {
+      placeCoordinatePick.value = coordinate;
+    }
+  });
+
+  const entered = props.editorSurface.enterMapWork({
+    modeName: 'Pick place location',
+    instruction: 'Click the map to choose this place location.',
+    statusText: placeCoordinatePickStatus,
+    canFinish: () => isValidCoordinate(placeCoordinatePick.value),
+    isDirty: () => !sameCoordinate(placeCoordinatePick.value, coordinateFromSnapshot(coordinateSnapshot)),
+    snapshot: () => coordinateSnapshot,
+    rollback: snapshot => {
+      restorePlaceCoordinate(snapshot as PlaceCoordinateSnapshot);
+    },
+    done: () => {
+      if (isValidCoordinate(placeCoordinatePick.value)) {
+        placeDraft.latitude = placeCoordinatePick.value.latitude;
+        placeDraft.longitude = placeCoordinatePick.value.longitude;
+      }
+      stopActivePlaceCoordinatePick();
+    },
+    cancel: () => {
+      stopActivePlaceCoordinatePick();
+    }
+  });
+  if (!entered) {
+    stopActivePlaceCoordinatePick();
+  }
+};
+
 const deleteDraftPlace = async (): Promise<void> => {
   if (!activePlace.value) {
     return;
@@ -469,6 +511,73 @@ function discardPlaceDraft(): void {
   resetFeedback();
 }
 
+type PlaceCoordinateSnapshot = {
+  latitude: string | number;
+  longitude: string | number;
+};
+
+function snapshotPlaceCoordinate(): PlaceCoordinateSnapshot {
+  return { latitude: placeDraft.latitude, longitude: placeDraft.longitude };
+}
+
+function restorePlaceCoordinate(snapshot: PlaceCoordinateSnapshot): void {
+  placeDraft.latitude = snapshot.latitude;
+  placeDraft.longitude = snapshot.longitude;
+  placeCoordinatePick.value = coordinateFromSnapshot(snapshot);
+}
+
+function parsePlaceDraftCoordinate(): EditorCoordinate | null {
+  return coordinateFromSnapshot(snapshotPlaceCoordinate());
+}
+
+function coordinateFromSnapshot(snapshot: PlaceCoordinateSnapshot): EditorCoordinate | null {
+  const latitudeText = String(snapshot.latitude ?? '').trim();
+  const longitudeText = String(snapshot.longitude ?? '').trim();
+  if (!latitudeText || !longitudeText) {
+    return null;
+  }
+
+  const latitude = Number(latitudeText);
+  const longitude = Number(longitudeText);
+  const coordinate = { latitude, longitude };
+  return isValidCoordinate(coordinate) ? coordinate : null;
+}
+
+function isValidCoordinate(coordinate: EditorCoordinate | null): coordinate is EditorCoordinate {
+  return coordinate !== null &&
+    Number.isFinite(coordinate.latitude) &&
+    Number.isFinite(coordinate.longitude) &&
+    coordinate.latitude >= -90 &&
+    coordinate.latitude <= 90 &&
+    coordinate.longitude >= -180 &&
+    coordinate.longitude <= 180;
+}
+
+function sameCoordinate(current: EditorCoordinate | null, snapshot: EditorCoordinate | null): boolean {
+  if (!current || !snapshot) {
+    return current === snapshot;
+  }
+
+  return current.latitude === snapshot.latitude && current.longitude === snapshot.longitude;
+}
+
+function placeCoordinatePickStatus(): string {
+  if (!isValidCoordinate(placeCoordinatePick.value)) {
+    return 'No coordinate selected';
+  }
+
+  return `Selected ${formatCoordinate(placeCoordinatePick.value.latitude)}, ${formatCoordinate(placeCoordinatePick.value.longitude)}`;
+}
+
+function formatCoordinate(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(6).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+function stopActivePlaceCoordinatePick(): void {
+  stopPlaceCoordinatePick?.();
+  stopPlaceCoordinatePick = null;
+}
+
 function isRegionEditOpen(region: EditorRegion): boolean {
   return Boolean(draft.id && activeRegion.value?.id === region.id && props.editorSurface.isTargetActive(activeRegionTarget.value));
 }
@@ -502,11 +611,11 @@ function isPlaceCreateOpen(region: EditorRegion): boolean {
       </template>
 
       <template #place-editor="{ place }">
-        <PlaceEditorSurface v-if="isPlaceEditOpen(place)" :active-place="activePlace" :controller="editorSurface" :draft="placeDraft" :field-errors="fieldErrors" :form-id="placeFormId" :form-summary-errors="formSummaryErrors" :is-dirty="placeDirty" :is-saving="isSaving" :normal-regions="normalRegions" :state="state" :status-text="statusText" :target="activePlaceTarget" @cancel="cancelPlaceDraft" @delete="deleteDraftPlace" @reset="resetPlaceDraft" @save="savePlaceDraft" />
+        <PlaceEditorSurface v-if="isPlaceEditOpen(place)" :active-place="activePlace" :controller="editorSurface" :draft="placeDraft" :field-errors="fieldErrors" :form-id="placeFormId" :form-summary-errors="formSummaryErrors" :is-dirty="placeDirty" :is-saving="isSaving" :normal-regions="normalRegions" :state="state" :status-text="statusText" :target="activePlaceTarget" @cancel="cancelPlaceDraft" @delete="deleteDraftPlace" @pick-coordinate="pickPlaceCoordinate" @reset="resetPlaceDraft" @save="savePlaceDraft" />
       </template>
 
       <template #add-place-editor="{ region }">
-        <PlaceEditorSurface v-if="isPlaceCreateOpen(region)" :active-place="activePlace" :controller="editorSurface" :draft="placeDraft" :field-errors="fieldErrors" :form-id="placeFormId" :form-summary-errors="formSummaryErrors" :is-dirty="placeDirty" :is-saving="isSaving" :normal-regions="normalRegions" :state="state" :status-text="statusText" :target="activePlaceTarget" @cancel="cancelPlaceDraft" @delete="deleteDraftPlace" @reset="resetPlaceDraft" @save="savePlaceDraft" />
+        <PlaceEditorSurface v-if="isPlaceCreateOpen(region)" :active-place="activePlace" :controller="editorSurface" :draft="placeDraft" :field-errors="fieldErrors" :form-id="placeFormId" :form-summary-errors="formSummaryErrors" :is-dirty="placeDirty" :is-saving="isSaving" :normal-regions="normalRegions" :state="state" :status-text="statusText" :target="activePlaceTarget" @cancel="cancelPlaceDraft" @delete="deleteDraftPlace" @pick-coordinate="pickPlaceCoordinate" @reset="resetPlaceDraft" @save="savePlaceDraft" />
       </template>
     </RegionPlaceList>
   </section>

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -8,9 +8,9 @@ import RegionEditorSurface from './RegionEditorSurface.vue';
 import RegionPlaceList from './RegionPlaceList.vue';
 import { buildPlaceCreateTarget, buildPlaceEditTarget, buildRegionCreateTarget, buildRegionEditTarget, placeDraftKey, regionDraftKey } from './regionPlaceEditorTargets';
 import { buildPlaceRequest, buildRegionRequest, emptyPlaceDraft, emptyRegionDraft, toPlaceDraft, toRegionDraft, withoutRegionId } from './regionPlaceDrafts';
+import { beginPlaceCoordinateMapWork, stopPlaceCoordinatePick, type PlaceCoordinateMapWorkState, type PlaceCoordinatePicker } from './placeCoordinateMapWork';
 import { useEditorMutationFeedback } from './useEditorMutationFeedback';
-import type { CoordinatePickOptions } from '../map/leafletAdapter';
-import type { EditorCoordinate, EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
+import type { EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
 
 const props = defineProps<{
   state: EditorTripState;
@@ -21,7 +21,7 @@ const props = defineProps<{
   searchRegions: EditorRegion[];
   searchPlaceIdsByRegionId: Record<Guid, Guid[]>;
   searchAreaIdsByRegionId: Record<Guid, Guid[]>;
-  coordinatePicker: { startCoordinatePick: (options: CoordinatePickOptions) => () => void };
+  coordinatePicker: PlaceCoordinatePicker;
 }>();
 
 const emit = defineEmits<{
@@ -42,8 +42,7 @@ const regionCreateBaselineRequest = ref<EditorRegionSaveRequest | null>(null);
 const placeCreateBaselineRequest = ref<EditorPlaceSaveRequest | null>(null);
 let unregisterRegionHandler: (() => void) | null = null;
 let unregisterPlaceHandler: (() => void) | null = null;
-let stopPlaceCoordinatePick: (() => void) | null = null;
-const placeCoordinatePick = ref<EditorCoordinate | null>(null);
+const placeCoordinateMapWork = reactive<PlaceCoordinateMapWorkState>({ coordinate: null, stopPick: null });
 
 const orderedRegions = computed(() => props.state.regionOrder.map(id => props.state.regionsById[id]).filter(region => region && (!region.isShadow || hasRegionChildren(region))) as EditorRegion[]);
 const activeRegion = computed(() => (draft.id ? props.state.regionsById[draft.id] ?? null : null));
@@ -132,7 +131,7 @@ onMounted(() => {
 onUnmounted(() => {
   unregisterRegionHandler?.();
   unregisterPlaceHandler?.();
-  stopActivePlaceCoordinatePick();
+  stopPlaceCoordinatePick(placeCoordinateMapWork);
   emit('dirtyStateChanged', false);
   window.removeEventListener('beforeunload', confirmUnload);
 });
@@ -339,42 +338,7 @@ const savePlaceDraft = async (): Promise<void> => {
   }
 };
 
-const pickPlaceCoordinate = (): void => {
-  const coordinateSnapshot = snapshotPlaceCoordinate();
-  placeCoordinatePick.value = parsePlaceDraftCoordinate();
-  stopActivePlaceCoordinatePick();
-  stopPlaceCoordinatePick = props.coordinatePicker.startCoordinatePick({
-    initialCoordinate: placeCoordinatePick.value,
-    onPicked: coordinate => {
-      placeCoordinatePick.value = coordinate;
-    }
-  });
-
-  const entered = props.editorSurface.enterMapWork({
-    modeName: 'Pick place location',
-    instruction: 'Click the map to choose this place location.',
-    statusText: placeCoordinatePickStatus,
-    canFinish: () => isValidCoordinate(placeCoordinatePick.value),
-    isDirty: () => !sameCoordinate(placeCoordinatePick.value, coordinateFromSnapshot(coordinateSnapshot)),
-    snapshot: () => coordinateSnapshot,
-    rollback: snapshot => {
-      restorePlaceCoordinate(snapshot as PlaceCoordinateSnapshot);
-    },
-    done: () => {
-      if (isValidCoordinate(placeCoordinatePick.value)) {
-        placeDraft.latitude = placeCoordinatePick.value.latitude;
-        placeDraft.longitude = placeCoordinatePick.value.longitude;
-      }
-      stopActivePlaceCoordinatePick();
-    },
-    cancel: () => {
-      stopActivePlaceCoordinatePick();
-    }
-  });
-  if (!entered) {
-    stopActivePlaceCoordinatePick();
-  }
-};
+const pickPlaceCoordinate = (): void => beginPlaceCoordinateMapWork(placeDraft, props.editorSurface, props.coordinatePicker, placeCoordinateMapWork);
 
 const deleteDraftPlace = async (): Promise<void> => {
   if (!activePlace.value) {
@@ -509,73 +473,6 @@ function discardPlaceDraft(): void {
   Object.assign(placeDraft, emptyPlaceDraft());
   placeCreateBaselineRequest.value = null;
   resetFeedback();
-}
-
-type PlaceCoordinateSnapshot = {
-  latitude: string | number;
-  longitude: string | number;
-};
-
-function snapshotPlaceCoordinate(): PlaceCoordinateSnapshot {
-  return { latitude: placeDraft.latitude, longitude: placeDraft.longitude };
-}
-
-function restorePlaceCoordinate(snapshot: PlaceCoordinateSnapshot): void {
-  placeDraft.latitude = snapshot.latitude;
-  placeDraft.longitude = snapshot.longitude;
-  placeCoordinatePick.value = coordinateFromSnapshot(snapshot);
-}
-
-function parsePlaceDraftCoordinate(): EditorCoordinate | null {
-  return coordinateFromSnapshot(snapshotPlaceCoordinate());
-}
-
-function coordinateFromSnapshot(snapshot: PlaceCoordinateSnapshot): EditorCoordinate | null {
-  const latitudeText = String(snapshot.latitude ?? '').trim();
-  const longitudeText = String(snapshot.longitude ?? '').trim();
-  if (!latitudeText || !longitudeText) {
-    return null;
-  }
-
-  const latitude = Number(latitudeText);
-  const longitude = Number(longitudeText);
-  const coordinate = { latitude, longitude };
-  return isValidCoordinate(coordinate) ? coordinate : null;
-}
-
-function isValidCoordinate(coordinate: EditorCoordinate | null): coordinate is EditorCoordinate {
-  return coordinate !== null &&
-    Number.isFinite(coordinate.latitude) &&
-    Number.isFinite(coordinate.longitude) &&
-    coordinate.latitude >= -90 &&
-    coordinate.latitude <= 90 &&
-    coordinate.longitude >= -180 &&
-    coordinate.longitude <= 180;
-}
-
-function sameCoordinate(current: EditorCoordinate | null, snapshot: EditorCoordinate | null): boolean {
-  if (!current || !snapshot) {
-    return current === snapshot;
-  }
-
-  return current.latitude === snapshot.latitude && current.longitude === snapshot.longitude;
-}
-
-function placeCoordinatePickStatus(): string {
-  if (!isValidCoordinate(placeCoordinatePick.value)) {
-    return 'No coordinate selected';
-  }
-
-  return `Selected ${formatCoordinate(placeCoordinatePick.value.latitude)}, ${formatCoordinate(placeCoordinatePick.value.longitude)}`;
-}
-
-function formatCoordinate(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(6).replace(/0+$/, '').replace(/\.$/, '');
-}
-
-function stopActivePlaceCoordinatePick(): void {
-  stopPlaceCoordinatePick?.();
-  stopPlaceCoordinatePick = null;
 }
 
 function isRegionEditOpen(region: EditorRegion): boolean {

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -4,6 +4,7 @@ import type { EditorArea, EditorMutationResult, EditorPlace, EditorRegion, Edito
 import type { EditorSurfaceController } from '../composables/useEditorSurface';
 import MetadataEditor from './MetadataEditor.vue';
 import RegionManager from './RegionManager.vue';
+import type { CoordinatePickOptions } from '../map/leafletAdapter';
 
 type SidebarSearchResult = {
   hasMatches: boolean;
@@ -19,6 +20,7 @@ const props = defineProps<{
   antiforgeryToken: string;
   tripIndexUrl: string;
   hasRegionDraftChanges: boolean;
+  coordinatePicker: { startCoordinatePick: (options: CoordinatePickOptions) => () => void };
 }>();
 
 const emit = defineEmits<{
@@ -173,6 +175,7 @@ function normalize(value: string): string {
       :editor-surface="editorSurface"
       :editor-endpoint="editorEndpoint"
       :antiforgery-token="antiforgeryToken"
+      :coordinate-picker="coordinatePicker"
       :search-active="isSearchActive"
       :search-regions="sidebarSearch.regions"
       :search-place-ids-by-region-id="sidebarSearch.placesByRegionId"

--- a/ClientApps/trip-editor/src/components/placeCoordinateMapWork.ts
+++ b/ClientApps/trip-editor/src/components/placeCoordinateMapWork.ts
@@ -1,0 +1,119 @@
+import type { EditorSurfaceController } from '../composables/useEditorSurface';
+import type { CoordinatePickOptions } from '../map/leafletAdapter';
+import type { EditorCoordinate, EditorPlaceDraft } from '../types';
+
+export type PlaceCoordinatePicker = {
+  startCoordinatePick: (options: CoordinatePickOptions) => () => void;
+};
+
+type PlaceCoordinateSnapshot = {
+  latitude: string | number;
+  longitude: string | number;
+};
+
+export type PlaceCoordinateMapWorkState = {
+  coordinate: EditorCoordinate | null;
+  stopPick: (() => void) | null;
+};
+
+/// Starts coordinate-only map-work for the active place draft.
+export function beginPlaceCoordinateMapWork(
+  draft: EditorPlaceDraft,
+  editorSurface: EditorSurfaceController,
+  coordinatePicker: PlaceCoordinatePicker,
+  state: PlaceCoordinateMapWorkState
+): void {
+  const coordinateSnapshot = snapshotPlaceCoordinate(draft);
+  state.coordinate = coordinateFromSnapshot(coordinateSnapshot);
+  stopPlaceCoordinatePick(state);
+  state.stopPick = coordinatePicker.startCoordinatePick({
+    initialCoordinate: state.coordinate,
+    onPicked: coordinate => {
+      state.coordinate = coordinate;
+    }
+  });
+
+  const entered = editorSurface.enterMapWork({
+    modeName: 'Pick place location',
+    instruction: 'Click the map to choose this place location.',
+    statusText: () => placeCoordinatePickStatus(state.coordinate),
+    canFinish: () => isValidCoordinate(state.coordinate),
+    isDirty: () => !sameCoordinate(state.coordinate, coordinateFromSnapshot(coordinateSnapshot)),
+    snapshot: () => coordinateSnapshot,
+    rollback: snapshot => {
+      restorePlaceCoordinate(draft, state, snapshot as PlaceCoordinateSnapshot);
+    },
+    done: () => {
+      if (isValidCoordinate(state.coordinate)) {
+        draft.latitude = state.coordinate.latitude;
+        draft.longitude = state.coordinate.longitude;
+      }
+      stopPlaceCoordinatePick(state);
+    },
+    cancel: () => {
+      stopPlaceCoordinatePick(state);
+    }
+  });
+  if (!entered) {
+    stopPlaceCoordinatePick(state);
+  }
+}
+
+/// Clears any active adapter-owned temporary coordinate marker/listener.
+export function stopPlaceCoordinatePick(state: PlaceCoordinateMapWorkState): void {
+  state.stopPick?.();
+  state.stopPick = null;
+}
+
+function snapshotPlaceCoordinate(draft: EditorPlaceDraft): PlaceCoordinateSnapshot {
+  return { latitude: draft.latitude, longitude: draft.longitude };
+}
+
+function restorePlaceCoordinate(draft: EditorPlaceDraft, state: PlaceCoordinateMapWorkState, snapshot: PlaceCoordinateSnapshot): void {
+  draft.latitude = snapshot.latitude;
+  draft.longitude = snapshot.longitude;
+  state.coordinate = coordinateFromSnapshot(snapshot);
+}
+
+function coordinateFromSnapshot(snapshot: PlaceCoordinateSnapshot): EditorCoordinate | null {
+  const latitudeText = String(snapshot.latitude ?? '').trim();
+  const longitudeText = String(snapshot.longitude ?? '').trim();
+  if (!latitudeText || !longitudeText) {
+    return null;
+  }
+
+  const latitude = Number(latitudeText);
+  const longitude = Number(longitudeText);
+  const coordinate = { latitude, longitude };
+  return isValidCoordinate(coordinate) ? coordinate : null;
+}
+
+function isValidCoordinate(coordinate: EditorCoordinate | null): coordinate is EditorCoordinate {
+  return coordinate !== null &&
+    Number.isFinite(coordinate.latitude) &&
+    Number.isFinite(coordinate.longitude) &&
+    coordinate.latitude >= -90 &&
+    coordinate.latitude <= 90 &&
+    coordinate.longitude >= -180 &&
+    coordinate.longitude <= 180;
+}
+
+function sameCoordinate(current: EditorCoordinate | null, snapshot: EditorCoordinate | null): boolean {
+  if (!current || !snapshot) {
+    return current === snapshot;
+  }
+
+  return current.latitude === snapshot.latitude && current.longitude === snapshot.longitude;
+}
+
+function placeCoordinatePickStatus(coordinate: EditorCoordinate | null): string {
+  if (!isValidCoordinate(coordinate)) {
+    return 'No coordinate selected';
+  }
+
+  return `Selected ${formatCoordinate(coordinate.latitude)}, ${formatCoordinate(coordinate.longitude)}`;
+}
+
+function formatCoordinate(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(6).replace(/0+$/, '').replace(/\.$/, '');
+}

--- a/ClientApps/trip-editor/src/composables/useEditorSurface.ts
+++ b/ClientApps/trip-editor/src/composables/useEditorSurface.ts
@@ -25,7 +25,8 @@ export interface EditorTargetHandler {
 export interface MapWorkOptions {
   modeName: string;
   instruction: string;
-  statusText?: string;
+  statusText?: string | (() => string);
+  canFinish?: () => boolean;
   isDirty?: () => boolean;
   snapshot: () => unknown;
   rollback: (snapshot: unknown) => void;
@@ -38,7 +39,8 @@ interface ActiveMapWork {
   target: EditorTarget;
   modeName: string;
   instruction: string;
-  statusText: string;
+  statusText: string | (() => string);
+  canFinish: () => boolean;
   isDirty: () => boolean;
   snapshot: unknown;
   rollback: (snapshot: unknown) => void;
@@ -166,6 +168,7 @@ export function enterMapWork(options: MapWorkOptions): boolean {
     modeName: options.modeName,
     instruction: options.instruction,
     statusText: options.statusText ?? 'Map work active',
+    canFinish: options.canFinish ?? (() => true),
     isDirty: options.isDirty ?? (() => true),
     snapshot: options.snapshot(),
     rollback: options.rollback,

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -27,6 +27,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
   }).addTo(map);
 
   const render = (state: EditorTripState): void => {
+    coordinatePick.clearRegisteredMarkers();
     layers.clearLayers();
 
     Object.values(state.regionsById).forEach(region => renderRegion(region, layers));
@@ -44,7 +45,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
     focusSavedTripView: metadata => focusSavedTripView(map, metadata),
     focusActiveEntity: (state, target) => focusActiveEntity(map, state, target),
     dispose: () => {
-      coordinatePick.stop();
+      coordinatePick.dispose();
       map.remove();
     }
   };
@@ -55,10 +56,20 @@ export interface CoordinatePickOptions {
   onPicked: (coordinate: EditorCoordinate) => void;
 }
 
-const createCoordinatePickLayer = (map: LeafletMap): { isActive: () => boolean; pick: (coordinate: EditorCoordinate) => void; start: (options: CoordinatePickOptions) => () => void; stop: () => void } => {
+const createCoordinatePickLayer = (map: LeafletMap): {
+  clearRegisteredMarkers: () => void;
+  dispose: () => void;
+  isActive: () => boolean;
+  pick: (coordinate: EditorCoordinate) => void;
+  registerMarker: (marker: L.Marker, coordinate: EditorCoordinate) => void;
+  start: (options: CoordinatePickOptions) => () => void;
+  stop: () => void;
+} => {
   const layer = L.layerGroup().addTo(map);
   let clickHandler: ((event: LeafletMouseEvent) => void) | null = null;
   let onPicked: ((coordinate: EditorCoordinate) => void) | null = null;
+  const markers: Array<{ marker: L.Marker; coordinate: EditorCoordinate }> = [];
+  const markerListeners: Array<() => void> = [];
 
   const setPreview = (coordinate: EditorCoordinate): void => {
     layer.clearLayers();
@@ -81,12 +92,48 @@ const createCoordinatePickLayer = (map: LeafletMap): { isActive: () => boolean; 
     }
 
     onPicked = null;
+    detachMarkerListeners();
     layer.clearLayers();
+  };
+
+  const attachMarkerListener = (marker: L.Marker, coordinate: EditorCoordinate): void => {
+    const handler = (event: LeafletMouseEvent): void => {
+      if (event.originalEvent) {
+        L.DomEvent.stop(event.originalEvent);
+      }
+
+      marker.closePopup();
+      pick(coordinate);
+    };
+    marker.on('click', handler);
+    markerListeners.push(() => marker.off('click', handler));
+  };
+
+  const attachMarkerListeners = (): void => {
+    detachMarkerListeners();
+    markers.forEach(({ marker, coordinate }) => attachMarkerListener(marker, coordinate));
+  };
+
+  const detachMarkerListeners = (): void => {
+    markerListeners.splice(0).forEach(detach => detach());
+  };
+
+  const registerMarker = (marker: L.Marker, coordinate: EditorCoordinate): void => {
+    markers.push({ marker, coordinate });
+    if (clickHandler) {
+      attachMarkerListener(marker, coordinate);
+    }
+  };
+
+  const clearRegisteredMarkers = (): void => {
+    detachMarkerListeners();
+    markers.splice(0);
   };
 
   const start = (options: CoordinatePickOptions): (() => void) => {
     stop();
     onPicked = options.onPicked;
+    attachMarkerListeners();
 
     if (options.initialCoordinate) {
       setPreview(options.initialCoordinate);
@@ -100,7 +147,18 @@ const createCoordinatePickLayer = (map: LeafletMap): { isActive: () => boolean; 
     return stop;
   };
 
-  return { isActive: () => clickHandler !== null, pick, start, stop };
+  return {
+    clearRegisteredMarkers,
+    dispose: () => {
+      stop();
+      clearRegisteredMarkers();
+    },
+    isActive: () => clickHandler !== null,
+    pick,
+    registerMarker,
+    start,
+    stop
+  };
 };
 
 const renderRegion = (region: EditorRegion, layers: LayerGroup): void => {
@@ -126,17 +184,7 @@ const renderPlace = (place: EditorPlace, layers: LayerGroup, coordinatePick: Ret
   });
   const visitText = place.visitSummary.isVisited ? ` · ${place.visitSummary.visitCount} visit(s)` : '';
   marker.bindPopup(`<strong>${escapeHtml(place.name)}</strong>${visitText}`);
-  marker.on('click', event => {
-    if (!coordinatePick.isActive()) {
-      return;
-    }
-
-    if (event.originalEvent) {
-      L.DomEvent.stop(event.originalEvent);
-    }
-    marker.closePopup();
-    coordinatePick.pick({ latitude: place.location!.latitude, longitude: place.location!.longitude });
-  });
+  coordinatePick.registerMarker(marker, place.location);
   marker.addTo(layers);
 };
 

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -1,4 +1,4 @@
-import L, { type LayerGroup, type Map as LeafletMap } from 'leaflet';
+import L, { type LayerGroup, type LeafletMouseEvent, type Map as LeafletMap } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import type { EditorTarget } from '../composables/useEditorSurface';
 import type { EditorArea, EditorCoordinate, EditorPlace, EditorRegion, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from '../types';
@@ -9,6 +9,7 @@ export type FocusActiveEntityResult = 'moved' | 'missing-target' | 'no-geometry'
 
 interface TripEditorMapAdapter {
   render: (state: EditorTripState) => void;
+  startCoordinatePick: (options: CoordinatePickOptions) => () => void;
   fitAllGeometry: (state: EditorTripState) => FitAllGeometryResult;
   focusSavedTripView: (metadata: EditorTripMetadata) => FocusSavedTripViewResult;
   focusActiveEntity: (state: EditorTripState, target: EditorTarget | null) => FocusActiveEntityResult;
@@ -18,6 +19,7 @@ interface TripEditorMapAdapter {
 export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): TripEditorMapAdapter => {
   const map = L.map(element, { zoomControl: true }).setView([20, 0], 2);
   const layers = L.layerGroup().addTo(map);
+  const coordinatePick = createCoordinatePickLayer(map);
 
   L.tileLayer(tilesUrl, {
     attribution: window.wayfarerTileConfig?.attribution ?? '&copy; OpenStreetMap contributors',
@@ -37,11 +39,60 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
 
   return {
     render,
+    startCoordinatePick: options => coordinatePick.start(options),
     fitAllGeometry: state => fitAllGeometry(map, state),
     focusSavedTripView: metadata => focusSavedTripView(map, metadata),
     focusActiveEntity: (state, target) => focusActiveEntity(map, state, target),
-    dispose: () => map.remove()
+    dispose: () => {
+      coordinatePick.stop();
+      map.remove();
+    }
   };
+};
+
+export interface CoordinatePickOptions {
+  initialCoordinate: EditorCoordinate | null;
+  onPicked: (coordinate: EditorCoordinate) => void;
+}
+
+const createCoordinatePickLayer = (map: LeafletMap): { start: (options: CoordinatePickOptions) => () => void; stop: () => void } => {
+  const layer = L.layerGroup().addTo(map);
+  let clickHandler: ((event: LeafletMouseEvent) => void) | null = null;
+
+  const stop = (): void => {
+    if (clickHandler) {
+      map.off('click', clickHandler);
+      clickHandler = null;
+    }
+
+    layer.clearLayers();
+  };
+
+  const start = (options: CoordinatePickOptions): (() => void) => {
+    stop();
+    const setPreview = (coordinate: EditorCoordinate): void => {
+      layer.clearLayers();
+      L.marker([coordinate.latitude, coordinate.longitude], {
+        interactive: false,
+        keyboard: false,
+        title: 'Selected place location preview'
+      }).addTo(layer);
+    };
+
+    if (options.initialCoordinate) {
+      setPreview(options.initialCoordinate);
+    }
+
+    clickHandler = event => {
+      const coordinate = { latitude: event.latlng.lat, longitude: event.latlng.lng };
+      setPreview(coordinate);
+      options.onPicked(coordinate);
+    };
+    map.on('click', clickHandler);
+    return stop;
+  };
+
+  return { start, stop };
 };
 
 const renderRegion = (region: EditorRegion, layers: LayerGroup): void => {

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -31,7 +31,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
 
     Object.values(state.regionsById).forEach(region => renderRegion(region, layers));
     Object.values(state.areasById).forEach(area => renderArea(area, layers));
-    Object.values(state.placesById).forEach(place => renderPlace(place, layers));
+    Object.values(state.placesById).forEach(place => renderPlace(place, layers, coordinatePick));
     Object.values(state.segmentsById).forEach(segment => renderSegment(segment, state, layers));
 
     fitMapToState(map, state);
@@ -55,9 +55,24 @@ export interface CoordinatePickOptions {
   onPicked: (coordinate: EditorCoordinate) => void;
 }
 
-const createCoordinatePickLayer = (map: LeafletMap): { start: (options: CoordinatePickOptions) => () => void; stop: () => void } => {
+const createCoordinatePickLayer = (map: LeafletMap): { isActive: () => boolean; pick: (coordinate: EditorCoordinate) => void; start: (options: CoordinatePickOptions) => () => void; stop: () => void } => {
   const layer = L.layerGroup().addTo(map);
   let clickHandler: ((event: LeafletMouseEvent) => void) | null = null;
+  let onPicked: ((coordinate: EditorCoordinate) => void) | null = null;
+
+  const setPreview = (coordinate: EditorCoordinate): void => {
+    layer.clearLayers();
+    L.marker([coordinate.latitude, coordinate.longitude], {
+      interactive: false,
+      keyboard: false,
+      title: 'Selected place location preview'
+    }).addTo(layer);
+  };
+
+  const pick = (coordinate: EditorCoordinate): void => {
+    setPreview(coordinate);
+    onPicked?.(coordinate);
+  };
 
   const stop = (): void => {
     if (clickHandler) {
@@ -65,19 +80,13 @@ const createCoordinatePickLayer = (map: LeafletMap): { start: (options: Coordina
       clickHandler = null;
     }
 
+    onPicked = null;
     layer.clearLayers();
   };
 
   const start = (options: CoordinatePickOptions): (() => void) => {
     stop();
-    const setPreview = (coordinate: EditorCoordinate): void => {
-      layer.clearLayers();
-      L.marker([coordinate.latitude, coordinate.longitude], {
-        interactive: false,
-        keyboard: false,
-        title: 'Selected place location preview'
-      }).addTo(layer);
-    };
+    onPicked = options.onPicked;
 
     if (options.initialCoordinate) {
       setPreview(options.initialCoordinate);
@@ -85,14 +94,13 @@ const createCoordinatePickLayer = (map: LeafletMap): { start: (options: Coordina
 
     clickHandler = event => {
       const coordinate = { latitude: event.latlng.lat, longitude: event.latlng.lng };
-      setPreview(coordinate);
-      options.onPicked(coordinate);
+      pick(coordinate);
     };
     map.on('click', clickHandler);
     return stop;
   };
 
-  return { start, stop };
+  return { isActive: () => clickHandler !== null, pick, start, stop };
 };
 
 const renderRegion = (region: EditorRegion, layers: LayerGroup): void => {
@@ -108,7 +116,7 @@ const renderRegion = (region: EditorRegion, layers: LayerGroup): void => {
   }).bindTooltip(escapeHtml(region.name)).addTo(layers);
 };
 
-const renderPlace = (place: EditorPlace, layers: LayerGroup): void => {
+const renderPlace = (place: EditorPlace, layers: LayerGroup, coordinatePick: ReturnType<typeof createCoordinatePickLayer>): void => {
   if (!place.location) {
     return;
   }
@@ -118,6 +126,17 @@ const renderPlace = (place: EditorPlace, layers: LayerGroup): void => {
   });
   const visitText = place.visitSummary.isVisited ? ` · ${place.visitSummary.visitCount} visit(s)` : '';
   marker.bindPopup(`<strong>${escapeHtml(place.name)}</strong>${visitText}`);
+  marker.on('click', event => {
+    if (!coordinatePick.isActive()) {
+      return;
+    }
+
+    if (event.originalEvent) {
+      L.DomEvent.stop(event.originalEvent);
+    }
+    marker.closePopup();
+    coordinatePick.pick({ latitude: place.location!.latitude, longitude: place.location!.longitude });
+  });
   marker.addTo(layers);
 };
 

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -15,6 +15,7 @@ type Coordinate = { latitude: number; longitude: number };
 const editablePlaceId = '00000000-0000-0000-0000-000000261001';
 const secondPlaceId = '00000000-0000-0000-0000-000000261002';
 const editablePlaceName = 'PW coordinate place';
+const secondPlaceName = 'PW coordinate switch place';
 const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
 const forbiddenPickRequest = /nominatim|geocode|geosearch|search-add|searchadd|\/search(?:[/?#]|$)/i;
 
@@ -56,6 +57,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
   test('edit-place docked Cancel restores coordinate fields only', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithCoordinateFixture(page);
+    const forbidden = watchForbiddenPickRequests(page);
 
     await openEditablePlace(page);
     const form = page.locator('#trip-editor-place-form');
@@ -73,6 +75,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await expectDraftCoordinates(page, before);
     await expect(form.getByLabel('Name')).toHaveValue('Unsaved coordinate test name');
     await expect(form.getByLabel('Address')).toHaveValue('Unsaved coordinate test address');
+    expect(forbidden(), 'Canceling coordinate pick must not call geocode/search providers.').toEqual([]);
   });
 
   test('edit-place expanded enters map-work and returns to expanded surface', async ({ page }) => {
@@ -92,6 +95,35 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
 
     await mapWork.getByRole('button', { name: 'Done' }).click();
     await expect(page.getByRole('dialog', { name: new RegExp(`Edit Place - ${editablePlaceName}`) })).toBeVisible();
+  });
+
+  test('active map-work consumes persisted place marker clicks without opening popups or switching editors', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+    const mutations = watchEditorMutations(page);
+    const forbidden = watchForbiddenPickRequests(page);
+
+    await openEditablePlace(page);
+    const form = page.locator('#trip-editor-place-form');
+    await expectDraftCoordinates(page, { latitude: '10', longitude: '20' });
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    const mapWork = page.getByRole('region', { name: 'Map work' });
+    await expect(mapWork).toContainText('Selected 10, 20');
+
+    await page.getByTitle(secondPlaceName).click();
+    await expect(page.locator('.leaflet-popup')).toHaveCount(0);
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${editablePlaceName}`) })).toBeVisible();
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${secondPlaceName}`) })).toHaveCount(0);
+    await expectDraftCoordinates(page, { latitude: '10', longitude: '20' });
+    await expect(mapWork).toContainText('Selected 11, 21');
+    expect(mutations(), 'Marker click during pick mode must not call editor mutations.').toEqual([]);
+
+    await mapWork.getByRole('button', { name: 'Done' }).click();
+    await expectDraftCoordinates(page, { latitude: '11', longitude: '21' });
+    expect(mutations(), 'Done after marker pick must still be draft-only.').toEqual([]);
+    expect(forbidden(), 'Marker-based coordinate picking must not call geocode/search providers.').toEqual([]);
+    await expect(form.getByLabel('Name')).toHaveValue(editablePlaceName);
   });
 
   test('dirty map-work switch prompts before the normal dirty draft prompt', async ({ page }) => {
@@ -121,6 +153,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
   test('Save after Done sends the picked coordinate through the existing place endpoint', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithCoordinateFixture(page);
+    const forbidden = watchForbiddenPickRequests(page);
     const savedRequests: Array<Record<string, any>> = [];
     await page.route(editorApiMatcher, async route => {
       const request = route.request();
@@ -153,6 +186,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await expect.poll(() => savedRequests.length).toBe(1);
     expect(String(savedRequests[0].location.latitude)).toBe(picked.latitude);
     expect(String(savedRequests[0].location.longitude)).toBe(picked.longitude);
+    expect(forbidden(), 'Saving a picked coordinate must not call geocode/search providers.').toEqual([]);
   });
 });
 
@@ -180,7 +214,7 @@ function prepareCoordinateState(state: MutableEditorState): void {
   }
 
   state.placesById[editablePlaceId] = placeFixture(state, region.id, editablePlaceId, editablePlaceName, { latitude: 10, longitude: 20 });
-  state.placesById[secondPlaceId] = placeFixture(state, region.id, secondPlaceId, 'PW coordinate switch place', { latitude: 11, longitude: 21 });
+  state.placesById[secondPlaceId] = placeFixture(state, region.id, secondPlaceId, secondPlaceName, { latitude: 11, longitude: 21 });
   state.placeOrderByRegionId[region.id] = [editablePlaceId, secondPlaceId, ...(state.placeOrderByRegionId[region.id] ?? []).filter((id: string) => id !== editablePlaceId && id !== secondPlaceId)];
 }
 

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -1,0 +1,298 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+import {
+  absoluteUrl,
+  editorApiPath,
+  expectMountedWorkspace,
+  expectNoSearchAddUi,
+  loadEditorStateFixture,
+  signIn,
+  workspacePath
+} from './tripEditorTestUtils';
+
+type MutableEditorState = Record<string, any>;
+type Coordinate = { latitude: number; longitude: number };
+
+const editablePlaceId = '00000000-0000-0000-0000-000000261001';
+const secondPlaceId = '00000000-0000-0000-0000-000000261002';
+const editablePlaceName = 'PW coordinate place';
+const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
+const forbiddenPickRequest = /nominatim|geocode|geosearch|search-add|searchadd|\/search(?:[/?#]|$)/i;
+
+test.describe.serial('Trip Editor place coordinate map-work', () => {
+  test('add-place picks a temporary coordinate and Done updates only the draft', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+    const mutations = watchEditorMutations(page);
+    const forbidden = watchForbiddenPickRequests(page);
+
+    await firstEditableRegion(page).getByRole('button', { name: 'Add Place' }).click();
+    const form = page.locator('#trip-editor-place-form');
+    await expect(page.getByRole('heading', { name: 'Add Place' })).toBeVisible();
+    await clickMap(page, { xRatio: 0.28, yRatio: 0.62 });
+    await expect(form.getByLabel('Latitude')).toHaveValue('');
+    await expect(form.getByLabel('Longitude')).toHaveValue('');
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    const mapWork = page.getByRole('region', { name: 'Map work' });
+    await expect(mapWork).toContainText('Pick place location');
+    await expect(mapWork).toContainText('No coordinate selected');
+    await expect(mapWork.getByRole('button', { name: 'Done' })).toBeDisabled();
+    await expectNoSearchAddUi(page);
+
+    await clickMap(page, { xRatio: 0.38, yRatio: 0.46 });
+    await expect(mapWork).toContainText('Selected');
+    await expect(page.getByTitle('Selected place location preview')).toHaveCount(1);
+    await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
+    expect(mutations(), 'Done has not been clicked and no mutation should have run.').toEqual([]);
+
+    await mapWork.getByRole('button', { name: 'Done' }).click();
+    await expect(form.getByLabel('Latitude')).not.toHaveValue('');
+    await expect(form.getByLabel('Longitude')).not.toHaveValue('');
+    await expect(page.getByTitle('Selected place location preview')).toHaveCount(0);
+    expect(mutations(), 'Done must not call create/update/order/delete endpoints.').toEqual([]);
+    expect(forbidden(), 'Coordinate picking must not call geocode/search providers.').toEqual([]);
+  });
+
+  test('edit-place docked Cancel restores coordinate fields only', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+
+    await openEditablePlace(page);
+    const form = page.locator('#trip-editor-place-form');
+    await form.getByLabel('Name').fill('Unsaved coordinate test name');
+    await form.getByLabel('Address').fill('Unsaved coordinate test address');
+    const before = await draftCoordinates(page);
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await clickMap(page, { xRatio: 0.64, yRatio: 0.38 });
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+    const dialog = page.getByRole('dialog', { name: 'Discard map editing changes?' });
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: 'Discard' }).click();
+
+    await expectDraftCoordinates(page, before);
+    await expect(form.getByLabel('Name')).toHaveValue('Unsaved coordinate test name');
+    await expect(form.getByLabel('Address')).toHaveValue('Unsaved coordinate test address');
+  });
+
+  test('edit-place expanded enters map-work and returns to expanded surface', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+
+    await openEditablePlace(page);
+    await page.getByRole('button', { name: 'Expand Editor' }).click();
+    const expanded = page.getByRole('dialog', { name: new RegExp(`Edit Place - ${editablePlaceName}`) });
+    await expect(expanded).toBeVisible();
+
+    await expanded.getByRole('button', { name: 'Pick on map' }).click();
+    const mapWork = page.getByRole('region', { name: 'Map work' });
+    await expect(mapWork).toContainText('Selected 10, 20');
+    await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
+    await expect(expanded).toHaveCount(0);
+
+    await mapWork.getByRole('button', { name: 'Done' }).click();
+    await expect(page.getByRole('dialog', { name: new RegExp(`Edit Place - ${editablePlaceName}`) })).toBeVisible();
+  });
+
+  test('dirty map-work switch prompts before the normal dirty draft prompt', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+
+    await openEditablePlace(page);
+    await page.locator('#trip-editor-place-form').getByLabel('Name').fill('Unsaved switch name');
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await clickMap(page, { xRatio: 0.54, yRatio: 0.34 });
+
+    await page.getByRole('button', { name: 'Add Region' }).click();
+    const mapDiscard = page.getByRole('dialog', { name: 'Discard map editing changes?' });
+    await expect(mapDiscard).toBeVisible();
+    await mapDiscard.getByRole('button', { name: 'Keep editing' }).click();
+    await expect(page.getByRole('region', { name: 'Map work' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Add Region' }).click();
+    await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
+    const draftDiscard = page.getByRole('dialog', { name: 'Discard changes?' });
+    await expect(draftDiscard).toBeVisible();
+    await draftDiscard.getByRole('button', { name: 'Keep editing' }).click();
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${editablePlaceName}`) })).toBeVisible();
+    await expect(page.locator('#trip-editor-place-form').getByLabel('Name')).toHaveValue('Unsaved switch name');
+  });
+
+  test('Save after Done sends the picked coordinate through the existing place endpoint', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+    const savedRequests: Array<Record<string, any>> = [];
+    await page.route(editorApiMatcher, async route => {
+      const request = route.request();
+      if (request.method() === 'GET') {
+        await route.fallback();
+        return;
+      }
+
+      if (request.method() !== 'PUT' || !request.url().endsWith(`/places/${editablePlaceId}`)) {
+        throw new Error(`Unexpected editor mutation ${request.method()} ${request.url()}`);
+      }
+
+      const body = request.postDataJSON() as Record<string, any>;
+      savedRequests.push(body);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(editorMutationResult({ ...body, id: editablePlaceId }))
+      });
+    });
+
+    await openEditablePlace(page);
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await clickMap(page, { xRatio: 0.42, yRatio: 0.42 });
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+    expect(savedRequests, 'Done should not save before Save Place is clicked.').toEqual([]);
+
+    const picked = await draftCoordinates(page);
+    await page.getByRole('button', { name: 'Save Place' }).click();
+    await expect.poll(() => savedRequests.length).toBe(1);
+    expect(String(savedRequests[0].location.latitude)).toBe(picked.latitude);
+    expect(String(savedRequests[0].location.longitude)).toBe(picked.longitude);
+  });
+});
+
+async function loadWorkspaceWithCoordinateFixture(page: Page): Promise<void> {
+  await page.unroute(editorApiMatcher).catch(() => undefined);
+  const state = await loadEditorStateFixture(page) as MutableEditorState;
+  prepareCoordinateState(state);
+  await page.route(editorApiMatcher, async route => routeEditorReadOnly(route, state));
+  await page.goto(absoluteUrl(workspacePath));
+  await expectMountedWorkspace(page);
+}
+
+async function routeEditorReadOnly(route: Route, state: MutableEditorState): Promise<void> {
+  if (route.request().method() !== 'GET') {
+    throw new Error(`Unexpected editor mutation ${route.request().method()} ${route.request().url()}`);
+  }
+
+  await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+}
+
+function prepareCoordinateState(state: MutableEditorState): void {
+  const region = Object.values(state.regionsById).find((item: any) => !item.isShadow) as any;
+  if (!region) {
+    throw new Error('Configured Trip Editor fixture must contain a normal region.');
+  }
+
+  state.placesById[editablePlaceId] = placeFixture(state, region.id, editablePlaceId, editablePlaceName, { latitude: 10, longitude: 20 });
+  state.placesById[secondPlaceId] = placeFixture(state, region.id, secondPlaceId, 'PW coordinate switch place', { latitude: 11, longitude: 21 });
+  state.placeOrderByRegionId[region.id] = [editablePlaceId, secondPlaceId, ...(state.placeOrderByRegionId[region.id] ?? []).filter((id: string) => id !== editablePlaceId && id !== secondPlaceId)];
+}
+
+function placeFixture(state: MutableEditorState, regionId: string, id: string, name: string, location: Coordinate): Record<string, any> {
+  return {
+    id,
+    tripId: state.tripId,
+    regionId,
+    name,
+    notesHtml: '',
+    address: 'Coordinate fixture address',
+    location,
+    iconName: state.options.iconNames[0] ?? 'marker',
+    markerColor: state.options.markerColorClasses[0] ?? 'bg-blue',
+    displayOrder: 1,
+    visitSummary: { placeId: id, visitCount: 0, isVisited: false, firstVisitAt: null, lastVisitAt: null },
+    capabilities: editableCapabilities()
+  };
+}
+
+function editableCapabilities(): Record<string, boolean> {
+  return {
+    canEdit: true,
+    canRename: true,
+    canDelete: true,
+    canReorder: true,
+    canMove: true,
+    canAddChildren: true,
+    canTargetForSearchAdd: false
+  };
+}
+
+async function openEditablePlace(page: Page): Promise<void> {
+  await firstEditableRegion(page).getByText(editablePlaceName).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
+  await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${editablePlaceName}`) })).toBeVisible();
+}
+
+function firstEditableRegion(page: Page) {
+  return page.locator('.trip-editor-region-card--normal').first();
+}
+
+async function clickMap(page: Page, position: { xRatio: number; yRatio: number }): Promise<void> {
+  const map = page.getByLabel('Read-only trip map');
+  await map.evaluate((element, point) => {
+    const box = element.getBoundingClientRect();
+    const clientX = box.left + box.width * point.xRatio;
+    const clientY = box.top + box.height * point.yRatio;
+    for (const type of ['mousedown', 'mouseup', 'click']) {
+      element.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, view: window }));
+    }
+  }, position);
+}
+
+async function draftCoordinates(page: Page): Promise<{ latitude: string; longitude: string }> {
+  const form = page.locator('#trip-editor-place-form');
+  return {
+    latitude: await form.getByLabel('Latitude').inputValue(),
+    longitude: await form.getByLabel('Longitude').inputValue()
+  };
+}
+
+async function expectDraftCoordinates(page: Page, values: { latitude: string; longitude: string }): Promise<void> {
+  const form = page.locator('#trip-editor-place-form');
+  await expect(form.getByLabel('Latitude')).toHaveValue(values.latitude);
+  await expect(form.getByLabel('Longitude')).toHaveValue(values.longitude);
+}
+
+function watchEditorMutations(page: Page): () => string[] {
+  const urls: string[] = [];
+  page.on('request', request => {
+    if (editorApiMatcher.test(request.url()) && request.method() !== 'GET') {
+      urls.push(`${request.method()} ${request.url()}`);
+    }
+  });
+  return () => urls;
+}
+
+function watchForbiddenPickRequests(page: Page): () => string[] {
+  const urls: string[] = [];
+  page.on('request', request => {
+    if (forbiddenPickRequest.test(request.url())) {
+      urls.push(request.url());
+    }
+  });
+  return () => urls;
+}
+
+function editorMutationResult(place: Record<string, any>): Record<string, any> {
+  return {
+    success: true,
+    data: {
+      ...place,
+      tripId: '00000000-0000-0000-0000-000000000000',
+      visitSummary: { placeId: editablePlaceId, visitCount: 0, isVisited: false, firstVisitAt: null, lastVisitAt: null },
+      capabilities: editableCapabilities()
+    },
+    affected: {
+      metadata: null,
+      regions: [],
+      regionOrder: null,
+      places: [],
+      placeOrdersByRegionId: {},
+      areas: [],
+      areaOrdersByRegionId: {},
+      segments: [],
+      segmentOrder: null,
+      tags: [],
+      tagOrder: null,
+      visitProgress: null,
+      options: null
+    },
+    deletedIds: { regions: [], places: [], areas: [], segments: [], tags: [] },
+    warnings: []
+  };
+}


### PR DESCRIPTION
Closes #261

## Summary
- Added Pick on map for add/edit place drafts.
- Reused shared map-work lifecycle.
- Added adapter-owned click-to-pick and temporary coordinate marker preview.
- Done writes only draft latitude/longitude and does not save.
- Cancel/discard restores only coordinate fields.
- Persisted marker clicks are consumed during coordinate map-work and do not open popups or switch editor targets.
- Normal Save persists through the existing place endpoint.

## Scope exclusions
- no backend/API changes
- no geocode/Nominatim/search-add
- no marker drag
- no area polygon drawing
- no segment editing
- no legacy editor changes

## Validation
- npm run build passed
- npx playwright test --config=playwright.config.ts --list passed, 32 tests listed
- npm run test:e2e:trip-editor passed earlier in worker live run before the marker fix: 30 passed, 1 skipped
- after marker fix, local E2E rerun was environment-blocked because ASP.NET was unavailable at http://localhost:5012
- LOC checker passed with accepted warnings for styles.css, RegionManager.vue, MetadataEditor.vue
- rg "window\\.confirm" no matches
- rg "\\bconfirm\\(" reviewed shared confirm usages only
- git diff --check origin/main...HEAD passed

## Test coverage note
- Playwright includes add/edit docked, expanded edit, Done no-auto-save, Cancel rollback, dirty discard, save-after-Done, normal map click non-mutation, persisted-marker click consumption, and no geocode/search-add requests.