### PR TITLE
Add Trip Editor area editing

### DIFF
--- a/Areas/Api/Controllers/TripEditorAreasController.cs
+++ b/Areas/Api/Controllers/TripEditorAreasController.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Wayfarer.Areas.Api.Controllers;
+
+public sealed partial class TripEditorController
+{
+    /// <summary>
+    /// Creates an area in a normal owned region.
+    /// </summary>
+    [HttpPost("regions/{regionId:guid}/areas")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CreateArea(Guid tripId, Guid regionId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var outcome = await _areaMutations.CreateAreaAsync(tripId, regionId, userId!, Request.Body, cancellationToken);
+        return ToActionResult(outcome);
+    }
+
+    /// <summary>
+    /// Updates complete editable fields for one owned area.
+    /// </summary>
+    [HttpPut("areas/{areaId:guid}")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateArea(Guid tripId, Guid areaId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var outcome = await _areaMutations.UpdateAreaAsync(tripId, areaId, userId!, Request.Body, cancellationToken);
+        return ToActionResult(outcome);
+    }
+
+    /// <summary>
+    /// Replaces only the polygon geometry for one owned area.
+    /// </summary>
+    [HttpPut("areas/{areaId:guid}/geometry")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateAreaGeometry(Guid tripId, Guid areaId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var outcome = await _areaMutations.UpdateAreaGeometryAsync(tripId, areaId, userId!, Request.Body, cancellationToken);
+        return ToActionResult(outcome);
+    }
+
+    /// <summary>
+    /// Deletes one owned area.
+    /// </summary>
+    [HttpDelete("areas/{areaId:guid}")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteArea(Guid tripId, Guid areaId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var outcome = await _areaMutations.DeleteAreaAsync(tripId, areaId, userId!, cancellationToken);
+        return ToActionResult(outcome);
+    }
+
+    /// <summary>
+    /// Persists the complete desired area order for one normal owned region.
+    /// </summary>
+    [HttpPut("regions/{regionId:guid}/areas/order")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> OrderAreas(Guid tripId, Guid regionId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var outcome = await _areaMutations.OrderAreasAsync(tripId, regionId, userId!, Request.Body, cancellationToken);
+        return ToActionResult(outcome);
+    }
+}

--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -28,6 +28,7 @@ public sealed partial class TripEditorController : ControllerBase
     private readonly ITripTagService _tripTagService;
     private readonly TripEditorRegionMutationService _regionMutations;
     private readonly TripEditorPlaceMutationService _placeMutations;
+    private readonly TripEditorAreaMutationService _areaMutations;
     private readonly ILogger<TripEditorController> _logger;
 
     /// <summary>
@@ -42,6 +43,7 @@ public sealed partial class TripEditorController : ControllerBase
         ITripTagService tripTagService,
         TripEditorRegionMutationService regionMutations,
         TripEditorPlaceMutationService placeMutations,
+        TripEditorAreaMutationService areaMutations,
         ILogger<TripEditorController> logger)
     {
         _dbContext = dbContext;
@@ -52,6 +54,7 @@ public sealed partial class TripEditorController : ControllerBase
         _tripTagService = tripTagService;
         _regionMutations = regionMutations;
         _placeMutations = placeMutations;
+        _areaMutations = areaMutations;
         _logger = logger;
     }
 

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -6,7 +6,7 @@ import MapWorkToolbar from './components/MapWorkToolbar.vue';
 import TripSidebar from './components/TripSidebar.vue';
 import { disposeConfirmDialogHost, setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
 import { useEditorSurface } from './composables/useEditorSurface';
-import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type CoordinatePickOptions, type FocusActiveEntityResult } from './map/leafletAdapter';
+import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type AreaPolygonWorkOptions, type CoordinatePickOptions, type FocusActiveEntityResult } from './map/leafletAdapter';
 import type { BootstrapConfig, EditorMutationResult, EditorTripMetadata, EditorTripState } from './types';
 
 const props = defineProps<{ config: BootstrapConfig }>();
@@ -22,6 +22,9 @@ const editorSurface = useEditorSurface();
 let mapAdapter: ReturnType<typeof createTripEditorMap> | null = null;
 const coordinatePicker = {
   startCoordinatePick: (options: CoordinatePickOptions): (() => void) => mapAdapter?.startCoordinatePick(options) ?? (() => undefined)
+};
+const polygonEditor = {
+  startAreaPolygonWork: (options: AreaPolygonWorkOptions): (() => void) => mapAdapter?.startAreaPolygonWork(options) ?? (() => undefined)
 };
 
 const updatedLabel = computed(() =>
@@ -207,6 +210,10 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
       return 'Focused place';
     }
 
+    if (kind === 'area') {
+      return 'Focused area';
+    }
+
     return 'Focused active entity';
   }
 
@@ -243,6 +250,7 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
         :trip-index-url="props.config.tripIndexUrl"
         :has-region-draft-changes="hasRegionDraftChanges"
         :coordinate-picker="coordinatePicker"
+        :polygon-editor="polygonEditor"
         @metadata-saved="applyMetadata"
         @mutation-applied="applyMutation"
         @region-draft-dirty-changed="setRegionDraftChanges"

--- a/ClientApps/trip-editor/src/api/tripEditorApi.ts
+++ b/ClientApps/trip-editor/src/api/tripEditorApi.ts
@@ -1,5 +1,10 @@
 import type {
   EditorMutationResult,
+  EditorArea,
+  EditorAreaDeleteResult,
+  EditorAreaOrderRequest,
+  EditorAreaOrderResult,
+  EditorAreaSaveRequest,
   EditorPlace,
   EditorPlaceDeleteResult,
   EditorPlaceOrderRequest,
@@ -159,6 +164,38 @@ export const orderPlaces = async (
   request: EditorPlaceOrderRequest
 ): Promise<EditorMutationResult<EditorPlaceOrderResult>> =>
   sendMutation(`${endpoint}/regions/${regionId}/places/order`, 'PUT', antiforgeryToken, request, 'place order');
+
+/// Creates an area in a normal region through the same-origin editor API.
+export const createArea = async (
+  endpoint: string,
+  regionId: string,
+  antiforgeryToken: string,
+  request: EditorAreaSaveRequest
+): Promise<EditorMutationResult<EditorArea>> => sendMutation(`${endpoint}/regions/${regionId}/areas`, 'POST', antiforgeryToken, request, 'area create');
+
+/// Updates an area through the same-origin editor API.
+export const updateArea = async (
+  endpoint: string,
+  areaId: string,
+  antiforgeryToken: string,
+  request: EditorAreaSaveRequest
+): Promise<EditorMutationResult<EditorArea>> => sendMutation(`${endpoint}/areas/${areaId}`, 'PUT', antiforgeryToken, request, 'area update');
+
+/// Deletes an area through the same-origin editor API.
+export const deleteArea = async (
+  endpoint: string,
+  areaId: string,
+  antiforgeryToken: string
+): Promise<EditorMutationResult<EditorAreaDeleteResult>> => sendMutation(`${endpoint}/areas/${areaId}`, 'DELETE', antiforgeryToken, null, 'area delete');
+
+/// Persists the complete area order for one normal region.
+export const orderAreas = async (
+  endpoint: string,
+  regionId: string,
+  antiforgeryToken: string,
+  request: EditorAreaOrderRequest
+): Promise<EditorMutationResult<EditorAreaOrderResult>> =>
+  sendMutation(`${endpoint}/regions/${regionId}/areas/order`, 'PUT', antiforgeryToken, request, 'area order');
 
 const sendMutation = async <TData>(
   url: string,

--- a/ClientApps/trip-editor/src/components/AreaEditorForm.vue
+++ b/ClientApps/trip-editor/src/components/AreaEditorForm.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { EditorAreaDraft } from '../types';
+
+const props = defineProps<{
+  draft: EditorAreaDraft;
+  fieldErrors: (key: string) => string[];
+  formId: string;
+  formSummaryErrors: string[];
+}>();
+
+const emit = defineEmits<{
+  save: [];
+}>();
+
+const geometryStatus = computed(() => {
+  const ring = props.draft.geometry?.coordinates?.[0] ?? [];
+  const vertices = Math.max(0, ring.length - 1);
+  return vertices >= 3 ? `${vertices} polygon vertices` : 'No polygon drawn';
+});
+</script>
+
+<template>
+  <form :id="props.formId" class="trip-editor-region-form" @submit.prevent="emit('save')">
+    <div v-if="props.formSummaryErrors.length > 0" class="trip-editor-form-error" role="alert">
+      <p v-for="message in props.formSummaryErrors" :key="message">{{ message }}</p>
+    </div>
+
+    <label class="trip-editor-field">
+      <span>Name</span>
+      <input v-model="props.draft.name" type="text" autocomplete="off" />
+      <small v-for="message in props.fieldErrors('name')" :key="message">{{ message }}</small>
+    </label>
+
+    <label class="trip-editor-field">
+      <span>Notes HTML</span>
+      <textarea v-model="props.draft.notesHtml" rows="6"></textarea>
+      <small v-for="message in props.fieldErrors('notesHtml')" :key="message">{{ message }}</small>
+    </label>
+
+    <div class="trip-editor-grid">
+      <label class="trip-editor-field">
+        <span>Fill Color</span>
+        <input v-model="props.draft.fillHex" type="color" />
+      </label>
+      <label class="trip-editor-field">
+        <span>Fill Hex</span>
+        <input v-model="props.draft.fillHex" type="text" autocomplete="off" />
+        <small v-for="message in props.fieldErrors('fillHex')" :key="message">{{ message }}</small>
+      </label>
+    </div>
+
+    <div class="trip-editor-field">
+      <span>Geometry</span>
+      <output>{{ geometryStatus }}</output>
+      <small v-for="message in props.fieldErrors('geometry')" :key="message">{{ message }}</small>
+      <small v-for="message in props.fieldErrors('geometry.coordinates')" :key="message">{{ message }}</small>
+    </div>
+  </form>
+</template>

--- a/ClientApps/trip-editor/src/components/AreaEditorSurface.vue
+++ b/ClientApps/trip-editor/src/components/AreaEditorSurface.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
+import type { EditorArea, EditorAreaDraft } from '../types';
+import AreaEditorForm from './AreaEditorForm.vue';
+import EditorSurface from './EditorSurface.vue';
+
+defineProps<{
+  activeArea: EditorArea | null;
+  controller: EditorSurfaceController;
+  draft: EditorAreaDraft;
+  fieldErrors: (key: string) => string[];
+  formId: string;
+  formSummaryErrors: string[];
+  isDirty: boolean;
+  isSaving: boolean;
+  statusText: string;
+  target: EditorTarget;
+}>();
+
+defineEmits<{
+  cancel: [];
+  delete: [];
+  drawArea: [];
+  reset: [];
+  save: [];
+}>();
+</script>
+
+<template>
+  <EditorSurface :controller="controller" :target="target" :status-text="statusText">
+    <template #body>
+      <AreaEditorForm
+        :draft="draft"
+        :field-errors="fieldErrors"
+        :form-id="formId"
+        :form-summary-errors="formSummaryErrors"
+        @save="$emit('save')"
+      />
+    </template>
+
+    <template #footer>
+      <button v-if="activeArea?.capabilities.canDelete" type="button" class="btn btn-outline-danger btn-sm me-auto" :disabled="isSaving" @click="$emit('delete')">
+        Delete
+      </button>
+      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="$emit('drawArea')">Draw/Edit Area</button>
+      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="$emit('cancel')">Cancel</button>
+      <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="isSaving || !isDirty" @click="$emit('reset')">Reset</button>
+      <button type="submit" :form="formId" class="btn btn-primary btn-sm" :disabled="isSaving">Save Area</button>
+    </template>
+  </EditorSurface>
+</template>

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
-import { createPlace, createRegion, deletePlace, deleteRegion, orderPlaces, orderRegions, updatePlace, updateRegion } from '../api/tripEditorApi';
+import { createArea, createPlace, createRegion, deleteArea, deletePlace, deleteRegion, orderAreas, orderPlaces, orderRegions, updateArea, updatePlace, updateRegion } from '../api/tripEditorApi';
 import { confirm } from '../composables/useConfirmDialog';
 import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
 import PlaceEditorSurface from './PlaceEditorSurface.vue';
+import AreaEditorSurface from './AreaEditorSurface.vue';
 import RegionEditorSurface from './RegionEditorSurface.vue';
 import RegionPlaceList from './RegionPlaceList.vue';
-import { buildPlaceCreateTarget, buildPlaceEditTarget, buildRegionCreateTarget, buildRegionEditTarget, placeDraftKey, regionDraftKey } from './regionPlaceEditorTargets';
-import { buildPlaceRequest, buildRegionRequest, emptyPlaceDraft, emptyRegionDraft, toPlaceDraft, toRegionDraft, withoutRegionId } from './regionPlaceDrafts';
+import { buildAreaCreateTarget, buildAreaEditTarget, buildPlaceCreateTarget, buildPlaceEditTarget, buildRegionCreateTarget, buildRegionEditTarget, areaDraftKey, placeDraftKey, regionDraftKey } from './regionPlaceEditorTargets';
+import { buildAreaRequest, buildPlaceRequest, buildRegionRequest, emptyAreaDraft, emptyPlaceDraft, emptyRegionDraft, toAreaDraft, toPlaceDraft, toRegionDraft, withoutRegionId } from './regionPlaceDrafts';
+import { beginAreaPolygonMapWork, stopAreaPolygonEdit, type AreaPolygonEditor, type AreaPolygonMapWorkState } from './areaPolygonMapWork';
 import { beginPlaceCoordinateMapWork, stopPlaceCoordinatePick, type PlaceCoordinateMapWorkState, type PlaceCoordinatePicker } from './placeCoordinateMapWork';
 import { useEditorMutationFeedback } from './useEditorMutationFeedback';
-import type { EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
+import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
 
 const props = defineProps<{
   state: EditorTripState;
@@ -22,6 +24,7 @@ const props = defineProps<{
   searchPlaceIdsByRegionId: Record<Guid, Guid[]>;
   searchAreaIdsByRegionId: Record<Guid, Guid[]>;
   coordinatePicker: PlaceCoordinatePicker;
+  polygonEditor: AreaPolygonEditor;
 }>();
 
 const emit = defineEmits<{
@@ -31,27 +34,36 @@ const emit = defineEmits<{
 
 const regionFields = ['name', 'notesHtml', 'coverImage.rawUrl', 'center.latitude', 'center.longitude'];
 const placeFields = ['regionId', 'name', 'notesHtml', 'address', 'location.latitude', 'location.longitude', 'iconName', 'markerColor', 'reverseGeocode'];
+const areaFields = ['name', 'notesHtml', 'fillHex', 'geometry', 'geometry.coordinates'];
 const regionListKey = ref(0);
 const regionFormId = 'trip-editor-region-form';
 const placeFormId = 'trip-editor-place-form';
+const areaFormId = 'trip-editor-area-form';
 const draft = reactive(emptyRegionDraft());
 const placeDraft = reactive<EditorPlaceDraft>(emptyPlaceDraft());
+const areaDraft = reactive<EditorAreaDraft>(emptyAreaDraft());
 const isSaving = ref(false);
 const isOrdering = ref(false);
 const regionCreateBaselineRequest = ref<EditorRegionSaveRequest | null>(null);
 const placeCreateBaselineRequest = ref<EditorPlaceSaveRequest | null>(null);
+const areaCreateBaselineRequest = ref<EditorAreaSaveRequest | null>(null);
 let unregisterRegionHandler: (() => void) | null = null;
 let unregisterPlaceHandler: (() => void) | null = null;
+let unregisterAreaHandler: (() => void) | null = null;
 const placeCoordinateMapWork = reactive<PlaceCoordinateMapWorkState>({ coordinate: null, stopPick: null });
+const areaPolygonMapWork = reactive<AreaPolygonMapWorkState>({ geometry: null, stopEdit: null });
 
 const orderedRegions = computed(() => props.state.regionOrder.map(id => props.state.regionsById[id]).filter(region => region && (!region.isShadow || hasRegionChildren(region))) as EditorRegion[]);
 const activeRegion = computed(() => (draft.id ? props.state.regionsById[draft.id] ?? null : null));
 const activePlace = computed(() => (placeDraft.id ? props.state.placesById[placeDraft.id] ?? null : null));
+const activeArea = computed(() => (areaDraft.id ? props.state.areasById[areaDraft.id] ?? null : null));
 const isDraftOpen = computed(() => draft.id !== null || Boolean(draft.name || draft.notesHtml || draft.coverImageRawUrl || draft.centerLatitude || draft.centerLongitude));
 const isPlaceDraftOpen = computed(() => placeDraft.regionId !== null || Boolean(placeDraft.name || placeDraft.notesHtml || placeDraft.address || placeDraft.latitude || placeDraft.longitude));
+const isAreaDraftOpen = computed(() => areaDraft.regionId !== null || Boolean(areaDraft.name || areaDraft.notesHtml || areaDraft.geometry));
 const regionDirty = computed(() => JSON.stringify(buildRegionRequest(draft)) !== JSON.stringify(regionBaselineRequest.value));
 const placeDirty = computed(() => JSON.stringify(buildPlaceRequest(placeDraft)) !== JSON.stringify(placeBaselineRequest.value));
-const isDirty = computed(() => regionDirty.value || placeDirty.value);
+const areaDirty = computed(() => JSON.stringify(buildAreaRequest(areaDraft)) !== JSON.stringify(areaBaselineRequest.value));
+const isDirty = computed(() => regionDirty.value || placeDirty.value || areaDirty.value);
 const normalRegions = computed(() => orderedRegions.value.filter(region => !region.isShadow));
 const renderedRegions = computed(() => {
   const regions = props.searchActive ? [...props.searchRegions] : [...orderedRegions.value];
@@ -78,10 +90,22 @@ const renderedPlaceIdsByRegionId = computed(() => {
 
   return result;
 });
-const renderedAreaIdsByRegionId = computed(() => (props.searchActive ? props.searchAreaIdsByRegionId : props.state.areaOrderByRegionId));
+const renderedAreaIdsByRegionId = computed(() => {
+  if (!props.searchActive) {
+    return props.state.areaOrderByRegionId;
+  }
+
+  const result = cloneIdRecord(props.searchAreaIdsByRegionId);
+  if (activeArea.value) {
+    pushUnique(result, activeArea.value.regionId, activeArea.value.id);
+  }
+
+  return result;
+});
 const forcedExpandedRegionIds = computed(() => new Set(props.searchActive ? renderedRegions.value.map(region => region.id) : []));
 const regionBaselineRequest = computed(() => draft.id ? buildRegionRequest(toRegionDraft(activeRegion.value)) : regionCreateBaselineRequest.value ?? buildRegionRequest(emptyRegionDraft()));
 const placeBaselineRequest = computed(() => placeDraft.id ? buildPlaceRequest(toPlaceDraft(activePlace.value, placeDraft.regionId)) : placeCreateBaselineRequest.value ?? buildPlaceRequest(emptyPlaceDraft(placeDraft.regionId)));
+const areaBaselineRequest = computed(() => areaDraft.id ? buildAreaRequest(toAreaDraft(activeArea.value, areaDraft.regionId, props.state.options.areaDefaults.fillHex)) : areaCreateBaselineRequest.value ?? buildAreaRequest(emptyAreaDraft(areaDraft.regionId, props.state.options.areaDefaults.fillHex)));
 const activeRegionTarget = computed<EditorTarget>(() => ({
   key: regionDraftKey,
   identity: draft.id ? `region:edit:${draft.id}` : 'region:add',
@@ -101,11 +125,23 @@ const activePlaceTarget = computed<EditorTarget>(() => ({
   entityId: placeDraft.id ?? undefined,
   parentRegionId: placeDraft.regionId ?? undefined
 }));
+const activeAreaTarget = computed<EditorTarget>(() => ({
+  key: areaDraftKey,
+  identity: areaDraft.id ? `area:edit:${areaDraft.id}` : `area:add:${areaDraft.regionId ?? 'none'}`,
+  kind: 'area',
+  mode: areaDraft.id ? 'edit' : 'add',
+  title: areaDraft.id ? `Edit Area - ${activeArea.value?.name ?? areaDraft.name}` : 'Add Area',
+  subtitle: areaDraft.regionId ? props.state.regionsById[areaDraft.regionId]?.name : undefined,
+  entityId: areaDraft.id ?? undefined,
+  parentRegionId: areaDraft.regionId ?? undefined
+}));
 const { applyError, fieldErrors, formSummaryErrors, markSaved, resetFeedback, saveError, saveWarning, statusText } = useEditorMutationFeedback({
   isDirty,
+  isAreaDraftOpen,
   isOrdering: computed(() => isOrdering.value),
   isPlaceDraftOpen,
   isSaving: computed(() => isSaving.value),
+  areaFields,
   placeFields,
   regionFields
 });
@@ -126,12 +162,18 @@ onMounted(() => {
     isDirty: () => placeDirty.value,
     discard: discardPlaceDraft
   });
+  unregisterAreaHandler = props.editorSurface.registerTargetHandler(areaDraftKey, {
+    isDirty: () => areaDirty.value,
+    discard: discardAreaDraft
+  });
 });
 
 onUnmounted(() => {
   unregisterRegionHandler?.();
   unregisterPlaceHandler?.();
+  unregisterAreaHandler?.();
   stopPlaceCoordinatePick(placeCoordinateMapWork);
+  stopAreaPolygonEdit(areaPolygonMapWork);
   emit('dirtyStateChanged', false);
   window.removeEventListener('beforeunload', confirmUnload);
 });
@@ -145,9 +187,11 @@ const openCreate = async (): Promise<void> => {
 
   Object.assign(draft, emptyRegionDraft());
   Object.assign(placeDraft, emptyPlaceDraft());
+  Object.assign(areaDraft, emptyAreaDraft());
   draft.name = 'New Region';
   regionCreateBaselineRequest.value = buildRegionRequest(draft);
   placeCreateBaselineRequest.value = null;
+  areaCreateBaselineRequest.value = null;
   resetFeedback();
 };
 
@@ -159,9 +203,11 @@ const openEdit = async (region: EditorRegion): Promise<void> => {
   }
 
   Object.assign(placeDraft, emptyPlaceDraft());
+  Object.assign(areaDraft, emptyAreaDraft());
   Object.assign(draft, toRegionDraft(region));
   regionCreateBaselineRequest.value = null;
   placeCreateBaselineRequest.value = null;
+  areaCreateBaselineRequest.value = null;
   resetFeedback();
 };
 
@@ -227,8 +273,10 @@ const deleteDraftRegion = async (): Promise<void> => {
     emit('mutationApplied', result as EditorMutationResult<unknown>);
     Object.assign(draft, emptyRegionDraft());
     Object.assign(placeDraft, emptyPlaceDraft());
+    Object.assign(areaDraft, emptyAreaDraft());
     regionCreateBaselineRequest.value = null;
     placeCreateBaselineRequest.value = null;
+    areaCreateBaselineRequest.value = null;
     props.editorSurface.clearActiveTarget(deletedTarget);
     markSaved();
   } catch (error) {
@@ -247,8 +295,10 @@ const reorderRegions = async (ids: Guid[], previousIds: Guid[]): Promise<void> =
   if (isDirty.value) {
     Object.assign(draft, emptyRegionDraft());
     Object.assign(placeDraft, emptyPlaceDraft());
+    Object.assign(areaDraft, emptyAreaDraft());
     regionCreateBaselineRequest.value = null;
     placeCreateBaselineRequest.value = null;
+    areaCreateBaselineRequest.value = null;
   }
 
   isOrdering.value = true;
@@ -275,11 +325,30 @@ const openPlaceCreate = async (region: EditorRegion): Promise<void> => {
 
   Object.assign(draft, emptyRegionDraft());
   Object.assign(placeDraft, emptyPlaceDraft(region.id));
+  Object.assign(areaDraft, emptyAreaDraft());
   placeDraft.name = 'New Place';
   placeDraft.iconName = props.state.options.iconNames[0] ?? 'marker';
   placeDraft.markerColor = props.state.options.markerColorClasses[0] ?? 'bg-blue';
   regionCreateBaselineRequest.value = null;
   placeCreateBaselineRequest.value = buildPlaceRequest(placeDraft);
+  areaCreateBaselineRequest.value = null;
+  resetFeedback();
+};
+
+const openAreaCreate = async (region: EditorRegion): Promise<void> => {
+  const target = buildAreaCreateTarget(region);
+  const isAlreadyActive = props.editorSurface.isTargetActive(target);
+  if (region.isShadow || !props.state.permissions.canEditAreas || !region.capabilities.canAddChildren || !(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
+    return;
+  }
+
+  Object.assign(draft, emptyRegionDraft());
+  Object.assign(placeDraft, emptyPlaceDraft());
+  Object.assign(areaDraft, emptyAreaDraft(region.id, props.state.options.areaDefaults.fillHex));
+  areaDraft.name = props.state.options.areaDefaults.name || 'Area';
+  regionCreateBaselineRequest.value = null;
+  placeCreateBaselineRequest.value = null;
+  areaCreateBaselineRequest.value = buildAreaRequest(areaDraft);
   resetFeedback();
 };
 
@@ -292,8 +361,26 @@ const openPlaceEdit = async (place: EditorPlace): Promise<void> => {
 
   Object.assign(draft, emptyRegionDraft());
   Object.assign(placeDraft, toPlaceDraft(place, place.regionId));
+  Object.assign(areaDraft, emptyAreaDraft());
   regionCreateBaselineRequest.value = null;
   placeCreateBaselineRequest.value = null;
+  areaCreateBaselineRequest.value = null;
+  resetFeedback();
+};
+
+const openAreaEdit = async (area: EditorArea): Promise<void> => {
+  const target = buildAreaEditTarget(area, props.state.regionsById[area.regionId]?.name);
+  const isAlreadyActive = props.editorSurface.isTargetActive(target);
+  if (!area.capabilities.canEdit || !(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
+    return;
+  }
+
+  Object.assign(draft, emptyRegionDraft());
+  Object.assign(placeDraft, emptyPlaceDraft());
+  Object.assign(areaDraft, toAreaDraft(area, area.regionId, props.state.options.areaDefaults.fillHex));
+  regionCreateBaselineRequest.value = null;
+  placeCreateBaselineRequest.value = null;
+  areaCreateBaselineRequest.value = null;
   resetFeedback();
 };
 
@@ -340,6 +427,8 @@ const savePlaceDraft = async (): Promise<void> => {
 
 const pickPlaceCoordinate = (): void => beginPlaceCoordinateMapWork(placeDraft, props.editorSurface, props.coordinatePicker, placeCoordinateMapWork);
 
+const drawAreaPolygon = (): void => beginAreaPolygonMapWork(areaDraft, props.editorSurface, props.polygonEditor, areaPolygonMapWork);
+
 const deleteDraftPlace = async (): Promise<void> => {
   if (!activePlace.value) {
     return;
@@ -366,7 +455,9 @@ const deleteDraftPlace = async (): Promise<void> => {
     const result = await deletePlace(props.editorEndpoint, activePlace.value.id, props.antiforgeryToken);
     emit('mutationApplied', result as EditorMutationResult<unknown>);
     Object.assign(placeDraft, emptyPlaceDraft());
+    Object.assign(areaDraft, emptyAreaDraft());
     placeCreateBaselineRequest.value = null;
+    areaCreateBaselineRequest.value = null;
     props.editorSurface.clearActiveTarget(deletedTarget);
     markSaved();
   } catch (error) {
@@ -385,8 +476,10 @@ async function reorderPlaces(regionId: Guid, ids: Guid[], previousIds: Guid[]): 
   if (isDirty.value) {
     Object.assign(draft, emptyRegionDraft());
     Object.assign(placeDraft, emptyPlaceDraft());
+    Object.assign(areaDraft, emptyAreaDraft());
     regionCreateBaselineRequest.value = null;
     placeCreateBaselineRequest.value = null;
+    areaCreateBaselineRequest.value = null;
   }
 
   isOrdering.value = true;
@@ -397,6 +490,110 @@ async function reorderPlaces(regionId: Guid, ids: Guid[], previousIds: Guid[]): 
     markSaved();
   } catch (error) {
     applyError(error, 'Place reorder failed.');
+    await restoreRegionOrder(previousIds);
+  } finally {
+    isOrdering.value = false;
+  }
+}
+
+const resetAreaDraft = (): void => {
+  if (!areaDraft.id) {
+    const regionId = areaDraft.regionId;
+    Object.assign(areaDraft, emptyAreaDraft(regionId, props.state.options.areaDefaults.fillHex));
+    areaDraft.name = props.state.options.areaDefaults.name || 'Area';
+  } else {
+    Object.assign(areaDraft, toAreaDraft(activeArea.value, areaDraft.regionId, props.state.options.areaDefaults.fillHex));
+  }
+  resetFeedback();
+};
+
+const cancelAreaDraft = async (): Promise<void> => {
+  await props.editorSurface.closeActiveTarget('Discard unsaved area changes?');
+};
+
+const saveAreaDraft = async (): Promise<void> => {
+  if (!areaDraft.regionId) {
+    return;
+  }
+
+  isSaving.value = true;
+  resetFeedback();
+  try {
+    const request = buildAreaRequest(areaDraft);
+    const result = areaDraft.id
+      ? await updateArea(props.editorEndpoint, areaDraft.id, props.antiforgeryToken, request)
+      : await createArea(props.editorEndpoint, areaDraft.regionId, props.antiforgeryToken, request);
+    emit('mutationApplied', result as EditorMutationResult<unknown>);
+    Object.assign(areaDraft, toAreaDraft(result.data, result.data.regionId, props.state.options.areaDefaults.fillHex));
+    areaCreateBaselineRequest.value = null;
+    props.editorSurface.replaceActiveTarget(activeAreaTarget.value);
+    markSaved();
+  } catch (error) {
+    applyError(error, 'Area save failed.');
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const deleteDraftArea = async (): Promise<void> => {
+  if (!activeArea.value) {
+    return;
+  }
+
+  if (!(await confirmDiscard('Discard unsaved area draft changes before deleting?'))) {
+    return;
+  }
+
+  if (!(await confirm({
+    title: 'Delete area?',
+    message: 'Delete this area?',
+    confirmLabel: 'Delete',
+    cancelLabel: 'Keep area',
+    variant: 'danger'
+  }))) {
+    return;
+  }
+
+  isSaving.value = true;
+  resetFeedback();
+  try {
+    const deletedTarget = activeAreaTarget.value;
+    const result = await deleteArea(props.editorEndpoint, activeArea.value.id, props.antiforgeryToken);
+    emit('mutationApplied', result as EditorMutationResult<unknown>);
+    Object.assign(areaDraft, emptyAreaDraft());
+    areaCreateBaselineRequest.value = null;
+    props.editorSurface.clearActiveTarget(deletedTarget);
+    markSaved();
+  } catch (error) {
+    applyError(error, 'Area delete failed.');
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+async function reorderAreas(regionId: Guid, ids: Guid[], previousIds: Guid[]): Promise<void> {
+  if (isDirty.value && !(await confirmDiscard('Discard unsaved draft changes before reordering areas?'))) {
+    await restoreRegionOrder(previousIds);
+    return;
+  }
+
+  if (isDirty.value) {
+    Object.assign(draft, emptyRegionDraft());
+    Object.assign(placeDraft, emptyPlaceDraft());
+    Object.assign(areaDraft, emptyAreaDraft());
+    regionCreateBaselineRequest.value = null;
+    placeCreateBaselineRequest.value = null;
+    areaCreateBaselineRequest.value = null;
+  }
+
+  isOrdering.value = true;
+  resetFeedback();
+  try {
+    const result = await orderAreas(props.editorEndpoint, regionId, props.antiforgeryToken, { areaIds: ids });
+    emit('mutationApplied', result as EditorMutationResult<unknown>);
+    markSaved();
+  } catch (error) {
+    applyError(error, 'Area reorder failed.');
     await restoreRegionOrder(previousIds);
   } finally {
     isOrdering.value = false;
@@ -421,6 +618,14 @@ function activeContextRegions(): EditorRegion[] {
   const activePlaceRegionId = activePlace.value?.regionId ?? placeDraft.regionId;
   if (activePlaceRegionId) {
     const region = props.state.regionsById[activePlaceRegionId];
+    if (region) {
+      regions.push(region);
+    }
+  }
+
+  const activeAreaRegionId = activeArea.value?.regionId ?? areaDraft.regionId;
+  if (activeAreaRegionId) {
+    const region = props.state.regionsById[activeAreaRegionId];
     if (region) {
       regions.push(region);
     }
@@ -475,6 +680,12 @@ function discardPlaceDraft(): void {
   resetFeedback();
 }
 
+function discardAreaDraft(): void {
+  Object.assign(areaDraft, emptyAreaDraft());
+  areaCreateBaselineRequest.value = null;
+  resetFeedback();
+}
+
 function isRegionEditOpen(region: EditorRegion): boolean {
   return Boolean(draft.id && activeRegion.value?.id === region.id && props.editorSurface.isTargetActive(activeRegionTarget.value));
 }
@@ -485,6 +696,14 @@ function isPlaceEditOpen(place: EditorPlace): boolean {
 
 function isPlaceCreateOpen(region: EditorRegion): boolean {
   return Boolean(!placeDraft.id && placeDraft.regionId === region.id && props.editorSurface.isTargetActive(activePlaceTarget.value));
+}
+
+function isAreaEditOpen(area: EditorArea): boolean {
+  return Boolean(areaDraft.id && activeArea.value?.id === area.id && props.editorSurface.isTargetActive(activeAreaTarget.value));
+}
+
+function isAreaCreateOpen(region: EditorRegion): boolean {
+  return Boolean(!areaDraft.id && areaDraft.regionId === region.id && props.editorSurface.isTargetActive(activeAreaTarget.value));
 }
 </script>
 
@@ -502,7 +721,7 @@ function isPlaceCreateOpen(region: EditorRegion): boolean {
 
     <RegionEditorSurface v-if="isDraftOpen && !draft.id" :active-region="activeRegion" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="regionFormId" :form-summary-errors="formSummaryErrors" :is-dirty="regionDirty" :is-saving="isSaving" :status-text="statusText" :target="activeRegionTarget" @cancel="cancelDraft" @delete="deleteDraftRegion" @reset="resetDraft" @save="saveDraft" />
 
-    <RegionPlaceList :key="regionListKey" :active-place-id="activePlace?.id ?? null" :active-region-id="activeRegion?.id ?? null" :force-expanded-region-ids="forcedExpandedRegionIds" :is-ordering="isOrdering" :is-saving="isSaving" :place-ids-by-region-id="renderedPlaceIdsByRegionId" :area-ids-by-region-id="renderedAreaIdsByRegionId" :regions="renderedRegions" :search-active="searchActive" :state="state" @add-place="openPlaceCreate" @edit-place="openPlaceEdit" @edit-region="openEdit" @place-reorder="reorderPlaces" @region-reorder="reorderRegions">
+    <RegionPlaceList :key="regionListKey" :active-area-id="activeArea?.id ?? null" :active-place-id="activePlace?.id ?? null" :active-region-id="activeRegion?.id ?? null" :force-expanded-region-ids="forcedExpandedRegionIds" :is-ordering="isOrdering" :is-saving="isSaving" :place-ids-by-region-id="renderedPlaceIdsByRegionId" :area-ids-by-region-id="renderedAreaIdsByRegionId" :regions="renderedRegions" :search-active="searchActive" :state="state" @add-area="openAreaCreate" @add-place="openPlaceCreate" @area-reorder="reorderAreas" @edit-area="openAreaEdit" @edit-place="openPlaceEdit" @edit-region="openEdit" @place-reorder="reorderPlaces" @region-reorder="reorderRegions">
       <template #region-editor="{ region }">
         <RegionEditorSurface v-if="isRegionEditOpen(region)" :active-region="activeRegion" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="regionFormId" :form-summary-errors="formSummaryErrors" :is-dirty="regionDirty" :is-saving="isSaving" :status-text="statusText" :target="activeRegionTarget" @cancel="cancelDraft" @delete="deleteDraftRegion" @reset="resetDraft" @save="saveDraft" />
       </template>
@@ -511,8 +730,16 @@ function isPlaceCreateOpen(region: EditorRegion): boolean {
         <PlaceEditorSurface v-if="isPlaceEditOpen(place)" :active-place="activePlace" :controller="editorSurface" :draft="placeDraft" :field-errors="fieldErrors" :form-id="placeFormId" :form-summary-errors="formSummaryErrors" :is-dirty="placeDirty" :is-saving="isSaving" :normal-regions="normalRegions" :state="state" :status-text="statusText" :target="activePlaceTarget" @cancel="cancelPlaceDraft" @delete="deleteDraftPlace" @pick-coordinate="pickPlaceCoordinate" @reset="resetPlaceDraft" @save="savePlaceDraft" />
       </template>
 
+      <template #area-editor="{ area }">
+        <AreaEditorSurface v-if="isAreaEditOpen(area)" :active-area="activeArea" :controller="editorSurface" :draft="areaDraft" :field-errors="fieldErrors" :form-id="areaFormId" :form-summary-errors="formSummaryErrors" :is-dirty="areaDirty" :is-saving="isSaving" :status-text="statusText" :target="activeAreaTarget" @cancel="cancelAreaDraft" @delete="deleteDraftArea" @draw-area="drawAreaPolygon" @reset="resetAreaDraft" @save="saveAreaDraft" />
+      </template>
+
       <template #add-place-editor="{ region }">
         <PlaceEditorSurface v-if="isPlaceCreateOpen(region)" :active-place="activePlace" :controller="editorSurface" :draft="placeDraft" :field-errors="fieldErrors" :form-id="placeFormId" :form-summary-errors="formSummaryErrors" :is-dirty="placeDirty" :is-saving="isSaving" :normal-regions="normalRegions" :state="state" :status-text="statusText" :target="activePlaceTarget" @cancel="cancelPlaceDraft" @delete="deleteDraftPlace" @pick-coordinate="pickPlaceCoordinate" @reset="resetPlaceDraft" @save="savePlaceDraft" />
+      </template>
+
+      <template #add-area-editor="{ region }">
+        <AreaEditorSurface v-if="isAreaCreateOpen(region)" :active-area="activeArea" :controller="editorSurface" :draft="areaDraft" :field-errors="fieldErrors" :form-id="areaFormId" :form-summary-errors="formSummaryErrors" :is-dirty="areaDirty" :is-saving="isSaving" :status-text="statusText" :target="activeAreaTarget" @cancel="cancelAreaDraft" @delete="deleteDraftArea" @draw-area="drawAreaPolygon" @reset="resetAreaDraft" @save="saveAreaDraft" />
       </template>
     </RegionPlaceList>
   </section>

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
-import { createPlace, createRegion, deletePlace, deleteRegion, orderPlaces, orderRegions, updatePlace, updateRegion } from '../api/tripEditorApi';
 import { confirm } from '../composables/useConfirmDialog';
 import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
 import PlaceEditorSurface from './PlaceEditorSurface.vue';
 import AreaEditorSurface from './AreaEditorSurface.vue';
 import RegionEditorSurface from './RegionEditorSurface.vue';
 import RegionPlaceList from './RegionPlaceList.vue';
-import { buildPlaceCreateTarget, buildPlaceEditTarget, buildRegionCreateTarget, buildRegionEditTarget, areaDraftKey, placeDraftKey, regionDraftKey } from './regionPlaceEditorTargets';
-import { buildAreaRequest, buildPlaceRequest, buildRegionRequest, emptyAreaDraft, emptyPlaceDraft, emptyRegionDraft, toAreaDraft, toPlaceDraft, toRegionDraft, withoutRegionId } from './regionPlaceDrafts';
+import { areaDraftKey, placeDraftKey, regionDraftKey } from './regionPlaceEditorTargets';
+import { buildAreaRequest, buildPlaceRequest, buildRegionRequest, emptyAreaDraft, emptyPlaceDraft, emptyRegionDraft, toAreaDraft, toPlaceDraft, toRegionDraft } from './regionPlaceDrafts';
 import { stopAreaPolygonEdit, type AreaPolygonEditor, type AreaPolygonMapWorkState } from './areaPolygonMapWork';
 import { useAreaEditorActions } from './areaEditorActions';
-import { beginPlaceCoordinateMapWork, stopPlaceCoordinatePick, type PlaceCoordinateMapWorkState, type PlaceCoordinatePicker } from './placeCoordinateMapWork';
+import { usePlaceEditorActions } from './placeEditorActions';
+import { useRegionEditorActions } from './regionEditorActions';
+import { stopPlaceCoordinatePick, type PlaceCoordinateMapWorkState, type PlaceCoordinatePicker } from './placeCoordinateMapWork';
 import { useEditorMutationFeedback } from './useEditorMutationFeedback';
 import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
 
@@ -146,6 +147,49 @@ const { applyError, fieldErrors, formSummaryErrors, markSaved, resetFeedback, sa
   placeFields,
   regionFields
 });
+const { cancelDraft, deleteDraftRegion, openCreate, openEdit, reorderRegions, resetDraft, saveDraft } = useRegionEditorActions({
+  activeRegion,
+  activeRegionTarget,
+  applyError,
+  areaCreateBaselineRequest,
+  areaDraft,
+  clearAllDraftsAndBaselines,
+  confirmDiscard,
+  draft,
+  emit,
+  isDirty,
+  isOrdering,
+  isSaving,
+  markSaved,
+  placeCreateBaselineRequest,
+  placeDraft,
+  props,
+  regionCreateBaselineRequest,
+  resetFeedback,
+  restoreRegionOrder
+});
+const { cancelPlaceDraft, deleteDraftPlace, openPlaceCreate, openPlaceEdit, pickPlaceCoordinate, reorderPlaces, resetPlaceDraft, savePlaceDraft } = usePlaceEditorActions({
+  activePlace,
+  activePlaceTarget,
+  applyError,
+  areaCreateBaselineRequest,
+  areaDraft,
+  clearAllDraftsAndBaselines,
+  confirmDiscard,
+  draft,
+  emit,
+  isDirty,
+  isOrdering,
+  isSaving,
+  markSaved,
+  placeCoordinateMapWork,
+  placeCreateBaselineRequest,
+  placeDraft,
+  props,
+  regionCreateBaselineRequest,
+  resetFeedback,
+  restoreRegionOrder
+});
 const { cancelAreaDraft, deleteDraftArea, drawAreaPolygon, openAreaCreate, openAreaEdit, reorderAreas, resetAreaDraft, saveAreaDraft } = useAreaEditorActions({
   activeArea,
   activeAreaTarget,
@@ -198,289 +242,6 @@ onUnmounted(() => {
   emit('dirtyStateChanged', false);
   window.removeEventListener('beforeunload', confirmUnload);
 });
-
-const openCreate = async (): Promise<void> => {
-  const target = buildRegionCreateTarget();
-  const isAlreadyActive = props.editorSurface.isTargetActive(target);
-  if (!(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
-    return;
-  }
-
-  Object.assign(draft, emptyRegionDraft());
-  Object.assign(placeDraft, emptyPlaceDraft());
-  Object.assign(areaDraft, emptyAreaDraft());
-  draft.name = 'New Region';
-  regionCreateBaselineRequest.value = buildRegionRequest(draft);
-  placeCreateBaselineRequest.value = null;
-  areaCreateBaselineRequest.value = null;
-  resetFeedback();
-};
-
-const openEdit = async (region: EditorRegion): Promise<void> => {
-  const target = buildRegionEditTarget(region);
-  const isAlreadyActive = props.editorSurface.isTargetActive(target);
-  if (!region.capabilities.canEdit || !(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
-    return;
-  }
-
-  Object.assign(placeDraft, emptyPlaceDraft());
-  Object.assign(areaDraft, emptyAreaDraft());
-  Object.assign(draft, toRegionDraft(region));
-  regionCreateBaselineRequest.value = null;
-  placeCreateBaselineRequest.value = null;
-  areaCreateBaselineRequest.value = null;
-  resetFeedback();
-};
-
-const resetDraft = (): void => {
-  if (!draft.id) {
-    Object.assign(draft, emptyRegionDraft());
-    draft.name = 'New Region';
-  } else {
-    Object.assign(draft, toRegionDraft(activeRegion.value));
-  }
-  resetFeedback();
-};
-
-const cancelDraft = async (): Promise<void> => {
-  await props.editorSurface.closeActiveTarget('Discard unsaved region changes?');
-};
-
-const saveDraft = async (): Promise<void> => {
-  isSaving.value = true;
-  resetFeedback();
-
-  try {
-    const request = buildRegionRequest(draft);
-    const result = draft.id
-      ? await updateRegion(props.editorEndpoint, draft.id, props.antiforgeryToken, request)
-      : await createRegion(props.editorEndpoint, props.antiforgeryToken, request);
-    emit('mutationApplied', result as EditorMutationResult<unknown>);
-    Object.assign(draft, toRegionDraft(result.data));
-    regionCreateBaselineRequest.value = null;
-    props.editorSurface.replaceActiveTarget(activeRegionTarget.value);
-    markSaved();
-  } catch (error) {
-    applyError(error, 'Region save failed.');
-  } finally {
-    isSaving.value = false;
-  }
-};
-
-const deleteDraftRegion = async (): Promise<void> => {
-  if (!activeRegion.value || !activeRegion.value.capabilities.canDelete) {
-    return;
-  }
-
-  if (!(await confirmDiscard('Discard unsaved region or place draft changes before deleting?'))) {
-    return;
-  }
-
-  if (!(await confirm({
-    title: 'Delete region?',
-    message: 'Delete this region, its child places and areas, and any segments connected to deleted places?',
-    confirmLabel: 'Delete',
-    cancelLabel: 'Keep region',
-    variant: 'danger'
-  }))) {
-    return;
-  }
-
-  isSaving.value = true;
-  resetFeedback();
-  try {
-    const deletedTarget = activeRegionTarget.value;
-    const result = await deleteRegion(props.editorEndpoint, activeRegion.value.id, props.antiforgeryToken);
-    emit('mutationApplied', result as EditorMutationResult<unknown>);
-    Object.assign(draft, emptyRegionDraft());
-    Object.assign(placeDraft, emptyPlaceDraft());
-    Object.assign(areaDraft, emptyAreaDraft());
-    regionCreateBaselineRequest.value = null;
-    placeCreateBaselineRequest.value = null;
-    areaCreateBaselineRequest.value = null;
-    props.editorSurface.clearActiveTarget(deletedTarget);
-    markSaved();
-  } catch (error) {
-    applyError(error, 'Region delete failed.');
-  } finally {
-    isSaving.value = false;
-  }
-};
-
-const reorderRegions = async (ids: Guid[], previousIds: Guid[]): Promise<void> => {
-  if (isDirty.value && !(await confirmDiscard('Discard unsaved draft changes before reordering?'))) {
-    await restoreRegionOrder(previousIds);
-    return;
-  }
-
-  if (isDirty.value) {
-    Object.assign(draft, emptyRegionDraft());
-    Object.assign(placeDraft, emptyPlaceDraft());
-    Object.assign(areaDraft, emptyAreaDraft());
-    regionCreateBaselineRequest.value = null;
-    placeCreateBaselineRequest.value = null;
-    areaCreateBaselineRequest.value = null;
-  }
-
-  isOrdering.value = true;
-  resetFeedback();
-  try {
-    const result = await orderRegions(props.editorEndpoint, props.antiforgeryToken, { regionIds: ids });
-    emit('mutationApplied', result as EditorMutationResult<unknown>);
-    Object.assign(draft, emptyRegionDraft());
-    markSaved();
-  } catch (error) {
-    applyError(error, 'Region reorder failed.');
-    await restoreRegionOrder(previousIds);
-  } finally {
-    isOrdering.value = false;
-  }
-};
-
-const openPlaceCreate = async (region: EditorRegion): Promise<void> => {
-  const target = buildPlaceCreateTarget(region);
-  const isAlreadyActive = props.editorSurface.isTargetActive(target);
-  if (region.isShadow || !(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
-    return;
-  }
-
-  Object.assign(draft, emptyRegionDraft());
-  Object.assign(placeDraft, emptyPlaceDraft(region.id));
-  Object.assign(areaDraft, emptyAreaDraft());
-  placeDraft.name = 'New Place';
-  placeDraft.iconName = props.state.options.iconNames[0] ?? 'marker';
-  placeDraft.markerColor = props.state.options.markerColorClasses[0] ?? 'bg-blue';
-  regionCreateBaselineRequest.value = null;
-  placeCreateBaselineRequest.value = buildPlaceRequest(placeDraft);
-  areaCreateBaselineRequest.value = null;
-  resetFeedback();
-};
-
-const openPlaceEdit = async (place: EditorPlace): Promise<void> => {
-  const target = buildPlaceEditTarget(place, props.state.regionsById[place.regionId]?.name);
-  const isAlreadyActive = props.editorSurface.isTargetActive(target);
-  if (!place.capabilities.canEdit || !(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
-    return;
-  }
-
-  Object.assign(draft, emptyRegionDraft());
-  Object.assign(placeDraft, toPlaceDraft(place, place.regionId));
-  Object.assign(areaDraft, emptyAreaDraft());
-  regionCreateBaselineRequest.value = null;
-  placeCreateBaselineRequest.value = null;
-  areaCreateBaselineRequest.value = null;
-  resetFeedback();
-};
-
-const resetPlaceDraft = (): void => {
-  if (!placeDraft.id) {
-    const regionId = placeDraft.regionId;
-    Object.assign(placeDraft, emptyPlaceDraft(regionId));
-    placeDraft.name = 'New Place';
-    placeDraft.iconName = props.state.options.iconNames[0] ?? 'marker';
-    placeDraft.markerColor = props.state.options.markerColorClasses[0] ?? 'bg-blue';
-  } else {
-    Object.assign(placeDraft, toPlaceDraft(activePlace.value, placeDraft.regionId));
-  }
-  resetFeedback();
-};
-
-const cancelPlaceDraft = async (): Promise<void> => {
-  await props.editorSurface.closeActiveTarget('Discard unsaved place changes?');
-};
-
-const savePlaceDraft = async (): Promise<void> => {
-  if (!placeDraft.regionId) {
-    return;
-  }
-
-  isSaving.value = true;
-  resetFeedback();
-  try {
-    const request = buildPlaceRequest(placeDraft);
-    const result = placeDraft.id
-      ? await updatePlace(props.editorEndpoint, placeDraft.id, props.antiforgeryToken, request)
-      : await createPlace(props.editorEndpoint, placeDraft.regionId, props.antiforgeryToken, withoutRegionId(request));
-    emit('mutationApplied', result as EditorMutationResult<unknown>);
-    Object.assign(placeDraft, toPlaceDraft(result.data, result.data.regionId));
-    placeCreateBaselineRequest.value = null;
-    props.editorSurface.replaceActiveTarget(activePlaceTarget.value);
-    markSaved(result.warnings.map(warning => warning.message));
-  } catch (error) {
-    applyError(error, 'Place save failed.');
-  } finally {
-    isSaving.value = false;
-  }
-};
-
-const pickPlaceCoordinate = (): void => beginPlaceCoordinateMapWork(placeDraft, props.editorSurface, props.coordinatePicker, placeCoordinateMapWork);
-
-const deleteDraftPlace = async (): Promise<void> => {
-  if (!activePlace.value) {
-    return;
-  }
-
-  if (!(await confirmDiscard('Discard unsaved place draft changes before deleting?'))) {
-    return;
-  }
-
-  if (!(await confirm({
-    title: 'Delete place?',
-    message: 'Delete this place and any segments connected to it?',
-    confirmLabel: 'Delete',
-    cancelLabel: 'Keep place',
-    variant: 'danger'
-  }))) {
-    return;
-  }
-
-  isSaving.value = true;
-  resetFeedback();
-  try {
-    const deletedTarget = activePlaceTarget.value;
-    const result = await deletePlace(props.editorEndpoint, activePlace.value.id, props.antiforgeryToken);
-    emit('mutationApplied', result as EditorMutationResult<unknown>);
-    Object.assign(placeDraft, emptyPlaceDraft());
-    Object.assign(areaDraft, emptyAreaDraft());
-    placeCreateBaselineRequest.value = null;
-    areaCreateBaselineRequest.value = null;
-    props.editorSurface.clearActiveTarget(deletedTarget);
-    markSaved();
-  } catch (error) {
-    applyError(error, 'Place delete failed.');
-  } finally {
-    isSaving.value = false;
-  }
-};
-
-async function reorderPlaces(regionId: Guid, ids: Guid[], previousIds: Guid[]): Promise<void> {
-  if (isDirty.value && !(await confirmDiscard('Discard unsaved draft changes before reordering places?'))) {
-    await restoreRegionOrder(previousIds);
-    return;
-  }
-
-  if (isDirty.value) {
-    Object.assign(draft, emptyRegionDraft());
-    Object.assign(placeDraft, emptyPlaceDraft());
-    Object.assign(areaDraft, emptyAreaDraft());
-    regionCreateBaselineRequest.value = null;
-    placeCreateBaselineRequest.value = null;
-    areaCreateBaselineRequest.value = null;
-  }
-
-  isOrdering.value = true;
-  resetFeedback();
-  try {
-    const result = await orderPlaces(props.editorEndpoint, regionId, props.antiforgeryToken, { placeIds: ids });
-    emit('mutationApplied', result as EditorMutationResult<unknown>);
-    markSaved();
-  } catch (error) {
-    applyError(error, 'Place reorder failed.');
-    await restoreRegionOrder(previousIds);
-  } finally {
-    isOrdering.value = false;
-  }
-}
 
 /// Rebuilds the Sortable-mutated list from persisted Vue state after canceled or failed reorder.
 async function restoreRegionOrder(_previousIds: string[]): Promise<void> {

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
-import { createArea, createPlace, createRegion, deleteArea, deletePlace, deleteRegion, orderAreas, orderPlaces, orderRegions, updateArea, updatePlace, updateRegion } from '../api/tripEditorApi';
+import { createPlace, createRegion, deletePlace, deleteRegion, orderPlaces, orderRegions, updatePlace, updateRegion } from '../api/tripEditorApi';
 import { confirm } from '../composables/useConfirmDialog';
 import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
 import PlaceEditorSurface from './PlaceEditorSurface.vue';
 import AreaEditorSurface from './AreaEditorSurface.vue';
 import RegionEditorSurface from './RegionEditorSurface.vue';
 import RegionPlaceList from './RegionPlaceList.vue';
-import { buildAreaCreateTarget, buildAreaEditTarget, buildPlaceCreateTarget, buildPlaceEditTarget, buildRegionCreateTarget, buildRegionEditTarget, areaDraftKey, placeDraftKey, regionDraftKey } from './regionPlaceEditorTargets';
+import { buildPlaceCreateTarget, buildPlaceEditTarget, buildRegionCreateTarget, buildRegionEditTarget, areaDraftKey, placeDraftKey, regionDraftKey } from './regionPlaceEditorTargets';
 import { buildAreaRequest, buildPlaceRequest, buildRegionRequest, emptyAreaDraft, emptyPlaceDraft, emptyRegionDraft, toAreaDraft, toPlaceDraft, toRegionDraft, withoutRegionId } from './regionPlaceDrafts';
-import { beginAreaPolygonMapWork, stopAreaPolygonEdit, type AreaPolygonEditor, type AreaPolygonMapWorkState } from './areaPolygonMapWork';
+import { stopAreaPolygonEdit, type AreaPolygonEditor, type AreaPolygonMapWorkState } from './areaPolygonMapWork';
+import { useAreaEditorActions } from './areaEditorActions';
 import { beginPlaceCoordinateMapWork, stopPlaceCoordinatePick, type PlaceCoordinateMapWorkState, type PlaceCoordinatePicker } from './placeCoordinateMapWork';
 import { useEditorMutationFeedback } from './useEditorMutationFeedback';
 import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
@@ -144,6 +145,26 @@ const { applyError, fieldErrors, formSummaryErrors, markSaved, resetFeedback, sa
   areaFields,
   placeFields,
   regionFields
+});
+const { cancelAreaDraft, deleteDraftArea, drawAreaPolygon, openAreaCreate, openAreaEdit, reorderAreas, resetAreaDraft, saveAreaDraft } = useAreaEditorActions({
+  activeArea,
+  activeAreaTarget,
+  applyError,
+  areaCreateBaselineRequest,
+  areaDraft,
+  areaPolygonMapWork,
+  clearAllDraftsAndBaselines,
+  clearRegionPlaceBaselines,
+  clearRegionPlaceDrafts,
+  confirmDiscard,
+  emit,
+  isDirty,
+  isOrdering,
+  isSaving,
+  markSaved,
+  props,
+  resetFeedback,
+  restoreRegionOrder
 });
 
 watch(
@@ -335,23 +356,6 @@ const openPlaceCreate = async (region: EditorRegion): Promise<void> => {
   resetFeedback();
 };
 
-const openAreaCreate = async (region: EditorRegion): Promise<void> => {
-  const target = buildAreaCreateTarget(region);
-  const isAlreadyActive = props.editorSurface.isTargetActive(target);
-  if (region.isShadow || !props.state.permissions.canEditAreas || !region.capabilities.canAddChildren || !(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
-    return;
-  }
-
-  Object.assign(draft, emptyRegionDraft());
-  Object.assign(placeDraft, emptyPlaceDraft());
-  Object.assign(areaDraft, emptyAreaDraft(region.id, props.state.options.areaDefaults.fillHex));
-  areaDraft.name = props.state.options.areaDefaults.name || 'Area';
-  regionCreateBaselineRequest.value = null;
-  placeCreateBaselineRequest.value = null;
-  areaCreateBaselineRequest.value = buildAreaRequest(areaDraft);
-  resetFeedback();
-};
-
 const openPlaceEdit = async (place: EditorPlace): Promise<void> => {
   const target = buildPlaceEditTarget(place, props.state.regionsById[place.regionId]?.name);
   const isAlreadyActive = props.editorSurface.isTargetActive(target);
@@ -362,22 +366,6 @@ const openPlaceEdit = async (place: EditorPlace): Promise<void> => {
   Object.assign(draft, emptyRegionDraft());
   Object.assign(placeDraft, toPlaceDraft(place, place.regionId));
   Object.assign(areaDraft, emptyAreaDraft());
-  regionCreateBaselineRequest.value = null;
-  placeCreateBaselineRequest.value = null;
-  areaCreateBaselineRequest.value = null;
-  resetFeedback();
-};
-
-const openAreaEdit = async (area: EditorArea): Promise<void> => {
-  const target = buildAreaEditTarget(area, props.state.regionsById[area.regionId]?.name);
-  const isAlreadyActive = props.editorSurface.isTargetActive(target);
-  if (!area.capabilities.canEdit || !(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
-    return;
-  }
-
-  Object.assign(draft, emptyRegionDraft());
-  Object.assign(placeDraft, emptyPlaceDraft());
-  Object.assign(areaDraft, toAreaDraft(area, area.regionId, props.state.options.areaDefaults.fillHex));
   regionCreateBaselineRequest.value = null;
   placeCreateBaselineRequest.value = null;
   areaCreateBaselineRequest.value = null;
@@ -426,8 +414,6 @@ const savePlaceDraft = async (): Promise<void> => {
 };
 
 const pickPlaceCoordinate = (): void => beginPlaceCoordinateMapWork(placeDraft, props.editorSurface, props.coordinatePicker, placeCoordinateMapWork);
-
-const drawAreaPolygon = (): void => beginAreaPolygonMapWork(areaDraft, props.editorSurface, props.polygonEditor, areaPolygonMapWork);
 
 const deleteDraftPlace = async (): Promise<void> => {
   if (!activePlace.value) {
@@ -496,110 +482,6 @@ async function reorderPlaces(regionId: Guid, ids: Guid[], previousIds: Guid[]): 
   }
 }
 
-const resetAreaDraft = (): void => {
-  if (!areaDraft.id) {
-    const regionId = areaDraft.regionId;
-    Object.assign(areaDraft, emptyAreaDraft(regionId, props.state.options.areaDefaults.fillHex));
-    areaDraft.name = props.state.options.areaDefaults.name || 'Area';
-  } else {
-    Object.assign(areaDraft, toAreaDraft(activeArea.value, areaDraft.regionId, props.state.options.areaDefaults.fillHex));
-  }
-  resetFeedback();
-};
-
-const cancelAreaDraft = async (): Promise<void> => {
-  await props.editorSurface.closeActiveTarget('Discard unsaved area changes?');
-};
-
-const saveAreaDraft = async (): Promise<void> => {
-  if (!areaDraft.regionId) {
-    return;
-  }
-
-  isSaving.value = true;
-  resetFeedback();
-  try {
-    const request = buildAreaRequest(areaDraft);
-    const result = areaDraft.id
-      ? await updateArea(props.editorEndpoint, areaDraft.id, props.antiforgeryToken, request)
-      : await createArea(props.editorEndpoint, areaDraft.regionId, props.antiforgeryToken, request);
-    emit('mutationApplied', result as EditorMutationResult<unknown>);
-    Object.assign(areaDraft, toAreaDraft(result.data, result.data.regionId, props.state.options.areaDefaults.fillHex));
-    areaCreateBaselineRequest.value = null;
-    props.editorSurface.replaceActiveTarget(activeAreaTarget.value);
-    markSaved();
-  } catch (error) {
-    applyError(error, 'Area save failed.');
-  } finally {
-    isSaving.value = false;
-  }
-};
-
-const deleteDraftArea = async (): Promise<void> => {
-  if (!activeArea.value) {
-    return;
-  }
-
-  if (!(await confirmDiscard('Discard unsaved area draft changes before deleting?'))) {
-    return;
-  }
-
-  if (!(await confirm({
-    title: 'Delete area?',
-    message: 'Delete this area?',
-    confirmLabel: 'Delete',
-    cancelLabel: 'Keep area',
-    variant: 'danger'
-  }))) {
-    return;
-  }
-
-  isSaving.value = true;
-  resetFeedback();
-  try {
-    const deletedTarget = activeAreaTarget.value;
-    const result = await deleteArea(props.editorEndpoint, activeArea.value.id, props.antiforgeryToken);
-    emit('mutationApplied', result as EditorMutationResult<unknown>);
-    Object.assign(areaDraft, emptyAreaDraft());
-    areaCreateBaselineRequest.value = null;
-    props.editorSurface.clearActiveTarget(deletedTarget);
-    markSaved();
-  } catch (error) {
-    applyError(error, 'Area delete failed.');
-  } finally {
-    isSaving.value = false;
-  }
-};
-
-async function reorderAreas(regionId: Guid, ids: Guid[], previousIds: Guid[]): Promise<void> {
-  if (isDirty.value && !(await confirmDiscard('Discard unsaved draft changes before reordering areas?'))) {
-    await restoreRegionOrder(previousIds);
-    return;
-  }
-
-  if (isDirty.value) {
-    Object.assign(draft, emptyRegionDraft());
-    Object.assign(placeDraft, emptyPlaceDraft());
-    Object.assign(areaDraft, emptyAreaDraft());
-    regionCreateBaselineRequest.value = null;
-    placeCreateBaselineRequest.value = null;
-    areaCreateBaselineRequest.value = null;
-  }
-
-  isOrdering.value = true;
-  resetFeedback();
-  try {
-    const result = await orderAreas(props.editorEndpoint, regionId, props.antiforgeryToken, { areaIds: ids });
-    emit('mutationApplied', result as EditorMutationResult<unknown>);
-    markSaved();
-  } catch (error) {
-    applyError(error, 'Area reorder failed.');
-    await restoreRegionOrder(previousIds);
-  } finally {
-    isOrdering.value = false;
-  }
-}
-
 /// Rebuilds the Sortable-mutated list from persisted Vue state after canceled or failed reorder.
 async function restoreRegionOrder(_previousIds: string[]): Promise<void> {
   regionListKey.value += 1;
@@ -632,6 +514,23 @@ function activeContextRegions(): EditorRegion[] {
   }
 
   return regions;
+}
+
+function clearRegionPlaceDrafts(): void {
+  Object.assign(draft, emptyRegionDraft());
+  Object.assign(placeDraft, emptyPlaceDraft());
+}
+
+function clearRegionPlaceBaselines(): void {
+  regionCreateBaselineRequest.value = null;
+  placeCreateBaselineRequest.value = null;
+}
+
+function clearAllDraftsAndBaselines(): void {
+  clearRegionPlaceDrafts();
+  Object.assign(areaDraft, emptyAreaDraft());
+  clearRegionPlaceBaselines();
+  areaCreateBaselineRequest.value = null;
 }
 
 function cloneIdRecord(record: Record<Guid, Guid[]>): Record<Guid, Guid[]> {

--- a/ClientApps/trip-editor/src/components/RegionPlaceList.vue
+++ b/ClientApps/trip-editor/src/components/RegionPlaceList.vue
@@ -12,6 +12,7 @@ declare global {
 
 const props = defineProps<{
   activePlaceId: Guid | null;
+  activeAreaId: Guid | null;
   activeRegionId: Guid | null;
   areaIdsByRegionId: Record<Guid, Guid[]>;
   forceExpandedRegionIds: Set<Guid>;
@@ -25,8 +26,11 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   addPlace: [region: EditorRegion];
+  addArea: [region: EditorRegion];
+  editArea: [area: EditorArea];
   editPlace: [place: EditorPlace];
   editRegion: [region: EditorRegion];
+  areaReorder: [regionId: Guid, ids: Guid[], previousIds: Guid[]];
   placeReorder: [regionId: Guid, ids: Guid[], previousIds: Guid[]];
   regionReorder: [ids: Guid[], previousIds: Guid[]];
 }>();
@@ -35,12 +39,14 @@ const regionList = ref<HTMLElement | null>(null);
 const collapsedRegionIds = ref<Set<Guid>>(new Set());
 const searchCollapsedSnapshot = ref<Set<Guid> | null>(null);
 const placeSortables = new Map<string, { destroy: () => void }>();
+const areaSortables = new Map<string, { destroy: () => void }>();
 let sortable: { destroy: () => void } | null = null;
 let reorderSnapshotIds: Guid[] | null = null;
 let placeReorderSnapshot: { regionId: Guid; ids: Guid[] } | null = null;
+let areaReorderSnapshot: { regionId: Guid; ids: Guid[] } | null = null;
 
 watch(
-  () => `${props.searchActive}|${props.regions.map(region => region.id).join('|')}|${Object.entries(props.placeIdsByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}`,
+  () => `${props.searchActive}|${props.regions.map(region => region.id).join('|')}|${Object.entries(props.placeIdsByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}|${Object.entries(props.areaIdsByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}`,
   async () => {
     await nextTick();
     attachSortables();
@@ -67,11 +73,13 @@ onMounted(attachSortables);
 onUnmounted(() => {
   sortable?.destroy();
   destroyPlaceSortables();
+  destroyAreaSortables();
 });
 
 function attachSortables(): void {
   attachRegionSortable();
   attachPlaceSortables();
+  attachAreaSortables();
 }
 
 function attachRegionSortable(): void {
@@ -135,6 +143,38 @@ function destroyPlaceSortables(): void {
   placeSortables.clear();
 }
 
+function attachAreaSortables(): void {
+  destroyAreaSortables();
+  if (props.searchActive || !window.Sortable) {
+    return;
+  }
+
+  document.querySelectorAll<HTMLElement>('[data-area-list-region-id]').forEach(element => {
+    const regionId = element.dataset.areaListRegionId!;
+    areaSortables.set(regionId, window.Sortable!.create(element, {
+      animation: 150,
+      draggable: '.trip-editor-area-row',
+      handle: '.trip-editor-area-drag-handle',
+      onStart: () => {
+        areaReorderSnapshot = { regionId, ids: [...(props.state.areaOrderByRegionId[regionId] ?? [])] };
+      },
+      onEnd: () => {
+        const previousIds = areaReorderSnapshot?.ids ?? [...(props.state.areaOrderByRegionId[regionId] ?? [])];
+        areaReorderSnapshot = null;
+        const ids = Array.from(element.querySelectorAll<HTMLElement>('[data-area-id]')).map(row => row.dataset.areaId!);
+        if (ids.join('|') !== previousIds.join('|')) {
+          emit('areaReorder', regionId, ids, previousIds);
+        }
+      }
+    }));
+  });
+}
+
+function destroyAreaSortables(): void {
+  areaSortables.forEach(instance => instance.destroy());
+  areaSortables.clear();
+}
+
 function normalRegionIds(): Guid[] {
   return props.regions.filter(region => !region.isShadow).map(region => region.id);
 }
@@ -145,6 +185,10 @@ function orderedPlaces(regionId: Guid): EditorPlace[] {
 
 function orderedAreas(regionId: Guid): EditorArea[] {
   return (props.areaIdsByRegionId[regionId] ?? []).map(id => props.state.areasById[id]).filter(Boolean) as EditorArea[];
+}
+
+function canAddArea(region: EditorRegion): boolean {
+  return props.state.permissions.canEditAreas && !region.isShadow && region.capabilities.canAddChildren;
 }
 
 function isCollapsed(regionId: Guid): boolean {
@@ -242,15 +286,44 @@ function toggleRegion(regionId: Guid): void {
             <slot name="place-editor" :place="place"></slot>
           </li>
         </template>
-        <li v-for="area in orderedAreas(region.id)" :key="area.id">
-          <span>{{ area.name }}</span>
-          <small>Area</small>
+        <li v-if="orderedAreas(region.id).length > 0" class="trip-editor-child-section">
+          <span>Areas</span>
+        </li>
+        <li v-show="!isCollapsed(region.id)" :data-area-list-region-id="region.id" class="trip-editor-area-list">
+          <template v-for="area in orderedAreas(region.id)" :key="area.id">
+            <div
+              class="trip-editor-area-row"
+              :class="{ 'trip-editor-area-row--active': props.activeAreaId === area.id }"
+              :data-area-id="area.id"
+            >
+              <button
+                v-if="!region.isShadow"
+                type="button"
+                class="trip-editor-icon-button trip-editor-area-drag-handle"
+                title="Drag to reorder area"
+                aria-label="Drag to reorder area"
+                :disabled="props.searchActive || props.isOrdering"
+              >
+                <span aria-hidden="true">::</span>
+              </button>
+              <span>{{ area.name }}</span>
+              <small>Area</small>
+              <button type="button" class="btn btn-outline-light btn-sm" :disabled="props.isSaving || props.isOrdering" @click="emit('editArea', area)">Edit</button>
+            </div>
+            <div v-if="props.activeAreaId === area.id" class="trip-editor-place-editor-row" aria-live="polite">
+              <slot name="area-editor" :area="area"></slot>
+            </div>
+          </template>
         </li>
       </ul>
       <button v-if="!region.isShadow" type="button" class="btn btn-outline-light btn-sm" :disabled="props.isSaving || props.isOrdering" @click="emit('addPlace', region)">
         Add Place
       </button>
+      <button v-if="canAddArea(region)" type="button" class="btn btn-outline-light btn-sm" :disabled="props.isSaving || props.isOrdering" @click="emit('addArea', region)">
+        Add Area
+      </button>
       <slot name="add-place-editor" :region="region"></slot>
+      <slot name="add-area-editor" :region="region"></slot>
     </article>
   </div>
 </template>

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -4,7 +4,7 @@ import type { EditorArea, EditorMutationResult, EditorPlace, EditorRegion, Edito
 import type { EditorSurfaceController } from '../composables/useEditorSurface';
 import MetadataEditor from './MetadataEditor.vue';
 import RegionManager from './RegionManager.vue';
-import type { CoordinatePickOptions } from '../map/leafletAdapter';
+import type { AreaPolygonWorkOptions, CoordinatePickOptions } from '../map/leafletAdapter';
 
 type SidebarSearchResult = {
   hasMatches: boolean;
@@ -21,6 +21,7 @@ const props = defineProps<{
   tripIndexUrl: string;
   hasRegionDraftChanges: boolean;
   coordinatePicker: { startCoordinatePick: (options: CoordinatePickOptions) => () => void };
+  polygonEditor: { startAreaPolygonWork: (options: AreaPolygonWorkOptions) => () => void };
 }>();
 
 const emit = defineEmits<{
@@ -176,6 +177,7 @@ function normalize(value: string): string {
       :editor-endpoint="editorEndpoint"
       :antiforgery-token="antiforgeryToken"
       :coordinate-picker="coordinatePicker"
+      :polygon-editor="polygonEditor"
       :search-active="isSearchActive"
       :search-regions="sidebarSearch.regions"
       :search-place-ids-by-region-id="sidebarSearch.placesByRegionId"

--- a/ClientApps/trip-editor/src/components/areaEditorActions.ts
+++ b/ClientApps/trip-editor/src/components/areaEditorActions.ts
@@ -1,0 +1,136 @@
+import { createArea, deleteArea, orderAreas, updateArea } from '../api/tripEditorApi';
+import type { EditorMutationResult, EditorArea, EditorRegion, Guid } from '../types';
+import { buildAreaCreateTarget, buildAreaEditTarget } from './regionPlaceEditorTargets';
+import { buildAreaRequest, emptyAreaDraft, toAreaDraft } from './regionPlaceDrafts';
+import { beginAreaPolygonMapWork } from './areaPolygonMapWork';
+import { confirm } from '../composables/useConfirmDialog';
+
+/// Coordinates area-specific editor actions while RegionManager owns shared draft state.
+export function useAreaEditorActions(context: any) {
+  const openAreaCreate = async (region: EditorRegion): Promise<void> => {
+    const target = buildAreaCreateTarget(region);
+    const isAlreadyActive = context.props.editorSurface.isTargetActive(target);
+    if (region.isShadow || !context.props.state.permissions.canEditAreas || !region.capabilities.canAddChildren || !(await context.props.editorSurface.activateTarget(target)) || isAlreadyActive) {
+      return;
+    }
+
+    context.clearRegionPlaceDrafts();
+    Object.assign(context.areaDraft, emptyAreaDraft(region.id, context.props.state.options.areaDefaults.fillHex));
+    context.areaDraft.name = context.props.state.options.areaDefaults.name || 'Area';
+    context.clearRegionPlaceBaselines();
+    context.areaCreateBaselineRequest.value = buildAreaRequest(context.areaDraft);
+    context.resetFeedback();
+  };
+
+  const openAreaEdit = async (area: EditorArea): Promise<void> => {
+    const target = buildAreaEditTarget(area, context.props.state.regionsById[area.regionId]?.name);
+    const isAlreadyActive = context.props.editorSurface.isTargetActive(target);
+    if (!area.capabilities.canEdit || !(await context.props.editorSurface.activateTarget(target)) || isAlreadyActive) {
+      return;
+    }
+
+    context.clearRegionPlaceDrafts();
+    Object.assign(context.areaDraft, toAreaDraft(area, area.regionId, context.props.state.options.areaDefaults.fillHex));
+    context.clearRegionPlaceBaselines();
+    context.areaCreateBaselineRequest.value = null;
+    context.resetFeedback();
+  };
+
+  const resetAreaDraft = (): void => {
+    if (!context.areaDraft.id) {
+      Object.assign(context.areaDraft, emptyAreaDraft(context.areaDraft.regionId, context.props.state.options.areaDefaults.fillHex));
+      context.areaDraft.name = context.props.state.options.areaDefaults.name || 'Area';
+    } else {
+      Object.assign(context.areaDraft, toAreaDraft(context.activeArea.value, context.areaDraft.regionId, context.props.state.options.areaDefaults.fillHex));
+    }
+    context.resetFeedback();
+  };
+
+  const cancelAreaDraft = async (): Promise<void> => {
+    await context.props.editorSurface.closeActiveTarget('Discard unsaved area changes?');
+  };
+
+  const saveAreaDraft = async (): Promise<void> => {
+    if (!context.areaDraft.regionId) {
+      return;
+    }
+
+    context.isSaving.value = true;
+    context.resetFeedback();
+    try {
+      const request = buildAreaRequest(context.areaDraft);
+      const result = context.areaDraft.id
+        ? await updateArea(context.props.editorEndpoint, context.areaDraft.id, context.props.antiforgeryToken, request)
+        : await createArea(context.props.editorEndpoint, context.areaDraft.regionId, context.props.antiforgeryToken, request);
+      context.emit('mutationApplied', result as EditorMutationResult<unknown>);
+      Object.assign(context.areaDraft, toAreaDraft(result.data, result.data.regionId, context.props.state.options.areaDefaults.fillHex));
+      context.areaCreateBaselineRequest.value = null;
+      context.props.editorSurface.replaceActiveTarget(context.activeAreaTarget.value);
+      context.markSaved();
+    } catch (error) {
+      context.applyError(error, 'Area save failed.');
+    } finally {
+      context.isSaving.value = false;
+    }
+  };
+
+  const deleteDraftArea = async (): Promise<void> => {
+    if (!context.activeArea.value || !(await context.confirmDiscard('Discard unsaved area draft changes before deleting?'))) {
+      return;
+    }
+
+    if (!(await confirm({
+      title: 'Delete area?',
+      message: 'Delete this area?',
+      confirmLabel: 'Delete',
+      cancelLabel: 'Keep area',
+      variant: 'danger'
+    }))) {
+      return;
+    }
+
+    context.isSaving.value = true;
+    context.resetFeedback();
+    try {
+      const deletedTarget = context.activeAreaTarget.value;
+      const result = await deleteArea(context.props.editorEndpoint, context.activeArea.value.id, context.props.antiforgeryToken);
+      context.emit('mutationApplied', result as EditorMutationResult<unknown>);
+      Object.assign(context.areaDraft, emptyAreaDraft());
+      context.areaCreateBaselineRequest.value = null;
+      context.props.editorSurface.clearActiveTarget(deletedTarget);
+      context.markSaved();
+    } catch (error) {
+      context.applyError(error, 'Area delete failed.');
+    } finally {
+      context.isSaving.value = false;
+    }
+  };
+
+  const reorderAreas = async (regionId: Guid, ids: Guid[], previousIds: Guid[]): Promise<void> => {
+    if (context.isDirty.value && !(await context.confirmDiscard('Discard unsaved draft changes before reordering areas?'))) {
+      await context.restoreRegionOrder(previousIds);
+      return;
+    }
+
+    if (context.isDirty.value) {
+      context.clearAllDraftsAndBaselines();
+    }
+
+    context.isOrdering.value = true;
+    context.resetFeedback();
+    try {
+      const result = await orderAreas(context.props.editorEndpoint, regionId, context.props.antiforgeryToken, { areaIds: ids });
+      context.emit('mutationApplied', result as EditorMutationResult<unknown>);
+      context.markSaved();
+    } catch (error) {
+      context.applyError(error, 'Area reorder failed.');
+      await context.restoreRegionOrder(previousIds);
+    } finally {
+      context.isOrdering.value = false;
+    }
+  };
+
+  const drawAreaPolygon = (): void => beginAreaPolygonMapWork(context.areaDraft, context.props.editorSurface, context.props.polygonEditor, context.areaPolygonMapWork);
+
+  return { cancelAreaDraft, deleteDraftArea, drawAreaPolygon, openAreaCreate, openAreaEdit, reorderAreas, resetAreaDraft, saveAreaDraft };
+}

--- a/ClientApps/trip-editor/src/components/areaPolygonMapWork.ts
+++ b/ClientApps/trip-editor/src/components/areaPolygonMapWork.ts
@@ -1,0 +1,89 @@
+import type { EditorSurfaceController } from '../composables/useEditorSurface';
+import type { AreaPolygonWorkOptions } from '../map/leafletAdapter';
+import type { EditorAreaDraft, GeoJsonPolygon } from '../types';
+
+export type AreaPolygonEditor = {
+  startAreaPolygonWork: (options: AreaPolygonWorkOptions) => () => void;
+};
+
+type AreaGeometrySnapshot = {
+  geometry: GeoJsonPolygon | null;
+};
+
+export type AreaPolygonMapWorkState = {
+  geometry: GeoJsonPolygon | null;
+  stopEdit: (() => void) | null;
+};
+
+/// Starts polygon-only map-work for the active area draft.
+export function beginAreaPolygonMapWork(
+  draft: EditorAreaDraft,
+  editorSurface: EditorSurfaceController,
+  polygonEditor: AreaPolygonEditor,
+  state: AreaPolygonMapWorkState
+): void {
+  const snapshot = snapshotAreaGeometry(draft);
+  state.geometry = cloneGeometry(snapshot.geometry);
+  stopAreaPolygonEdit(state);
+  state.stopEdit = polygonEditor.startAreaPolygonWork({
+    initialGeometry: state.geometry,
+    fillHex: draft.fillHex || '#ff6600',
+    onChanged: geometry => {
+      state.geometry = cloneGeometry(geometry);
+    }
+  });
+
+  const entered = editorSurface.enterMapWork({
+    modeName: 'Draw area polygon',
+    instruction: 'Click the map to place polygon vertices.',
+    statusText: () => areaPolygonStatus(state.geometry),
+    canFinish: () => hasValidPolygon(state.geometry),
+    isDirty: () => !sameGeometry(state.geometry, snapshot.geometry),
+    snapshot: () => snapshot,
+    rollback: rollbackSnapshot => {
+      restoreAreaGeometry(draft, state, rollbackSnapshot as AreaGeometrySnapshot);
+    },
+    done: () => {
+      draft.geometry = cloneGeometry(state.geometry);
+      stopAreaPolygonEdit(state);
+    },
+    cancel: () => {
+      stopAreaPolygonEdit(state);
+    }
+  });
+  if (!entered) {
+    stopAreaPolygonEdit(state);
+  }
+}
+
+/// Clears any active adapter-owned temporary polygon/listener.
+export function stopAreaPolygonEdit(state: AreaPolygonMapWorkState): void {
+  state.stopEdit?.();
+  state.stopEdit = null;
+}
+
+function snapshotAreaGeometry(draft: EditorAreaDraft): AreaGeometrySnapshot {
+  return { geometry: cloneGeometry(draft.geometry) };
+}
+
+function restoreAreaGeometry(draft: EditorAreaDraft, state: AreaPolygonMapWorkState, snapshot: AreaGeometrySnapshot): void {
+  draft.geometry = cloneGeometry(snapshot.geometry);
+  state.geometry = cloneGeometry(snapshot.geometry);
+}
+
+function hasValidPolygon(geometry: GeoJsonPolygon | null): boolean {
+  return Boolean(geometry?.coordinates?.[0] && geometry.coordinates[0].length >= 4);
+}
+
+function sameGeometry(left: GeoJsonPolygon | null, right: GeoJsonPolygon | null): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function areaPolygonStatus(geometry: GeoJsonPolygon | null): string {
+  const vertices = Math.max(0, (geometry?.coordinates?.[0]?.length ?? 1) - 1);
+  return vertices >= 3 ? `${vertices} vertices ready` : 'No polygon ready';
+}
+
+function cloneGeometry<T>(geometry: T): T {
+  return geometry ? JSON.parse(JSON.stringify(geometry)) as T : geometry;
+}

--- a/ClientApps/trip-editor/src/components/placeEditorActions.ts
+++ b/ClientApps/trip-editor/src/components/placeEditorActions.ts
@@ -1,0 +1,155 @@
+import { createPlace, deletePlace, orderPlaces, updatePlace } from '../api/tripEditorApi';
+import type { EditorMutationResult, EditorPlace, EditorRegion, Guid } from '../types';
+import { confirm } from '../composables/useConfirmDialog';
+import { buildPlaceCreateTarget, buildPlaceEditTarget } from './regionPlaceEditorTargets';
+import { buildPlaceRequest, emptyAreaDraft, emptyPlaceDraft, emptyRegionDraft, toPlaceDraft, withoutRegionId } from './regionPlaceDrafts';
+import { beginPlaceCoordinateMapWork } from './placeCoordinateMapWork';
+
+/// Coordinates place-specific editor actions while RegionManager owns shared draft state.
+export function usePlaceEditorActions(context: any) {
+  const openPlaceCreate = async (region: EditorRegion): Promise<void> => {
+    const target = buildPlaceCreateTarget(region);
+    const isAlreadyActive = context.props.editorSurface.isTargetActive(target);
+    if (region.isShadow || !(await context.props.editorSurface.activateTarget(target)) || isAlreadyActive) {
+      return;
+    }
+
+    Object.assign(context.draft, emptyRegionDraft());
+    Object.assign(context.placeDraft, emptyPlaceDraft(region.id));
+    Object.assign(context.areaDraft, emptyAreaDraft());
+    context.placeDraft.name = 'New Place';
+    context.placeDraft.iconName = context.props.state.options.iconNames[0] ?? 'marker';
+    context.placeDraft.markerColor = context.props.state.options.markerColorClasses[0] ?? 'bg-blue';
+    context.regionCreateBaselineRequest.value = null;
+    context.placeCreateBaselineRequest.value = buildPlaceRequest(context.placeDraft);
+    context.areaCreateBaselineRequest.value = null;
+    context.resetFeedback();
+  };
+
+  const openPlaceEdit = async (place: EditorPlace): Promise<void> => {
+    const target = buildPlaceEditTarget(place, context.props.state.regionsById[place.regionId]?.name);
+    const isAlreadyActive = context.props.editorSurface.isTargetActive(target);
+    if (!place.capabilities.canEdit || !(await context.props.editorSurface.activateTarget(target)) || isAlreadyActive) {
+      return;
+    }
+
+    Object.assign(context.draft, emptyRegionDraft());
+    Object.assign(context.placeDraft, toPlaceDraft(place, place.regionId));
+    Object.assign(context.areaDraft, emptyAreaDraft());
+    context.regionCreateBaselineRequest.value = null;
+    context.placeCreateBaselineRequest.value = null;
+    context.areaCreateBaselineRequest.value = null;
+    context.resetFeedback();
+  };
+
+  const resetPlaceDraft = (): void => {
+    if (!context.placeDraft.id) {
+      const regionId = context.placeDraft.regionId;
+      Object.assign(context.placeDraft, emptyPlaceDraft(regionId));
+      context.placeDraft.name = 'New Place';
+      context.placeDraft.iconName = context.props.state.options.iconNames[0] ?? 'marker';
+      context.placeDraft.markerColor = context.props.state.options.markerColorClasses[0] ?? 'bg-blue';
+    } else {
+      Object.assign(context.placeDraft, toPlaceDraft(context.activePlace.value, context.placeDraft.regionId));
+    }
+    context.resetFeedback();
+  };
+
+  const cancelPlaceDraft = async (): Promise<void> => {
+    await context.props.editorSurface.closeActiveTarget('Discard unsaved place changes?');
+  };
+
+  const savePlaceDraft = async (): Promise<void> => {
+    if (!context.placeDraft.regionId) {
+      return;
+    }
+
+    context.isSaving.value = true;
+    context.resetFeedback();
+    try {
+      const request = buildPlaceRequest(context.placeDraft);
+      const result = context.placeDraft.id
+        ? await updatePlace(context.props.editorEndpoint, context.placeDraft.id, context.props.antiforgeryToken, request)
+        : await createPlace(context.props.editorEndpoint, context.placeDraft.regionId, context.props.antiforgeryToken, withoutRegionId(request));
+      context.emit('mutationApplied', result as EditorMutationResult<unknown>);
+      Object.assign(context.placeDraft, toPlaceDraft(result.data, result.data.regionId));
+      context.placeCreateBaselineRequest.value = null;
+      context.props.editorSurface.replaceActiveTarget(context.activePlaceTarget.value);
+      context.markSaved(result.warnings.map((warning: { message: string }) => warning.message));
+    } catch (error) {
+      context.applyError(error, 'Place save failed.');
+    } finally {
+      context.isSaving.value = false;
+    }
+  };
+
+  const pickPlaceCoordinate = (): void => beginPlaceCoordinateMapWork(
+    context.placeDraft,
+    context.props.editorSurface,
+    context.props.coordinatePicker,
+    context.placeCoordinateMapWork);
+
+  const deleteDraftPlace = async (): Promise<void> => {
+    if (!context.activePlace.value) {
+      return;
+    }
+
+    if (!(await context.confirmDiscard('Discard unsaved place draft changes before deleting?'))) {
+      return;
+    }
+
+    if (!(await confirm({
+      title: 'Delete place?',
+      message: 'Delete this place and any segments connected to it?',
+      confirmLabel: 'Delete',
+      cancelLabel: 'Keep place',
+      variant: 'danger'
+    }))) {
+      return;
+    }
+
+    context.isSaving.value = true;
+    context.resetFeedback();
+    try {
+      const deletedTarget = context.activePlaceTarget.value;
+      const result = await deletePlace(context.props.editorEndpoint, context.activePlace.value.id, context.props.antiforgeryToken);
+      context.emit('mutationApplied', result as EditorMutationResult<unknown>);
+      Object.assign(context.placeDraft, emptyPlaceDraft());
+      Object.assign(context.areaDraft, emptyAreaDraft());
+      context.placeCreateBaselineRequest.value = null;
+      context.areaCreateBaselineRequest.value = null;
+      context.props.editorSurface.clearActiveTarget(deletedTarget);
+      context.markSaved();
+    } catch (error) {
+      context.applyError(error, 'Place delete failed.');
+    } finally {
+      context.isSaving.value = false;
+    }
+  };
+
+  const reorderPlaces = async (regionId: Guid, ids: Guid[], previousIds: Guid[]): Promise<void> => {
+    if (context.isDirty.value && !(await context.confirmDiscard('Discard unsaved draft changes before reordering places?'))) {
+      await context.restoreRegionOrder(previousIds);
+      return;
+    }
+
+    if (context.isDirty.value) {
+      context.clearAllDraftsAndBaselines();
+    }
+
+    context.isOrdering.value = true;
+    context.resetFeedback();
+    try {
+      const result = await orderPlaces(context.props.editorEndpoint, regionId, context.props.antiforgeryToken, { placeIds: ids });
+      context.emit('mutationApplied', result as EditorMutationResult<unknown>);
+      context.markSaved();
+    } catch (error) {
+      context.applyError(error, 'Place reorder failed.');
+      await context.restoreRegionOrder(previousIds);
+    } finally {
+      context.isOrdering.value = false;
+    }
+  };
+
+  return { cancelPlaceDraft, deleteDraftPlace, openPlaceCreate, openPlaceEdit, pickPlaceCoordinate, reorderPlaces, resetPlaceDraft, savePlaceDraft };
+}

--- a/ClientApps/trip-editor/src/components/regionEditorActions.ts
+++ b/ClientApps/trip-editor/src/components/regionEditorActions.ts
@@ -1,0 +1,138 @@
+import { createRegion, deleteRegion, orderRegions, updateRegion } from '../api/tripEditorApi';
+import type { EditorMutationResult, EditorRegion, EditorRegionSaveRequest, Guid } from '../types';
+import { confirm } from '../composables/useConfirmDialog';
+import { buildRegionCreateTarget, buildRegionEditTarget } from './regionPlaceEditorTargets';
+import { buildRegionRequest, emptyAreaDraft, emptyPlaceDraft, emptyRegionDraft, toRegionDraft } from './regionPlaceDrafts';
+
+/// Coordinates region-specific editor actions while RegionManager owns shared draft state.
+export function useRegionEditorActions(context: any) {
+  const openCreate = async (): Promise<void> => {
+    const target = buildRegionCreateTarget();
+    const isAlreadyActive = context.props.editorSurface.isTargetActive(target);
+    if (!(await context.props.editorSurface.activateTarget(target)) || isAlreadyActive) {
+      return;
+    }
+
+    Object.assign(context.draft, emptyRegionDraft());
+    Object.assign(context.placeDraft, emptyPlaceDraft());
+    Object.assign(context.areaDraft, emptyAreaDraft());
+    context.draft.name = 'New Region';
+    context.regionCreateBaselineRequest.value = buildRegionRequest(context.draft);
+    context.placeCreateBaselineRequest.value = null;
+    context.areaCreateBaselineRequest.value = null;
+    context.resetFeedback();
+  };
+
+  const openEdit = async (region: EditorRegion): Promise<void> => {
+    const target = buildRegionEditTarget(region);
+    const isAlreadyActive = context.props.editorSurface.isTargetActive(target);
+    if (!region.capabilities.canEdit || !(await context.props.editorSurface.activateTarget(target)) || isAlreadyActive) {
+      return;
+    }
+
+    Object.assign(context.placeDraft, emptyPlaceDraft());
+    Object.assign(context.areaDraft, emptyAreaDraft());
+    Object.assign(context.draft, toRegionDraft(region));
+    context.regionCreateBaselineRequest.value = null;
+    context.placeCreateBaselineRequest.value = null;
+    context.areaCreateBaselineRequest.value = null;
+    context.resetFeedback();
+  };
+
+  const resetDraft = (): void => {
+    if (!context.draft.id) {
+      Object.assign(context.draft, emptyRegionDraft());
+      context.draft.name = 'New Region';
+    } else {
+      Object.assign(context.draft, toRegionDraft(context.activeRegion.value));
+    }
+    context.resetFeedback();
+  };
+
+  const cancelDraft = async (): Promise<void> => {
+    await context.props.editorSurface.closeActiveTarget('Discard unsaved region changes?');
+  };
+
+  const saveDraft = async (): Promise<void> => {
+    context.isSaving.value = true;
+    context.resetFeedback();
+
+    try {
+      const request = buildRegionRequest(context.draft);
+      const result = context.draft.id
+        ? await updateRegion(context.props.editorEndpoint, context.draft.id, context.props.antiforgeryToken, request)
+        : await createRegion(context.props.editorEndpoint, context.props.antiforgeryToken, request);
+      context.emit('mutationApplied', result as EditorMutationResult<unknown>);
+      Object.assign(context.draft, toRegionDraft(result.data));
+      context.regionCreateBaselineRequest.value = null;
+      context.props.editorSurface.replaceActiveTarget(context.activeRegionTarget.value);
+      context.markSaved();
+    } catch (error) {
+      context.applyError(error, 'Region save failed.');
+    } finally {
+      context.isSaving.value = false;
+    }
+  };
+
+  const deleteDraftRegion = async (): Promise<void> => {
+    if (!context.activeRegion.value || !context.activeRegion.value.capabilities.canDelete) {
+      return;
+    }
+
+    if (!(await context.confirmDiscard('Discard unsaved region or place draft changes before deleting?'))) {
+      return;
+    }
+
+    if (!(await confirm({
+      title: 'Delete region?',
+      message: 'Delete this region, its child places and areas, and any segments connected to deleted places?',
+      confirmLabel: 'Delete',
+      cancelLabel: 'Keep region',
+      variant: 'danger'
+    }))) {
+      return;
+    }
+
+    context.isSaving.value = true;
+    context.resetFeedback();
+    try {
+      const deletedTarget = context.activeRegionTarget.value;
+      const result = await deleteRegion(context.props.editorEndpoint, context.activeRegion.value.id, context.props.antiforgeryToken);
+      context.emit('mutationApplied', result as EditorMutationResult<unknown>);
+      context.clearAllDraftsAndBaselines();
+      context.props.editorSurface.clearActiveTarget(deletedTarget);
+      context.markSaved();
+    } catch (error) {
+      context.applyError(error, 'Region delete failed.');
+    } finally {
+      context.isSaving.value = false;
+    }
+  };
+
+  const reorderRegions = async (ids: Guid[], previousIds: Guid[]): Promise<void> => {
+    if (context.isDirty.value && !(await context.confirmDiscard('Discard unsaved draft changes before reordering?'))) {
+      await context.restoreRegionOrder(previousIds);
+      return;
+    }
+
+    if (context.isDirty.value) {
+      context.clearAllDraftsAndBaselines();
+    }
+
+    context.isOrdering.value = true;
+    context.resetFeedback();
+    try {
+      const result = await orderRegions(context.props.editorEndpoint, context.props.antiforgeryToken, { regionIds: ids });
+      context.emit('mutationApplied', result as EditorMutationResult<unknown>);
+      Object.assign(context.draft, emptyRegionDraft());
+      context.markSaved();
+    } catch (error) {
+      context.applyError(error, 'Region reorder failed.');
+      await context.restoreRegionOrder(previousIds);
+    } finally {
+      context.isOrdering.value = false;
+    }
+  };
+
+  return { cancelDraft, deleteDraftRegion, openCreate, openEdit, reorderRegions, resetDraft, saveDraft };
+}

--- a/ClientApps/trip-editor/src/components/regionPlaceDrafts.ts
+++ b/ClientApps/trip-editor/src/components/regionPlaceDrafts.ts
@@ -1,4 +1,4 @@
-import type { EditorCoordinate, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest } from '../types';
+import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorCoordinate, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest } from '../types';
 
 export type RegionDraft = {
   id: string | null;
@@ -84,6 +84,38 @@ export function buildPlaceRequest(value: EditorPlaceDraft): EditorPlaceSaveReque
 export function withoutRegionId(request: EditorPlaceSaveRequest): EditorPlaceSaveRequest {
   const { regionId: _regionId, ...createRequest } = request;
   return createRequest;
+}
+
+export function emptyAreaDraft(regionId: string | null = null, fillHex = '#ff6600'): EditorAreaDraft {
+  return { id: null, regionId, name: '', notesHtml: '', fillHex, geometry: null };
+}
+
+export function toAreaDraft(area: EditorArea | null, fallbackRegionId: string | null, fillHex = '#ff6600'): EditorAreaDraft {
+  if (!area) {
+    return emptyAreaDraft(fallbackRegionId, fillHex);
+  }
+
+  return {
+    id: area.id,
+    regionId: area.regionId,
+    name: area.name,
+    notesHtml: area.notesHtml,
+    fillHex: area.fillHex || fillHex,
+    geometry: cloneGeometry(area.geometry)
+  };
+}
+
+export function buildAreaRequest(value: EditorAreaDraft): EditorAreaSaveRequest {
+  return {
+    name: value.name,
+    notesHtml: value.notesHtml,
+    fillHex: value.fillHex,
+    geometry: cloneGeometry(value.geometry)
+  };
+}
+
+function cloneGeometry<T>(geometry: T): T {
+  return geometry ? JSON.parse(JSON.stringify(geometry)) as T : geometry;
 }
 
 function coordinateText(coordinate: EditorCoordinate | null, key: keyof EditorCoordinate): string {

--- a/ClientApps/trip-editor/src/components/regionPlaceEditorTargets.ts
+++ b/ClientApps/trip-editor/src/components/regionPlaceEditorTargets.ts
@@ -1,8 +1,9 @@
 import type { EditorTarget } from '../composables/useEditorSurface';
-import type { EditorPlace, EditorRegion } from '../types';
+import type { EditorArea, EditorPlace, EditorRegion } from '../types';
 
 export const regionDraftKey = 'region-draft';
 export const placeDraftKey = 'place-draft';
+export const areaDraftKey = 'area-draft';
 
 export function buildRegionCreateTarget(): EditorTarget {
   return {
@@ -49,5 +50,30 @@ export function buildPlaceEditTarget(place: EditorPlace, subtitle?: string): Edi
     subtitle,
     entityId: place.id,
     parentRegionId: place.regionId
+  };
+}
+
+export function buildAreaCreateTarget(region: EditorRegion): EditorTarget {
+  return {
+    key: areaDraftKey,
+    identity: `area:add:${region.id}`,
+    kind: 'area',
+    mode: 'add',
+    title: 'Add Area',
+    subtitle: region.name,
+    parentRegionId: region.id
+  };
+}
+
+export function buildAreaEditTarget(area: EditorArea, subtitle?: string): EditorTarget {
+  return {
+    key: areaDraftKey,
+    identity: `area:edit:${area.id}`,
+    kind: 'area',
+    mode: 'edit',
+    title: `Edit Area - ${area.name}`,
+    subtitle,
+    entityId: area.id,
+    parentRegionId: area.regionId
   };
 }

--- a/ClientApps/trip-editor/src/components/useEditorMutationFeedback.ts
+++ b/ClientApps/trip-editor/src/components/useEditorMutationFeedback.ts
@@ -3,9 +3,11 @@ import { EditorValidationError } from '../api/tripEditorApi';
 
 type FeedbackOptions = {
   isDirty: ComputedRef<boolean>;
+  isAreaDraftOpen: ComputedRef<boolean>;
   isOrdering: ComputedRef<boolean>;
   isPlaceDraftOpen: ComputedRef<boolean>;
   isSaving: ComputedRef<boolean>;
+  areaFields: string[];
   placeFields: string[];
   regionFields: string[];
 };
@@ -42,7 +44,7 @@ export function useEditorMutationFeedback(options: FeedbackOptions) {
   });
 
   const formSummaryErrors = computed(() => {
-    const fields = options.isPlaceDraftOpen.value ? options.placeFields : options.regionFields;
+    const fields = options.isAreaDraftOpen.value ? options.areaFields : options.isPlaceDraftOpen.value ? options.placeFields : options.regionFields;
     return Object.entries(validationErrors.value).filter(([key]) => !fields.includes(key)).flatMap(([, messages]) => messages);
   });
 

--- a/ClientApps/trip-editor/src/composables/useEditorSurface.ts
+++ b/ClientApps/trip-editor/src/composables/useEditorSurface.ts
@@ -3,7 +3,7 @@ import { confirm } from './useConfirmDialog';
 import type { Guid } from '../types';
 
 export type EditorSurfaceMode = 'docked' | 'expanded' | 'map-work';
-export type EditorTargetKind = 'metadata' | 'region' | 'place';
+export type EditorTargetKind = 'metadata' | 'region' | 'place' | 'area';
 export type EditorTargetMode = 'edit' | 'add';
 
 export interface EditorTarget {

--- a/ClientApps/trip-editor/src/map/areaPolygonWorkLayer.ts
+++ b/ClientApps/trip-editor/src/map/areaPolygonWorkLayer.ts
@@ -1,0 +1,153 @@
+import L, { type Map as LeafletMap } from 'leaflet';
+import { ensureLeafletDraw } from './leafletDrawPlugin';
+import type { GeoJsonPolygon } from '../types';
+
+export interface AreaPolygonWorkOptions {
+  initialGeometry: GeoJsonPolygon | null;
+  fillHex: string;
+  onChanged: (geometry: GeoJsonPolygon | null) => void;
+}
+
+type DrawnLayerEvent = { layer: L.Layer };
+type LeafletDrawHandler = { disable: () => void; enable: () => void; enabled?: () => boolean };
+
+/// Owns the single temporary Leaflet.Draw polygon used by Trip Editor area map-work.
+export const createAreaPolygonWorkLayer = (map: LeafletMap): {
+  dispose: () => void;
+  start: (options: AreaPolygonWorkOptions) => () => void;
+  stop: () => void;
+} => {
+  ensureLeafletDraw();
+  const featureGroup = L.featureGroup().addTo(map);
+  let drawHandler: LeafletDrawHandler | null = null;
+  let editHandler: LeafletDrawHandler | null = null;
+  let polygon: L.Polygon | null = null;
+  let options: AreaPolygonWorkOptions | null = null;
+
+  const publish = (): void => {
+    options?.onChanged(polygon ? latLngsToPolygon(flattenPolygonLatLngs(polygon)) : null);
+  };
+
+  const stopHandlers = (): void => {
+    drawHandler?.disable();
+    editHandler?.disable();
+    drawHandler = null;
+    editHandler = null;
+    map.off(drawCreatedEvent(), onDrawCreated);
+    map.off(drawEditedEvent(), publish);
+    map.off(drawEditVertexEvent(), publish);
+  };
+
+  const stop = (): void => {
+    stopHandlers();
+    featureGroup.clearLayers();
+    polygon = null;
+    options = null;
+  };
+
+  const start = (workOptions: AreaPolygonWorkOptions): (() => void) => {
+    stop();
+    options = workOptions;
+    const initialPoints = polygonToLatLngs(workOptions.initialGeometry);
+    if (initialPoints.length >= 3) {
+      polygon = createPolygon(initialPoints, workOptions.fillHex);
+      featureGroup.addLayer(polygon);
+      startEditMode();
+      if (polygon.getBounds().isValid()) {
+        map.fitBounds(polygon.getBounds(), { padding: [32, 32], maxZoom: 14 });
+      }
+    } else {
+      startDrawMode();
+    }
+
+    publish();
+    return stop;
+  };
+
+  const startDrawMode = (): void => {
+    drawHandler = new (drawPolygonHandler())(map, {
+      allowIntersection: false,
+      repeatMode: false,
+      shapeOptions: polygonStyle(options?.fillHex ?? '#ff6600'),
+      showArea: false
+    }) as LeafletDrawHandler;
+    map.on(drawCreatedEvent(), onDrawCreated);
+    drawHandler.enable();
+  };
+
+  const startEditMode = (): void => {
+    editHandler = new (editToolbarHandler())(map, {
+      featureGroup,
+      poly: { allowIntersection: false },
+      selectedPathOptions: { maintainColor: true }
+    }) as LeafletDrawHandler;
+    map.on(drawEditedEvent(), publish);
+    map.on(drawEditVertexEvent(), publish);
+    editHandler.enable();
+  };
+
+  function onDrawCreated(event: DrawnLayerEvent): void {
+    if (!(event.layer instanceof L.Polygon)) {
+      return;
+    }
+
+    featureGroup.clearLayers();
+    polygon = event.layer;
+    polygon.setStyle(polygonStyle(options?.fillHex ?? '#ff6600'));
+    featureGroup.addLayer(polygon);
+    drawHandler?.disable();
+    drawHandler = null;
+    startEditMode();
+    publish();
+  }
+
+  return {
+    dispose: stop,
+    start,
+    stop
+  };
+};
+
+const polygonStyle = (fillHex: string): L.PathOptions => ({
+  color: fillHex,
+  fillColor: fillHex,
+  fillOpacity: 0.25,
+  weight: 2
+});
+
+const polygonToLatLngs = (geometry: GeoJsonPolygon | null): L.LatLng[] => {
+  const exterior = geometry?.coordinates?.[0] ?? [];
+  return exterior.slice(0, -1).map(([longitude, latitude]) => L.latLng(latitude, longitude));
+};
+
+const createPolygon = (points: L.LatLng[], fillHex: string): L.Polygon =>
+  L.polygon(points, polygonStyle(fillHex));
+
+const flattenPolygonLatLngs = (polygon: L.Polygon): L.LatLng[] => {
+  const latLngs = polygon.getLatLngs();
+  const exterior = latLngs[0] ?? [];
+  return (Array.isArray(exterior[0]) ? exterior[0] : exterior) as L.LatLng[];
+};
+
+const latLngsToPolygon = (latLngs: L.LatLng[]): GeoJsonPolygon | null => {
+  if (latLngs.length < 3) {
+    return null;
+  }
+
+  const ring = latLngs.map(point => [point.lng, point.lat] as [number, number]);
+  ring.push([latLngs[0].lng, latLngs[0].lat]);
+  return { type: 'Polygon', coordinates: [ring] };
+};
+
+const drawPolygonHandler = (): new (map: LeafletMap, options: Record<string, unknown>) => unknown =>
+  (L as unknown as { Draw: { Polygon: new (map: LeafletMap, options: Record<string, unknown>) => unknown } }).Draw.Polygon;
+
+const editToolbarHandler = (): new (map: LeafletMap, options: Record<string, unknown>) => unknown =>
+  (L as unknown as { EditToolbar: { Edit: new (map: LeafletMap, options: Record<string, unknown>) => unknown } }).EditToolbar.Edit;
+
+const drawEvent = (name: 'CREATED' | 'EDITED' | 'EDITVERTEX'): string =>
+  (L as unknown as { Draw: { Event: Record<string, string> } }).Draw.Event[name];
+
+const drawCreatedEvent = (): string => drawEvent('CREATED');
+const drawEditedEvent = (): string => drawEvent('EDITED');
+const drawEditVertexEvent = (): string => drawEvent('EDITVERTEX');

--- a/ClientApps/trip-editor/src/map/areaPolygonWorkLayer.ts
+++ b/ClientApps/trip-editor/src/map/areaPolygonWorkLayer.ts
@@ -10,6 +10,7 @@ export interface AreaPolygonWorkOptions {
 
 type DrawnLayerEvent = { layer: L.Layer };
 type LeafletDrawHandler = { disable: () => void; enable: () => void; enabled?: () => boolean };
+type LatLngRing = L.LatLng[];
 
 /// Owns the single temporary Leaflet.Draw polygon used by Trip Editor area map-work.
 export const createAreaPolygonWorkLayer = (map: LeafletMap): {
@@ -25,7 +26,7 @@ export const createAreaPolygonWorkLayer = (map: LeafletMap): {
   let options: AreaPolygonWorkOptions | null = null;
 
   const publish = (): void => {
-    options?.onChanged(polygon ? latLngsToPolygon(flattenPolygonLatLngs(polygon)) : null);
+    options?.onChanged(polygon ? latLngRingsToPolygon(polygonLatLngRings(polygon)) : null);
   };
 
   const stopHandlers = (): void => {
@@ -48,9 +49,9 @@ export const createAreaPolygonWorkLayer = (map: LeafletMap): {
   const start = (workOptions: AreaPolygonWorkOptions): (() => void) => {
     stop();
     options = workOptions;
-    const initialPoints = polygonToLatLngs(workOptions.initialGeometry);
-    if (initialPoints.length >= 3) {
-      polygon = createPolygon(initialPoints, workOptions.fillHex);
+    const initialRings = polygonToLatLngRings(workOptions.initialGeometry);
+    if (initialRings[0]?.length >= 3) {
+      polygon = createPolygon(initialRings, workOptions.fillHex);
       featureGroup.addLayer(polygon);
       startEditMode();
       if (polygon.getBounds().isValid()) {
@@ -115,28 +116,41 @@ const polygonStyle = (fillHex: string): L.PathOptions => ({
   weight: 2
 });
 
-const polygonToLatLngs = (geometry: GeoJsonPolygon | null): L.LatLng[] => {
-  const exterior = geometry?.coordinates?.[0] ?? [];
-  return exterior.slice(0, -1).map(([longitude, latitude]) => L.latLng(latitude, longitude));
-};
+const polygonToLatLngRings = (geometry: GeoJsonPolygon | null): LatLngRing[] =>
+  (geometry?.coordinates ?? [])
+    .map(ring => ring.slice(0, -1).map(([longitude, latitude]) => L.latLng(latitude, longitude)))
+    .filter(ring => ring.length >= 3);
 
-const createPolygon = (points: L.LatLng[], fillHex: string): L.Polygon =>
-  L.polygon(points, polygonStyle(fillHex));
+const createPolygon = (rings: LatLngRing[], fillHex: string): L.Polygon =>
+  L.polygon(rings, polygonStyle(fillHex));
 
-const flattenPolygonLatLngs = (polygon: L.Polygon): L.LatLng[] => {
+const polygonLatLngRings = (polygon: L.Polygon): LatLngRing[] => {
   const latLngs = polygon.getLatLngs();
-  const exterior = latLngs[0] ?? [];
-  return (Array.isArray(exterior[0]) ? exterior[0] : exterior) as L.LatLng[];
+  if (latLngs.length === 0) {
+    return [];
+  }
+
+  if (latLngs[0] instanceof L.LatLng) {
+    return [latLngs as LatLngRing];
+  }
+
+  const rings = latLngs as LatLngRing[] | LatLngRing[][];
+  return Array.isArray(rings[0]?.[0]) ? (rings[0] as LatLngRing[]) : rings as LatLngRing[];
 };
 
-const latLngsToPolygon = (latLngs: L.LatLng[]): GeoJsonPolygon | null => {
-  if (latLngs.length < 3) {
+const latLngRingsToPolygon = (rings: LatLngRing[]): GeoJsonPolygon | null => {
+  if (!rings[0] || rings[0].length < 3) {
     return null;
   }
 
-  const ring = latLngs.map(point => [point.lng, point.lat] as [number, number]);
-  ring.push([latLngs[0].lng, latLngs[0].lat]);
-  return { type: 'Polygon', coordinates: [ring] };
+  const coordinates = rings
+    .filter(ring => ring.length >= 3)
+    .map(ring => {
+      const coordinatesRing = ring.map(point => [point.lng, point.lat] as [number, number]);
+      coordinatesRing.push([ring[0].lng, ring[0].lat]);
+      return coordinatesRing;
+    });
+  return { type: 'Polygon', coordinates };
 };
 
 const drawPolygonHandler = (): new (map: LeafletMap, options: Record<string, unknown>) => unknown =>

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -1,7 +1,7 @@
 import L, { type LayerGroup, type LeafletMouseEvent, type Map as LeafletMap } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import type { EditorTarget } from '../composables/useEditorSurface';
-import type { EditorArea, EditorCoordinate, EditorPlace, EditorRegion, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from '../types';
+import type { EditorArea, EditorCoordinate, EditorPlace, EditorRegion, EditorSegment, EditorTripMetadata, EditorTripState, GeoJsonPolygon, Guid } from '../types';
 
 export type FitAllGeometryResult = 'moved' | 'no-geometry';
 export type FocusSavedTripViewResult = 'moved' | 'missing-view';
@@ -10,6 +10,7 @@ export type FocusActiveEntityResult = 'moved' | 'missing-target' | 'no-geometry'
 interface TripEditorMapAdapter {
   render: (state: EditorTripState) => void;
   startCoordinatePick: (options: CoordinatePickOptions) => () => void;
+  startAreaPolygonWork: (options: AreaPolygonWorkOptions) => () => void;
   fitAllGeometry: (state: EditorTripState) => FitAllGeometryResult;
   focusSavedTripView: (metadata: EditorTripMetadata) => FocusSavedTripViewResult;
   focusActiveEntity: (state: EditorTripState, target: EditorTarget | null) => FocusActiveEntityResult;
@@ -20,6 +21,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
   const map = L.map(element, { zoomControl: true }).setView([20, 0], 2);
   const layers = L.layerGroup().addTo(map);
   const coordinatePick = createCoordinatePickLayer(map);
+  const areaPolygonWork = createAreaPolygonWorkLayer(map);
 
   L.tileLayer(tilesUrl, {
     attribution: window.wayfarerTileConfig?.attribution ?? '&copy; OpenStreetMap contributors',
@@ -28,6 +30,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
 
   const render = (state: EditorTripState): void => {
     coordinatePick.clearRegisteredMarkers();
+    areaPolygonWork.stop();
     layers.clearLayers();
 
     Object.values(state.regionsById).forEach(region => renderRegion(region, layers));
@@ -41,11 +44,13 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
   return {
     render,
     startCoordinatePick: options => coordinatePick.start(options),
+    startAreaPolygonWork: options => areaPolygonWork.start(options),
     fitAllGeometry: state => fitAllGeometry(map, state),
     focusSavedTripView: metadata => focusSavedTripView(map, metadata),
     focusActiveEntity: (state, target) => focusActiveEntity(map, state, target),
     dispose: () => {
       coordinatePick.dispose();
+      areaPolygonWork.dispose();
       map.remove();
     }
   };
@@ -54,6 +59,12 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
 export interface CoordinatePickOptions {
   initialCoordinate: EditorCoordinate | null;
   onPicked: (coordinate: EditorCoordinate) => void;
+}
+
+export interface AreaPolygonWorkOptions {
+  initialGeometry: GeoJsonPolygon | null;
+  fillHex: string;
+  onChanged: (geometry: GeoJsonPolygon | null) => void;
 }
 
 const createCoordinatePickLayer = (map: LeafletMap): {
@@ -156,6 +167,83 @@ const createCoordinatePickLayer = (map: LeafletMap): {
     isActive: () => clickHandler !== null,
     pick,
     registerMarker,
+    start,
+    stop
+  };
+};
+
+const createAreaPolygonWorkLayer = (map: LeafletMap): {
+  dispose: () => void;
+  start: (options: AreaPolygonWorkOptions) => () => void;
+  stop: () => void;
+} => {
+  const layer = L.layerGroup().addTo(map);
+  let clickHandler: ((event: LeafletMouseEvent) => void) | null = null;
+  let polygon: L.Polygon | null = null;
+  let points: L.LatLng[] = [];
+  let options: AreaPolygonWorkOptions | null = null;
+
+  const redraw = (): void => {
+    layer.clearLayers();
+    polygon = null;
+    if (points.length === 0) {
+      options?.onChanged(null);
+      return;
+    }
+
+    polygon = L.polygon(points, {
+      color: options?.fillHex ?? '#ff6600',
+      fillColor: options?.fillHex ?? '#ff6600',
+      fillOpacity: 0.25,
+      weight: 2
+    }).addTo(layer);
+    points.forEach(point => {
+      L.circleMarker(point, {
+        radius: 4,
+        color: '#111827',
+        fillColor: '#ffffff',
+        fillOpacity: 1,
+        interactive: false
+      }).addTo(layer);
+    });
+    options?.onChanged(points.length >= 3 ? latLngsToPolygon(points) : null);
+  };
+
+  const stop = (): void => {
+    if (clickHandler) {
+      map.off('click', clickHandler);
+      clickHandler = null;
+    }
+
+    layer.clearLayers();
+    polygon = null;
+    points = [];
+    options = null;
+  };
+
+  const start = (workOptions: AreaPolygonWorkOptions): (() => void) => {
+    stop();
+    options = workOptions;
+    points = polygonToLatLngs(workOptions.initialGeometry);
+    redraw();
+    if (polygon?.getBounds().isValid()) {
+      map.fitBounds(polygon.getBounds(), { padding: [32, 32], maxZoom: 14 });
+    }
+
+    clickHandler = event => {
+      if (event.originalEvent) {
+        L.DomEvent.stop(event.originalEvent);
+      }
+
+      points.push(event.latlng);
+      redraw();
+    };
+    map.on('click', clickHandler);
+    return stop;
+  };
+
+  return {
+    dispose: stop,
     start,
     stop
   };
@@ -285,6 +373,19 @@ const focusActiveEntity = (map: LeafletMap, state: EditorTripState, target: Edit
     return fitBounds(map, coordinateBounds(place.location));
   }
 
+  if (target.kind === 'area') {
+    if (target.mode === 'add') {
+      return target.parentRegionId ? fitBounds(map, regionGeometryBounds(state, target.parentRegionId)) : 'no-geometry';
+    }
+
+    if (!target.entityId) {
+      return 'missing-target';
+    }
+
+    const area = state.areasById[target.entityId];
+    return area ? fitBounds(map, areaBounds(area)) : 'missing-target';
+  }
+
   return 'unsupported-target';
 };
 
@@ -321,6 +422,14 @@ export const canFocusActiveEntity = (state: EditorTripState, target: EditorTarge
     }
 
     return coordinateBounds(state.placesById[target.entityId]?.location ?? null).isValid();
+  }
+
+  if (target.kind === 'area') {
+    if (target.mode === 'add') {
+      return Boolean(target.parentRegionId) && regionGeometryBounds(state, target.parentRegionId!).isValid();
+    }
+
+    return Boolean(target.entityId) && areaBounds(state.areasById[target.entityId!]).isValid();
   }
 
   return false;
@@ -374,6 +483,15 @@ const coordinateBounds = (coordinate: EditorCoordinate | null): L.LatLngBounds =
   return bounds;
 };
 
+const areaBounds = (area: EditorArea | undefined): L.LatLngBounds => {
+  const bounds = L.latLngBounds([]);
+  if (area) {
+    extendArea(bounds, area);
+  }
+
+  return bounds;
+};
+
 const extendCoordinate = (bounds: L.LatLngBounds, coordinate: EditorCoordinate | null | undefined): void => {
   if (coordinate && isFiniteCoordinate(coordinate)) {
     bounds.extend([coordinate.latitude, coordinate.longitude]);
@@ -411,6 +529,17 @@ const escapeHtml = (value: string): string =>
     '"': '&quot;',
     "'": '&#39;'
   })[character] ?? character);
+
+const polygonToLatLngs = (geometry: GeoJsonPolygon | null): L.LatLng[] => {
+  const exterior = geometry?.coordinates?.[0] ?? [];
+  return exterior.slice(0, -1).map(([longitude, latitude]) => L.latLng(latitude, longitude));
+};
+
+const latLngsToPolygon = (latLngs: L.LatLng[]): GeoJsonPolygon => {
+  const ring = latLngs.map(point => [point.lng, point.lat] as [number, number]);
+  ring.push([latLngs[0].lng, latLngs[0].lat]);
+  return { type: 'Polygon', coordinates: [ring] };
+};
 
 declare global {
   interface Window {

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -1,7 +1,9 @@
 import L, { type LayerGroup, type LeafletMouseEvent, type Map as LeafletMap } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import type { EditorTarget } from '../composables/useEditorSurface';
-import type { EditorArea, EditorCoordinate, EditorPlace, EditorRegion, EditorSegment, EditorTripMetadata, EditorTripState, GeoJsonPolygon, Guid } from '../types';
+import type { EditorArea, EditorCoordinate, EditorPlace, EditorRegion, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from '../types';
+import { createAreaPolygonWorkLayer } from './areaPolygonWorkLayer';
+export type { AreaPolygonWorkOptions } from './areaPolygonWorkLayer';
 
 export type FitAllGeometryResult = 'moved' | 'no-geometry';
 export type FocusSavedTripViewResult = 'moved' | 'missing-view';
@@ -59,12 +61,6 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
 export interface CoordinatePickOptions {
   initialCoordinate: EditorCoordinate | null;
   onPicked: (coordinate: EditorCoordinate) => void;
-}
-
-export interface AreaPolygonWorkOptions {
-  initialGeometry: GeoJsonPolygon | null;
-  fillHex: string;
-  onChanged: (geometry: GeoJsonPolygon | null) => void;
 }
 
 const createCoordinatePickLayer = (map: LeafletMap): {
@@ -167,83 +163,6 @@ const createCoordinatePickLayer = (map: LeafletMap): {
     isActive: () => clickHandler !== null,
     pick,
     registerMarker,
-    start,
-    stop
-  };
-};
-
-const createAreaPolygonWorkLayer = (map: LeafletMap): {
-  dispose: () => void;
-  start: (options: AreaPolygonWorkOptions) => () => void;
-  stop: () => void;
-} => {
-  const layer = L.layerGroup().addTo(map);
-  let clickHandler: ((event: LeafletMouseEvent) => void) | null = null;
-  let polygon: L.Polygon | null = null;
-  let points: L.LatLng[] = [];
-  let options: AreaPolygonWorkOptions | null = null;
-
-  const redraw = (): void => {
-    layer.clearLayers();
-    polygon = null;
-    if (points.length === 0) {
-      options?.onChanged(null);
-      return;
-    }
-
-    polygon = L.polygon(points, {
-      color: options?.fillHex ?? '#ff6600',
-      fillColor: options?.fillHex ?? '#ff6600',
-      fillOpacity: 0.25,
-      weight: 2
-    }).addTo(layer);
-    points.forEach(point => {
-      L.circleMarker(point, {
-        radius: 4,
-        color: '#111827',
-        fillColor: '#ffffff',
-        fillOpacity: 1,
-        interactive: false
-      }).addTo(layer);
-    });
-    options?.onChanged(points.length >= 3 ? latLngsToPolygon(points) : null);
-  };
-
-  const stop = (): void => {
-    if (clickHandler) {
-      map.off('click', clickHandler);
-      clickHandler = null;
-    }
-
-    layer.clearLayers();
-    polygon = null;
-    points = [];
-    options = null;
-  };
-
-  const start = (workOptions: AreaPolygonWorkOptions): (() => void) => {
-    stop();
-    options = workOptions;
-    points = polygonToLatLngs(workOptions.initialGeometry);
-    redraw();
-    if (polygon?.getBounds().isValid()) {
-      map.fitBounds(polygon.getBounds(), { padding: [32, 32], maxZoom: 14 });
-    }
-
-    clickHandler = event => {
-      if (event.originalEvent) {
-        L.DomEvent.stop(event.originalEvent);
-      }
-
-      points.push(event.latlng);
-      redraw();
-    };
-    map.on('click', clickHandler);
-    return stop;
-  };
-
-  return {
-    dispose: stop,
     start,
     stop
   };
@@ -529,17 +448,6 @@ const escapeHtml = (value: string): string =>
     '"': '&quot;',
     "'": '&#39;'
   })[character] ?? character);
-
-const polygonToLatLngs = (geometry: GeoJsonPolygon | null): L.LatLng[] => {
-  const exterior = geometry?.coordinates?.[0] ?? [];
-  return exterior.slice(0, -1).map(([longitude, latitude]) => L.latLng(latitude, longitude));
-};
-
-const latLngsToPolygon = (latLngs: L.LatLng[]): GeoJsonPolygon => {
-  const ring = latLngs.map(point => [point.lng, point.lat] as [number, number]);
-  ring.push([latLngs[0].lng, latLngs[0].lat]);
-  return { type: 'Polygon', coordinates: [ring] };
-};
 
 declare global {
   interface Window {

--- a/ClientApps/trip-editor/src/map/leafletDrawPlugin.ts
+++ b/ClientApps/trip-editor/src/map/leafletDrawPlugin.ts
@@ -1,0 +1,31 @@
+import L from 'leaflet';
+import leafletDrawSource from '../../../../wwwroot/lib/leaflet/leaflet.draw.js?raw';
+import '../../../../wwwroot/lib/leaflet/leaflet.draw.css';
+
+declare global {
+  interface Window {
+    L?: typeof L;
+  }
+}
+
+let isLoaded = false;
+
+/// Loads the repo-local Leaflet.Draw UMD asset into the Vite-bundled Leaflet instance.
+export function ensureLeafletDraw(): void {
+  if (isLoaded && hasLeafletDraw()) {
+    return;
+  }
+
+  window.L = L;
+  Function('window', 'document', leafletDrawSource)(window, document);
+  if (!hasLeafletDraw()) {
+    throw new Error('Leaflet.Draw failed to initialize for Trip Editor area map-work.');
+  }
+
+  isLoaded = true;
+}
+
+function hasLeafletDraw(): boolean {
+  const leaflet = L as unknown as { Draw?: unknown; EditToolbar?: unknown };
+  return Boolean(leaflet.Draw && leaflet.EditToolbar);
+}

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -413,16 +413,29 @@ body {
   padding: 0.5rem 0.65rem;
 }
 
-.trip-editor-place-row {
+.trip-editor-place-row,
+.trip-editor-area-row {
   align-items: center;
   display: grid;
   gap: 0.45rem;
   grid-template-columns: auto minmax(0, 1fr) auto;
 }
 
-.trip-editor-place-row > span {
+.trip-editor-place-row > span,
+.trip-editor-area-row > span {
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.trip-editor-area-list {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.trip-editor-child-section {
+  color: var(--trip-editor-muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
 }
 
 .trip-editor-place-editor-row {

--- a/ClientApps/trip-editor/src/types.ts
+++ b/ClientApps/trip-editor/src/types.ts
@@ -220,6 +220,26 @@ export interface EditorPlaceDeleteResult {
   placeId: Guid;
 }
 
+export interface EditorAreaSaveRequest {
+  name: string;
+  notesHtml: string | null;
+  fillHex: string;
+  geometry: GeoJsonPolygon | null;
+}
+
+export interface EditorAreaOrderRequest {
+  areaIds: Guid[];
+}
+
+export interface EditorAreaOrderResult {
+  regionId: Guid;
+  areaOrder: Guid[];
+}
+
+export interface EditorAreaDeleteResult {
+  areaId: Guid;
+}
+
 export interface EditorPlaceDraft {
   id: Guid | null;
   regionId: Guid | null;
@@ -231,6 +251,15 @@ export interface EditorPlaceDraft {
   iconName: string;
   markerColor: string;
   reverseGeocode: boolean;
+}
+
+export interface EditorAreaDraft {
+  id: Guid | null;
+  regionId: Guid | null;
+  name: string;
+  notesHtml: string;
+  fillHex: string;
+  geometry: GeoJsonPolygon | null;
 }
 
 export interface EditorMutationResult<TData> {

--- a/ClientApps/trip-editor/src/vite-env.d.ts
+++ b/ClientApps/trip-editor/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/Models/Dtos/Editor/EditorAreaRequestParser.cs
+++ b/Models/Dtos/Editor/EditorAreaRequestParser.cs
@@ -1,0 +1,350 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using NetTopologySuite.Geometries;
+
+namespace Wayfarer.Models.Dtos.Editor;
+
+/// <summary>
+/// Parses and validates area mutation JSON while preserving ownership-first request handling.
+/// </summary>
+internal static class EditorAreaRequestParser
+{
+    private static readonly string[] SaveServerOwnedFields = { "id", "tripId", "displayOrder", "capabilities" };
+    private static readonly string[] GeometryForbiddenFields = { "id", "tripId", "regionId", "displayOrder", "capabilities", "name", "notesHtml", "fillHex" };
+    private static readonly Regex FillHexRegex = new("^#[0-9a-fA-F]{6}$", RegexOptions.Compiled);
+    private static readonly Regex DataImageSourceRegex = new(
+        @"<img\b[^>]*?\bsrc\s*=\s*[""']?\s*data:image/",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Attempts to parse a complete-draft area create request.
+    /// </summary>
+    public static bool TryParseCreate(JsonElement request, out EditorAreaSaveRequest update, out Dictionary<string, string[]> errors)
+    {
+        errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        update = new EditorAreaSaveRequest("Area", null, "#ff6600", EmptyPolygon());
+        if (!ValidateObject(request, errors, "Area mutation request must be a JSON object."))
+        {
+            return false;
+        }
+
+        RejectFields(request, SaveServerOwnedFields.Append("regionId"), "The field is server-owned and cannot be updated.", errors);
+        var name = ReadRequiredNullableString(request, "name", errors);
+        var notesHtml = ReadRequiredNullableString(request, "notesHtml", errors);
+        var fillHex = ReadRequiredNullableString(request, "fillHex", errors);
+        var geometry = ReadRequiredGeometry(request, errors);
+        if (!string.IsNullOrWhiteSpace(fillHex))
+        {
+            ValidateFillHex(fillHex, errors);
+        }
+
+        ValidateNotes(notesHtml, errors);
+
+        if (errors.Count > 0)
+        {
+            return false;
+        }
+
+        update = new EditorAreaSaveRequest(
+            string.IsNullOrWhiteSpace(name) ? "Area" : name!.Trim(),
+            notesHtml,
+            string.IsNullOrWhiteSpace(fillHex) ? "#ff6600" : fillHex!.Trim().ToLowerInvariant(),
+            geometry!);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to parse a complete-draft area update request.
+    /// </summary>
+    public static bool TryParseUpdate(JsonElement request, out EditorAreaSaveRequest update, out Dictionary<string, string[]> errors)
+    {
+        errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        update = new EditorAreaSaveRequest(string.Empty, null, string.Empty, EmptyPolygon());
+        if (!ValidateObject(request, errors, "Area mutation request must be a JSON object."))
+        {
+            return false;
+        }
+
+        RejectFields(request, SaveServerOwnedFields.Append("regionId"), "The field is server-owned and cannot be updated.", errors);
+        var name = ReadRequiredString(request, "name", errors);
+        var notesHtml = ReadRequiredNullableString(request, "notesHtml", errors);
+        var fillHex = ReadRequiredString(request, "fillHex", errors);
+        var geometry = ReadRequiredGeometry(request, errors);
+        ValidateRequiredName(name, errors);
+        ValidateFillHex(fillHex, errors);
+        ValidateNotes(notesHtml, errors);
+
+        if (errors.Count > 0)
+        {
+            return false;
+        }
+
+        update = new EditorAreaSaveRequest(name!.Trim(), notesHtml, fillHex!.Trim().ToLowerInvariant(), geometry!);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to parse a geometry-only area update request.
+    /// </summary>
+    public static bool TryParseGeometryUpdate(JsonElement request, out EditorAreaGeometryUpdateRequest update, out Dictionary<string, string[]> errors)
+    {
+        errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        update = new EditorAreaGeometryUpdateRequest(EmptyPolygon());
+        if (!ValidateObject(request, errors, "Area geometry request must be a JSON object."))
+        {
+            return false;
+        }
+
+        RejectFields(request, GeometryForbiddenFields, "The field cannot be supplied for a geometry-only update.", errors);
+        var geometry = ReadRequiredGeometry(request, errors);
+        if (errors.Count > 0)
+        {
+            return false;
+        }
+
+        update = new EditorAreaGeometryUpdateRequest(geometry!);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to parse a complete region-scoped area order request.
+    /// </summary>
+    public static bool TryParseOrder(JsonElement request, out EditorAreaOrderRequest update, out Dictionary<string, string[]> errors)
+    {
+        errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        update = new EditorAreaOrderRequest(Array.Empty<Guid>());
+        if (!ValidateObject(request, errors, "Area order request must be a JSON object."))
+        {
+            return false;
+        }
+
+        if (!request.TryGetProperty("areaIds", out var idsProperty))
+        {
+            errors["areaIds"] = new[] { "The field is required." };
+            return false;
+        }
+
+        if (idsProperty.ValueKind != JsonValueKind.Array)
+        {
+            errors["areaIds"] = new[] { "Area IDs must be an array." };
+            return false;
+        }
+
+        var areaIds = new List<Guid>();
+        foreach (var item in idsProperty.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String || !Guid.TryParse(item.GetString(), out var id))
+            {
+                errors["areaIds"] = new[] { "Every area ID must be a GUID string." };
+                return false;
+            }
+
+            areaIds.Add(id);
+        }
+
+        update = new EditorAreaOrderRequest(areaIds);
+        return true;
+    }
+
+    private static bool ValidateObject(JsonElement request, Dictionary<string, string[]> errors, string message)
+    {
+        if (request.ValueKind == JsonValueKind.Object)
+        {
+            return true;
+        }
+
+        errors["request"] = new[] { message };
+        return false;
+    }
+
+    private static void RejectFields(JsonElement request, IEnumerable<string> fields, string message, Dictionary<string, string[]> errors)
+    {
+        foreach (var field in fields)
+        {
+            if (request.TryGetProperty(field, out _))
+            {
+                errors[field] = new[] { message };
+            }
+        }
+    }
+
+    private static string? ReadRequiredString(JsonElement request, string name, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty(name, out var property))
+        {
+            errors[name] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.String)
+        {
+            errors[name] = new[] { "The field must be a string." };
+            return null;
+        }
+
+        return property.GetString();
+    }
+
+    private static string? ReadRequiredNullableString(JsonElement request, string name, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty(name, out var property))
+        {
+            errors[name] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.String)
+        {
+            errors[name] = new[] { "The field must be a string or null." };
+            return null;
+        }
+
+        return property.GetString();
+    }
+
+    private static Polygon? ReadRequiredGeometry(JsonElement request, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty("geometry", out var property))
+        {
+            errors["geometry"] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.Object)
+        {
+            errors["geometry"] = new[] { "Geometry must be a GeoJSON Polygon object." };
+            return null;
+        }
+
+        if (!property.TryGetProperty("type", out var typeProperty) || typeProperty.ValueKind != JsonValueKind.String || typeProperty.GetString() != "Polygon")
+        {
+            errors["geometry"] = new[] { "Geometry type must be Polygon." };
+            return null;
+        }
+
+        if (!property.TryGetProperty("coordinates", out var coordinatesProperty) || coordinatesProperty.ValueKind != JsonValueKind.Array)
+        {
+            errors["geometry.coordinates"] = new[] { "Polygon coordinates must be an array of rings." };
+            return null;
+        }
+
+        var rings = new List<LinearRing>();
+        foreach (var ringProperty in coordinatesProperty.EnumerateArray())
+        {
+            var ring = ReadRing(ringProperty, errors);
+            if (ring == null)
+            {
+                return null;
+            }
+
+            rings.Add(ring);
+        }
+
+        if (rings.Count == 0)
+        {
+            errors["geometry.coordinates"] = new[] { "Polygon must include an exterior ring." };
+            return null;
+        }
+
+        return new Polygon(rings[0], rings.Skip(1).ToArray()) { SRID = 4326 };
+    }
+
+    private static LinearRing? ReadRing(JsonElement ringProperty, Dictionary<string, string[]> errors)
+    {
+        if (ringProperty.ValueKind != JsonValueKind.Array)
+        {
+            errors["geometry.coordinates"] = new[] { "Every polygon ring must be an array." };
+            return null;
+        }
+
+        var coordinates = new List<Coordinate>();
+        foreach (var positionProperty in ringProperty.EnumerateArray())
+        {
+            var coordinate = ReadPosition(positionProperty, errors);
+            if (coordinate == null)
+            {
+                return null;
+            }
+
+            coordinates.Add(coordinate);
+        }
+
+        if (coordinates.Count < 4)
+        {
+            errors["geometry.coordinates"] = new[] { "Every polygon ring must contain at least four positions." };
+            return null;
+        }
+
+        if (!coordinates[0].Equals2D(coordinates[^1]))
+        {
+            errors["geometry.coordinates"] = new[] { "Every polygon ring must be closed." };
+            return null;
+        }
+
+        return new LinearRing(coordinates.ToArray()) { SRID = 4326 };
+    }
+
+    private static Coordinate? ReadPosition(JsonElement positionProperty, Dictionary<string, string[]> errors)
+    {
+        if (positionProperty.ValueKind != JsonValueKind.Array || positionProperty.GetArrayLength() != 2)
+        {
+            errors["geometry.coordinates"] = new[] { "Every position must contain exactly longitude and latitude." };
+            return null;
+        }
+
+        var values = positionProperty.EnumerateArray().ToArray();
+        if (!TryReadFiniteDouble(values[0], out var longitude) || !TryReadFiniteDouble(values[1], out var latitude))
+        {
+            errors["geometry.coordinates"] = new[] { "Every position must contain finite numeric longitude and latitude." };
+            return null;
+        }
+
+        if (longitude is < -180 or > 180 || latitude is < -90 or > 90)
+        {
+            errors["geometry.coordinates"] = new[] { "Coordinates must use longitude -180..180 and latitude -90..90." };
+            return null;
+        }
+
+        return new Coordinate(longitude, latitude);
+    }
+
+    private static bool TryReadFiniteDouble(JsonElement property, out double value)
+    {
+        value = default;
+        return property.ValueKind == JsonValueKind.Number
+            && property.TryGetDouble(out value)
+            && !double.IsNaN(value)
+            && !double.IsInfinity(value);
+    }
+
+    private static void ValidateRequiredName(string? name, Dictionary<string, string[]> errors)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            errors["name"] = new[] { "Name is required." };
+        }
+    }
+
+    private static void ValidateFillHex(string? fillHex, Dictionary<string, string[]> errors)
+    {
+        if (string.IsNullOrWhiteSpace(fillHex) || !FillHexRegex.IsMatch(fillHex.Trim()))
+        {
+            errors["fillHex"] = new[] { "Fill color must be a #RRGGBB hex color." };
+        }
+    }
+
+    private static void ValidateNotes(string? notesHtml, Dictionary<string, string[]> errors)
+    {
+        if (!string.IsNullOrEmpty(notesHtml) && DataImageSourceRegex.IsMatch(notesHtml))
+        {
+            errors["notesHtml"] = new[] { "Notes cannot contain data image sources." };
+        }
+    }
+
+    private static Polygon EmptyPolygon() => new(new LinearRing(Array.Empty<Coordinate>()));
+}

--- a/Models/Dtos/Editor/EditorAreaRequestParser.cs
+++ b/Models/Dtos/Editor/EditorAreaRequestParser.cs
@@ -10,7 +10,6 @@ namespace Wayfarer.Models.Dtos.Editor;
 internal static class EditorAreaRequestParser
 {
     private static readonly string[] SaveServerOwnedFields = { "id", "tripId", "displayOrder", "capabilities" };
-    private static readonly string[] GeometryForbiddenFields = { "id", "tripId", "regionId", "displayOrder", "capabilities", "name", "notesHtml", "fillHex" };
     private static readonly Regex FillHexRegex = new("^#[0-9a-fA-F]{6}$", RegexOptions.Compiled);
     private static readonly Regex DataImageSourceRegex = new(
         @"<img\b[^>]*?\bsrc\s*=\s*[""']?\s*data:image/",
@@ -95,7 +94,7 @@ internal static class EditorAreaRequestParser
             return false;
         }
 
-        RejectFields(request, GeometryForbiddenFields, "The field cannot be supplied for a geometry-only update.", errors);
+        RejectGeometryOnlyFields(request, errors);
         var geometry = ReadRequiredGeometry(request, errors);
         if (errors.Count > 0)
         {
@@ -164,6 +163,17 @@ internal static class EditorAreaRequestParser
             if (request.TryGetProperty(field, out _))
             {
                 errors[field] = new[] { message };
+            }
+        }
+    }
+
+    private static void RejectGeometryOnlyFields(JsonElement request, Dictionary<string, string[]> errors)
+    {
+        foreach (var property in request.EnumerateObject())
+        {
+            if (!string.Equals(property.Name, "geometry", StringComparison.Ordinal))
+            {
+                errors[property.Name] = new[] { "The field cannot be supplied for a geometry-only update." };
             }
         }
     }

--- a/Models/Dtos/Editor/EditorMutationDtos.cs
+++ b/Models/Dtos/Editor/EditorMutationDtos.cs
@@ -86,6 +86,31 @@ public sealed record EditorPlaceOrderResult(Guid RegionId, IReadOnlyList<Guid> P
 public sealed record EditorPlaceDeleteResult(Guid PlaceId);
 
 /// <summary>
+/// Complete-draft request for creating or updating an area from the same-origin editor.
+/// </summary>
+public sealed record EditorAreaSaveRequest(string Name, string? NotesHtml, string FillHex, NetTopologySuite.Geometries.Polygon Geometry);
+
+/// <summary>
+/// Geometry-only request for replacing an area polygon.
+/// </summary>
+public sealed record EditorAreaGeometryUpdateRequest(NetTopologySuite.Geometries.Polygon Geometry);
+
+/// <summary>
+/// Complete desired area order for one normal editor region.
+/// </summary>
+public sealed record EditorAreaOrderRequest(IReadOnlyList<Guid> AreaIds);
+
+/// <summary>
+/// Area order data returned by the area order endpoint.
+/// </summary>
+public sealed record EditorAreaOrderResult(Guid RegionId, IReadOnlyList<Guid> AreaOrder);
+
+/// <summary>
+/// Area delete data returned by the area delete endpoint.
+/// </summary>
+public sealed record EditorAreaDeleteResult(Guid AreaId);
+
+/// <summary>
 /// Standard success envelope returned by editor mutation endpoints.
 /// </summary>
 public sealed record EditorMutationResult<TData>(

--- a/Models/Dtos/Editor/EditorTripStateMapper.cs
+++ b/Models/Dtos/Editor/EditorTripStateMapper.cs
@@ -143,7 +143,10 @@ public static class EditorTripStateMapper
             visitSummary,
             EditableLeafCapabilities());
 
-    private static EditorAreaDto ToArea(Guid tripId, Guid regionId, Area area) =>
+    /// <summary>
+    /// Maps an area into the editor area contract.
+    /// </summary>
+    public static EditorAreaDto ToArea(Guid tripId, Guid regionId, Area area) =>
         new(
             area.Id,
             tripId,

--- a/Program.cs
+++ b/Program.cs
@@ -594,7 +594,7 @@ static void ConfigureServices(WebApplicationBuilder builder)
 
     builder.Services.AddScoped<IRazorViewRenderer, RazorViewRenderer>();
     builder.Services.AddSingleton<MapSnapshotService>();
-    builder.Services.AddScoped<TripEditorRegionMutationService>(); builder.Services.AddScoped<TripEditorPlaceMutationReader>(); builder.Services.AddScoped<TripEditorPlaceRouteEffects>(); builder.Services.AddScoped<TripEditorPlaceMutationService>();
+    builder.Services.AddScoped<TripEditorRegionMutationService>(); builder.Services.AddScoped<TripEditorPlaceMutationReader>(); builder.Services.AddScoped<TripEditorPlaceRouteEffects>(); builder.Services.AddScoped<TripEditorPlaceMutationService>(); builder.Services.AddScoped<TripEditorAreaMutationService>();
 
     builder.Services.AddScoped<ITripThumbnailService, TripThumbnailService>();
     builder.Services.AddSingleton<ITripMapThumbnailGenerator, TripMapThumbnailGenerator>();

--- a/Services/TripEditorAreaMutationService.cs
+++ b/Services/TripEditorAreaMutationService.cs
@@ -1,0 +1,359 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Wayfarer.Models;
+using Wayfarer.Models.Dtos.Editor;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Executes Trip Editor area mutations and builds their mutation result envelopes.
+/// </summary>
+public sealed class TripEditorAreaMutationService
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    /// <summary>
+    /// Initializes a new area mutation service for the editor API.
+    /// </summary>
+    public TripEditorAreaMutationService(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    /// <summary>
+    /// Creates an area in a normal owned region and appends it to that region.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>> CreateAreaAsync(
+        Guid tripId,
+        Guid regionId,
+        string userId,
+        Stream requestBody,
+        CancellationToken cancellationToken)
+    {
+        var trip = await LoadTripGraphAsync(tripId, userId, cancellationToken);
+        if (trip == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.NotFound();
+        }
+
+        var region = trip.Regions.FirstOrDefault(r => r.Id == regionId);
+        if (region == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.NotFound();
+        }
+
+        if (IsShadowRegion(region))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.Forbidden("Areas cannot be created in the shadow region.");
+        }
+
+        var parsed = await ParseAndValidateCreateAsync(requestBody, cancellationToken);
+        if (parsed.ValidationErrors != null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.ValidationFailed(parsed.ValidationErrors);
+        }
+
+        var area = new Area
+        {
+            Id = Guid.NewGuid(),
+            Region = region,
+            RegionId = region.Id,
+            Name = parsed.Value!.Name,
+            Notes = parsed.Value.NotesHtml ?? string.Empty,
+            FillHex = parsed.Value.FillHex,
+            Geometry = parsed.Value.Geometry,
+            DisplayOrder = NextAreaOrder(region)
+        };
+        _dbContext.Areas.Add(area);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var dto = await LoadAreaDtoAsync(area.Id, tripId, cancellationToken);
+        var affected = await BuildAffectedAsync(tripId, new[] { dto }, new[] { region.Id }, cancellationToken);
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.Succeeded(
+            new EditorMutationResult<EditorAreaDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Updates complete editable fields for one owned area.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>> UpdateAreaAsync(
+        Guid tripId,
+        Guid areaId,
+        string userId,
+        Stream requestBody,
+        CancellationToken cancellationToken)
+    {
+        var area = await LoadOwnedAreaAsync(tripId, areaId, userId, cancellationToken);
+        if (area == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.NotFound();
+        }
+
+        var parsed = await ParseAndValidateUpdateAsync(requestBody, cancellationToken);
+        if (parsed.ValidationErrors != null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.ValidationFailed(parsed.ValidationErrors);
+        }
+
+        area.Name = parsed.Value!.Name;
+        area.Notes = parsed.Value.NotesHtml ?? string.Empty;
+        area.FillHex = parsed.Value.FillHex;
+        area.Geometry = parsed.Value.Geometry;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var dto = await LoadAreaDtoAsync(areaId, tripId, cancellationToken);
+        var affected = await BuildAffectedAsync(tripId, new[] { dto }, Array.Empty<Guid>(), cancellationToken);
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.Succeeded(
+            new EditorMutationResult<EditorAreaDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Replaces only the polygon geometry for one owned area.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>> UpdateAreaGeometryAsync(
+        Guid tripId,
+        Guid areaId,
+        string userId,
+        Stream requestBody,
+        CancellationToken cancellationToken)
+    {
+        var area = await LoadOwnedAreaAsync(tripId, areaId, userId, cancellationToken);
+        if (area == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.NotFound();
+        }
+
+        var parsed = await ParseAndValidateGeometryAsync(requestBody, cancellationToken);
+        if (parsed.ValidationErrors != null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.ValidationFailed(parsed.ValidationErrors);
+        }
+
+        area.Geometry = parsed.Value!.Geometry;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var dto = await LoadAreaDtoAsync(areaId, tripId, cancellationToken);
+        var affected = await BuildAffectedAsync(tripId, new[] { dto }, Array.Empty<Guid>(), cancellationToken);
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDto>>.Succeeded(
+            new EditorMutationResult<EditorAreaDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Deletes one owned area without touching sibling entities.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDeleteResult>>> DeleteAreaAsync(
+        Guid tripId,
+        Guid areaId,
+        string userId,
+        CancellationToken cancellationToken)
+    {
+        var area = await LoadOwnedAreaAsync(tripId, areaId, userId, cancellationToken);
+        if (area == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDeleteResult>>.NotFound();
+        }
+
+        var regionId = area.RegionId;
+        _dbContext.Areas.Remove(area);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await NormalizeAreaOrdersAsync(regionId, cancellationToken);
+
+        var affected = await BuildAffectedAsync(tripId, Array.Empty<EditorAreaDto>(), new[] { regionId }, cancellationToken);
+        var deletedIds = new EditorDeletedIdsDto(Array.Empty<Guid>(), Array.Empty<Guid>(), new[] { areaId }, Array.Empty<Guid>(), Array.Empty<string>());
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaDeleteResult>>.Succeeded(
+            new EditorMutationResult<EditorAreaDeleteResult>(true, new EditorAreaDeleteResult(areaId), affected, deletedIds, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Persists the complete desired order for areas inside one normal region.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorAreaOrderResult>>> OrderAreasAsync(
+        Guid tripId,
+        Guid regionId,
+        string userId,
+        Stream requestBody,
+        CancellationToken cancellationToken)
+    {
+        var trip = await LoadTripGraphAsync(tripId, userId, cancellationToken);
+        if (trip == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaOrderResult>>.NotFound();
+        }
+
+        var region = trip.Regions.FirstOrDefault(r => r.Id == regionId);
+        if (region == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaOrderResult>>.NotFound();
+        }
+
+        if (IsShadowRegion(region))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaOrderResult>>.Forbidden("Areas in the shadow region cannot be reordered.");
+        }
+
+        var request = await ParseJsonBodyAsync(requestBody, "Area order request must be valid JSON.", cancellationToken);
+        if (request.ValidationErrors != null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaOrderResult>>.ValidationFailed(request.ValidationErrors);
+        }
+
+        if (!EditorAreaRequestParser.TryParseOrder(request.Value!.Value, out var orderRequest, out var errors))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaOrderResult>>.ValidationFailed(errors);
+        }
+
+        var currentIds = region.Areas.OrderBy(a => a.DisplayOrder).ThenBy(a => a.Name).Select(a => a.Id).ToList();
+        if (orderRequest.AreaIds.Count != currentIds.Count
+            || orderRequest.AreaIds.Distinct().Count() != orderRequest.AreaIds.Count
+            || orderRequest.AreaIds.Any(id => !currentIds.Contains(id)))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaOrderResult>>.ValidationFailed(new Dictionary<string, string[]>
+            {
+                ["areaIds"] = new[] { "Area IDs must include every area in this region exactly once." }
+            });
+        }
+
+        var areasById = region.Areas.ToDictionary(a => a.Id);
+        for (var i = 0; i < orderRequest.AreaIds.Count; i++)
+        {
+            areasById[orderRequest.AreaIds[i]].DisplayOrder = i + 1;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var areaOrder = await LoadAreaOrderAsync(region.Id, cancellationToken);
+        var areaDtos = await LoadAreaDtosAsync(orderRequest.AreaIds, tripId, cancellationToken);
+        var affected = await BuildAffectedAsync(tripId, areaDtos, new[] { region.Id }, cancellationToken);
+        var data = new EditorAreaOrderResult(region.Id, areaOrder);
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorAreaOrderResult>>.Succeeded(
+            new EditorMutationResult<EditorAreaOrderResult>(true, data, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    private async Task<(EditorAreaSaveRequest? Value, Dictionary<string, string[]>? ValidationErrors)> ParseAndValidateCreateAsync(Stream body, CancellationToken token)
+    {
+        var request = await ParseJsonBodyAsync(body, "Area create request must be valid JSON.", token);
+        if (request.ValidationErrors != null)
+        {
+            return (null, request.ValidationErrors);
+        }
+
+        return EditorAreaRequestParser.TryParseCreate(request.Value!.Value, out var value, out var errors) ? (value, null) : (null, errors);
+    }
+
+    private async Task<(EditorAreaSaveRequest? Value, Dictionary<string, string[]>? ValidationErrors)> ParseAndValidateUpdateAsync(Stream body, CancellationToken token)
+    {
+        var request = await ParseJsonBodyAsync(body, "Area update request must be valid JSON.", token);
+        if (request.ValidationErrors != null)
+        {
+            return (null, request.ValidationErrors);
+        }
+
+        return EditorAreaRequestParser.TryParseUpdate(request.Value!.Value, out var value, out var errors) ? (value, null) : (null, errors);
+    }
+
+    private async Task<(EditorAreaGeometryUpdateRequest? Value, Dictionary<string, string[]>? ValidationErrors)> ParseAndValidateGeometryAsync(Stream body, CancellationToken token)
+    {
+        var request = await ParseJsonBodyAsync(body, "Area geometry request must be valid JSON.", token);
+        if (request.ValidationErrors != null)
+        {
+            return (null, request.ValidationErrors);
+        }
+
+        return EditorAreaRequestParser.TryParseGeometryUpdate(request.Value!.Value, out var value, out var errors) ? (value, null) : (null, errors);
+    }
+
+    private async Task<Trip?> LoadTripGraphAsync(Guid tripId, string userId, CancellationToken cancellationToken) =>
+        await _dbContext.Trips
+            .Include(t => t.Regions).ThenInclude(r => r.Areas)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+
+    private async Task<Area?> LoadOwnedAreaAsync(Guid tripId, Guid areaId, string userId, CancellationToken cancellationToken) =>
+        await _dbContext.Areas
+            .Include(a => a.Region)
+            .ThenInclude(r => r.Trip)
+            .FirstOrDefaultAsync(a => a.Id == areaId && a.Region.TripId == tripId && a.Region.Trip.UserId == userId, cancellationToken);
+
+    private async Task<EditorAreaDto> LoadAreaDtoAsync(Guid areaId, Guid tripId, CancellationToken cancellationToken)
+    {
+        var area = await _dbContext.Areas.AsNoTracking().SingleAsync(a => a.Id == areaId, cancellationToken);
+        return EditorTripStateMapper.ToArea(tripId, area.RegionId, area);
+    }
+
+    private async Task<IReadOnlyList<EditorAreaDto>> LoadAreaDtosAsync(IReadOnlyList<Guid> ids, Guid tripId, CancellationToken cancellationToken)
+    {
+        var areas = await _dbContext.Areas.AsNoTracking().Where(a => ids.Contains(a.Id)).ToListAsync(cancellationToken);
+        var byId = areas.ToDictionary(a => a.Id);
+        return ids.Select(id => EditorTripStateMapper.ToArea(tripId, byId[id].RegionId, byId[id])).ToList();
+    }
+
+    private async Task<EditorAffectedSlicesDto> BuildAffectedAsync(
+        Guid tripId,
+        IReadOnlyList<EditorAreaDto> areas,
+        IReadOnlyList<Guid> areaOrderRegionIds,
+        CancellationToken cancellationToken)
+    {
+        var areaOrders = new Dictionary<Guid, IReadOnlyList<Guid>>();
+        foreach (var regionId in areaOrderRegionIds.Distinct())
+        {
+            areaOrders[regionId] = await LoadAreaOrderAsync(regionId, cancellationToken);
+        }
+
+        return new EditorAffectedSlicesDto(
+            null,
+            Array.Empty<EditorRegionDto>(),
+            null,
+            Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            areas,
+            areaOrders,
+            Array.Empty<EditorSegmentDto>(),
+            null,
+            Array.Empty<EditorTagDto>(),
+            null,
+            null,
+            null);
+    }
+
+    private async Task<IReadOnlyList<Guid>> LoadAreaOrderAsync(Guid regionId, CancellationToken cancellationToken) =>
+        await _dbContext.Areas
+            .AsNoTracking()
+            .Where(a => a.RegionId == regionId)
+            .OrderBy(a => a.DisplayOrder)
+            .ThenBy(a => a.Name)
+            .Select(a => a.Id)
+            .ToListAsync(cancellationToken);
+
+    private async Task NormalizeAreaOrdersAsync(Guid regionId, CancellationToken cancellationToken)
+    {
+        var areas = await _dbContext.Areas.Where(a => a.RegionId == regionId).OrderBy(a => a.DisplayOrder).ThenBy(a => a.Name).ToListAsync(cancellationToken);
+        for (var i = 0; i < areas.Count; i++)
+        {
+            areas[i].DisplayOrder = i + 1;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static async Task<(JsonElement? Value, Dictionary<string, string[]>? ValidationErrors)> ParseJsonBodyAsync(
+        Stream requestBody,
+        string invalidJsonMessage,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var document = await JsonDocument.ParseAsync(requestBody, cancellationToken: cancellationToken);
+            return (document.RootElement.Clone(), null);
+        }
+        catch (JsonException)
+        {
+            return (null, new Dictionary<string, string[]> { ["request"] = new[] { invalidJsonMessage } });
+        }
+    }
+
+    private static int NextAreaOrder(Region region) =>
+        (region.Areas.Count == 0 ? 0 : region.Areas.Max(a => a.DisplayOrder ?? 0)) + 1;
+
+    private static bool IsShadowRegion(Region region) =>
+        region.DisplayOrder == 0
+        && string.Equals(region.Name, EditorRegionRequestParser.ShadowRegionName, StringComparison.Ordinal);
+}

--- a/tests/Wayfarer.Tests/Controllers/TripEditorAreaControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorAreaControllerTests.cs
@@ -155,6 +155,11 @@ public sealed class TripEditorAreaControllerTests : TestBase
         """);
         var geometry = await SendJson(controller, c => c.UpdateAreaGeometry(trip.Id, area.Id, CancellationToken.None), $$"""
         {
+          "id": "00000000-0000-0000-0000-000000000011",
+          "tripId": "00000000-0000-0000-0000-000000000012",
+          "regionId": "00000000-0000-0000-0000-000000000013",
+          "displayOrder": 77,
+          "capabilities": {},
           "name": "Nope",
           "notesHtml": "",
           "fillHex": "#ffffff",
@@ -169,7 +174,7 @@ public sealed class TripEditorAreaControllerTests : TestBase
         }
 
         var geometryProblem = AssertValidationProblem(geometry);
-        foreach (var key in new[] { "name", "notesHtml", "fillHex" })
+        foreach (var key in new[] { "id", "tripId", "regionId", "displayOrder", "capabilities", "name", "notesHtml", "fillHex" })
         {
             Assert.Contains(key, geometryProblem.Errors.Keys);
         }
@@ -195,20 +200,33 @@ public sealed class TripEditorAreaControllerTests : TestBase
         Assert.Contains(AssertValidationProblem(result).Errors.Keys, key => key.StartsWith("geometry", StringComparison.Ordinal));
     }
 
-    [Theory]
-    [InlineData("""{ "areaIds": [] }""")]
-    [InlineData("""{ "areaIds": [ "00000000-0000-0000-0000-000000000001" ] }""")]
-    public async Task OrderAreasRejectsMissingDuplicateUnknownAndCrossRegionIds(string body)
+    [Fact]
+    public async Task OrderAreasRejectsMissingDuplicateUnknownCrossRegionAndCrossTripIds()
     {
         using var db = CreateDbContext();
         var trip = SeedTripGraph(db, "owner-user");
         var region = trip.Regions.Single(r => r.Name == "Athens");
+        var currentArea = region.Areas.Single();
+        var crossRegionArea = trip.Regions.Single(r => r.Name == "Other").Areas.Single();
+        var otherTrip = SeedTripGraph(db, "other-user");
+        var crossTripArea = otherTrip.Regions.Single(r => r.Name == "Athens").Areas.Single();
         var controller = BuildController(db);
         ConfigureControllerWithUserRole(controller, "owner-user");
 
-        var result = await SendJson(controller, c => c.OrderAreas(trip.Id, region.Id, CancellationToken.None), body);
+        var bodies = new[]
+        {
+            """{ "areaIds": [] }""",
+            $$"""{ "areaIds": [ "{{currentArea.Id}}", "{{currentArea.Id}}" ] }""",
+            """{ "areaIds": [ "00000000-0000-0000-0000-000000000001" ] }""",
+            $$"""{ "areaIds": [ "{{crossRegionArea.Id}}" ] }""",
+            $$"""{ "areaIds": [ "{{crossTripArea.Id}}" ] }"""
+        };
 
-        Assert.Contains("areaIds", AssertValidationProblem(result).Errors.Keys);
+        foreach (var body in bodies)
+        {
+            var result = await SendJson(controller, c => c.OrderAreas(trip.Id, region.Id, CancellationToken.None), body);
+            Assert.Contains("areaIds", AssertValidationProblem(result).Errors.Keys);
+        }
     }
 
     private static Trip SeedTripGraph(ApplicationDbContext db, string userId)

--- a/tests/Wayfarer.Tests/Controllers/TripEditorAreaControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorAreaControllerTests.cs
@@ -163,6 +163,7 @@ public sealed class TripEditorAreaControllerTests : TestBase
           "name": "Nope",
           "notesHtml": "",
           "fillHex": "#ffffff",
+          "unexpected": true,
           "geometry": {{PolygonJson(0)}}
         }
         """);
@@ -174,7 +175,7 @@ public sealed class TripEditorAreaControllerTests : TestBase
         }
 
         var geometryProblem = AssertValidationProblem(geometry);
-        foreach (var key in new[] { "id", "tripId", "regionId", "displayOrder", "capabilities", "name", "notesHtml", "fillHex" })
+        foreach (var key in new[] { "id", "tripId", "regionId", "displayOrder", "capabilities", "name", "notesHtml", "fillHex", "unexpected" })
         {
             Assert.Contains(key, geometryProblem.Errors.Keys);
         }

--- a/tests/Wayfarer.Tests/Controllers/TripEditorAreaControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorAreaControllerTests.cs
@@ -1,0 +1,308 @@
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NetTopologySuite.Geometries;
+using Wayfarer.Areas.Api.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Models.Dtos.Editor;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Controllers;
+
+/// <summary>
+/// Focused tests for Trip Editor area mutations.
+/// </summary>
+public sealed class TripEditorAreaControllerTests : TestBase
+{
+    [Fact]
+    public async Task CreateUpdateGeometryDeleteAndOrderAreasForOwnerReturnDeterministicSlices()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripGraph(db, "owner-user");
+        var region = trip.Regions.Single(r => r.Name == "Athens");
+        var existing = region.Areas.Single();
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var created = await SendJson(controller, c => c.CreateArea(trip.Id, region.Id, CancellationToken.None), ValidCreateBody(" ", null));
+        var createEnvelope = AssertMutation<EditorAreaDto>(created);
+        Assert.Equal("Area", createEnvelope.Data.Name);
+        Assert.Equal("#ff6600", createEnvelope.Data.FillHex);
+        Assert.Equal(new[] { existing.Id, createEnvelope.Data.Id }, createEnvelope.Affected.AreaOrdersByRegionId[region.Id]);
+        Assert.Empty(createEnvelope.DeletedIds.Areas);
+
+        var updated = await SendJson(controller, c => c.UpdateArea(trip.Id, createEnvelope.Data.Id, CancellationToken.None), ValidUpdateBody("Updated", "#ABCDEF"));
+        var updateEnvelope = AssertMutation<EditorAreaDto>(updated);
+        Assert.Equal("Updated", updateEnvelope.Data.Name);
+        Assert.Equal("#abcdef", updateEnvelope.Data.FillHex);
+        Assert.Single(updateEnvelope.Affected.Areas);
+
+        var geometry = await SendJson(controller, c => c.UpdateAreaGeometry(trip.Id, createEnvelope.Data.Id, CancellationToken.None), $$"""{ "geometry": {{PolygonJson(5)}} }""");
+        var geometryEnvelope = AssertMutation<EditorAreaDto>(geometry);
+        Assert.Equal(5, geometryEnvelope.Data.Geometry.GetProperty("coordinates")[0][0][0].GetDouble());
+
+        var order = await SendJson(controller, c => c.OrderAreas(trip.Id, region.Id, CancellationToken.None), $$"""
+        { "areaIds": [ "{{createEnvelope.Data.Id}}", "{{existing.Id}}" ] }
+        """);
+        var orderEnvelope = AssertMutation<EditorAreaOrderResult>(order);
+        Assert.Equal(new[] { createEnvelope.Data.Id, existing.Id }, orderEnvelope.Data.AreaOrder);
+        Assert.Equal(1, db.Areas.Single(a => a.Id == createEnvelope.Data.Id).DisplayOrder);
+        Assert.Equal(2, db.Areas.Single(a => a.Id == existing.Id).DisplayOrder);
+
+        var deleted = await controller.DeleteArea(trip.Id, createEnvelope.Data.Id, CancellationToken.None);
+        var deleteEnvelope = AssertMutation<EditorAreaDeleteResult>(deleted);
+        Assert.Equal(createEnvelope.Data.Id, deleteEnvelope.Data.AreaId);
+        Assert.Equal(new[] { createEnvelope.Data.Id }, deleteEnvelope.DeletedIds.Areas);
+        Assert.Equal(new[] { existing.Id }, deleteEnvelope.Affected.AreaOrdersByRegionId[region.Id]);
+    }
+
+    [Fact]
+    public async Task AreaMutationAuthAndMissingOwnedResourcesReturnBeforeBodyParsing()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripGraph(db, "owner-user");
+        var region = trip.Regions.Single(r => r.Name == "Athens");
+        var area = region.Areas.Single();
+        var controller = BuildController(db);
+
+        var anonymous = await SendJson(controller, c => c.CreateArea(trip.Id, region.Id, CancellationToken.None), ValidCreateBody("Blocked", "#ff6600"));
+        ConfigureControllerWithUserRole(controller, "owner-user", "Manager");
+        var wrongRole = await SendJson(controller, c => c.CreateArea(trip.Id, region.Id, CancellationToken.None), ValidCreateBody("Blocked", "#ff6600"));
+        ConfigureControllerWithUserRole(controller, "other-user");
+        var nonOwnerTrip = await SendJson(controller, c => c.CreateArea(trip.Id, region.Id, CancellationToken.None), "{");
+        ConfigureControllerWithUserRole(controller, "owner-user");
+        var missingRegion = await SendJson(controller, c => c.CreateArea(trip.Id, Guid.NewGuid(), CancellationToken.None), "{");
+        var missingArea = await SendJson(controller, c => c.UpdateArea(trip.Id, Guid.NewGuid(), CancellationToken.None), "{");
+        var missingDelete = await controller.DeleteArea(trip.Id, Guid.NewGuid(), CancellationToken.None);
+        var nonOwnedArea = await SendJson(controller, c => c.UpdateArea(Guid.NewGuid(), area.Id, CancellationToken.None), "{");
+
+        Assert.IsType<UnauthorizedResult>(anonymous);
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<StatusCodeResult>(wrongRole).StatusCode);
+        Assert.IsType<NotFoundResult>(nonOwnerTrip);
+        Assert.IsType<NotFoundResult>(missingRegion);
+        Assert.IsType<NotFoundResult>(missingArea);
+        Assert.IsType<NotFoundResult>(missingDelete);
+        Assert.IsType<NotFoundResult>(nonOwnedArea);
+    }
+
+    [Fact]
+    public async Task ShadowRegionRejectsCreateAndOrderWithForbidden()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripGraph(db, "owner-user");
+        var shadow = trip.Regions.Single(r => r.Name == "Unassigned Places");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var create = await SendJson(controller, c => c.CreateArea(trip.Id, shadow.Id, CancellationToken.None), ValidCreateBody("Shadow", "#ff6600"));
+        var order = await SendJson(controller, c => c.OrderAreas(trip.Id, shadow.Id, CancellationToken.None), """{ "areaIds": [] }""");
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ObjectResult>(create).StatusCode);
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ObjectResult>(order).StatusCode);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("{")]
+    [InlineData("[]")]
+    public async Task OwnedAreaMutationsWithInvalidBodyReturnRequestValidationProblem(string body)
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripGraph(db, "owner-user");
+        var region = trip.Regions.Single(r => r.Name == "Athens");
+        var area = region.Areas.Single();
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var create = await SendJson(controller, c => c.CreateArea(trip.Id, region.Id, CancellationToken.None), body);
+        var update = await SendJson(controller, c => c.UpdateArea(trip.Id, area.Id, CancellationToken.None), body);
+        var geometry = await SendJson(controller, c => c.UpdateAreaGeometry(trip.Id, area.Id, CancellationToken.None), body);
+        var order = await SendJson(controller, c => c.OrderAreas(trip.Id, region.Id, CancellationToken.None), body);
+
+        Assert.Contains("request", AssertValidationProblem(create).Errors.Keys);
+        Assert.Contains("request", AssertValidationProblem(update).Errors.Keys);
+        Assert.Contains("request", AssertValidationProblem(geometry).Errors.Keys);
+        Assert.Contains("request", AssertValidationProblem(order).Errors.Keys);
+    }
+
+    [Fact]
+    public async Task AreaValidationRejectsForbiddenFieldsInvalidEditableFieldsAndGeometry()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripGraph(db, "owner-user");
+        var area = trip.Regions.Single(r => r.Name == "Athens").Areas.Single();
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var update = await SendJson(controller, c => c.UpdateArea(trip.Id, area.Id, CancellationToken.None), """
+        {
+          "id": "00000000-0000-0000-0000-000000000001",
+          "tripId": "00000000-0000-0000-0000-000000000002",
+          "regionId": "00000000-0000-0000-0000-000000000003",
+          "displayOrder": 99,
+          "capabilities": {},
+          "name": " ",
+          "notesHtml": "<img src=\"   data:image/png;base64,abc\">",
+          "fillHex": "orange",
+          "geometry": { "type": "LineString", "coordinates": [] }
+        }
+        """);
+        var geometry = await SendJson(controller, c => c.UpdateAreaGeometry(trip.Id, area.Id, CancellationToken.None), $$"""
+        {
+          "name": "Nope",
+          "notesHtml": "",
+          "fillHex": "#ffffff",
+          "geometry": {{PolygonJson(0)}}
+        }
+        """);
+
+        var updateProblem = AssertValidationProblem(update);
+        foreach (var key in new[] { "id", "tripId", "regionId", "displayOrder", "capabilities", "name", "notesHtml", "fillHex", "geometry" })
+        {
+            Assert.Contains(key, updateProblem.Errors.Keys);
+        }
+
+        var geometryProblem = AssertValidationProblem(geometry);
+        foreach (var key in new[] { "name", "notesHtml", "fillHex" })
+        {
+            Assert.Contains(key, geometryProblem.Errors.Keys);
+        }
+    }
+
+    [Theory]
+    [InlineData("""{ "type": "MultiPolygon", "coordinates": [] }""")]
+    [InlineData("""{ "type": "Polygon", "coordinates": [] }""")]
+    [InlineData("""{ "type": "Polygon", "coordinates": [[[0,0],[1,0],[0,0]]] }""")]
+    [InlineData("""{ "type": "Polygon", "coordinates": [[[0,0],[1,0],[1,1],[0,1]]] }""")]
+    [InlineData("""{ "type": "Polygon", "coordinates": [[[181,0],[1,0],[1,1],[181,0]]] }""")]
+    [InlineData("""{ "type": "Polygon", "coordinates": [[[0,0,1],[1,0],[1,1],[0,0,1]]] }""")]
+    public async Task AreaGeometryValidationRejectsInvalidPolygonCases(string geometryJson)
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripGraph(db, "owner-user");
+        var area = trip.Regions.Single(r => r.Name == "Athens").Areas.Single();
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.UpdateAreaGeometry(trip.Id, area.Id, CancellationToken.None), $$"""{ "geometry": {{geometryJson}} }""");
+
+        Assert.Contains(AssertValidationProblem(result).Errors.Keys, key => key.StartsWith("geometry", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("""{ "areaIds": [] }""")]
+    [InlineData("""{ "areaIds": [ "00000000-0000-0000-0000-000000000001" ] }""")]
+    public async Task OrderAreasRejectsMissingDuplicateUnknownAndCrossRegionIds(string body)
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTripGraph(db, "owner-user");
+        var region = trip.Regions.Single(r => r.Name == "Athens");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await SendJson(controller, c => c.OrderAreas(trip.Id, region.Id, CancellationToken.None), body);
+
+        Assert.Contains("areaIds", AssertValidationProblem(result).Errors.Keys);
+    }
+
+    private static Trip SeedTripGraph(ApplicationDbContext db, string userId)
+    {
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = userId, Name = "Trip", UpdatedAt = DateTime.UtcNow };
+        var shadow = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, Name = "Unassigned Places", DisplayOrder = 0 };
+        var athens = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, Name = "Athens", DisplayOrder = 1 };
+        var other = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, Name = "Other", DisplayOrder = 2 };
+        athens.Areas.Add(new Area { Id = Guid.NewGuid(), Region = athens, RegionId = athens.Id, Name = "Alpha", Notes = "", FillHex = "#112233", DisplayOrder = 1, Geometry = Square(0) });
+        other.Areas.Add(new Area { Id = Guid.NewGuid(), Region = other, RegionId = other.Id, Name = "Other Area", Notes = "", FillHex = "#445566", DisplayOrder = 1, Geometry = Square(10) });
+        trip.Regions.Add(shadow);
+        trip.Regions.Add(athens);
+        trip.Regions.Add(other);
+        db.Trips.Add(trip);
+        db.SaveChanges();
+        return trip;
+    }
+
+    private static string ValidCreateBody(string name, string? fillHex) =>
+        $$"""
+        {
+          "name": "{{name}}",
+          "notesHtml": null,
+          "fillHex": {{(fillHex == null ? "null" : $"\"{fillHex}\"")}},
+          "geometry": {{PolygonJson(1)}}
+        }
+        """;
+
+    private static string ValidUpdateBody(string name, string fillHex) =>
+        $$"""
+        {
+          "name": "{{name}}",
+          "notesHtml": "<p>Notes</p>",
+          "fillHex": "{{fillHex}}",
+          "geometry": {{PolygonJson(2)}}
+        }
+        """;
+
+    private static string PolygonJson(int offset) =>
+        $$"""{ "type": "Polygon", "coordinates": [[[{{offset}},0],[{{offset + 1}},0],[{{offset + 1}},1],[{{offset}},0]]] }""";
+
+    private static Polygon Square(int offset) =>
+        new(new LinearRing(new[] { new Coordinate(offset, 0), new Coordinate(offset + 1, 0), new Coordinate(offset + 1, 1), new Coordinate(offset, 0) })) { SRID = 4326 };
+
+    private static void ConfigureControllerWithUserRole(ControllerBase controller, string userId, string role = "User")
+    {
+        controller.ControllerContext = new ControllerContext { HttpContext = BuildHttpContextWithUser(userId, role) };
+    }
+
+    private static TripEditorController BuildController(ApplicationDbContext db)
+    {
+        var environment = BuildEnvironment();
+        var iconColorProvider = new IconColorProvider(environment);
+        return new TripEditorController(
+            db,
+            environment,
+            iconColorProvider,
+            Mock.Of<ITripMapThumbnailGenerator>(),
+            Mock.Of<ICacheWarmupScheduler>(),
+            Mock.Of<ITripTagService>(),
+            new TripEditorRegionMutationService(db),
+            new TripEditorPlaceMutationService(db, environment, iconColorProvider, new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
+            new TripEditorAreaMutationService(db),
+            Mock.Of<ILogger<TripEditorController>>());
+    }
+
+    private static IWebHostEnvironment BuildEnvironment()
+    {
+        var mock = new Mock<IWebHostEnvironment>();
+        mock.SetupGet(e => e.WebRootPath).Returns(Path.GetTempPath());
+        return mock.Object;
+    }
+
+    private static async Task<IActionResult> SendJson(TripEditorController controller, Func<TripEditorController, Task<IActionResult>> action, string requestBody)
+    {
+        var httpContext = controller.ControllerContext.HttpContext ?? new DefaultHttpContext();
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        var body = Encoding.UTF8.GetBytes(requestBody);
+        httpContext.Request.Body = new MemoryStream(body);
+        httpContext.Request.ContentLength = body.Length;
+        httpContext.Request.ContentType = "application/json";
+        return await action(controller);
+    }
+
+    private static ValidationProblemDetails AssertValidationProblem(IActionResult result)
+    {
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("application/problem+json", badRequest.ContentTypes);
+        return Assert.IsType<ValidationProblemDetails>(badRequest.Value);
+    }
+
+    private static EditorMutationResult<T> AssertMutation<T>(IActionResult result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result);
+        return Assert.IsType<EditorMutationResult<T>>(ok.Value);
+    }
+}

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -293,6 +293,7 @@ public sealed class TripEditorControllerTests : TestBase
             Mock.Of<ITripTagService>(),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
+            new TripEditorAreaMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
         var url = new Mock<IUrlHelper>();

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
@@ -208,6 +208,7 @@ public sealed class TripEditorMetadataControllerTests : TestBase
             Mock.Of<ITripTagService>(),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
+            new TripEditorAreaMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
         var url = new Mock<IUrlHelper>();

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataValidationControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataValidationControllerTests.cs
@@ -256,6 +256,7 @@ public sealed class TripEditorMetadataValidationControllerTests : TestBase
             Mock.Of<ITripTagService>(),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
+            new TripEditorAreaMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
     }
 

--- a/tests/Wayfarer.Tests/Controllers/TripEditorPlaceControllerTestBase.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorPlaceControllerTestBase.cs
@@ -103,6 +103,7 @@ public abstract class TripEditorPlaceControllerTestBase : TestBase
             Mock.Of<ITripTagService>(),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, iconColorProvider, reverseGeocodingService ?? new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
+            new TripEditorAreaMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
     }
 

--- a/tests/Wayfarer.Tests/Controllers/TripEditorRegionControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorRegionControllerTests.cs
@@ -326,6 +326,7 @@ public sealed class TripEditorRegionControllerTests : TestBase
             Mock.Of<ITripTagService>(),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
+            new TripEditorAreaMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
     }
 

--- a/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
@@ -229,6 +229,7 @@ public sealed class TripEditorTagsShareProgressControllerTests : TestBase
             new TripTagService(db, NullLogger<TripTagService>.Instance),
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
+            new TripEditorAreaMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
         var url = new Mock<IUrlHelper>();

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -1,0 +1,247 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+import {
+  absoluteUrl,
+  editorApiPath,
+  expectMountedWorkspace,
+  expectNoSearchAddUi,
+  loadEditorStateFixture,
+  signIn,
+  workspacePath
+} from './tripEditorTestUtils';
+
+type MutableEditorState = Record<string, any>;
+
+const areaId = '00000000-0000-0000-0000-000000248001';
+const secondAreaId = '00000000-0000-0000-0000-000000248002';
+const areaName = 'PW editable area';
+const secondAreaName = 'PW second area';
+const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
+
+test.describe.serial('Trip Editor area editing', () => {
+  test('adds and edits areas through one docked or expanded shared draft', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithAreaFixture(page);
+
+    const region = firstEditableRegion(page);
+    await region.getByRole('button', { name: 'Add Area' }).click();
+    await expect(page.getByRole('heading', { name: 'Add Area' })).toBeVisible();
+    await expect(page.locator('#trip-editor-area-form')).toHaveCount(1);
+    await expect(page.locator('#trip-editor-area-form').getByLabel('Name')).toHaveValue('Area');
+    await expect(page.locator('#trip-editor-area-form')).toContainText('No polygon drawn');
+    await expect(page.getByRole('button', { name: 'Save Geometry' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await openEditableArea(page);
+    await expect(page.locator('#trip-editor-area-form').getByLabel('Name')).toHaveValue(areaName);
+    await page.getByRole('button', { name: 'Expand Editor' }).click();
+    await expect(page.getByRole('dialog', { name: new RegExp(`Edit Area - ${areaName}`) })).toBeVisible();
+    await expect(page.locator('#trip-editor-area-form')).toHaveCount(1);
+  });
+
+  test('Draw/Edit Area enters map-work and Done updates only the draft', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithAreaFixture(page);
+    const mutations = watchEditorMutations(page);
+
+    await openEditableArea(page);
+    await page.getByRole('button', { name: 'Draw/Edit Area' }).click();
+    const mapWork = page.getByRole('region', { name: 'Map work' });
+    await expect(mapWork).toContainText('Draw area polygon');
+    await expect(mapWork).toContainText('3 vertices ready');
+    await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
+    await expect(page.locator('.trip-editor-toolbar').getByRole('button', { name: 'Fit All' })).toHaveCount(0);
+    await expectNoSearchAddUi(page);
+
+    await mapWork.getByRole('button', { name: 'Done' }).click();
+    await expect(page.locator('#trip-editor-area-form')).toContainText('3 polygon vertices');
+    expect(mutations(), 'Area map-work Done must not call create/update/geometry endpoints.').toEqual([]);
+  });
+
+  test('new area starts without a temporary polygon and Save after Done persists it', async ({ page }) => {
+    await signIn(page);
+    const state = await loadWorkspaceWithAreaFixture(page);
+    const regionId = normalRegion(state).id;
+    const savedRequests: Array<Record<string, any>> = [];
+    await page.route(editorApiMatcher, async route => {
+      if (route.request().method() === 'GET') {
+        await route.fallback();
+        return;
+      }
+
+      expect(route.request().method()).toBe('POST');
+      expect(route.request().url()).toContain(`/regions/${regionId}/areas`);
+      const body = route.request().postDataJSON() as Record<string, any>;
+      savedRequests.push(body);
+      const savedArea = areaFixture(state, regionId, '00000000-0000-0000-0000-000000248099', body.name, body.geometry);
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(areaMutationResult(savedArea, { [regionId]: [areaId, secondAreaId, savedArea.id] })) });
+    });
+
+    await firstEditableRegion(page).getByRole('button', { name: 'Add Area' }).click();
+    await page.getByRole('button', { name: 'Draw/Edit Area' }).click();
+    const mapWork = page.getByRole('region', { name: 'Map work' });
+    await expect(mapWork).toContainText('No polygon ready');
+    await expect(mapWork.getByRole('button', { name: 'Done' })).toBeDisabled();
+    await clickMap(page, { xRatio: 0.35, yRatio: 0.35 });
+    await clickMap(page, { xRatio: 0.45, yRatio: 0.35 });
+    await clickMap(page, { xRatio: 0.40, yRatio: 0.45 });
+    await expect(mapWork).toContainText('3 vertices ready');
+    expect(savedRequests).toEqual([]);
+
+    await mapWork.getByRole('button', { name: 'Done' }).click();
+    await page.locator('#trip-editor-area-form').getByLabel('Name').fill('PW saved area');
+    await page.getByRole('button', { name: 'Save Area' }).click();
+    await expect.poll(() => savedRequests.length).toBe(1);
+    expect(savedRequests[0].geometry.type).toBe('Polygon');
+    expect(savedRequests[0].geometry.coordinates[0]).toHaveLength(4);
+  });
+
+  test('Cancel rolls back only geometry and delete confirms dirty discard before danger', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithAreaFixture(page);
+
+    await openEditableArea(page);
+    const form = page.locator('#trip-editor-area-form');
+    await form.getByLabel('Name').fill('Unsaved area name');
+    await page.getByRole('button', { name: 'Draw/Edit Area' }).click();
+    await clickMap(page, { xRatio: 0.50, yRatio: 0.50 });
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+    await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await expect(form.getByLabel('Name')).toHaveValue('Unsaved area name');
+
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await expect(page.getByRole('dialog', { name: 'Discard changes?' })).toBeVisible();
+    await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await expect(page.getByRole('dialog', { name: 'Delete area?' })).toBeVisible();
+  });
+
+  test('shadow region exposes no area add or reorder affordance', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithAreaFixture(page);
+    const shadow = page.locator('.trip-editor-region-card--shadow').first();
+    if (await shadow.count()) {
+      await expect(shadow.getByRole('button', { name: 'Add Area' })).toHaveCount(0);
+      await expect(shadow.getByRole('button', { name: 'Drag to reorder area' })).toHaveCount(0);
+    }
+  });
+});
+
+async function loadWorkspaceWithAreaFixture(page: Page): Promise<MutableEditorState> {
+  await page.unroute(editorApiMatcher).catch(() => undefined);
+  const state = await loadEditorStateFixture(page) as MutableEditorState;
+  prepareAreaState(state);
+  await page.route(editorApiMatcher, async route => routeEditorReadOnly(route, state));
+  await page.goto(absoluteUrl(workspacePath));
+  await expectMountedWorkspace(page);
+  return state;
+}
+
+async function routeEditorReadOnly(route: Route, state: MutableEditorState): Promise<void> {
+  if (route.request().method() !== 'GET') {
+    throw new Error(`Unexpected editor mutation ${route.request().method()} ${route.request().url()}`);
+  }
+
+  await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+}
+
+function prepareAreaState(state: MutableEditorState): void {
+  const region = normalRegion(state);
+  state.permissions.canEditAreas = true;
+  region.capabilities.canAddChildren = true;
+  state.areasById[areaId] = areaFixture(state, region.id, areaId, areaName, polygon(0));
+  state.areasById[secondAreaId] = areaFixture(state, region.id, secondAreaId, secondAreaName, polygon(2));
+  state.areaOrderByRegionId[region.id] = [areaId, secondAreaId];
+}
+
+function normalRegion(state: MutableEditorState): any {
+  const region = Object.values(state.regionsById).find((item: any) => !item.isShadow) as any;
+  if (!region) {
+    throw new Error('Configured Trip Editor fixture must contain a normal region.');
+  }
+
+  return region;
+}
+
+function areaFixture(state: MutableEditorState, regionId: string, id: string, name: string, geometry: any): Record<string, any> {
+  return {
+    id,
+    tripId: state.tripId,
+    regionId,
+    name,
+    notesHtml: '',
+    fillHex: '#ff6600',
+    geometry,
+    displayOrder: 1,
+    capabilities: {
+      canEdit: true,
+      canRename: true,
+      canDelete: true,
+      canReorder: true,
+      canMove: false,
+      canAddChildren: false,
+      canTargetForSearchAdd: false
+    }
+  };
+}
+
+async function openEditableArea(page: Page): Promise<void> {
+  await firstEditableRegion(page).getByText(areaName).locator('xpath=ancestor::*[contains(@class, "trip-editor-area-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
+  await expect(page.getByRole('heading', { name: new RegExp(`Edit Area - ${areaName}`) })).toBeVisible();
+}
+
+function firstEditableRegion(page: Page) {
+  return page.locator('.trip-editor-region-card--normal').first();
+}
+
+async function clickMap(page: Page, position: { xRatio: number; yRatio: number }): Promise<void> {
+  const map = page.getByLabel('Read-only trip map');
+  await map.evaluate((element, point) => {
+    const box = element.getBoundingClientRect();
+    const clientX = box.left + box.width * point.xRatio;
+    const clientY = box.top + box.height * point.yRatio;
+    for (const type of ['mousedown', 'mouseup', 'click']) {
+      element.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, view: window }));
+    }
+  }, position);
+}
+
+function watchEditorMutations(page: Page): () => string[] {
+  const urls: string[] = [];
+  page.on('request', request => {
+    if (editorApiMatcher.test(request.url()) && request.method() !== 'GET') {
+      urls.push(`${request.method()} ${request.url()}`);
+    }
+  });
+  return () => urls;
+}
+
+function areaMutationResult(area: Record<string, any>, orderByRegion: Record<string, string[]>): Record<string, any> {
+  return {
+    success: true,
+    data: area,
+    affected: {
+      metadata: null,
+      regions: [],
+      regionOrder: null,
+      places: [],
+      placeOrdersByRegionId: {},
+      areas: [area],
+      areaOrdersByRegionId: orderByRegion,
+      segments: [],
+      segmentOrder: null,
+      tags: [],
+      tagOrder: null,
+      visitProgress: null,
+      options: null
+    },
+    deletedIds: { regions: [], places: [], areas: [], segments: [], tags: [] },
+    warnings: []
+  };
+}
+
+function polygon(offset: number): Record<string, any> {
+  return {
+    type: 'Polygon',
+    coordinates: [[[offset, 0], [offset + 1, 0], [offset + 1, 1], [offset, 0]]]
+  };
+}

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -98,6 +98,35 @@ test.describe.serial('Trip Editor area editing', () => {
     expect(savedRequests[0].geometry.coordinates[0]).toHaveLength(4);
   });
 
+  test('existing polygon map-work preserves interior rings on Done and Save', async ({ page }) => {
+    await signIn(page);
+    const savedRequests: Array<Record<string, any>> = [];
+    const state = await loadWorkspaceWithAreaFixture(page, fixture => {
+      fixture.areasById[areaId].geometry = polygonWithHole();
+    });
+    await page.route(editorApiMatcher, async route => {
+      if (route.request().method() === 'GET') {
+        await route.fallback();
+        return;
+      }
+
+      expect(route.request().method()).toBe('PUT');
+      expect(route.request().url()).toContain(`/areas/${areaId}`);
+      const body = route.request().postDataJSON() as Record<string, any>;
+      savedRequests.push(body);
+      state.areasById[areaId] = { ...state.areasById[areaId], ...body };
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(areaMutationResult(state.areasById[areaId], { [state.areasById[areaId].regionId]: [areaId, secondAreaId] })) });
+    });
+
+    await openEditableArea(page);
+    await page.getByRole('button', { name: 'Draw/Edit Area' }).click();
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+    await page.getByRole('button', { name: 'Save Area' }).click();
+    await expect.poll(() => savedRequests.length).toBe(1);
+    expect(savedRequests[0].geometry.coordinates).toHaveLength(2);
+    expect(savedRequests[0].geometry.coordinates[1]).toEqual([[0.2, 0.2], [0.4, 0.2], [0.4, 0.4], [0.2, 0.2]]);
+  });
+
   test('Cancel rolls back only geometry and delete confirms dirty discard before danger', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithAreaFixture(page);
@@ -211,10 +240,11 @@ test.describe.serial('Trip Editor area editing', () => {
   });
 });
 
-async function loadWorkspaceWithAreaFixture(page: Page): Promise<MutableEditorState> {
+async function loadWorkspaceWithAreaFixture(page: Page, configure?: (state: MutableEditorState) => void): Promise<MutableEditorState> {
   await page.unroute(editorApiMatcher).catch(() => undefined);
   const state = await loadEditorStateFixture(page) as MutableEditorState;
   prepareAreaState(state);
+  configure?.(state);
   await page.route(editorApiMatcher, async route => routeEditorReadOnly(route, state));
   await page.goto(absoluteUrl(workspacePath));
   await expectMountedWorkspace(page);
@@ -386,5 +416,15 @@ function polygon(offset: number): Record<string, any> {
   return {
     type: 'Polygon',
     coordinates: [[[offset, 0], [offset + 1, 0], [offset + 1, 1], [offset, 0]]]
+  };
+}
+
+function polygonWithHole(): Record<string, any> {
+  return {
+    type: 'Polygon',
+    coordinates: [
+      [[0, 0], [1, 0], [1, 1], [0, 0]],
+      [[0.2, 0.2], [0.4, 0.2], [0.4, 0.4], [0.2, 0.2]]
+    ]
   };
 }

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -4,6 +4,7 @@ import {
   editorApiPath,
   expectMountedWorkspace,
   expectNoSearchAddUi,
+  legacyEditPath,
   loadEditorStateFixture,
   signIn,
   workspacePath
@@ -51,6 +52,9 @@ test.describe.serial('Trip Editor area editing', () => {
     await expect(mapWork).toContainText('3 vertices ready');
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
     await expect(page.locator('.trip-editor-toolbar').getByRole('button', { name: 'Fit All' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Pick on map' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /save geometry/i })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /marker drag|drag marker|route edit|edit route|geocode|search.?add/i })).toHaveCount(0);
     await expectNoSearchAddUi(page);
 
     await mapWork.getByRole('button', { name: 'Done' }).click();
@@ -82,9 +86,7 @@ test.describe.serial('Trip Editor area editing', () => {
     const mapWork = page.getByRole('region', { name: 'Map work' });
     await expect(mapWork).toContainText('No polygon ready');
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeDisabled();
-    await clickMap(page, { xRatio: 0.35, yRatio: 0.35 });
-    await clickMap(page, { xRatio: 0.45, yRatio: 0.35 });
-    await clickMap(page, { xRatio: 0.40, yRatio: 0.45 });
+    await drawTriangle(page);
     await expect(mapWork).toContainText('3 vertices ready');
     expect(savedRequests).toEqual([]);
 
@@ -104,7 +106,7 @@ test.describe.serial('Trip Editor area editing', () => {
     const form = page.locator('#trip-editor-area-form');
     await form.getByLabel('Name').fill('Unsaved area name');
     await page.getByRole('button', { name: 'Draw/Edit Area' }).click();
-    await clickMap(page, { xRatio: 0.50, yRatio: 0.50 });
+    await dragFirstEditableVertex(page);
     await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
     await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
     await expect(form.getByLabel('Name')).toHaveValue('Unsaved area name');
@@ -122,6 +124,89 @@ test.describe.serial('Trip Editor area editing', () => {
     if (await shadow.count()) {
       await expect(shadow.getByRole('button', { name: 'Add Area' })).toHaveCount(0);
       await expect(shadow.getByRole('button', { name: 'Drag to reorder area' })).toHaveCount(0);
+    }
+  });
+
+  test('reorders areas within one normal region and persists after reload', async ({ page }) => {
+    await signIn(page);
+    const state = await loadWorkspaceWithAreaFixture(page);
+    const regionId = normalRegion(state).id;
+    await page.unroute(editorApiMatcher);
+    await page.route(editorApiMatcher, async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+        return;
+      }
+
+      expect(route.request().method()).toBe('PUT');
+      expect(route.request().url()).toContain(`/regions/${regionId}/areas/order`);
+      const body = route.request().postDataJSON() as { areaIds: string[] };
+      state.areaOrderByRegionId[regionId] = [...body.areaIds];
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(areaOrderMutationResult(regionId, body.areaIds, state)) });
+    });
+
+    await expectAreaOrder(page, [areaName, secondAreaName]);
+    await dragAreaRow(page, areaName, secondAreaName);
+    await expectAreaOrder(page, [secondAreaName, areaName]);
+    await page.reload();
+    await expectMountedWorkspace(page);
+    await expectAreaOrder(page, [secondAreaName, areaName]);
+  });
+
+  test('expanded map-work returns to the expanded area editor without duplicating the draft', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithAreaFixture(page);
+
+    await openEditableArea(page);
+    await page.getByRole('button', { name: 'Expand Editor' }).click();
+    const dialog = page.getByRole('dialog', { name: new RegExp(`Edit Area - ${areaName}`) });
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: 'Draw/Edit Area' }).click();
+    await expect(page.getByRole('region', { name: 'Map work' })).toContainText('Draw area polygon');
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+    await expect(dialog).toBeVisible();
+    await expect(page.locator('#trip-editor-area-form')).toHaveCount(1);
+  });
+
+  test('dirty area map-work prompts before switching or closing', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithAreaFixture(page);
+
+    await openEditableArea(page);
+    await page.getByRole('button', { name: 'Draw/Edit Area' }).click();
+    await dragFirstEditableVertex(page);
+    await page.getByRole('button', { name: 'Add Region' }).click();
+    const mapDialog = page.getByRole('dialog', { name: 'Discard map editing changes?' });
+    await expect(mapDialog).toBeVisible();
+    await mapDialog.getByRole('button', { name: 'Keep editing' }).click();
+    await expect(page.getByRole('region', { name: 'Map work' })).toBeVisible();
+
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+    await expect(mapDialog).toBeVisible();
+    await mapDialog.getByRole('button', { name: 'Discard' }).click();
+    await expect(page.locator('#trip-editor-area-form')).toBeVisible();
+  });
+
+  test('legacy trip edit page still loads', async ({ page }) => {
+    await signIn(page);
+    await page.goto(absoluteUrl(legacyEditPath));
+    await expect(page).toHaveURL(new RegExp(`/User/Trip/Edit/${configTripIdPattern()}$`, 'i'));
+    await expect(page.locator('body')).not.toContainText('Trip Editor development server is not available');
+  });
+
+  test('map and marker clicks outside area map-work do not mutate area geometry', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithAreaFixture(page);
+
+    await openEditableArea(page);
+    const form = page.locator('#trip-editor-area-form');
+    await expect(form).toContainText('3 polygon vertices');
+    await clickMap(page, { xRatio: 0.25, yRatio: 0.25 });
+    await expect(form).toContainText('3 polygon vertices');
+    const marker = page.locator('.leaflet-marker-icon').first();
+    if (await marker.count()) {
+      await marker.click({ force: true });
+      await expect(form).toContainText('3 polygon vertices');
     }
   });
 });
@@ -195,14 +280,44 @@ function firstEditableRegion(page: Page) {
 
 async function clickMap(page: Page, position: { xRatio: number; yRatio: number }): Promise<void> {
   const map = page.getByLabel('Read-only trip map');
-  await map.evaluate((element, point) => {
-    const box = element.getBoundingClientRect();
-    const clientX = box.left + box.width * point.xRatio;
-    const clientY = box.top + box.height * point.yRatio;
-    for (const type of ['mousedown', 'mouseup', 'click']) {
-      element.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, view: window }));
-    }
-  }, position);
+  const box = await map.boundingBox();
+  expect(box, 'Trip Editor map should be visible before clicking it.').not.toBeNull();
+  await page.mouse.click(box!.x + box!.width * position.xRatio, box!.y + box!.height * position.yRatio);
+}
+
+async function drawTriangle(page: Page): Promise<void> {
+  await clickMap(page, { xRatio: 0.35, yRatio: 0.35 });
+  await clickMap(page, { xRatio: 0.45, yRatio: 0.35 });
+  await clickMap(page, { xRatio: 0.40, yRatio: 0.45 });
+  await clickMap(page, { xRatio: 0.35, yRatio: 0.35 });
+}
+
+async function dragFirstEditableVertex(page: Page): Promise<void> {
+  const vertex = page.locator('.leaflet-editing-icon').first();
+  await expect(vertex).toBeVisible();
+  const box = await vertex.boundingBox();
+  expect(box, 'Editable area vertex should have a rendered box.').not.toBeNull();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box!.x + box!.width / 2 + 24, box!.y + box!.height / 2 + 16, { steps: 4 });
+  await page.mouse.up();
+}
+
+async function dragAreaRow(page: Page, fromName: string, toName: string): Promise<void> {
+  const from = areaRow(page, fromName);
+  const to = areaRow(page, toName);
+  await from.getByRole('button', { name: 'Drag to reorder area' }).dragTo(to);
+}
+
+async function expectAreaOrder(page: Page, names: string[]): Promise<void> {
+  await expect.poll(async () => {
+    const rows = await firstEditableRegion(page).locator('[data-area-id]').all();
+    return Promise.all(rows.map(row => row.locator('span').first().innerText()));
+  }).toEqual(names);
+}
+
+function areaRow(page: Page, name: string) {
+  return firstEditableRegion(page).locator('[data-area-id]').filter({ hasText: name });
 }
 
 function watchEditorMutations(page: Page): () => string[] {
@@ -237,6 +352,34 @@ function areaMutationResult(area: Record<string, any>, orderByRegion: Record<str
     deletedIds: { regions: [], places: [], areas: [], segments: [], tags: [] },
     warnings: []
   };
+}
+
+function areaOrderMutationResult(regionId: string, order: string[], state: MutableEditorState): Record<string, any> {
+  return {
+    success: true,
+    data: { regionId, areaOrder: order },
+    affected: {
+      metadata: null,
+      regions: [],
+      regionOrder: null,
+      places: [],
+      placeOrdersByRegionId: {},
+      areas: order.map(id => state.areasById[id]),
+      areaOrdersByRegionId: { [regionId]: order },
+      segments: [],
+      segmentOrder: null,
+      tags: [],
+      tagOrder: null,
+      visitProgress: null,
+      options: null
+    },
+    deletedIds: { regions: [], places: [], areas: [], segments: [], tags: [] },
+    warnings: []
+  };
+}
+
+function configTripIdPattern(): string {
+  return '[0-9a-f-]+';
 }
 
 function polygon(offset: number): Record<string, any> {


### PR DESCRIPTION
Closes #248

## Summary
- Added Trip Editor area create/update/delete/order API endpoints.
- Added deterministic area parsing/validation and GeoJSON Polygon handling.
- Added mutation envelopes for affected.areas, affected.areaOrdersByRegionId, and deletedIds.areas.
- Added area rows/forms under regions with docked/expanded shared surfaces.
- Added shared map-work polygon draw/edit using repo-local Leaflet.Draw assets.
- New areas draw a polygon with L.Draw.Polygon; existing area polygons edit through Leaflet.Draw edit mode.
- Done writes draft geometry only and does not save.
- Normal Save persists through area create/update endpoints.
- Area reorder uses drag handles and complete region area order.

## Scope exclusions
- no geocode/search-add
- no place coordinate changes
- no marker drag
- no segment editing
- no final cutover
- no legacy editor behavior changes
- no Quill/rich text parity
- no visible Save Geometry UI

## Validation
- dotnet build passed, existing ASP0000 warning only
- dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --filter TripEditor passed, 108 tests
- full dotnet test passed earlier in the branch, 1539 tests, before the Leaflet.Draw fix; not rerun after final fix
- npm run build passed
- npx playwright test --config=playwright.config.ts --list passed, 42 tests listed
- npm run test:e2e:trip-editor was not runnable locally because ASP.NET was unavailable at http://localhost:5012
- LOC checker passed with accepted warnings for styles.css and MetadataEditor.vue
- rg "window\\.confirm" no matches
- rg "\\bconfirm\\(" reviewed shared confirm usages only
- git diff --check origin/main...HEAD passed

## Testing note
Backend tests cover area API success, validation, forbidden fields, geometry-only endpoint, and order invalid IDs.

Playwright coverage added for area add/edit/reorder/map-work/expanded/dirty-confirmation/out-of-scope absence, but runtime E2E still needs GitHub or local dev server execution.