### PR TITLE
[Trip Editor] Add segment editing

### DIFF
--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -29,6 +29,7 @@ public sealed partial class TripEditorController : ControllerBase
     private readonly TripEditorRegionMutationService _regionMutations;
     private readonly TripEditorPlaceMutationService _placeMutations;
     private readonly TripEditorAreaMutationService _areaMutations;
+    private readonly TripEditorSegmentMutationService _segmentMutations;
     private readonly ILogger<TripEditorController> _logger;
 
     /// <summary>
@@ -44,6 +45,7 @@ public sealed partial class TripEditorController : ControllerBase
         TripEditorRegionMutationService regionMutations,
         TripEditorPlaceMutationService placeMutations,
         TripEditorAreaMutationService areaMutations,
+        TripEditorSegmentMutationService segmentMutations,
         ILogger<TripEditorController> logger)
     {
         _dbContext = dbContext;
@@ -55,6 +57,7 @@ public sealed partial class TripEditorController : ControllerBase
         _regionMutations = regionMutations;
         _placeMutations = placeMutations;
         _areaMutations = areaMutations;
+        _segmentMutations = segmentMutations;
         _logger = logger;
     }
 

--- a/Areas/Api/Controllers/TripEditorSegmentsController.cs
+++ b/Areas/Api/Controllers/TripEditorSegmentsController.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Wayfarer.Areas.Api.Controllers;
+
+public sealed partial class TripEditorController
+{
+    /// <summary>
+    /// Creates a trip-level segment in an owned trip.
+    /// </summary>
+    [HttpPost("segments")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CreateSegment(Guid tripId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var outcome = await _segmentMutations.CreateSegmentAsync(tripId, userId!, Request.Body, cancellationToken);
+        return ToActionResult(outcome);
+    }
+
+    /// <summary>
+    /// Updates complete editable fields for one owned segment.
+    /// </summary>
+    [HttpPut("segments/{segmentId:guid}")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateSegment(Guid tripId, Guid segmentId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var outcome = await _segmentMutations.UpdateSegmentAsync(tripId, segmentId, userId!, Request.Body, cancellationToken);
+        return ToActionResult(outcome);
+    }
+
+    /// <summary>
+    /// Deletes one owned segment.
+    /// </summary>
+    [HttpDelete("segments/{segmentId:guid}")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteSegment(Guid tripId, Guid segmentId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var outcome = await _segmentMutations.DeleteSegmentAsync(tripId, segmentId, userId!, cancellationToken);
+        return ToActionResult(outcome);
+    }
+
+    /// <summary>
+    /// Persists the complete desired trip-level segment order.
+    /// </summary>
+    [HttpPut("segments/order")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> OrderSegments(Guid tripId, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var outcome = await _segmentMutations.OrderSegmentsAsync(tripId, userId!, Request.Body, cancellationToken);
+        return ToActionResult(outcome);
+    }
+}

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -292,7 +292,7 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
               </button>
               <button type="button" class="btn btn-outline-light btn-sm" :disabled="!canFocusTarget" @click="focusActiveEntity">Focus Active Entity</button>
             </template>
-            <a class="btn btn-outline-light btn-sm" :href="`/User/Trip/Edit/${state.tripId}`">Legacy editor</a>
+            <a v-if="!isMapWorkActive" class="btn btn-outline-light btn-sm" :href="`/User/Trip/Edit/${state.tripId}`">Legacy editor</a>
           </div>
         </header>
         <MapWorkToolbar :controller="editorSurface" />

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -6,8 +6,8 @@ import MapWorkToolbar from './components/MapWorkToolbar.vue';
 import TripSidebar from './components/TripSidebar.vue';
 import { disposeConfirmDialogHost, setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
 import { useEditorSurface } from './composables/useEditorSurface';
-import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type AreaPolygonWorkOptions, type CoordinatePickOptions, type FocusActiveEntityResult } from './map/leafletAdapter';
-import type { BootstrapConfig, EditorMutationResult, EditorTripMetadata, EditorTripState } from './types';
+import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type AreaPolygonWorkOptions, type CoordinatePickOptions, type FocusActiveEntityResult, type SegmentRouteWorkOptions } from './map/leafletAdapter';
+import type { BootstrapConfig, EditorMutationResult, EditorSegment, EditorTripMetadata, EditorTripState } from './types';
 
 const props = defineProps<{ config: BootstrapConfig }>();
 
@@ -18,6 +18,7 @@ const hasRegionDraftChanges = ref(false);
 const workspaceElement = ref<HTMLElement | null>(null);
 const mapElement = ref<HTMLElement | null>(null);
 const navigationStatus = ref<string | null>(null);
+const hiddenSegmentIds = ref<Set<string>>(new Set());
 const editorSurface = useEditorSurface();
 let mapAdapter: ReturnType<typeof createTripEditorMap> | null = null;
 const coordinatePicker = {
@@ -25,6 +26,10 @@ const coordinatePicker = {
 };
 const polygonEditor = {
   startAreaPolygonWork: (options: AreaPolygonWorkOptions): (() => void) => mapAdapter?.startAreaPolygonWork(options) ?? (() => undefined)
+};
+const routeEditor = {
+  setSegmentRouteWorkRoute: (route: EditorSegment['route']): void => mapAdapter?.setSegmentRouteWorkRoute(route),
+  startSegmentRouteWork: (options: SegmentRouteWorkOptions): (() => void) => mapAdapter?.startSegmentRouteWork(options) ?? (() => undefined)
 };
 
 const updatedLabel = computed(() =>
@@ -56,7 +61,7 @@ onMounted(async () => {
     }
 
     mapAdapter = createTripEditorMap(mapElement.value, props.config.tilesUrl);
-    mapAdapter.render(loadedState);
+    mapAdapter.render(loadedState, hiddenSegmentIds.value);
   } catch (loadError) {
     error.value = loadError instanceof Error ? loadError.message : 'Trip Editor failed to load.';
     isLoading.value = false;
@@ -75,7 +80,7 @@ const applyMetadata = (metadata: EditorTripMetadata): void => {
   }
 
   state.value = { ...state.value, metadata };
-  mapAdapter?.render(state.value);
+  mapAdapter?.render(state.value, hiddenSegmentIds.value);
 };
 
 /// Runs a navigation-only adapter command without mutating editor drafts or metadata.
@@ -150,6 +155,7 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
   });
   result.deletedIds.segments.forEach(id => {
     delete next.segmentsById[id];
+    hiddenSegmentIds.value.delete(id);
   });
   result.deletedIds.tags.forEach(slug => {
     delete next.tagsBySlug[slug];
@@ -188,7 +194,15 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
   });
 
   state.value = next;
-  mapAdapter?.render(next);
+  mapAdapter?.render(next, hiddenSegmentIds.value);
+};
+
+/// Updates client-session-only segment visibility without touching the API contract.
+const updateHiddenSegmentIds = (ids: Set<string>): void => {
+  hiddenSegmentIds.value = ids;
+  if (state.value) {
+    mapAdapter?.render(state.value, hiddenSegmentIds.value);
+  }
 };
 
 function focusStatusText(result: FocusActiveEntityResult, target: { kind: string; mode: string } | null): string {
@@ -212,6 +226,10 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
 
     if (kind === 'area') {
       return 'Focused area';
+    }
+
+    if (kind === 'segment') {
+      return 'Focused segment';
     }
 
     return 'Focused active entity';
@@ -249,11 +267,14 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
         :antiforgery-token="props.config.antiforgeryToken"
         :trip-index-url="props.config.tripIndexUrl"
         :has-region-draft-changes="hasRegionDraftChanges"
+        :hidden-segment-ids="hiddenSegmentIds"
         :coordinate-picker="coordinatePicker"
         :polygon-editor="polygonEditor"
+        :route-editor="routeEditor"
         @metadata-saved="applyMetadata"
         @mutation-applied="applyMutation"
         @region-draft-dirty-changed="setRegionDraftChanges"
+        @hidden-segment-ids-changed="updateHiddenSegmentIds"
       />
       <main class="trip-editor-map-shell">
         <header class="trip-editor-toolbar">

--- a/ClientApps/trip-editor/src/api/tripEditorApi.ts
+++ b/ClientApps/trip-editor/src/api/tripEditorApi.ts
@@ -14,6 +14,11 @@ import type {
   EditorRegionOrderRequest,
   EditorRegionOrderResult,
   EditorRegionSaveRequest,
+  EditorSegment,
+  EditorSegmentDeleteResult,
+  EditorSegmentOrderRequest,
+  EditorSegmentOrderResult,
+  EditorSegmentSaveRequest,
   EditorShareProgressUpdateRequest,
   EditorTag,
   EditorTripTagsUpdateRequest,
@@ -196,6 +201,35 @@ export const orderAreas = async (
   request: EditorAreaOrderRequest
 ): Promise<EditorMutationResult<EditorAreaOrderResult>> =>
   sendMutation(`${endpoint}/regions/${regionId}/areas/order`, 'PUT', antiforgeryToken, request, 'area order');
+
+/// Creates a trip-level segment through the same-origin editor API.
+export const createSegment = async (
+  endpoint: string,
+  antiforgeryToken: string,
+  request: EditorSegmentSaveRequest
+): Promise<EditorMutationResult<EditorSegment>> => sendMutation(`${endpoint}/segments`, 'POST', antiforgeryToken, request, 'segment create');
+
+/// Updates a segment through the same-origin editor API.
+export const updateSegment = async (
+  endpoint: string,
+  segmentId: string,
+  antiforgeryToken: string,
+  request: EditorSegmentSaveRequest
+): Promise<EditorMutationResult<EditorSegment>> => sendMutation(`${endpoint}/segments/${segmentId}`, 'PUT', antiforgeryToken, request, 'segment update');
+
+/// Deletes a segment through the same-origin editor API.
+export const deleteSegment = async (
+  endpoint: string,
+  segmentId: string,
+  antiforgeryToken: string
+): Promise<EditorMutationResult<EditorSegmentDeleteResult>> => sendMutation(`${endpoint}/segments/${segmentId}`, 'DELETE', antiforgeryToken, null, 'segment delete');
+
+/// Persists the complete trip-level segment order.
+export const orderSegments = async (
+  endpoint: string,
+  antiforgeryToken: string,
+  request: EditorSegmentOrderRequest
+): Promise<EditorMutationResult<EditorSegmentOrderResult>> => sendMutation(`${endpoint}/segments/order`, 'PUT', antiforgeryToken, request, 'segment order');
 
 const sendMutation = async <TData>(
   url: string,

--- a/ClientApps/trip-editor/src/components/MapWorkToolbar.vue
+++ b/ClientApps/trip-editor/src/components/MapWorkToolbar.vue
@@ -13,6 +13,7 @@ const statusText = computed(() => {
   return typeof status === 'function' ? status() : status;
 });
 const canFinish = computed(() => mapWork.value?.canFinish() ?? false);
+const canClear = computed(() => Boolean(mapWork.value?.clear));
 
 const onKeydown = async (event: KeyboardEvent): Promise<void> => {
   if (event.key !== 'Escape') {
@@ -46,6 +47,7 @@ watch(
     </div>
     <div class="trip-editor-map-work-toolbar__actions">
       <button ref="doneButton" type="button" class="btn btn-primary btn-sm" :disabled="!canFinish" @click="controller.finishMapWork()">Done</button>
+      <button v-if="canClear" type="button" class="btn btn-outline-light btn-sm" @click="mapWork?.clear?.()">Clear Route</button>
       <button type="button" class="btn btn-outline-light btn-sm" @click="controller.cancelMapWork()">Cancel</button>
     </div>
   </div>

--- a/ClientApps/trip-editor/src/components/SegmentEditorForm.vue
+++ b/ClientApps/trip-editor/src/components/SegmentEditorForm.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { EditorRegion, EditorSegmentDraft, EditorTripState, Guid } from '../types';
+import { fallbackRoute } from './segmentRouteMapWork';
+
+const props = defineProps<{
+  draft: EditorSegmentDraft;
+  fieldErrors: (key: string) => string[];
+  formId: string;
+  formSummaryErrors: string[];
+  state: EditorTripState;
+}>();
+
+defineEmits<{
+  save: [];
+}>();
+
+const normalRegions = computed(() => props.state.regionOrder.map(id => props.state.regionsById[id]).filter(region => region && !region.isShadow) as EditorRegion[]);
+const routeSummary = computed(() => {
+  if (props.draft.route) {
+    return `${props.draft.route.coordinates.length} custom route points`;
+  }
+
+  return fallbackRoute(props.draft, props.state) ? 'Endpoint fallback available until saved' : 'No route';
+});
+
+function orderedPlaceIds(regionId: Guid): Guid[] {
+  return props.state.placeOrderByRegionId[regionId] ?? [];
+}
+</script>
+
+<template>
+  <form :id="formId" class="trip-editor-form" @submit.prevent="$emit('save')">
+    <div v-if="formSummaryErrors.length > 0" class="trip-editor-form-error" role="alert">
+      <p v-for="message in formSummaryErrors" :key="message">{{ message }}</p>
+    </div>
+
+    <label class="trip-editor-field">
+      <span>From place</span>
+      <select v-model="draft.fromPlaceId">
+        <option :value="null">Unlinked</option>
+        <optgroup v-for="region in normalRegions" :key="region.id" :label="region.name">
+          <option v-for="placeId in orderedPlaceIds(region.id)" :key="placeId" :value="placeId">{{ state.placesById[placeId]?.name }}</option>
+        </optgroup>
+      </select>
+      <small v-for="message in fieldErrors('fromPlaceId')" :key="message">{{ message }}</small>
+    </label>
+
+    <label class="trip-editor-field">
+      <span>To place</span>
+      <select v-model="draft.toPlaceId">
+        <option :value="null">Unlinked</option>
+        <optgroup v-for="region in normalRegions" :key="region.id" :label="region.name">
+          <option v-for="placeId in orderedPlaceIds(region.id)" :key="placeId" :value="placeId">{{ state.placesById[placeId]?.name }}</option>
+        </optgroup>
+      </select>
+      <small v-for="message in fieldErrors('toPlaceId')" :key="message">{{ message }}</small>
+    </label>
+
+    <label class="trip-editor-field">
+      <span>Transport mode</span>
+      <select v-model="draft.mode">
+        <option value="">Unset</option>
+        <option v-for="mode in state.options.transportModes" :key="mode.value" :value="mode.value">{{ mode.label }}</option>
+      </select>
+      <small v-for="message in fieldErrors('mode')" :key="message">{{ message }}</small>
+    </label>
+
+    <div class="trip-editor-field-grid">
+      <label class="trip-editor-field">
+        <span>Estimated distance km</span>
+        <input v-model="draft.estimatedDistanceKm" type="number" min="0" step="any" />
+        <small v-for="message in fieldErrors('estimatedDistanceKm')" :key="message">{{ message }}</small>
+      </label>
+
+      <label class="trip-editor-field">
+        <span>Estimated duration minutes</span>
+        <input v-model="draft.estimatedDurationMinutes" type="number" min="0" step="any" />
+        <small v-for="message in fieldErrors('estimatedDurationMinutes')" :key="message">{{ message }}</small>
+      </label>
+    </div>
+
+    <label class="trip-editor-field">
+      <span>Notes HTML</span>
+      <textarea v-model="draft.notesHtml" rows="4"></textarea>
+      <small v-for="message in fieldErrors('notesHtml')" :key="message">{{ message }}</small>
+    </label>
+
+    <div class="trip-editor-field">
+      <span>Route</span>
+      <p class="trip-editor-empty-state">{{ routeSummary }}</p>
+      <small v-for="message in [...fieldErrors('route'), ...fieldErrors('route.coordinates')]" :key="message">{{ message }}</small>
+    </div>
+  </form>
+</template>

--- a/ClientApps/trip-editor/src/components/SegmentEditorSurface.vue
+++ b/ClientApps/trip-editor/src/components/SegmentEditorSurface.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
+import type { EditorSegment, EditorSegmentDraft, EditorTripState } from '../types';
+import EditorSurface from './EditorSurface.vue';
+import SegmentEditorForm from './SegmentEditorForm.vue';
+
+defineProps<{
+  activeSegment: EditorSegment | null;
+  controller: EditorSurfaceController;
+  draft: EditorSegmentDraft;
+  fieldErrors: (key: string) => string[];
+  formId: string;
+  formSummaryErrors: string[];
+  isDirty: boolean;
+  isSaving: boolean;
+  state: EditorTripState;
+  statusText: string;
+  target: EditorTarget;
+}>();
+
+defineEmits<{
+  cancel: [];
+  clearRoute: [];
+  delete: [];
+  drawRoute: [];
+  reset: [];
+  save: [];
+}>();
+</script>
+
+<template>
+  <EditorSurface :controller="controller" :target="target" :status-text="statusText">
+    <template #body>
+      <SegmentEditorForm
+        :draft="draft"
+        :field-errors="fieldErrors"
+        :form-id="formId"
+        :form-summary-errors="formSummaryErrors"
+        :state="state"
+        @save="$emit('save')"
+      />
+    </template>
+
+    <template #footer>
+      <button v-if="activeSegment?.capabilities.canDelete" type="button" class="btn btn-outline-danger btn-sm me-auto" :disabled="isSaving" @click="$emit('delete')">Delete</button>
+      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="$emit('drawRoute')">Draw/Edit Route</button>
+      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving || draft.route === null" @click="$emit('clearRoute')">Clear Route</button>
+      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="$emit('cancel')">Cancel</button>
+      <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="isSaving || !isDirty" @click="$emit('reset')">Reset</button>
+      <button type="submit" :form="formId" class="btn btn-primary btn-sm" :disabled="isSaving">Save Segment</button>
+    </template>
+  </EditorSurface>
+</template>

--- a/ClientApps/trip-editor/src/components/SegmentManager.vue
+++ b/ClientApps/trip-editor/src/components/SegmentManager.vue
@@ -51,7 +51,7 @@ let sortable: { destroy: () => void } | null = null;
 let reorderSnapshotIds: Guid[] | null = null;
 
 const activeSegment = computed(() => (draft.id ? props.state.segmentsById[draft.id] ?? null : null));
-const isDraftOpen = computed(() => draft.id !== null || Boolean(draft.fromPlaceId || draft.toPlaceId || draft.mode || draft.estimatedDistanceKm || draft.estimatedDurationMinutes || draft.notesHtml || draft.route));
+const isDraftOpen = computed(() => props.editorSurface.isTargetActive(activeSegmentTarget.value) || draft.id !== null || Boolean(draft.fromPlaceId || draft.toPlaceId || draft.mode || draft.estimatedDistanceKm || draft.estimatedDurationMinutes || draft.notesHtml || draft.route));
 const baselineRequest = computed(() => draft.id ? buildSegmentRequest(toSegmentDraft(activeSegment.value)) : createBaselineRequest.value ?? buildSegmentRequest(emptySegmentDraft()));
 const isDirty = computed(() => JSON.stringify(buildSegmentRequest(draft)) !== JSON.stringify(baselineRequest.value));
 const statusText = computed(() => isSaving.value ? 'Saving...' : isOrdering.value ? 'Saving order...' : saveError.value ? 'Save failed' : isDirty.value ? 'Unsaved changes' : lastSavedAt.value ? `Saved ${lastSavedAt.value}` : 'Saved');

--- a/ClientApps/trip-editor/src/components/SegmentManager.vue
+++ b/ClientApps/trip-editor/src/components/SegmentManager.vue
@@ -89,16 +89,25 @@ async function openCreate(): Promise<void> {
   resetFeedback();
 }
 
-async function openEdit(segment: EditorSegment): Promise<void> {
+async function openEdit(segment: EditorSegment): Promise<boolean> {
   const target = buildSegmentEditTarget(segment, segmentLabel(segment));
   const isAlreadyActive = props.editorSurface.isTargetActive(target);
-  if (!segment.capabilities.canEdit || !(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
-    return;
+  if (!segment.capabilities.canEdit) {
+    return false;
+  }
+
+  if (isAlreadyActive) {
+    return true;
+  }
+
+  if (!(await props.editorSurface.activateTarget(target))) {
+    return false;
   }
 
   Object.assign(draft, toSegmentDraft(segment));
   createBaselineRequest.value = null;
   resetFeedback();
+  return true;
 }
 
 function resetDraft(): void {
@@ -131,7 +140,41 @@ async function saveDraft(): Promise<void> {
 }
 
 async function deleteDraft(): Promise<void> {
-  if (!activeSegment.value || !(await confirmDiscard('Discard unsaved segment draft changes before deleting?'))) {
+  const segment = activeSegment.value;
+  if (!segment) {
+    return;
+  }
+
+  await deleteSegmentWithConfirmation(segment, activeSegmentTarget.value);
+}
+
+async function deleteSegmentFromRow(segment: EditorSegment): Promise<void> {
+  if (!segment.capabilities.canDelete) {
+    return;
+  }
+
+  const target = buildSegmentEditTarget(segment, segmentLabel(segment));
+  const isAlreadyActive = props.editorSurface.isTargetActive(target);
+  if (!isAlreadyActive) {
+    const activated = await props.editorSurface.activateTarget(target);
+    if (!activated) {
+      return;
+    }
+
+    Object.assign(draft, toSegmentDraft(segment));
+    createBaselineRequest.value = null;
+    resetFeedback();
+  }
+
+  if (!props.editorSurface.isTargetActive(target) || draft.id !== segment.id) {
+    return;
+  }
+
+  await deleteSegmentWithConfirmation(segment, target);
+}
+
+async function deleteSegmentWithConfirmation(segment: EditorSegment, deletedTarget: EditorTarget): Promise<void> {
+  if (!(await confirmDiscard('Discard unsaved segment draft changes before deleting?'))) {
     return;
   }
 
@@ -148,11 +191,10 @@ async function deleteDraft(): Promise<void> {
   isSaving.value = true;
   resetFeedback();
   try {
-    const deletedTarget = activeSegmentTarget.value;
-    const result = await deleteSegment(props.editorEndpoint, activeSegment.value.id, props.antiforgeryToken);
+    const result = await deleteSegment(props.editorEndpoint, segment.id, props.antiforgeryToken);
     emit('mutationApplied', result as EditorMutationResult<unknown>);
     const hidden = new Set(props.hiddenSegmentIds);
-    hidden.delete(activeSegment.value.id);
+    hidden.delete(segment.id);
     emit('hiddenSegmentIdsChanged', hidden);
     Object.assign(draft, emptySegmentDraft());
     createBaselineRequest.value = null;
@@ -315,7 +357,7 @@ function modeText(segment: EditorSegment): string {
           <span>{{ segmentLabel(segment) }}</span>
           <small>{{ modeText(segment) }}</small>
         </button>
-        <button type="button" class="trip-editor-icon-button" title="Delete segment" aria-label="Delete segment" @click="openEdit(segment).then(deleteDraft)">×</button>
+        <button type="button" class="trip-editor-icon-button" title="Delete segment" aria-label="Delete segment" @click="deleteSegmentFromRow(segment)">×</button>
 
         <SegmentEditorSurface v-if="draft.id === segment.id && editorSurface.isTargetActive(activeSegmentTarget)" :active-segment="activeSegment" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="segmentFormId" :form-summary-errors="formSummaryErrors" :is-dirty="isDirty" :is-saving="isSaving" :state="state" :status-text="statusText" :target="activeSegmentTarget" @cancel="cancelDraft" @clear-route="clearRoute" @delete="deleteDraft" @draw-route="drawRoute" @reset="resetDraft" @save="saveDraft" />
       </li>

--- a/ClientApps/trip-editor/src/components/SegmentManager.vue
+++ b/ClientApps/trip-editor/src/components/SegmentManager.vue
@@ -1,0 +1,325 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
+import { createSegment, deleteSegment, orderSegments, updateSegment } from '../api/tripEditorApi';
+import { confirm } from '../composables/useConfirmDialog';
+import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
+import type { EditorMutationResult, EditorSegment, EditorSegmentDraft, EditorSegmentSaveRequest, EditorTripState, Guid } from '../types';
+import { buildSegmentCreateTarget, buildSegmentEditTarget, segmentDraftKey } from './regionPlaceEditorTargets';
+import { buildSegmentRequest, emptySegmentDraft, toSegmentDraft } from './regionPlaceDrafts';
+import SegmentEditorSurface from './SegmentEditorSurface.vue';
+import { beginSegmentRouteMapWork, stopSegmentRouteEdit, type SegmentRouteEditor, type SegmentRouteMapWorkState } from './segmentRouteMapWork';
+
+declare global {
+  interface Window {
+    Sortable?: {
+      create: (element: HTMLElement, options: Record<string, unknown>) => { destroy: () => void };
+    };
+  }
+}
+
+const props = defineProps<{
+  editorEndpoint: string;
+  editorSurface: EditorSurfaceController;
+  antiforgeryToken: string;
+  hiddenSegmentIds: ReadonlySet<Guid>;
+  routeEditor: SegmentRouteEditor;
+  searchActive: boolean;
+  segments: EditorSegment[];
+  state: EditorTripState;
+}>();
+
+const emit = defineEmits<{
+  dirtyStateChanged: [isDirty: boolean];
+  hiddenSegmentIdsChanged: [ids: Set<Guid>];
+  mutationApplied: [result: EditorMutationResult<unknown>];
+}>();
+
+const segmentFields = ['fromPlaceId', 'toPlaceId', 'mode', 'estimatedDistanceKm', 'estimatedDurationMinutes', 'notesHtml', 'route', 'route.coordinates'];
+const segmentFormId = 'trip-editor-segment-form';
+const segmentList = ref<HTMLElement | null>(null);
+const segmentListKey = ref(0);
+const draft = reactive<EditorSegmentDraft>(emptySegmentDraft());
+const createBaselineRequest = ref<EditorSegmentSaveRequest | null>(null);
+const isSaving = ref(false);
+const isOrdering = ref(false);
+const validationErrors = ref<Record<string, string[]>>({});
+const saveError = ref<string | null>(null);
+const lastSavedAt = ref<string | null>(null);
+const routeMapWork = reactive<SegmentRouteMapWorkState>({ route: null, stopEdit: null });
+let unregisterHandler: (() => void) | null = null;
+let sortable: { destroy: () => void } | null = null;
+let reorderSnapshotIds: Guid[] | null = null;
+
+const activeSegment = computed(() => (draft.id ? props.state.segmentsById[draft.id] ?? null : null));
+const isDraftOpen = computed(() => draft.id !== null || Boolean(draft.fromPlaceId || draft.toPlaceId || draft.mode || draft.estimatedDistanceKm || draft.estimatedDurationMinutes || draft.notesHtml || draft.route));
+const baselineRequest = computed(() => draft.id ? buildSegmentRequest(toSegmentDraft(activeSegment.value)) : createBaselineRequest.value ?? buildSegmentRequest(emptySegmentDraft()));
+const isDirty = computed(() => JSON.stringify(buildSegmentRequest(draft)) !== JSON.stringify(baselineRequest.value));
+const statusText = computed(() => isSaving.value ? 'Saving...' : isOrdering.value ? 'Saving order...' : saveError.value ? 'Save failed' : isDirty.value ? 'Unsaved changes' : lastSavedAt.value ? `Saved ${lastSavedAt.value}` : 'Saved');
+const formSummaryErrors = computed(() => Object.entries(validationErrors.value).filter(([key]) => !segmentFields.includes(key)).flatMap(([, messages]) => messages));
+const activeSegmentTarget = computed<EditorTarget>(() => draft.id && activeSegment.value
+  ? buildSegmentEditTarget(activeSegment.value, segmentLabel(activeSegment.value))
+  : buildSegmentCreateTarget());
+
+watch(isDirty, value => emit('dirtyStateChanged', value), { immediate: true });
+watch(() => [props.segments.length, props.searchActive, segmentListKey.value], () => nextTick(attachSortable), { immediate: true });
+
+onMounted(() => {
+  unregisterHandler = props.editorSurface.registerTargetHandler(segmentDraftKey, {
+    isDirty: () => isDirty.value,
+    discard: discardDraft
+  });
+});
+
+onUnmounted(() => {
+  unregisterHandler?.();
+  destroySortable();
+  stopSegmentRouteEdit(routeMapWork);
+  emit('dirtyStateChanged', false);
+});
+
+async function openCreate(): Promise<void> {
+  const target = buildSegmentCreateTarget();
+  const isAlreadyActive = props.editorSurface.isTargetActive(target);
+  if (!props.state.permissions.canEditSegments || !(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
+    return;
+  }
+
+  Object.assign(draft, emptySegmentDraft());
+  createBaselineRequest.value = buildSegmentRequest(draft);
+  resetFeedback();
+}
+
+async function openEdit(segment: EditorSegment): Promise<void> {
+  const target = buildSegmentEditTarget(segment, segmentLabel(segment));
+  const isAlreadyActive = props.editorSurface.isTargetActive(target);
+  if (!segment.capabilities.canEdit || !(await props.editorSurface.activateTarget(target)) || isAlreadyActive) {
+    return;
+  }
+
+  Object.assign(draft, toSegmentDraft(segment));
+  createBaselineRequest.value = null;
+  resetFeedback();
+}
+
+function resetDraft(): void {
+  Object.assign(draft, draft.id ? toSegmentDraft(activeSegment.value) : emptySegmentDraft());
+  resetFeedback();
+}
+
+async function cancelDraft(): Promise<void> {
+  await props.editorSurface.closeActiveTarget('Discard unsaved segment changes?');
+}
+
+async function saveDraft(): Promise<void> {
+  isSaving.value = true;
+  resetFeedback();
+  try {
+    const request = buildSegmentRequest(draft);
+    const result = draft.id
+      ? await updateSegment(props.editorEndpoint, draft.id, props.antiforgeryToken, request)
+      : await createSegment(props.editorEndpoint, props.antiforgeryToken, request);
+    emit('mutationApplied', result as EditorMutationResult<unknown>);
+    Object.assign(draft, toSegmentDraft(result.data));
+    createBaselineRequest.value = null;
+    props.editorSurface.replaceActiveTarget(activeSegmentTarget.value);
+    markSaved();
+  } catch (error) {
+    applyError(error, 'Segment save failed.');
+  } finally {
+    isSaving.value = false;
+  }
+}
+
+async function deleteDraft(): Promise<void> {
+  if (!activeSegment.value || !(await confirmDiscard('Discard unsaved segment draft changes before deleting?'))) {
+    return;
+  }
+
+  if (!(await confirm({
+    title: 'Delete segment?',
+    message: 'Delete this segment?',
+    confirmLabel: 'Delete',
+    cancelLabel: 'Keep segment',
+    variant: 'danger'
+  }))) {
+    return;
+  }
+
+  isSaving.value = true;
+  resetFeedback();
+  try {
+    const deletedTarget = activeSegmentTarget.value;
+    const result = await deleteSegment(props.editorEndpoint, activeSegment.value.id, props.antiforgeryToken);
+    emit('mutationApplied', result as EditorMutationResult<unknown>);
+    const hidden = new Set(props.hiddenSegmentIds);
+    hidden.delete(activeSegment.value.id);
+    emit('hiddenSegmentIdsChanged', hidden);
+    Object.assign(draft, emptySegmentDraft());
+    createBaselineRequest.value = null;
+    props.editorSurface.clearActiveTarget(deletedTarget);
+    markSaved();
+  } catch (error) {
+    applyError(error, 'Segment delete failed.');
+  } finally {
+    isSaving.value = false;
+  }
+}
+
+function drawRoute(): void {
+  beginSegmentRouteMapWork(draft, props.editorSurface, props.routeEditor, routeMapWork, props.state);
+}
+
+function clearRoute(): void {
+  draft.route = null;
+}
+
+function toggleVisibility(segment: EditorSegment): void {
+  const hidden = new Set(props.hiddenSegmentIds);
+  if (hidden.has(segment.id)) {
+    hidden.delete(segment.id);
+  } else {
+    hidden.add(segment.id);
+  }
+
+  emit('hiddenSegmentIdsChanged', hidden);
+}
+
+async function reorder(ids: Guid[], previousIds: Guid[]): Promise<void> {
+  if (isDirty.value && !(await confirmDiscard('Discard unsaved segment changes before reordering?'))) {
+    restoreSegmentOrder(previousIds);
+    return;
+  }
+
+  if (isDirty.value) {
+    discardDraft();
+  }
+
+  isOrdering.value = true;
+  resetFeedback();
+  try {
+    const result = await orderSegments(props.editorEndpoint, props.antiforgeryToken, { segmentIds: ids });
+    emit('mutationApplied', result as EditorMutationResult<unknown>);
+    markSaved();
+  } catch (error) {
+    applyError(error, 'Segment reorder failed.');
+    restoreSegmentOrder(previousIds);
+  } finally {
+    isOrdering.value = false;
+  }
+}
+
+function attachSortable(): void {
+  destroySortable();
+  if (props.searchActive || !segmentList.value || !window.Sortable) {
+    return;
+  }
+
+  sortable = window.Sortable.create(segmentList.value, {
+    animation: 150,
+    draggable: '.trip-editor-segment-row',
+    handle: '.trip-editor-segment-drag-handle',
+    onStart: () => {
+      reorderSnapshotIds = props.state.segmentOrder.filter(id => props.state.segmentsById[id]);
+    },
+    onEnd: () => {
+      if (!segmentList.value) {
+        return;
+      }
+
+      const previousIds = reorderSnapshotIds ?? props.state.segmentOrder;
+      reorderSnapshotIds = null;
+      const ids = Array.from(segmentList.value.querySelectorAll<HTMLElement>('[data-segment-id]')).map(element => element.dataset.segmentId!);
+      void reorder(ids, previousIds);
+    }
+  });
+}
+
+function destroySortable(): void {
+  sortable?.destroy();
+  sortable = null;
+}
+
+function restoreSegmentOrder(_previousIds: Guid[]): void {
+  segmentListKey.value += 1;
+}
+
+function discardDraft(): void {
+  Object.assign(draft, emptySegmentDraft());
+  createBaselineRequest.value = null;
+  resetFeedback();
+}
+
+function confirmDiscard(message: string): Promise<boolean> {
+  if (!isDirty.value) {
+    return Promise.resolve(true);
+  }
+
+  return confirm({
+    title: 'Discard changes?',
+    message,
+    confirmLabel: 'Discard',
+    cancelLabel: 'Keep editing',
+    variant: 'warning'
+  });
+}
+
+function fieldErrors(key: string): string[] {
+  return validationErrors.value[key] ?? [];
+}
+
+function applyError(error: unknown, fallback: string): void {
+  if (error instanceof Error && 'errors' in error) {
+    validationErrors.value = (error as Error & { errors: Record<string, string[]> }).errors;
+  }
+
+  saveError.value = error instanceof Error ? error.message : fallback;
+}
+
+function resetFeedback(): void {
+  validationErrors.value = {};
+  saveError.value = null;
+}
+
+function markSaved(): void {
+  lastSavedAt.value = new Intl.DateTimeFormat(undefined, { timeStyle: 'short' }).format(new Date());
+  saveError.value = null;
+}
+
+function segmentLabel(segment: EditorSegment): string {
+  const from = segment.fromPlaceId ? props.state.placesById[segment.fromPlaceId]?.name : null;
+  const to = segment.toPlaceId ? props.state.placesById[segment.toPlaceId]?.name : null;
+  return [from, to].filter(Boolean).join(' to ') || segment.mode || 'Segment';
+}
+
+function modeText(segment: EditorSegment): string {
+  return props.state.options.transportModes.find(mode => mode.value === segment.mode)?.label ?? segment.mode || 'mode unset';
+}
+</script>
+
+<template>
+  <section class="trip-editor-panel">
+    <div class="trip-editor-panel__line">
+      <h2>Segments</h2>
+      <span class="trip-editor-save-state">{{ statusText }}</span>
+    </div>
+    <div v-if="saveError" class="trip-editor-form-error" role="alert">{{ saveError }}</div>
+    <button type="button" class="btn btn-primary btn-sm trip-editor-add-button" :disabled="isSaving || isOrdering" @click="openCreate">Add Segment</button>
+
+    <SegmentEditorSurface v-if="isDraftOpen && !draft.id" :active-segment="activeSegment" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="segmentFormId" :form-summary-errors="formSummaryErrors" :is-dirty="isDirty" :is-saving="isSaving" :state="state" :status-text="statusText" :target="activeSegmentTarget" @cancel="cancelDraft" @clear-route="clearRoute" @delete="deleteDraft" @draw-route="drawRoute" @reset="resetDraft" @save="saveDraft" />
+
+    <ul v-if="segments.length > 0" :key="segmentListKey" ref="segmentList" class="trip-editor-segments">
+      <li v-for="segment in segments" :key="segment.id" class="trip-editor-segment-row" :data-segment-id="segment.id">
+        <button type="button" class="trip-editor-icon-button trip-editor-segment-drag-handle" title="Drag to reorder segment" aria-label="Drag to reorder segment">↕</button>
+        <button type="button" class="trip-editor-icon-button" :title="hiddenSegmentIds.has(segment.id) ? 'Show segment' : 'Hide segment'" :aria-label="hiddenSegmentIds.has(segment.id) ? 'Show segment' : 'Hide segment'" @click="toggleVisibility(segment)">{{ hiddenSegmentIds.has(segment.id) ? '○' : '●' }}</button>
+        <button type="button" class="trip-editor-list-button" @click="openEdit(segment)">
+          <span>{{ segmentLabel(segment) }}</span>
+          <small>{{ modeText(segment) }}</small>
+        </button>
+        <button type="button" class="trip-editor-icon-button" title="Delete segment" aria-label="Delete segment" @click="openEdit(segment).then(deleteDraft)">×</button>
+
+        <SegmentEditorSurface v-if="draft.id === segment.id && editorSurface.isTargetActive(activeSegmentTarget)" :active-segment="activeSegment" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="segmentFormId" :form-summary-errors="formSummaryErrors" :is-dirty="isDirty" :is-saving="isSaving" :state="state" :status-text="statusText" :target="activeSegmentTarget" @cancel="cancelDraft" @clear-route="clearRoute" @delete="deleteDraft" @draw-route="drawRoute" @reset="resetDraft" @save="saveDraft" />
+      </li>
+    </ul>
+    <p v-else class="trip-editor-empty-state">No travel segments added yet.</p>
+  </section>
+</template>

--- a/ClientApps/trip-editor/src/components/SegmentManager.vue
+++ b/ClientApps/trip-editor/src/components/SegmentManager.vue
@@ -292,7 +292,7 @@ function segmentLabel(segment: EditorSegment): string {
 }
 
 function modeText(segment: EditorSegment): string {
-  return props.state.options.transportModes.find(mode => mode.value === segment.mode)?.label ?? segment.mode || 'mode unset';
+  return props.state.options.transportModes.find(mode => mode.value === segment.mode)?.label ?? (segment.mode || 'mode unset');
 }
 </script>
 

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -4,7 +4,8 @@ import type { EditorArea, EditorMutationResult, EditorPlace, EditorRegion, Edito
 import type { EditorSurfaceController } from '../composables/useEditorSurface';
 import MetadataEditor from './MetadataEditor.vue';
 import RegionManager from './RegionManager.vue';
-import type { AreaPolygonWorkOptions, CoordinatePickOptions } from '../map/leafletAdapter';
+import SegmentManager from './SegmentManager.vue';
+import type { AreaPolygonWorkOptions, CoordinatePickOptions, SegmentRouteWorkOptions } from '../map/leafletAdapter';
 
 type SidebarSearchResult = {
   hasMatches: boolean;
@@ -20,17 +21,24 @@ const props = defineProps<{
   antiforgeryToken: string;
   tripIndexUrl: string;
   hasRegionDraftChanges: boolean;
+  hiddenSegmentIds: ReadonlySet<Guid>;
   coordinatePicker: { startCoordinatePick: (options: CoordinatePickOptions) => () => void };
   polygonEditor: { startAreaPolygonWork: (options: AreaPolygonWorkOptions) => () => void };
+  routeEditor: {
+    setSegmentRouteWorkRoute: (route: EditorSegment['route']) => void;
+    startSegmentRouteWork: (options: SegmentRouteWorkOptions) => () => void;
+  };
 }>();
 
 const emit = defineEmits<{
   metadataSaved: [metadata: EditorTripState['metadata']];
   mutationApplied: [result: EditorMutationResult<unknown>];
   regionDraftDirtyChanged: [isDirty: boolean];
+  hiddenSegmentIdsChanged: [ids: Set<Guid>];
 }>();
 
 const searchQuery = ref('');
+const segmentDraftDirty = ref(false);
 const normalizedSearchQuery = computed(() => normalize(searchQuery.value));
 const searchMinimumCharacters = computed(() => props.state.options.limits?.sidebarSearchMinCharacters ?? 1);
 const isSearchActive = computed(() => normalizedSearchQuery.value.length >= searchMinimumCharacters.value);
@@ -73,6 +81,7 @@ const sidebarSearch = computed<SidebarSearchResult>(() => {
   return result;
 });
 const hasSidebarSearchMatches = computed(() => sidebarSearch.value.hasMatches || filteredSegments.value.length > 0);
+const hasAnyDraftChanges = computed(() => props.hasRegionDraftChanges || segmentDraftDirty.value);
 
 const segmentLabel = (state: EditorTripState, segment: EditorSegment): string => {
   const from = segment.fromPlaceId ? state.placesById[segment.fromPlaceId]?.name : null;
@@ -140,7 +149,7 @@ function normalize(value: string): string {
       :editor-endpoint="editorEndpoint"
       :antiforgery-token="antiforgeryToken"
       :trip-index-url="tripIndexUrl"
-      :has-region-draft-changes="hasRegionDraftChanges"
+      :has-region-draft-changes="hasAnyDraftChanges"
       @saved="metadata => emit('metadataSaved', metadata)"
       @mutation-applied="result => emit('mutationApplied', result)"
     />
@@ -186,14 +195,18 @@ function normalize(value: string): string {
       @dirty-state-changed="isDirty => emit('regionDraftDirtyChanged', isDirty)"
     />
 
-    <section v-if="state.segmentOrder.length > 0 && (!isSearchActive || filteredSegments.length > 0)" class="trip-editor-panel">
-      <h2>Segments</h2>
-      <ul class="trip-editor-segments">
-        <li v-for="segment in filteredSegments" :key="segment.id">
-          <span>{{ segmentLabel(state, segment) }}</span>
-          <small>{{ segmentModeText(state, segment) }}</small>
-        </li>
-      </ul>
-    </section>
+    <SegmentManager
+      :state="state"
+      :editor-surface="editorSurface"
+      :editor-endpoint="editorEndpoint"
+      :antiforgery-token="antiforgeryToken"
+      :hidden-segment-ids="hiddenSegmentIds"
+      :route-editor="routeEditor"
+      :search-active="isSearchActive"
+      :segments="filteredSegments"
+      @dirty-state-changed="isDirty => { segmentDraftDirty = isDirty; emit('regionDraftDirtyChanged', hasAnyDraftChanges); }"
+      @hidden-segment-ids-changed="ids => emit('hiddenSegmentIdsChanged', ids)"
+      @mutation-applied="result => emit('mutationApplied', result)"
+    />
   </aside>
 </template>

--- a/ClientApps/trip-editor/src/components/regionPlaceDrafts.ts
+++ b/ClientApps/trip-editor/src/components/regionPlaceDrafts.ts
@@ -1,4 +1,4 @@
-import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorCoordinate, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest } from '../types';
+import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorCoordinate, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorSegment, EditorSegmentDraft, EditorSegmentSaveRequest } from '../types';
 
 export type RegionDraft = {
   id: string | null;
@@ -114,6 +114,39 @@ export function buildAreaRequest(value: EditorAreaDraft): EditorAreaSaveRequest 
   };
 }
 
+export function emptySegmentDraft(): EditorSegmentDraft {
+  return { id: null, fromPlaceId: null, toPlaceId: null, mode: '', estimatedDistanceKm: '', estimatedDurationMinutes: '', notesHtml: '', route: null };
+}
+
+export function toSegmentDraft(segment: EditorSegment | null): EditorSegmentDraft {
+  if (!segment) {
+    return emptySegmentDraft();
+  }
+
+  return {
+    id: segment.id,
+    fromPlaceId: segment.fromPlaceId,
+    toPlaceId: segment.toPlaceId,
+    mode: segment.mode,
+    estimatedDistanceKm: segment.estimatedDistanceKm ?? '',
+    estimatedDurationMinutes: segment.estimatedDurationMinutes ?? '',
+    notesHtml: segment.notesHtml,
+    route: cloneGeometry(segment.route)
+  };
+}
+
+export function buildSegmentRequest(value: EditorSegmentDraft): EditorSegmentSaveRequest {
+  return {
+    fromPlaceId: value.fromPlaceId || null,
+    toPlaceId: value.toPlaceId || null,
+    mode: value.mode || null,
+    estimatedDistanceKm: nullableNumber(value.estimatedDistanceKm),
+    estimatedDurationMinutes: nullableNumber(value.estimatedDurationMinutes),
+    notesHtml: value.notesHtml,
+    route: cloneGeometry(value.route)
+  };
+}
+
 function cloneGeometry<T>(geometry: T): T {
   return geometry ? JSON.parse(JSON.stringify(geometry)) as T : geometry;
 }
@@ -125,4 +158,9 @@ function coordinateText(coordinate: EditorCoordinate | null, key: keyof EditorCo
 /// Normalizes Vue number-input values before validation and API serialization.
 function draftText(value: string | number): string {
   return String(value ?? '').trim();
+}
+
+function nullableNumber(value: string | number): number | null {
+  const text = draftText(value);
+  return text ? Number(text) : null;
 }

--- a/ClientApps/trip-editor/src/components/regionPlaceEditorTargets.ts
+++ b/ClientApps/trip-editor/src/components/regionPlaceEditorTargets.ts
@@ -1,9 +1,10 @@
 import type { EditorTarget } from '../composables/useEditorSurface';
-import type { EditorArea, EditorPlace, EditorRegion } from '../types';
+import type { EditorArea, EditorPlace, EditorRegion, EditorSegment } from '../types';
 
 export const regionDraftKey = 'region-draft';
 export const placeDraftKey = 'place-draft';
 export const areaDraftKey = 'area-draft';
+export const segmentDraftKey = 'segment-draft';
 
 export function buildRegionCreateTarget(): EditorTarget {
   return {
@@ -75,5 +76,28 @@ export function buildAreaEditTarget(area: EditorArea, subtitle?: string): Editor
     subtitle,
     entityId: area.id,
     parentRegionId: area.regionId
+  };
+}
+
+export function buildSegmentCreateTarget(): EditorTarget {
+  return {
+    key: segmentDraftKey,
+    identity: 'segment:add',
+    kind: 'segment',
+    mode: 'add',
+    title: 'Add Segment',
+    subtitle: 'New segment'
+  };
+}
+
+export function buildSegmentEditTarget(segment: EditorSegment, title: string): EditorTarget {
+  return {
+    key: segmentDraftKey,
+    identity: `segment:edit:${segment.id}`,
+    kind: 'segment',
+    mode: 'edit',
+    title: `Edit Segment - ${title}`,
+    subtitle: 'Trip segment',
+    entityId: segment.id
   };
 }

--- a/ClientApps/trip-editor/src/components/segmentRouteMapWork.ts
+++ b/ClientApps/trip-editor/src/components/segmentRouteMapWork.ts
@@ -1,0 +1,101 @@
+import type { EditorSurfaceController } from '../composables/useEditorSurface';
+import type { SegmentRouteWorkOptions } from '../map/leafletAdapter';
+import type { EditorSegmentDraft, EditorTripState, GeoJsonLineString } from '../types';
+
+export type SegmentRouteEditor = {
+  setSegmentRouteWorkRoute: (route: GeoJsonLineString | null) => void;
+  startSegmentRouteWork: (options: SegmentRouteWorkOptions) => () => void;
+};
+
+type SegmentRouteSnapshot = {
+  route: GeoJsonLineString | null;
+};
+
+export type SegmentRouteMapWorkState = {
+  route: GeoJsonLineString | null;
+  stopEdit: (() => void) | null;
+};
+
+/// Starts route-only map-work for the active segment draft.
+export function beginSegmentRouteMapWork(
+  draft: EditorSegmentDraft,
+  editorSurface: EditorSurfaceController,
+  routeEditor: SegmentRouteEditor,
+  state: SegmentRouteMapWorkState,
+  editorState: EditorTripState
+): void {
+  const snapshot = snapshotSegmentRoute(draft);
+  state.route = cloneGeometry(draft.route ?? fallbackRoute(draft, editorState));
+  stopSegmentRouteEdit(state);
+  state.stopEdit = routeEditor.startSegmentRouteWork({
+    initialRoute: state.route,
+    onChanged: route => {
+      state.route = cloneGeometry(route);
+    }
+  });
+
+  const entered = editorSurface.enterMapWork({
+    modeName: 'Draw segment route',
+    instruction: 'Draw or edit one route polyline.',
+    statusText: () => segmentRouteStatus(state.route),
+    canFinish: () => hasValidRoute(state.route),
+    isDirty: () => !sameGeometry(state.route, snapshot.route),
+    snapshot: () => snapshot,
+    rollback: rollbackSnapshot => {
+      restoreSegmentRoute(draft, state, rollbackSnapshot as SegmentRouteSnapshot);
+    },
+    clear: () => {
+      state.route = null;
+      draft.route = null;
+      routeEditor.setSegmentRouteWorkRoute(null);
+    },
+    done: () => {
+      draft.route = cloneGeometry(state.route);
+      stopSegmentRouteEdit(state);
+    },
+    cancel: () => {
+      stopSegmentRouteEdit(state);
+    }
+  });
+  if (!entered) {
+    stopSegmentRouteEdit(state);
+  }
+}
+
+/// Clears any active adapter-owned temporary route/listener.
+export function stopSegmentRouteEdit(state: SegmentRouteMapWorkState): void {
+  state.stopEdit?.();
+  state.stopEdit = null;
+}
+
+export function fallbackRoute(draft: Pick<EditorSegmentDraft, 'fromPlaceId' | 'toPlaceId'>, state: EditorTripState): GeoJsonLineString | null {
+  const from = draft.fromPlaceId ? state.placesById[draft.fromPlaceId]?.location : null;
+  const to = draft.toPlaceId ? state.placesById[draft.toPlaceId]?.location : null;
+  return from && to ? { type: 'LineString', coordinates: [[from.longitude, from.latitude], [to.longitude, to.latitude]] } : null;
+}
+
+function snapshotSegmentRoute(draft: EditorSegmentDraft): SegmentRouteSnapshot {
+  return { route: cloneGeometry(draft.route) };
+}
+
+function restoreSegmentRoute(draft: EditorSegmentDraft, state: SegmentRouteMapWorkState, snapshot: SegmentRouteSnapshot): void {
+  draft.route = cloneGeometry(snapshot.route);
+  state.route = cloneGeometry(snapshot.route);
+}
+
+function hasValidRoute(route: GeoJsonLineString | null): boolean {
+  return Boolean(route?.coordinates && route.coordinates.length >= 2);
+}
+
+function sameGeometry(left: GeoJsonLineString | null, right: GeoJsonLineString | null): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function segmentRouteStatus(route: GeoJsonLineString | null): string {
+  const points = route?.coordinates.length ?? 0;
+  return points >= 2 ? `${points} route points ready` : 'No route ready';
+}
+
+function cloneGeometry<T>(geometry: T): T {
+  return geometry ? JSON.parse(JSON.stringify(geometry)) as T : geometry;
+}

--- a/ClientApps/trip-editor/src/composables/useEditorSurface.ts
+++ b/ClientApps/trip-editor/src/composables/useEditorSurface.ts
@@ -3,7 +3,7 @@ import { confirm } from './useConfirmDialog';
 import type { Guid } from '../types';
 
 export type EditorSurfaceMode = 'docked' | 'expanded' | 'map-work';
-export type EditorTargetKind = 'metadata' | 'region' | 'place' | 'area';
+export type EditorTargetKind = 'metadata' | 'region' | 'place' | 'area' | 'segment';
 export type EditorTargetMode = 'edit' | 'add';
 
 export interface EditorTarget {
@@ -28,6 +28,7 @@ export interface MapWorkOptions {
   statusText?: string | (() => string);
   canFinish?: () => boolean;
   isDirty?: () => boolean;
+  clear?: () => void | Promise<void>;
   snapshot: () => unknown;
   rollback: (snapshot: unknown) => void;
   done: () => void | Promise<void>;
@@ -42,6 +43,7 @@ interface ActiveMapWork {
   statusText: string | (() => string);
   canFinish: () => boolean;
   isDirty: () => boolean;
+  clear?: () => void | Promise<void>;
   snapshot: unknown;
   rollback: (snapshot: unknown) => void;
   done: () => void | Promise<void>;
@@ -170,6 +172,7 @@ export function enterMapWork(options: MapWorkOptions): boolean {
     statusText: options.statusText ?? 'Map work active',
     canFinish: options.canFinish ?? (() => true),
     isDirty: options.isDirty ?? (() => true),
+    clear: options.clear,
     snapshot: options.snapshot(),
     rollback: options.rollback,
     done: options.done,

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -3,16 +3,20 @@ import 'leaflet/dist/leaflet.css';
 import type { EditorTarget } from '../composables/useEditorSurface';
 import type { EditorArea, EditorCoordinate, EditorPlace, EditorRegion, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from '../types';
 import { createAreaPolygonWorkLayer } from './areaPolygonWorkLayer';
+import { createSegmentRouteWorkLayer } from './segmentRouteWorkLayer';
 export type { AreaPolygonWorkOptions } from './areaPolygonWorkLayer';
+export type { SegmentRouteWorkOptions } from './segmentRouteWorkLayer';
 
 export type FitAllGeometryResult = 'moved' | 'no-geometry';
 export type FocusSavedTripViewResult = 'moved' | 'missing-view';
 export type FocusActiveEntityResult = 'moved' | 'missing-target' | 'no-geometry' | 'unsupported-target';
 
 interface TripEditorMapAdapter {
-  render: (state: EditorTripState) => void;
+  render: (state: EditorTripState, hiddenSegmentIds?: ReadonlySet<Guid>) => void;
   startCoordinatePick: (options: CoordinatePickOptions) => () => void;
   startAreaPolygonWork: (options: AreaPolygonWorkOptions) => () => void;
+  startSegmentRouteWork: (options: SegmentRouteWorkOptions) => () => void;
+  setSegmentRouteWorkRoute: (route: EditorSegment['route']) => void;
   fitAllGeometry: (state: EditorTripState) => FitAllGeometryResult;
   focusSavedTripView: (metadata: EditorTripMetadata) => FocusSavedTripViewResult;
   focusActiveEntity: (state: EditorTripState, target: EditorTarget | null) => FocusActiveEntityResult;
@@ -24,21 +28,27 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
   const layers = L.layerGroup().addTo(map);
   const coordinatePick = createCoordinatePickLayer(map);
   const areaPolygonWork = createAreaPolygonWorkLayer(map);
+  const segmentRouteWork = createSegmentRouteWorkLayer(map);
 
   L.tileLayer(tilesUrl, {
     attribution: window.wayfarerTileConfig?.attribution ?? '&copy; OpenStreetMap contributors',
     maxZoom: 19
   }).addTo(map);
 
-  const render = (state: EditorTripState): void => {
+  const render = (state: EditorTripState, hiddenSegmentIds: ReadonlySet<Guid> = new Set()): void => {
     coordinatePick.clearRegisteredMarkers();
     areaPolygonWork.stop();
+    segmentRouteWork.stop();
     layers.clearLayers();
 
     Object.values(state.regionsById).forEach(region => renderRegion(region, layers));
     Object.values(state.areasById).forEach(area => renderArea(area, layers));
     Object.values(state.placesById).forEach(place => renderPlace(place, layers, coordinatePick));
-    Object.values(state.segmentsById).forEach(segment => renderSegment(segment, state, layers));
+    Object.values(state.segmentsById).forEach(segment => {
+      if (!hiddenSegmentIds.has(segment.id)) {
+        renderSegment(segment, state, layers);
+      }
+    });
 
     fitMapToState(map, state);
   };
@@ -47,12 +57,15 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
     render,
     startCoordinatePick: options => coordinatePick.start(options),
     startAreaPolygonWork: options => areaPolygonWork.start(options),
+    startSegmentRouteWork: options => segmentRouteWork.start(options),
+    setSegmentRouteWorkRoute: route => segmentRouteWork.setRoute(route),
     fitAllGeometry: state => fitAllGeometry(map, state),
     focusSavedTripView: metadata => focusSavedTripView(map, metadata),
     focusActiveEntity: (state, target) => focusActiveEntity(map, state, target),
     dispose: () => {
       coordinatePick.dispose();
       areaPolygonWork.dispose();
+      segmentRouteWork.dispose();
       map.remove();
     }
   };
@@ -305,6 +318,15 @@ const focusActiveEntity = (map: LeafletMap, state: EditorTripState, target: Edit
     return area ? fitBounds(map, areaBounds(area)) : 'missing-target';
   }
 
+  if (target.kind === 'segment') {
+    if (target.mode !== 'edit' || !target.entityId) {
+      return allGeometryBounds(state).isValid() ? fitAllGeometry(map, state) : 'no-geometry';
+    }
+
+    const segment = state.segmentsById[target.entityId];
+    return segment ? fitBounds(map, segmentBounds(segment, state)) : 'missing-target';
+  }
+
   return 'unsupported-target';
 };
 
@@ -349,6 +371,14 @@ export const canFocusActiveEntity = (state: EditorTripState, target: EditorTarge
     }
 
     return Boolean(target.entityId) && areaBounds(state.areasById[target.entityId!]).isValid();
+  }
+
+  if (target.kind === 'segment') {
+    if (target.mode === 'add') {
+      return hasAnyGeometry(state);
+    }
+
+    return Boolean(target.entityId) && segmentBounds(state.segmentsById[target.entityId!], state).isValid();
   }
 
   return false;
@@ -406,6 +436,15 @@ const areaBounds = (area: EditorArea | undefined): L.LatLngBounds => {
   const bounds = L.latLngBounds([]);
   if (area) {
     extendArea(bounds, area);
+  }
+
+  return bounds;
+};
+
+const segmentBounds = (segment: EditorSegment | undefined, state: EditorTripState): L.LatLngBounds => {
+  const bounds = L.latLngBounds([]);
+  if (segment) {
+    extendSegment(bounds, segment, state);
   }
 
   return bounds;

--- a/ClientApps/trip-editor/src/map/segmentRouteWorkLayer.ts
+++ b/ClientApps/trip-editor/src/map/segmentRouteWorkLayer.ts
@@ -1,0 +1,148 @@
+import L, { type Map as LeafletMap } from 'leaflet';
+import { ensureLeafletDraw } from './leafletDrawPlugin';
+import type { GeoJsonLineString } from '../types';
+
+export interface SegmentRouteWorkOptions {
+  initialRoute: GeoJsonLineString | null;
+  onChanged: (route: GeoJsonLineString | null) => void;
+}
+
+type DrawnLayerEvent = { layer: L.Layer };
+type LeafletDrawHandler = { disable: () => void; enable: () => void };
+type LatLngRoute = L.LatLng[];
+
+/// Owns the single temporary Leaflet.Draw polyline used by Trip Editor segment route map-work.
+export const createSegmentRouteWorkLayer = (map: LeafletMap): {
+  dispose: () => void;
+  setRoute: (route: GeoJsonLineString | null) => void;
+  start: (options: SegmentRouteWorkOptions) => () => void;
+  stop: () => void;
+} => {
+  ensureLeafletDraw();
+  const featureGroup = L.featureGroup().addTo(map);
+  let drawHandler: LeafletDrawHandler | null = null;
+  let editHandler: LeafletDrawHandler | null = null;
+  let polyline: L.Polyline | null = null;
+  let options: SegmentRouteWorkOptions | null = null;
+
+  const publish = (): void => {
+    options?.onChanged(polyline ? latLngsToLineString(routeLatLngs(polyline)) : null);
+  };
+
+  const stopHandlers = (): void => {
+    drawHandler?.disable();
+    editHandler?.disable();
+    drawHandler = null;
+    editHandler = null;
+    map.off(drawCreatedEvent(), onDrawCreated);
+    map.off(drawEditedEvent(), publish);
+    map.off(drawEditVertexEvent(), publish);
+  };
+
+  const stop = (): void => {
+    stopHandlers();
+    featureGroup.clearLayers();
+    polyline = null;
+    options = null;
+  };
+
+  const setRoute = (route: GeoJsonLineString | null): void => {
+    featureGroup.clearLayers();
+    polyline = routeToLatLngs(route).length >= 2 ? createPolyline(routeToLatLngs(route)) : null;
+    if (polyline) {
+      featureGroup.addLayer(polyline);
+      startEditMode();
+    } else {
+      startDrawMode();
+    }
+
+    publish();
+  };
+
+  const start = (workOptions: SegmentRouteWorkOptions): (() => void) => {
+    stop();
+    options = workOptions;
+    setRoute(workOptions.initialRoute);
+    if (polyline?.getBounds().isValid()) {
+      map.fitBounds(polyline.getBounds(), { padding: [32, 32], maxZoom: 14 });
+    }
+
+    return stop;
+  };
+
+  const startDrawMode = (): void => {
+    stopHandlers();
+    drawHandler = new (drawPolylineHandler())(map, {
+      repeatMode: false,
+      shapeOptions: routeStyle()
+    }) as LeafletDrawHandler;
+    map.on(drawCreatedEvent(), onDrawCreated);
+    drawHandler.enable();
+  };
+
+  const startEditMode = (): void => {
+    stopHandlers();
+    editHandler = new (editToolbarHandler())(map, {
+      featureGroup,
+      selectedPathOptions: { maintainColor: true }
+    }) as LeafletDrawHandler;
+    map.on(drawEditedEvent(), publish);
+    map.on(drawEditVertexEvent(), publish);
+    editHandler.enable();
+  };
+
+  function onDrawCreated(event: DrawnLayerEvent): void {
+    if (!(event.layer instanceof L.Polyline) || event.layer instanceof L.Polygon) {
+      return;
+    }
+
+    featureGroup.clearLayers();
+    polyline = event.layer;
+    polyline.setStyle(routeStyle());
+    featureGroup.addLayer(polyline);
+    startEditMode();
+    publish();
+  }
+
+  return {
+    dispose: stop,
+    setRoute,
+    start,
+    stop
+  };
+};
+
+const routeStyle = (): L.PathOptions => ({
+  color: '#f97316',
+  opacity: 0.9,
+  weight: 4
+});
+
+const routeToLatLngs = (route: GeoJsonLineString | null): LatLngRoute =>
+  (route?.coordinates ?? []).map(([longitude, latitude]) => L.latLng(latitude, longitude));
+
+const createPolyline = (latLngs: LatLngRoute): L.Polyline =>
+  L.polyline(latLngs, routeStyle());
+
+const routeLatLngs = (polyline: L.Polyline): LatLngRoute => {
+  const latLngs = polyline.getLatLngs();
+  return latLngs.filter(point => point instanceof L.LatLng) as LatLngRoute;
+};
+
+const latLngsToLineString = (latLngs: LatLngRoute): GeoJsonLineString | null =>
+  latLngs.length >= 2
+    ? { type: 'LineString', coordinates: latLngs.map(point => [point.lng, point.lat] as [number, number]) }
+    : null;
+
+const drawPolylineHandler = (): new (map: LeafletMap, options: Record<string, unknown>) => unknown =>
+  (L as unknown as { Draw: { Polyline: new (map: LeafletMap, options: Record<string, unknown>) => unknown } }).Draw.Polyline;
+
+const editToolbarHandler = (): new (map: LeafletMap, options: Record<string, unknown>) => unknown =>
+  (L as unknown as { EditToolbar: { Edit: new (map: LeafletMap, options: Record<string, unknown>) => unknown } }).EditToolbar.Edit;
+
+const drawEvent = (name: 'CREATED' | 'EDITED' | 'EDITVERTEX'): string =>
+  (L as unknown as { Draw: { Event: Record<string, string> } }).Draw.Event[name];
+
+const drawCreatedEvent = (): string => drawEvent('CREATED');
+const drawEditedEvent = (): string => drawEvent('EDITED');
+const drawEditVertexEvent = (): string => drawEvent('EDITVERTEX');

--- a/ClientApps/trip-editor/src/types.ts
+++ b/ClientApps/trip-editor/src/types.ts
@@ -240,6 +240,28 @@ export interface EditorAreaDeleteResult {
   areaId: Guid;
 }
 
+export interface EditorSegmentSaveRequest {
+  fromPlaceId: Guid | null;
+  toPlaceId: Guid | null;
+  mode: string | null;
+  estimatedDistanceKm: number | null;
+  estimatedDurationMinutes: number | null;
+  notesHtml: string | null;
+  route: GeoJsonLineString | null;
+}
+
+export interface EditorSegmentOrderRequest {
+  segmentIds: Guid[];
+}
+
+export interface EditorSegmentOrderResult {
+  segmentOrder: Guid[];
+}
+
+export interface EditorSegmentDeleteResult {
+  segmentId: Guid;
+}
+
 export interface EditorPlaceDraft {
   id: Guid | null;
   regionId: Guid | null;
@@ -260,6 +282,17 @@ export interface EditorAreaDraft {
   notesHtml: string;
   fillHex: string;
   geometry: GeoJsonPolygon | null;
+}
+
+export interface EditorSegmentDraft {
+  id: Guid | null;
+  fromPlaceId: Guid | null;
+  toPlaceId: Guid | null;
+  mode: string;
+  estimatedDistanceKm: string | number;
+  estimatedDurationMinutes: string | number;
+  notesHtml: string;
+  route: GeoJsonLineString | null;
 }
 
 export interface EditorMutationResult<TData> {

--- a/Models/Dtos/Editor/EditorMutationDtos.cs
+++ b/Models/Dtos/Editor/EditorMutationDtos.cs
@@ -111,6 +111,33 @@ public sealed record EditorAreaOrderResult(Guid RegionId, IReadOnlyList<Guid> Ar
 public sealed record EditorAreaDeleteResult(Guid AreaId);
 
 /// <summary>
+/// Complete-draft request for creating or updating a segment from the same-origin editor.
+/// </summary>
+public sealed record EditorSegmentSaveRequest(
+    Guid? FromPlaceId,
+    Guid? ToPlaceId,
+    string Mode,
+    double? EstimatedDistanceKm,
+    double? EstimatedDurationMinutes,
+    string? NotesHtml,
+    NetTopologySuite.Geometries.LineString? Route);
+
+/// <summary>
+/// Complete desired trip-level segment order.
+/// </summary>
+public sealed record EditorSegmentOrderRequest(IReadOnlyList<Guid> SegmentIds);
+
+/// <summary>
+/// Segment order data returned by the segment order endpoint.
+/// </summary>
+public sealed record EditorSegmentOrderResult(IReadOnlyList<Guid> SegmentOrder);
+
+/// <summary>
+/// Segment delete data returned by the segment delete endpoint.
+/// </summary>
+public sealed record EditorSegmentDeleteResult(Guid SegmentId);
+
+/// <summary>
 /// Standard success envelope returned by editor mutation endpoints.
 /// </summary>
 public sealed record EditorMutationResult<TData>(

--- a/Models/Dtos/Editor/EditorSegmentRequestParser.cs
+++ b/Models/Dtos/Editor/EditorSegmentRequestParser.cs
@@ -1,0 +1,296 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using NetTopologySuite.Geometries;
+using Wayfarer.Services;
+
+namespace Wayfarer.Models.Dtos.Editor;
+
+/// <summary>
+/// Parses and validates segment mutation JSON while preserving ownership-first request handling.
+/// </summary>
+internal static class EditorSegmentRequestParser
+{
+    private static readonly string[] ServerOwnedFields = { "id", "tripId", "displayOrder", "capabilities" };
+    private static readonly Regex DataImageSourceRegex = new(
+        @"<img\b[^>]*?\bsrc\s*=\s*[""']?\s*data:image/",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Attempts to parse a complete-draft segment save request.
+    /// </summary>
+    public static bool TryParseSave(JsonElement request, out EditorSegmentSaveRequest update, out Dictionary<string, string[]> errors)
+    {
+        errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        update = new EditorSegmentSaveRequest(null, null, string.Empty, null, null, null, null);
+        if (!ValidateObject(request, errors, "Segment mutation request must be a JSON object."))
+        {
+            return false;
+        }
+
+        RejectFields(request, ServerOwnedFields, "The field is server-owned and cannot be updated.", errors);
+        var fromPlaceId = ReadRequiredNullableGuid(request, "fromPlaceId", errors);
+        var toPlaceId = ReadRequiredNullableGuid(request, "toPlaceId", errors);
+        var mode = ReadRequiredNullableString(request, "mode", errors);
+        var distance = ReadRequiredNullableNonNegativeDouble(request, "estimatedDistanceKm", errors);
+        var duration = ReadRequiredNullableNonNegativeDouble(request, "estimatedDurationMinutes", errors);
+        var notesHtml = ReadRequiredNullableString(request, "notesHtml", errors);
+        var route = ReadRequiredNullableRoute(request, errors);
+        ValidateMode(mode, errors);
+        ValidateNotes(notesHtml, errors);
+
+        if (errors.Count > 0)
+        {
+            return false;
+        }
+
+        update = new EditorSegmentSaveRequest(
+            fromPlaceId,
+            toPlaceId,
+            CanonicalMode(mode),
+            distance,
+            duration,
+            notesHtml,
+            route);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to parse a complete trip-level segment order request.
+    /// </summary>
+    public static bool TryParseOrder(JsonElement request, out EditorSegmentOrderRequest update, out Dictionary<string, string[]> errors)
+    {
+        errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        update = new EditorSegmentOrderRequest(Array.Empty<Guid>());
+        if (!ValidateObject(request, errors, "Segment order request must be a JSON object."))
+        {
+            return false;
+        }
+
+        RejectFields(request, ServerOwnedFields, "The field is server-owned and cannot be updated.", errors);
+        if (!request.TryGetProperty("segmentIds", out var idsProperty))
+        {
+            errors["segmentIds"] = new[] { "The field is required." };
+            return false;
+        }
+
+        if (idsProperty.ValueKind != JsonValueKind.Array)
+        {
+            errors["segmentIds"] = new[] { "Segment IDs must be an array." };
+            return false;
+        }
+
+        var segmentIds = new List<Guid>();
+        foreach (var item in idsProperty.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String || !Guid.TryParse(item.GetString(), out var id))
+            {
+                errors["segmentIds"] = new[] { "Every segment ID must be a GUID string." };
+                return false;
+            }
+
+            segmentIds.Add(id);
+        }
+
+        update = new EditorSegmentOrderRequest(segmentIds);
+        return true;
+    }
+
+    private static bool ValidateObject(JsonElement request, Dictionary<string, string[]> errors, string message)
+    {
+        if (request.ValueKind == JsonValueKind.Object)
+        {
+            return true;
+        }
+
+        errors["request"] = new[] { message };
+        return false;
+    }
+
+    private static void RejectFields(JsonElement request, IEnumerable<string> fields, string message, Dictionary<string, string[]> errors)
+    {
+        foreach (var field in fields)
+        {
+            if (request.TryGetProperty(field, out _))
+            {
+                errors[field] = new[] { message };
+            }
+        }
+    }
+
+    private static Guid? ReadRequiredNullableGuid(JsonElement request, string name, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty(name, out var property))
+        {
+            errors[name] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.String || !Guid.TryParse(property.GetString(), out var value))
+        {
+            errors[name] = new[] { "The field must be a GUID string or null." };
+            return null;
+        }
+
+        return value;
+    }
+
+    private static string? ReadRequiredNullableString(JsonElement request, string name, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty(name, out var property))
+        {
+            errors[name] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.String)
+        {
+            errors[name] = new[] { "The field must be a string or null." };
+            return null;
+        }
+
+        return property.GetString();
+    }
+
+    private static double? ReadRequiredNullableNonNegativeDouble(JsonElement request, string name, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty(name, out var property))
+        {
+            errors[name] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        if (!TryReadFiniteDouble(property, out var value) || value < 0)
+        {
+            errors[name] = new[] { "The field must be a finite non-negative number or null." };
+            return null;
+        }
+
+        return value;
+    }
+
+    private static LineString? ReadRequiredNullableRoute(JsonElement request, Dictionary<string, string[]> errors)
+    {
+        if (!request.TryGetProperty("route", out var property))
+        {
+            errors["route"] = new[] { "The field is required." };
+            return null;
+        }
+
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.Object)
+        {
+            errors["route"] = new[] { "Route must be a GeoJSON LineString object or null." };
+            return null;
+        }
+
+        if (!property.TryGetProperty("type", out var typeProperty) || typeProperty.ValueKind != JsonValueKind.String || typeProperty.GetString() != "LineString")
+        {
+            errors["route"] = new[] { "Route type must be LineString." };
+            return null;
+        }
+
+        if (!property.TryGetProperty("coordinates", out var coordinatesProperty) || coordinatesProperty.ValueKind != JsonValueKind.Array)
+        {
+            errors["route.coordinates"] = new[] { "LineString coordinates must be an array of positions." };
+            return null;
+        }
+
+        var coordinates = new List<Coordinate>();
+        foreach (var positionProperty in coordinatesProperty.EnumerateArray())
+        {
+            var coordinate = ReadPosition(positionProperty, errors);
+            if (coordinate == null)
+            {
+                return null;
+            }
+
+            coordinates.Add(coordinate);
+        }
+
+        if (coordinates.Count < 2)
+        {
+            errors["route.coordinates"] = new[] { "LineString must contain at least two positions." };
+            return null;
+        }
+
+        return new LineString(coordinates.ToArray()) { SRID = 4326 };
+    }
+
+    private static Coordinate? ReadPosition(JsonElement positionProperty, Dictionary<string, string[]> errors)
+    {
+        if (positionProperty.ValueKind != JsonValueKind.Array || positionProperty.GetArrayLength() != 2)
+        {
+            errors["route.coordinates"] = new[] { "Every position must contain exactly longitude and latitude." };
+            return null;
+        }
+
+        var values = positionProperty.EnumerateArray().ToArray();
+        if (!TryReadFiniteDouble(values[0], out var longitude) || !TryReadFiniteDouble(values[1], out var latitude))
+        {
+            errors["route.coordinates"] = new[] { "Every position must contain finite numeric longitude and latitude." };
+            return null;
+        }
+
+        if (longitude is < -180 or > 180 || latitude is < -90 or > 90)
+        {
+            errors["route.coordinates"] = new[] { "Coordinates must use longitude -180..180 and latitude -90..90." };
+            return null;
+        }
+
+        return new Coordinate(longitude, latitude);
+    }
+
+    private static bool TryReadFiniteDouble(JsonElement property, out double value)
+    {
+        value = default;
+        return property.ValueKind == JsonValueKind.Number
+            && property.TryGetDouble(out value)
+            && !double.IsNaN(value)
+            && !double.IsInfinity(value);
+    }
+
+    private static void ValidateMode(string? mode, Dictionary<string, string[]> errors)
+    {
+        if (string.IsNullOrWhiteSpace(mode))
+        {
+            return;
+        }
+
+        if (!SegmentTransportModes.Options.Any(option => string.Equals(option.Value, mode.Trim(), StringComparison.OrdinalIgnoreCase)))
+        {
+            errors["mode"] = new[] { "Mode must match a supported transport mode." };
+        }
+    }
+
+    private static string CanonicalMode(string? mode) =>
+        string.IsNullOrWhiteSpace(mode)
+            ? string.Empty
+            : SegmentTransportModes.Options.First(option => string.Equals(option.Value, mode.Trim(), StringComparison.OrdinalIgnoreCase)).Value;
+
+    private static void ValidateNotes(string? notesHtml, Dictionary<string, string[]> errors)
+    {
+        if (!string.IsNullOrEmpty(notesHtml) && DataImageSourceRegex.IsMatch(notesHtml))
+        {
+            errors["notesHtml"] = new[] { "Notes cannot contain data image sources." };
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -594,7 +594,7 @@ static void ConfigureServices(WebApplicationBuilder builder)
 
     builder.Services.AddScoped<IRazorViewRenderer, RazorViewRenderer>();
     builder.Services.AddSingleton<MapSnapshotService>();
-    builder.Services.AddScoped<TripEditorRegionMutationService>(); builder.Services.AddScoped<TripEditorPlaceMutationReader>(); builder.Services.AddScoped<TripEditorPlaceRouteEffects>(); builder.Services.AddScoped<TripEditorPlaceMutationService>(); builder.Services.AddScoped<TripEditorAreaMutationService>();
+    builder.Services.AddScoped<TripEditorRegionMutationService>(); builder.Services.AddScoped<TripEditorPlaceMutationReader>(); builder.Services.AddScoped<TripEditorPlaceRouteEffects>(); builder.Services.AddScoped<TripEditorPlaceMutationService>(); builder.Services.AddScoped<TripEditorAreaMutationService>(); builder.Services.AddScoped<TripEditorSegmentMutationService>();
 
     builder.Services.AddScoped<ITripThumbnailService, TripThumbnailService>();
     builder.Services.AddSingleton<ITripMapThumbnailGenerator, TripMapThumbnailGenerator>();

--- a/Services/TripEditorSegmentMutationService.cs
+++ b/Services/TripEditorSegmentMutationService.cs
@@ -1,0 +1,314 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Wayfarer.Models;
+using Wayfarer.Models.Dtos.Editor;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Executes Trip Editor segment mutations and builds their mutation result envelopes.
+/// </summary>
+public sealed class TripEditorSegmentMutationService
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    /// <summary>
+    /// Initializes a new segment mutation service for the editor API.
+    /// </summary>
+    public TripEditorSegmentMutationService(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    /// <summary>
+    /// Creates a trip-level segment after the owned trip is verified.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>> CreateSegmentAsync(
+        Guid tripId,
+        string userId,
+        Stream requestBody,
+        CancellationToken cancellationToken)
+    {
+        var trip = await LoadTripGraphAsync(tripId, userId, cancellationToken);
+        if (trip == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>.NotFound();
+        }
+
+        var parsed = await ParseAndValidateSaveAsync(requestBody, cancellationToken);
+        if (parsed.ValidationErrors != null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>.ValidationFailed(parsed.ValidationErrors);
+        }
+
+        var referenceErrors = ValidatePlaceReferences(parsed.Value!, trip);
+        if (referenceErrors.Count > 0)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>.ValidationFailed(referenceErrors);
+        }
+
+        var segment = new Segment
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Trip = trip,
+            TripId = trip.Id,
+            DisplayOrder = NextSegmentOrder(trip),
+        };
+        Apply(segment, parsed.Value!);
+        _dbContext.Segments.Add(segment);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var dto = await LoadSegmentDtoAsync(segment.Id, tripId, cancellationToken);
+        var affected = await BuildAffectedAsync(tripId, new[] { dto }, includeOrder: true, cancellationToken);
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>.Succeeded(
+            new EditorMutationResult<EditorSegmentDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Updates complete editable fields for one owned segment.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>> UpdateSegmentAsync(
+        Guid tripId,
+        Guid segmentId,
+        string userId,
+        Stream requestBody,
+        CancellationToken cancellationToken)
+    {
+        var trip = await LoadTripGraphAsync(tripId, userId, cancellationToken);
+        if (trip == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>.NotFound();
+        }
+
+        var segment = trip.Segments.FirstOrDefault(s => s.Id == segmentId);
+        if (segment == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>.NotFound();
+        }
+
+        var parsed = await ParseAndValidateSaveAsync(requestBody, cancellationToken);
+        if (parsed.ValidationErrors != null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>.ValidationFailed(parsed.ValidationErrors);
+        }
+
+        var referenceErrors = ValidatePlaceReferences(parsed.Value!, trip);
+        if (referenceErrors.Count > 0)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>.ValidationFailed(referenceErrors);
+        }
+
+        Apply(segment, parsed.Value!);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var dto = await LoadSegmentDtoAsync(segmentId, tripId, cancellationToken);
+        var affected = await BuildAffectedAsync(tripId, new[] { dto }, includeOrder: false, cancellationToken);
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDto>>.Succeeded(
+            new EditorMutationResult<EditorSegmentDto>(true, dto, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Deletes one owned segment and returns the updated trip-level segment order.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDeleteResult>>> DeleteSegmentAsync(
+        Guid tripId,
+        Guid segmentId,
+        string userId,
+        CancellationToken cancellationToken)
+    {
+        var segment = await LoadOwnedSegmentAsync(tripId, segmentId, userId, cancellationToken);
+        if (segment == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDeleteResult>>.NotFound();
+        }
+
+        _dbContext.Segments.Remove(segment);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await NormalizeSegmentOrdersAsync(tripId, userId, cancellationToken);
+
+        var affected = await BuildAffectedAsync(tripId, Array.Empty<EditorSegmentDto>(), includeOrder: true, cancellationToken);
+        var deletedIds = new EditorDeletedIdsDto(Array.Empty<Guid>(), Array.Empty<Guid>(), Array.Empty<Guid>(), new[] { segmentId }, Array.Empty<string>());
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentDeleteResult>>.Succeeded(
+            new EditorMutationResult<EditorSegmentDeleteResult>(true, new EditorSegmentDeleteResult(segmentId), affected, deletedIds, Array.Empty<EditorWarningDto>()));
+    }
+
+    /// <summary>
+    /// Persists the complete desired trip-level segment order.
+    /// </summary>
+    public async Task<EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentOrderResult>>> OrderSegmentsAsync(
+        Guid tripId,
+        string userId,
+        Stream requestBody,
+        CancellationToken cancellationToken)
+    {
+        var trip = await LoadTripGraphAsync(tripId, userId, cancellationToken);
+        if (trip == null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentOrderResult>>.NotFound();
+        }
+
+        var request = await ParseJsonBodyAsync(requestBody, "Segment order request must be valid JSON.", cancellationToken);
+        if (request.ValidationErrors != null)
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentOrderResult>>.ValidationFailed(request.ValidationErrors);
+        }
+
+        if (!EditorSegmentRequestParser.TryParseOrder(request.Value!.Value, out var orderRequest, out var errors))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentOrderResult>>.ValidationFailed(errors);
+        }
+
+        var currentIds = trip.Segments.OrderBy(s => s.DisplayOrder).ThenBy(s => s.Id).Select(s => s.Id).ToList();
+        if (orderRequest.SegmentIds.Count != currentIds.Count
+            || orderRequest.SegmentIds.Distinct().Count() != orderRequest.SegmentIds.Count
+            || orderRequest.SegmentIds.Any(id => !currentIds.Contains(id)))
+        {
+            return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentOrderResult>>.ValidationFailed(new Dictionary<string, string[]>
+            {
+                ["segmentIds"] = new[] { "Segment IDs must include every segment in this trip exactly once." }
+            });
+        }
+
+        var segmentsById = trip.Segments.ToDictionary(s => s.Id);
+        for (var i = 0; i < orderRequest.SegmentIds.Count; i++)
+        {
+            segmentsById[orderRequest.SegmentIds[i]].DisplayOrder = i + 1;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var segmentOrder = await LoadSegmentOrderAsync(tripId, cancellationToken);
+        var segmentDtos = await LoadSegmentDtosAsync(orderRequest.SegmentIds, tripId, cancellationToken);
+        var affected = await BuildAffectedAsync(tripId, segmentDtos, includeOrder: true, cancellationToken);
+        var data = new EditorSegmentOrderResult(segmentOrder);
+        return EditorRegionMutationOutcome<EditorMutationResult<EditorSegmentOrderResult>>.Succeeded(
+            new EditorMutationResult<EditorSegmentOrderResult>(true, data, affected, EditorDeletedIdsDto.Empty, Array.Empty<EditorWarningDto>()));
+    }
+
+    private async Task<(EditorSegmentSaveRequest? Value, Dictionary<string, string[]>? ValidationErrors)> ParseAndValidateSaveAsync(Stream body, CancellationToken token)
+    {
+        var request = await ParseJsonBodyAsync(body, "Segment mutation request must be valid JSON.", token);
+        if (request.ValidationErrors != null)
+        {
+            return (null, request.ValidationErrors);
+        }
+
+        return EditorSegmentRequestParser.TryParseSave(request.Value!.Value, out var value, out var errors) ? (value, null) : (null, errors);
+    }
+
+    private async Task<Trip?> LoadTripGraphAsync(Guid tripId, string userId, CancellationToken cancellationToken) =>
+        await _dbContext.Trips
+            .Include(t => t.Regions).ThenInclude(r => r.Places)
+            .Include(t => t.Segments)
+            .FirstOrDefaultAsync(t => t.Id == tripId && t.UserId == userId, cancellationToken);
+
+    private async Task<Segment?> LoadOwnedSegmentAsync(Guid tripId, Guid segmentId, string userId, CancellationToken cancellationToken) =>
+        await _dbContext.Segments
+            .Include(s => s.Trip)
+            .FirstOrDefaultAsync(s => s.Id == segmentId && s.TripId == tripId && s.Trip.UserId == userId, cancellationToken);
+
+    private static Dictionary<string, string[]> ValidatePlaceReferences(EditorSegmentSaveRequest request, Trip trip)
+    {
+        var errors = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        var placeIds = trip.Regions.SelectMany(r => r.Places).Select(p => p.Id).ToHashSet();
+        if (request.FromPlaceId.HasValue && !placeIds.Contains(request.FromPlaceId.Value))
+        {
+            errors["fromPlaceId"] = new[] { "From place must belong to this trip." };
+        }
+
+        if (request.ToPlaceId.HasValue && !placeIds.Contains(request.ToPlaceId.Value))
+        {
+            errors["toPlaceId"] = new[] { "To place must belong to this trip." };
+        }
+
+        return errors;
+    }
+
+    private static void Apply(Segment segment, EditorSegmentSaveRequest request)
+    {
+        segment.FromPlaceId = request.FromPlaceId;
+        segment.ToPlaceId = request.ToPlaceId;
+        segment.Mode = request.Mode;
+        segment.EstimatedDistanceKm = request.EstimatedDistanceKm;
+        segment.EstimatedDuration = request.EstimatedDurationMinutes.HasValue ? TimeSpan.FromMinutes(request.EstimatedDurationMinutes.Value) : null;
+        segment.Notes = request.NotesHtml ?? string.Empty;
+        segment.RouteGeometry = request.Route;
+    }
+
+    private async Task<EditorSegmentDto> LoadSegmentDtoAsync(Guid segmentId, Guid tripId, CancellationToken cancellationToken)
+    {
+        var segment = await _dbContext.Segments.AsNoTracking().SingleAsync(s => s.Id == segmentId, cancellationToken);
+        return EditorTripStateMapper.ToSegment(tripId, segment);
+    }
+
+    private async Task<IReadOnlyList<EditorSegmentDto>> LoadSegmentDtosAsync(IReadOnlyList<Guid> ids, Guid tripId, CancellationToken cancellationToken)
+    {
+        var segments = await _dbContext.Segments.AsNoTracking().Where(s => ids.Contains(s.Id)).ToListAsync(cancellationToken);
+        var byId = segments.ToDictionary(s => s.Id);
+        return ids.Select(id => EditorTripStateMapper.ToSegment(tripId, byId[id])).ToList();
+    }
+
+    private async Task<EditorAffectedSlicesDto> BuildAffectedAsync(
+        Guid tripId,
+        IReadOnlyList<EditorSegmentDto> segments,
+        bool includeOrder,
+        CancellationToken cancellationToken) =>
+        new(
+            null,
+            Array.Empty<EditorRegionDto>(),
+            null,
+            Array.Empty<EditorPlaceDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            Array.Empty<EditorAreaDto>(),
+            new Dictionary<Guid, IReadOnlyList<Guid>>(),
+            segments,
+            includeOrder ? await LoadSegmentOrderAsync(tripId, cancellationToken) : null,
+            Array.Empty<EditorTagDto>(),
+            null,
+            null,
+            null);
+
+    private async Task<IReadOnlyList<Guid>> LoadSegmentOrderAsync(Guid tripId, CancellationToken cancellationToken) =>
+        await _dbContext.Segments
+            .AsNoTracking()
+            .Where(s => s.TripId == tripId)
+            .OrderBy(s => s.DisplayOrder)
+            .ThenBy(s => s.Id)
+            .Select(s => s.Id)
+            .ToListAsync(cancellationToken);
+
+    private async Task NormalizeSegmentOrdersAsync(Guid tripId, string userId, CancellationToken cancellationToken)
+    {
+        var segments = await _dbContext.Segments
+            .Where(s => s.TripId == tripId && s.UserId == userId)
+            .OrderBy(s => s.DisplayOrder)
+            .ThenBy(s => s.Id)
+            .ToListAsync(cancellationToken);
+        for (var i = 0; i < segments.Count; i++)
+        {
+            segments[i].DisplayOrder = i + 1;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static int NextSegmentOrder(Trip trip) =>
+        (trip.Segments.Count == 0 ? 0 : trip.Segments.Max(s => s.DisplayOrder)) + 1;
+
+    private static async Task<(JsonElement? Value, Dictionary<string, string[]>? ValidationErrors)> ParseJsonBodyAsync(
+        Stream requestBody,
+        string invalidJsonMessage,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var document = await JsonDocument.ParseAsync(requestBody, cancellationToken: cancellationToken);
+            return (document.RootElement.Clone(), null);
+        }
+        catch (JsonException)
+        {
+            return (null, new Dictionary<string, string[]> { ["request"] = new[] { invalidJsonMessage } });
+        }
+    }
+}

--- a/tests/Wayfarer.Tests/Controllers/TripEditorAreaControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorAreaControllerTests.cs
@@ -291,6 +291,7 @@ public sealed class TripEditorAreaControllerTests : TestBase
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, iconColorProvider, new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             new TripEditorAreaMutationService(db),
+            new TripEditorSegmentMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
     }
 

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -294,6 +294,7 @@ public sealed class TripEditorControllerTests : TestBase
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             new TripEditorAreaMutationService(db),
+            new TripEditorSegmentMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
         var url = new Mock<IUrlHelper>();

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
@@ -209,6 +209,7 @@ public sealed class TripEditorMetadataControllerTests : TestBase
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             new TripEditorAreaMutationService(db),
+            new TripEditorSegmentMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
         var url = new Mock<IUrlHelper>();

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataValidationControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataValidationControllerTests.cs
@@ -257,6 +257,7 @@ public sealed class TripEditorMetadataValidationControllerTests : TestBase
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             new TripEditorAreaMutationService(db),
+            new TripEditorSegmentMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
     }
 

--- a/tests/Wayfarer.Tests/Controllers/TripEditorPlaceControllerTestBase.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorPlaceControllerTestBase.cs
@@ -104,6 +104,7 @@ public abstract class TripEditorPlaceControllerTestBase : TestBase
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, iconColorProvider, reverseGeocodingService ?? new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             new TripEditorAreaMutationService(db),
+            new TripEditorSegmentMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
     }
 

--- a/tests/Wayfarer.Tests/Controllers/TripEditorRegionControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorRegionControllerTests.cs
@@ -327,6 +327,7 @@ public sealed class TripEditorRegionControllerTests : TestBase
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             new TripEditorAreaMutationService(db),
+            new TripEditorSegmentMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
     }
 

--- a/tests/Wayfarer.Tests/Controllers/TripEditorSegmentControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorSegmentControllerTests.cs
@@ -1,0 +1,215 @@
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NetTopologySuite.Geometries;
+using Wayfarer.Areas.Api.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Models.Dtos.Editor;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Controllers;
+
+/// <summary>
+/// Focused success and ownership tests for Trip Editor segment mutations.
+/// </summary>
+public sealed class TripEditorSegmentControllerTests : TestBase
+{
+    [Fact]
+    public async Task OwnerCreateUpdateDeleteAndOrderSegmentsReturnDeterministicSlices()
+    {
+        using var db = CreateDbContext();
+        var graph = SeedTripGraph(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var created = await SendJson(controller, c => c.CreateSegment(graph.Trip.Id, CancellationToken.None), ValidBody(graph.FirstPlace.Id, graph.SecondPlace.Id, "WALK", RouteJson(1)));
+        var createEnvelope = AssertMutation<EditorSegmentDto>(created);
+        Assert.Equal("walk", createEnvelope.Data.Mode);
+        Assert.Equal(new[] { graph.FirstSegment.Id, graph.SecondSegment.Id, createEnvelope.Data.Id }, createEnvelope.Affected.SegmentOrder);
+        Assert.Empty(createEnvelope.DeletedIds.Segments);
+
+        var updated = await SendJson(controller, c => c.UpdateSegment(graph.Trip.Id, createEnvelope.Data.Id, CancellationToken.None), ValidBody(null, graph.FirstPlace.Id, null, "null"));
+        var updateEnvelope = AssertMutation<EditorSegmentDto>(updated);
+        Assert.Null(updateEnvelope.Data.FromPlaceId);
+        Assert.Equal(string.Empty, updateEnvelope.Data.Mode);
+        Assert.Null(updateEnvelope.Data.Route);
+        Assert.Null(updateEnvelope.Affected.SegmentOrder);
+
+        var order = await SendJson(controller, c => c.OrderSegments(graph.Trip.Id, CancellationToken.None), $$"""
+        { "segmentIds": [ "{{createEnvelope.Data.Id}}", "{{graph.SecondSegment.Id}}", "{{graph.FirstSegment.Id}}" ] }
+        """);
+        var orderEnvelope = AssertMutation<EditorSegmentOrderResult>(order);
+        Assert.Equal(new[] { createEnvelope.Data.Id, graph.SecondSegment.Id, graph.FirstSegment.Id }, orderEnvelope.Data.SegmentOrder);
+        Assert.Equal(1, db.Segments.Single(s => s.Id == createEnvelope.Data.Id).DisplayOrder);
+        Assert.Equal(3, db.Segments.Single(s => s.Id == graph.FirstSegment.Id).DisplayOrder);
+
+        var deleted = await controller.DeleteSegment(graph.Trip.Id, createEnvelope.Data.Id, CancellationToken.None);
+        var deleteEnvelope = AssertMutation<EditorSegmentDeleteResult>(deleted);
+        Assert.Equal(createEnvelope.Data.Id, deleteEnvelope.Data.SegmentId);
+        Assert.Equal(new[] { createEnvelope.Data.Id }, deleteEnvelope.DeletedIds.Segments);
+        Assert.Equal(new[] { graph.SecondSegment.Id, graph.FirstSegment.Id }, deleteEnvelope.Affected.SegmentOrder);
+    }
+
+    [Fact]
+    public async Task RouteSaveAndClearPersistOnlyExplicitSubmittedRoute()
+    {
+        using var db = CreateDbContext();
+        var graph = SeedTripGraph(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var saved = await SendJson(controller, c => c.UpdateSegment(graph.Trip.Id, graph.FirstSegment.Id, CancellationToken.None), ValidBody(graph.FirstPlace.Id, graph.SecondPlace.Id, "car", RouteJson(10)));
+        var savedEnvelope = AssertMutation<EditorSegmentDto>(saved);
+        Assert.Equal(10, savedEnvelope.Data.Route!.Value.GetProperty("coordinates")[0][0].GetDouble());
+        Assert.NotNull(db.Segments.Single(s => s.Id == graph.FirstSegment.Id).RouteGeometry);
+
+        var cleared = await SendJson(controller, c => c.UpdateSegment(graph.Trip.Id, graph.FirstSegment.Id, CancellationToken.None), ValidBody(graph.FirstPlace.Id, graph.SecondPlace.Id, "car", "null"));
+        var clearedEnvelope = AssertMutation<EditorSegmentDto>(cleared);
+        Assert.Null(clearedEnvelope.Data.Route);
+        Assert.Null(db.Segments.Single(s => s.Id == graph.FirstSegment.Id).RouteGeometry);
+    }
+
+    [Fact]
+    public async Task AuthAndMissingOwnedResourcesReturnBeforeBodyParsing()
+    {
+        using var db = CreateDbContext();
+        var graph = SeedTripGraph(db, "owner-user");
+        var controller = BuildController(db);
+
+        var anonymous = await SendJson(controller, c => c.CreateSegment(graph.Trip.Id, CancellationToken.None), ValidBody(graph.FirstPlace.Id, graph.SecondPlace.Id, "walk", "null"));
+        ConfigureControllerWithUserRole(controller, "owner-user", "Manager");
+        var wrongRole = await SendJson(controller, c => c.CreateSegment(graph.Trip.Id, CancellationToken.None), ValidBody(graph.FirstPlace.Id, graph.SecondPlace.Id, "walk", "null"));
+        ConfigureControllerWithUserRole(controller, "other-user");
+        var nonOwnerTrip = await SendJson(controller, c => c.CreateSegment(graph.Trip.Id, CancellationToken.None), "{");
+        ConfigureControllerWithUserRole(controller, "owner-user");
+        var missingSegment = await SendJson(controller, c => c.UpdateSegment(graph.Trip.Id, Guid.NewGuid(), CancellationToken.None), "{");
+        var missingDelete = await controller.DeleteSegment(graph.Trip.Id, Guid.NewGuid(), CancellationToken.None);
+        var nonOwnedSegment = await SendJson(controller, c => c.UpdateSegment(Guid.NewGuid(), graph.FirstSegment.Id, CancellationToken.None), "{");
+
+        Assert.IsType<UnauthorizedResult>(anonymous);
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<StatusCodeResult>(wrongRole).StatusCode);
+        Assert.IsType<NotFoundResult>(nonOwnerTrip);
+        Assert.IsType<NotFoundResult>(missingSegment);
+        Assert.IsType<NotFoundResult>(missingDelete);
+        Assert.IsType<NotFoundResult>(nonOwnedSegment);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("{")]
+    [InlineData("[]")]
+    public async Task OwnedSegmentMutationsWithInvalidBodyReturnRequestValidationProblem(string body)
+    {
+        using var db = CreateDbContext();
+        var graph = SeedTripGraph(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var create = await SendJson(controller, c => c.CreateSegment(graph.Trip.Id, CancellationToken.None), body);
+        var update = await SendJson(controller, c => c.UpdateSegment(graph.Trip.Id, graph.FirstSegment.Id, CancellationToken.None), body);
+        var order = await SendJson(controller, c => c.OrderSegments(graph.Trip.Id, CancellationToken.None), body);
+
+        Assert.Contains("request", AssertValidationProblem(create).Errors.Keys);
+        Assert.Contains("request", AssertValidationProblem(update).Errors.Keys);
+        Assert.Contains("request", AssertValidationProblem(order).Errors.Keys);
+    }
+
+    internal static SegmentGraph SeedTripGraph(ApplicationDbContext db, string userId)
+    {
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = userId, Name = "Trip", UpdatedAt = DateTime.UtcNow };
+        var region = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, Name = "Region", DisplayOrder = 1 };
+        var first = new Place { Id = Guid.NewGuid(), UserId = userId, Region = region, RegionId = region.Id, Name = "Alpha", DisplayOrder = 1, Location = new Point(23, 37) { SRID = 4326 } };
+        var second = new Place { Id = Guid.NewGuid(), UserId = userId, Region = region, RegionId = region.Id, Name = "Beta", DisplayOrder = 2, Location = new Point(24, 38) { SRID = 4326 } };
+        var firstSegment = new Segment { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, FromPlaceId = first.Id, ToPlaceId = second.Id, Mode = "walk", DisplayOrder = 1, Notes = "" };
+        var secondSegment = new Segment { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = userId, FromPlaceId = second.Id, ToPlaceId = first.Id, Mode = "bike", DisplayOrder = 2, Notes = "" };
+        region.Places.Add(first);
+        region.Places.Add(second);
+        trip.Regions.Add(region);
+        trip.Segments.Add(firstSegment);
+        trip.Segments.Add(secondSegment);
+        db.Trips.Add(trip);
+        db.SaveChanges();
+        return new SegmentGraph(trip, first, second, firstSegment, secondSegment);
+    }
+
+    internal static string ValidBody(Guid? fromPlaceId, Guid? toPlaceId, string? mode, string routeJson) =>
+        $$"""
+        {
+          "fromPlaceId": {{GuidJson(fromPlaceId)}},
+          "toPlaceId": {{GuidJson(toPlaceId)}},
+          "mode": {{StringJson(mode)}},
+          "estimatedDistanceKm": 12.5,
+          "estimatedDurationMinutes": 35,
+          "notesHtml": null,
+          "route": {{routeJson}}
+        }
+        """;
+
+    internal static string RouteJson(int offset) =>
+        $$"""{ "type": "LineString", "coordinates": [[{{offset}}, 1], [{{offset + 1}}, 2]] }""";
+
+    internal static string StringJson(string? value) => value == null ? "null" : $"\"{value}\"";
+
+    internal static string GuidJson(Guid? value) => value.HasValue ? $"\"{value.Value}\"" : "null";
+
+    internal static void ConfigureControllerWithUserRole(ControllerBase controller, string userId, string role = "User")
+    {
+        controller.ControllerContext = new ControllerContext { HttpContext = BuildHttpContextWithUser(userId, role) };
+    }
+
+    internal static TripEditorController BuildController(ApplicationDbContext db)
+    {
+        var environment = BuildEnvironment();
+        var iconColorProvider = new IconColorProvider(environment);
+        return new TripEditorController(
+            db,
+            environment,
+            iconColorProvider,
+            Mock.Of<ITripMapThumbnailGenerator>(),
+            Mock.Of<ICacheWarmupScheduler>(),
+            Mock.Of<ITripTagService>(),
+            new TripEditorRegionMutationService(db),
+            new TripEditorPlaceMutationService(db, environment, iconColorProvider, new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
+            new TripEditorAreaMutationService(db),
+            new TripEditorSegmentMutationService(db),
+            Mock.Of<ILogger<TripEditorController>>());
+    }
+
+    internal static async Task<IActionResult> SendJson(TripEditorController controller, Func<TripEditorController, Task<IActionResult>> action, string requestBody)
+    {
+        var httpContext = controller.ControllerContext.HttpContext ?? new DefaultHttpContext();
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        var body = Encoding.UTF8.GetBytes(requestBody);
+        httpContext.Request.Body = new MemoryStream(body);
+        httpContext.Request.ContentLength = body.Length;
+        httpContext.Request.ContentType = "application/json";
+        return await action(controller);
+    }
+
+    internal static ValidationProblemDetails AssertValidationProblem(IActionResult result)
+    {
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        return Assert.IsType<ValidationProblemDetails>(badRequest.Value);
+    }
+
+    internal static EditorMutationResult<T> AssertMutation<T>(IActionResult result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result);
+        return Assert.IsType<EditorMutationResult<T>>(ok.Value);
+    }
+
+    private static IWebHostEnvironment BuildEnvironment()
+    {
+        var mock = new Mock<IWebHostEnvironment>();
+        mock.SetupGet(e => e.WebRootPath).Returns(Path.GetTempPath());
+        return mock.Object;
+    }
+
+    internal sealed record SegmentGraph(Trip Trip, Place FirstPlace, Place SecondPlace, Segment FirstSegment, Segment SecondSegment);
+}

--- a/tests/Wayfarer.Tests/Controllers/TripEditorSegmentValidationControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorSegmentValidationControllerTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.AspNetCore.Mvc;
+using Wayfarer.Models;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Controllers;
+
+/// <summary>
+/// Focused validation tests for Trip Editor segment mutation requests.
+/// </summary>
+public sealed class TripEditorSegmentValidationControllerTests : TestBase
+{
+    [Fact]
+    public async Task SaveRejectsForbiddenFieldsAndInvalidEditableFields()
+    {
+        using var db = CreateDbContext();
+        var graph = TripEditorSegmentControllerTests.SeedTripGraph(db, "owner-user");
+        var controller = TripEditorSegmentControllerTests.BuildController(db);
+        TripEditorSegmentControllerTests.ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await TripEditorSegmentControllerTests.SendJson(controller, c => c.UpdateSegment(graph.Trip.Id, graph.FirstSegment.Id, CancellationToken.None), $$"""
+        {
+          "id": "00000000-0000-0000-0000-000000000001",
+          "tripId": "00000000-0000-0000-0000-000000000002",
+          "displayOrder": 99,
+          "capabilities": {},
+          "fromPlaceId": null,
+          "toPlaceId": null,
+          "mode": "hoverboard",
+          "estimatedDistanceKm": -1,
+          "estimatedDurationMinutes": -2,
+          "notesHtml": "<img src=\"   data:image/png;base64,abc\">",
+          "route": { "type": "Point", "coordinates": [0, 0] }
+        }
+        """);
+
+        var keys = TripEditorSegmentControllerTests.AssertValidationProblem(result).Errors.Keys;
+        foreach (var key in new[] { "id", "tripId", "displayOrder", "capabilities", "mode", "estimatedDistanceKm", "estimatedDurationMinutes", "notesHtml", "route" })
+        {
+            Assert.Contains(key, keys);
+        }
+    }
+
+    [Fact]
+    public async Task SaveRejectsInvalidPlaceReferences()
+    {
+        using var db = CreateDbContext();
+        var graph = TripEditorSegmentControllerTests.SeedTripGraph(db, "owner-user");
+        var otherGraph = TripEditorSegmentControllerTests.SeedTripGraph(db, "other-user");
+        var controller = TripEditorSegmentControllerTests.BuildController(db);
+        TripEditorSegmentControllerTests.ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await TripEditorSegmentControllerTests.SendJson(
+            controller,
+            c => c.UpdateSegment(graph.Trip.Id, graph.FirstSegment.Id, CancellationToken.None),
+            TripEditorSegmentControllerTests.ValidBody(otherGraph.FirstPlace.Id, otherGraph.SecondPlace.Id, "walk", TripEditorSegmentControllerTests.RouteJson(1)));
+
+        var keys = TripEditorSegmentControllerTests.AssertValidationProblem(result).Errors.Keys;
+        Assert.Contains("fromPlaceId", keys);
+        Assert.Contains("toPlaceId", keys);
+    }
+
+    [Theory]
+    [InlineData("""{ "type": "Point", "coordinates": [0, 0] }""", "route")]
+    [InlineData("\"not-geometry\"", "route")]
+    [InlineData("""{ "type": "MultiLineString", "coordinates": [] }""", "route")]
+    [InlineData("""{ "type": "LineString", "coordinates": [] }""", "route.coordinates")]
+    [InlineData("""{ "type": "LineString", "coordinates": [[0,0]] }""", "route.coordinates")]
+    [InlineData("""{ "type": "LineString", "coordinates": [[181,0],[1,1]] }""", "route.coordinates")]
+    [InlineData("""{ "type": "LineString", "coordinates": [[0,91],[1,1]] }""", "route.coordinates")]
+    [InlineData("""{ "type": "LineString", "coordinates": [[0,0,1],[1,1,1]] }""", "route.coordinates")]
+    public async Task RouteValidationRejectsInvalidGeometryCases(string routeJson, string expectedKey)
+    {
+        using var db = CreateDbContext();
+        var graph = TripEditorSegmentControllerTests.SeedTripGraph(db, "owner-user");
+        var controller = TripEditorSegmentControllerTests.BuildController(db);
+        TripEditorSegmentControllerTests.ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await TripEditorSegmentControllerTests.SendJson(
+            controller,
+            c => c.UpdateSegment(graph.Trip.Id, graph.FirstSegment.Id, CancellationToken.None),
+            TripEditorSegmentControllerTests.ValidBody(graph.FirstPlace.Id, graph.SecondPlace.Id, "walk", routeJson));
+
+        Assert.Contains(expectedKey, TripEditorSegmentControllerTests.AssertValidationProblem(result).Errors.Keys);
+    }
+
+    [Fact]
+    public async Task SaveRequiresExplicitRoutePropertyButAcceptsNullClear()
+    {
+        using var db = CreateDbContext();
+        var graph = TripEditorSegmentControllerTests.SeedTripGraph(db, "owner-user");
+        var controller = TripEditorSegmentControllerTests.BuildController(db);
+        TripEditorSegmentControllerTests.ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var missing = await TripEditorSegmentControllerTests.SendJson(controller, c => c.UpdateSegment(graph.Trip.Id, graph.FirstSegment.Id, CancellationToken.None), $$"""
+        {
+          "fromPlaceId": "{{graph.FirstPlace.Id}}",
+          "toPlaceId": "{{graph.SecondPlace.Id}}",
+          "mode": "walk",
+          "estimatedDistanceKm": null,
+          "estimatedDurationMinutes": null,
+          "notesHtml": null
+        }
+        """);
+        var clear = await TripEditorSegmentControllerTests.SendJson(controller, c => c.UpdateSegment(graph.Trip.Id, graph.FirstSegment.Id, CancellationToken.None), TripEditorSegmentControllerTests.ValidBody(graph.FirstPlace.Id, graph.SecondPlace.Id, "walk", "null"));
+
+        Assert.Contains("route", TripEditorSegmentControllerTests.AssertValidationProblem(missing).Errors.Keys);
+        Assert.Null(TripEditorSegmentControllerTests.AssertMutation<Wayfarer.Models.Dtos.Editor.EditorSegmentDto>(clear).Data.Route);
+    }
+
+    [Fact]
+    public async Task OrderRejectsMissingDuplicateUnknownAndCrossTripIds()
+    {
+        using var db = CreateDbContext();
+        var graph = TripEditorSegmentControllerTests.SeedTripGraph(db, "owner-user");
+        var otherGraph = TripEditorSegmentControllerTests.SeedTripGraph(db, "other-user");
+        var controller = TripEditorSegmentControllerTests.BuildController(db);
+        TripEditorSegmentControllerTests.ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var bodies = new[]
+        {
+            """{ "segmentIds": [] }""",
+            $$"""{ "segmentIds": [ "{{graph.FirstSegment.Id}}", "{{graph.FirstSegment.Id}}" ] }""",
+            """{ "segmentIds": [ "00000000-0000-0000-0000-000000000001" ] }""",
+            $$"""{ "segmentIds": [ "{{otherGraph.FirstSegment.Id}}" ] }"""
+        };
+
+        foreach (var body in bodies)
+        {
+            var result = await TripEditorSegmentControllerTests.SendJson(controller, c => c.OrderSegments(graph.Trip.Id, CancellationToken.None), body);
+            Assert.Contains("segmentIds", TripEditorSegmentControllerTests.AssertValidationProblem(result).Errors.Keys);
+        }
+    }
+}

--- a/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
@@ -230,6 +230,7 @@ public sealed class TripEditorTagsShareProgressControllerTests : TestBase
             new TripEditorRegionMutationService(db),
             new TripEditorPlaceMutationService(db, environment, new IconColorProvider(environment), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
             new TripEditorAreaMutationService(db),
+            new TripEditorSegmentMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
         var url = new Mock<IUrlHelper>();

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -178,7 +178,7 @@ test.describe.serial('Trip Editor dev verification', () => {
     await expectTripLevelTagsOnly(page);
     await expectMockupOnlyPlaceControlsAbsent(page);
     await expectAddPlaceButtonsAreRegionScoped(page);
-    await expectUnimplementedAreaAndSegmentActionsAbsent(page);
+  await expectMockupOnlySegmentControlsAbsent(page);
 
     const card = firstRegionWithChildren(page);
     const children = card.locator('ul');
@@ -344,12 +344,10 @@ async function expectAddPlaceButtonsAreRegionScoped(page: Page): Promise<void> {
   }
 }
 
-// Keeps future Add Area/Add Segment work from appearing as inert controls in this tooling baseline.
-async function expectUnimplementedAreaAndSegmentActionsAbsent(page: Page): Promise<void> {
-  await expect(page.getByRole('button', { name: /add area/i })).toHaveCount(0);
-  await expect(page.getByRole('button', { name: /add segment/i })).toHaveCount(0);
-  await expect(page.getByRole('link', { name: /add area/i })).toHaveCount(0);
-  await expect(page.getByRole('link', { name: /add segment/i })).toHaveCount(0);
+// Guards against segment controls that are explicitly outside the current slice.
+async function expectMockupOnlySegmentControlsAbsent(page: Page): Promise<void> {
+  await expect(page.getByRole('button', { name: /geocode|search.?add|marker drag/i })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /geocode|search.?add|marker drag/i })).toHaveCount(0);
 }
 
 async function openFirstPlaceFormIfAvailable(page: Page): Promise<Locator | null> {

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -372,7 +372,7 @@ async function cleanupTemporaryPlace(page: Page, name: string, shouldCleanup: bo
   }
 
   await page.getByText(name).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
-  await page.getByRole('button', { name: 'Delete' }).click();
+  await page.getByRole('button', { name: 'Delete', exact: true }).click();
   await page.getByRole('dialog', { name: 'Delete place?' }).getByRole('button', { name: 'Delete' }).click();
   await expect(page.getByText(name)).toHaveCount(0);
 }

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page, type Route } from '@playwright/test';
 import {
   absoluteUrl,
+  closeDraftWithDiscard,
   editorApiPath,
   expectMountedWorkspace,
   expectNoSearchAddUi,
@@ -31,8 +32,7 @@ test.describe.serial('Trip Editor area editing', () => {
     await expect(page.locator('#trip-editor-area-form')).toContainText('No polygon drawn');
     await expect(page.getByRole('button', { name: 'Save Geometry' })).toHaveCount(0);
 
-    await page.getByRole('button', { name: 'Cancel' }).click();
-    await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await closeDraftWithDiscard(page);
     await openEditableArea(page);
     await expect(page.locator('#trip-editor-area-form').getByLabel('Name')).toHaveValue(areaName);
     await page.getByRole('button', { name: 'Expand Editor' }).click();

--- a/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
@@ -1,0 +1,237 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+import {
+  absoluteUrl,
+  editorApiPath,
+  expectMountedWorkspace,
+  expectNoSearchAddUi,
+  loadEditorStateFixture,
+  signIn,
+  workspacePath
+} from './tripEditorTestUtils';
+
+type MutableEditorState = Record<string, any>;
+
+const segmentId = '00000000-0000-0000-0000-000000266001';
+const secondSegmentId = '00000000-0000-0000-0000-000000266002';
+const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
+
+test.describe.serial('Trip Editor segment editing', () => {
+  test('adds and edits segments through docked and expanded shared draft', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithSegmentFixture(page);
+
+    await page.getByRole('button', { name: 'Add Segment' }).click();
+    await expect(page.getByRole('heading', { name: 'Add Segment' })).toBeVisible();
+    await expect(page.locator('#trip-editor-segment-form')).toHaveCount(1);
+    await page.locator('#trip-editor-segment-form').getByLabel('Transport mode').selectOption('walk');
+
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await openEditableSegment(page);
+    await page.getByRole('button', { name: 'Expand Editor' }).click();
+    await expect(page.getByRole('dialog', { name: /Edit Segment -/ })).toBeVisible();
+    await expect(page.locator('#trip-editor-segment-form')).toHaveCount(1);
+  });
+
+  test('route map-work from docked and expanded writes draft only until Save', async ({ page }) => {
+    await signIn(page);
+    const state = await loadWorkspaceWithSegmentFixture(page);
+    const savedRequests: Array<Record<string, any>> = [];
+    await page.unroute(editorApiMatcher);
+    await page.route(editorApiMatcher, async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+        return;
+      }
+
+      expect(route.request().method()).toBe('PUT');
+      expect(route.request().url()).toContain(`/segments/${segmentId}`);
+      const body = route.request().postDataJSON() as Record<string, any>;
+      savedRequests.push(body);
+      state.segmentsById[segmentId] = { ...state.segmentsById[segmentId], ...body };
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(segmentMutationResult(state.segmentsById[segmentId], null)) });
+    });
+
+    await openEditableSegment(page);
+    await page.getByRole('button', { name: 'Draw/Edit Route' }).click();
+    const mapWork = page.getByRole('region', { name: 'Map work' });
+    await expect(mapWork).toContainText('Draw segment route');
+    await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
+    await expect(page.locator('.trip-editor-toolbar').getByRole('button', { name: 'Fit All' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /pick on map|draw\/edit area|geocode|search.?add|marker drag/i })).toHaveCount(0);
+    await expectNoSearchAddUi(page);
+
+    await mapWork.getByRole('button', { name: 'Done' }).click();
+    expect(savedRequests, 'Done must not call the segment save endpoint.').toEqual([]);
+    await expect(page.locator('#trip-editor-segment-form')).toContainText('2 custom route points');
+
+    await page.getByRole('button', { name: 'Clear Route' }).click();
+    expect(savedRequests, 'Clear Route must not call the segment save endpoint.').toEqual([]);
+    await expect(page.locator('#trip-editor-segment-form')).toContainText('Endpoint fallback available until saved');
+
+    await page.getByRole('button', { name: 'Save Segment' }).click();
+    await expect.poll(() => savedRequests.length).toBe(1);
+    expect(savedRequests[0].route).toBeNull();
+
+    await openEditableSegment(page);
+    await page.getByRole('button', { name: 'Expand Editor' }).click();
+    await page.getByRole('dialog', { name: /Edit Segment -/ }).getByRole('button', { name: 'Draw/Edit Route' }).click();
+    await expect(page.getByRole('region', { name: 'Map work' })).toContainText('Draw segment route');
+  });
+
+  test('Cancel route map-work rolls back only route and delete confirms dirty discard first', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithSegmentFixture(page);
+
+    await openEditableSegment(page);
+    const form = page.locator('#trip-editor-segment-form');
+    await form.getByLabel('Estimated distance km').fill('99');
+    await page.getByRole('button', { name: 'Draw/Edit Route' }).click();
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Clear Route' }).click();
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+    await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await expect(form.getByLabel('Estimated distance km')).toHaveValue('99');
+
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await expect(page.getByRole('dialog', { name: 'Discard changes?' })).toBeVisible();
+    await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await expect(page.getByRole('dialog', { name: 'Delete segment?' })).toBeVisible();
+  });
+
+  test('client-session visibility hides map route without changing API or reload defaults', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithSegmentFixture(page);
+    const routeCount = async () => page.locator('.leaflet-overlay-pane path').count();
+    const initialRoutes = await routeCount();
+
+    await page.getByRole('button', { name: 'Hide segment' }).first().click();
+    await expect.poll(routeCount).toBeLessThan(initialRoutes);
+    await page.reload();
+    await expectMountedWorkspace(page);
+    await expect.poll(routeCount).toBeGreaterThan(0);
+  });
+
+  test('reorders segments and persists order after reload', async ({ page }) => {
+    await signIn(page);
+    const state = await loadWorkspaceWithSegmentFixture(page);
+    await page.unroute(editorApiMatcher);
+    await page.route(editorApiMatcher, async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+        return;
+      }
+
+      expect(route.request().url()).toContain('/segments/order');
+      const body = route.request().postDataJSON() as { segmentIds: string[] };
+      state.segmentOrder = [...body.segmentIds];
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(segmentOrderMutationResult(state)) });
+    });
+
+    await expectSegmentOrder(page, ['PW first segment', 'PW second segment']);
+    await segmentRow(page, 'PW first segment').getByRole('button', { name: 'Drag to reorder segment' }).dragTo(segmentRow(page, 'PW second segment'));
+    await expectSegmentOrder(page, ['PW second segment', 'PW first segment']);
+    await page.reload();
+    await expectMountedWorkspace(page);
+    await expectSegmentOrder(page, ['PW second segment', 'PW first segment']);
+  });
+});
+
+async function loadWorkspaceWithSegmentFixture(page: Page): Promise<MutableEditorState> {
+  await page.unroute(editorApiMatcher).catch(() => undefined);
+  const state = await loadEditorStateFixture(page) as MutableEditorState;
+  prepareSegmentState(state);
+  await page.route(editorApiMatcher, async route => routeEditorReadOnly(route, state));
+  await page.goto(absoluteUrl(workspacePath));
+  await expectMountedWorkspace(page);
+  return state;
+}
+
+async function routeEditorReadOnly(route: Route, state: MutableEditorState): Promise<void> {
+  if (route.request().method() !== 'GET') {
+    throw new Error(`Unexpected editor mutation ${route.request().method()} ${route.request().url()}`);
+  }
+
+  await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+}
+
+function prepareSegmentState(state: MutableEditorState): void {
+  const [first, second] = Object.values(state.placesById) as Array<Record<string, any>>;
+  if (!first || !second) {
+    throw new Error('Configured Trip Editor fixture must contain at least two places for segment coverage.');
+  }
+
+  state.permissions.canEditSegments = true;
+  state.segmentsById[segmentId] = segmentFixture(state, segmentId, first.id, second.id, 'PW first segment', [[23, 37], [24, 38]]);
+  state.segmentsById[secondSegmentId] = segmentFixture(state, secondSegmentId, second.id, first.id, 'PW second segment', null);
+  state.segmentOrder = [segmentId, secondSegmentId];
+}
+
+function segmentFixture(state: MutableEditorState, id: string, fromPlaceId: string, toPlaceId: string, notesHtml: string, route: any): Record<string, any> {
+  return {
+    id,
+    tripId: state.tripId,
+    fromPlaceId,
+    toPlaceId,
+    mode: 'walk',
+    estimatedDistanceKm: 2,
+    estimatedDurationMinutes: 30,
+    notesHtml,
+    route: route ? { type: 'LineString', coordinates: route } : null,
+    displayOrder: id === segmentId ? 1 : 2,
+    capabilities: { canEdit: true, canRename: false, canDelete: true, canReorder: true, canMove: false, canAddChildren: false, canTargetForSearchAdd: false }
+  };
+}
+
+async function openEditableSegment(page: Page): Promise<void> {
+  await segmentRow(page, 'PW first segment').click();
+  await expect(page.getByRole('heading', { name: /Edit Segment -/ })).toBeVisible();
+}
+
+function segmentRow(page: Page, notesText: string) {
+  return page.locator('[data-segment-id]').filter({ hasText: notesText });
+}
+
+async function expectSegmentOrder(page: Page, expected: string[]): Promise<void> {
+  await expect.poll(async () => {
+    const rows = await page.locator('[data-segment-id]').all();
+    return Promise.all(rows.map(row => row.innerText()));
+  }).toEqual(expected.map(text => expect.stringContaining(text)));
+}
+
+function segmentMutationResult(segment: Record<string, any>, order: string[] | null): Record<string, any> {
+  return {
+    success: true,
+    data: segment,
+    affected: affectedSlices([segment], order),
+    deletedIds: { regions: [], places: [], areas: [], segments: [], tags: [] },
+    warnings: []
+  };
+}
+
+function segmentOrderMutationResult(state: MutableEditorState): Record<string, any> {
+  return {
+    success: true,
+    data: { segmentOrder: state.segmentOrder },
+    affected: affectedSlices(state.segmentOrder.map((id: string) => state.segmentsById[id]), state.segmentOrder),
+    deletedIds: { regions: [], places: [], areas: [], segments: [], tags: [] },
+    warnings: []
+  };
+}
+
+function affectedSlices(segments: Record<string, any>[], segmentOrder: string[] | null): Record<string, any> {
+  return {
+    metadata: null,
+    regions: [],
+    regionOrder: null,
+    places: [],
+    placeOrdersByRegionId: {},
+    areas: [],
+    areaOrdersByRegionId: {},
+    segments,
+    segmentOrder,
+    tags: [],
+    tagOrder: null,
+    visitProgress: null,
+    options: null
+  };
+}

--- a/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
@@ -92,7 +92,7 @@ test.describe.serial('Trip Editor segment editing', () => {
     await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
     await expect(form.getByLabel('Estimated distance km')).toHaveValue('99');
 
-    await page.getByRole('button', { name: 'Delete' }).click();
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
     await expect(page.getByRole('dialog', { name: 'Discard changes?' })).toBeVisible();
     await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
     await expect(page.getByRole('dialog', { name: 'Delete segment?' })).toBeVisible();
@@ -127,12 +127,12 @@ test.describe.serial('Trip Editor segment editing', () => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(segmentOrderMutationResult(state)) });
     });
 
-    await expectSegmentOrder(page, ['PW first segment', 'PW second segment']);
-    await segmentRow(page, 'PW first segment').getByRole('button', { name: 'Drag to reorder segment' }).dragTo(segmentRow(page, 'PW second segment'));
-    await expectSegmentOrder(page, ['PW second segment', 'PW first segment']);
+    await expectSegmentOrder(page, [segmentId, secondSegmentId]);
+    await segmentRow(page, segmentId).getByRole('button', { name: 'Drag to reorder segment' }).dragTo(segmentRow(page, secondSegmentId));
+    await expectSegmentOrder(page, [secondSegmentId, segmentId]);
     await page.reload();
     await expectMountedWorkspace(page);
-    await expectSegmentOrder(page, ['PW second segment', 'PW first segment']);
+    await expectSegmentOrder(page, [secondSegmentId, segmentId]);
   });
 });
 
@@ -183,19 +183,18 @@ function segmentFixture(state: MutableEditorState, id: string, fromPlaceId: stri
 }
 
 async function openEditableSegment(page: Page): Promise<void> {
-  await segmentRow(page, 'PW first segment').click();
+  await segmentRow(page, segmentId).locator('.trip-editor-list-button').click();
   await expect(page.getByRole('heading', { name: /Edit Segment -/ })).toBeVisible();
 }
 
-function segmentRow(page: Page, notesText: string) {
-  return page.locator('[data-segment-id]').filter({ hasText: notesText });
+function segmentRow(page: Page, id: string) {
+  return page.locator(`[data-segment-id="${id}"]`);
 }
 
 async function expectSegmentOrder(page: Page, expected: string[]): Promise<void> {
   await expect.poll(async () => {
-    const rows = await page.locator('[data-segment-id]').all();
-    return Promise.all(rows.map(row => row.innerText()));
-  }).toEqual(expected.map(text => expect.stringContaining(text)));
+    return await page.locator('[data-segment-id]').evaluateAll(rows => rows.map(row => (row as HTMLElement).dataset.segmentId));
+  }).toEqual(expected);
 }
 
 function segmentMutationResult(segment: Record<string, any>, order: string[] | null): Record<string, any> {

--- a/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
@@ -53,15 +53,18 @@ test.describe.serial('Trip Editor segment editing', () => {
     });
 
     await openEditableSegment(page);
+    await expect(page.getByRole('link', { name: 'Legacy editor' })).toBeVisible();
     await page.getByRole('button', { name: 'Draw/Edit Route' }).click();
     const mapWork = page.getByRole('region', { name: 'Map work' });
     await expect(mapWork).toContainText('Draw segment route');
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
     await expect(page.locator('.trip-editor-toolbar').getByRole('button', { name: 'Fit All' })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Legacy editor' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: /pick on map|draw\/edit area|geocode|search.?add|marker drag/i })).toHaveCount(0);
     await expectNoSearchAddUi(page);
 
     await mapWork.getByRole('button', { name: 'Done' }).click();
+    await expect(page.getByRole('link', { name: 'Legacy editor' })).toBeVisible();
     expect(savedRequests, 'Done must not call the segment save endpoint.').toEqual([]);
     await expect(page.locator('#trip-editor-segment-form')).toContainText('2 custom route points');
 
@@ -96,6 +99,25 @@ test.describe.serial('Trip Editor segment editing', () => {
     await expect(page.getByRole('dialog', { name: 'Discard changes?' })).toBeVisible();
     await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
     await expect(page.getByRole('dialog', { name: 'Delete segment?' })).toBeVisible();
+  });
+
+  test('row delete canceled dirty switch keeps the active segment and skips destructive delete', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithSegmentFixture(page);
+
+    await openEditableSegment(page);
+    const form = page.locator('#trip-editor-segment-form');
+    await form.getByLabel('Estimated distance km').fill('99');
+
+    await segmentRow(page, secondSegmentId).getByRole('button', { name: 'Delete segment' }).click();
+    const discardDialog = page.getByRole('dialog', { name: 'Discard changes?' });
+    await expect(discardDialog).toBeVisible();
+    await discardDialog.getByRole('button', { name: 'Keep editing' }).click();
+
+    await expect(page.getByRole('dialog', { name: 'Delete segment?' })).toHaveCount(0);
+    await expect(segmentRow(page, secondSegmentId)).toBeVisible();
+    await expect(form.getByLabel('Estimated distance km')).toHaveValue('99');
+    await expect(segmentRow(page, segmentId).locator('#trip-editor-segment-form')).toHaveCount(1);
   });
 
   test('client-session visibility hides map route without changing API or reload defaults', async ({ page }) => {


### PR DESCRIPTION
Closes #266

Summary:
- Added Trip Editor segment create/update/delete/order API endpoints.
- Added deterministic segment complete-draft parsing and validation.
- Added mutation envelopes for affected.segments, affected.segmentOrder, and deletedIds.segments.
- Added trip-level segment list with Add/Edit/Delete/Visibility/Drag Handle.
- Added docked/expanded segment editor surfaces using `segment-draft`.
- Added client-session-only segment visibility.
- Added route map-work using a dedicated segment route work layer and existing Leaflet editing dependency.
- Done writes draft route only and does not save.
- Clear Route sets draft route = null and does not save.
- Normal Save persists route or route null through existing segment save endpoint.
- Fixed row-delete targeting so canceled dirty target switches cannot delete the wrong segment.
- Hid Legacy editor navigation during map-work.

Scope exclusions:
- no geocode/search-add
- no place coordinate changes
- no area polygon changes
- no marker drag
- no final cutover
- no legacy behavior changes
- no Quill/rich text parity
- no mobile/API contract changes

Validation:
- dotnet build passed, existing ASP0000 warning only
- dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --filter TripEditor passed, 126 tests
- full dotnet test passed earlier in the branch: 1556 tests
- npm run build passed
- npx playwright test --config=playwright.config.ts --list passed, 49 tests listed
- focused segment Playwright spec passed earlier when ASP.NET/Vite were available: 6/6
- latest focused segment Playwright rerun was skipped because ASP.NET/Vite were unavailable
- LOC checker passed from clean temporary archive of HEAD with accepted warnings for styles.css, MetadataEditor.vue, leafletAdapter.ts
- direct LOC run was blocked by stale ignored playwright-report trace reference; no tracked artifact included
- rg "window\\.confirm" no matches
- rg "\\bconfirm\\(" reviewed shared confirm usages only
- git diff --check origin/main...HEAD passed

Required validation-debt note:
- Full `npm run test:e2e:trip-editor` is not green yet.
- Existing non-segment area/place map-work E2E failures are tracked in #267.
- #267 must remain linked as immediate validation debt until fixed and rerun.
- Do not claim full Trip Editor E2E passed for this PR.
