### PR TITLE
Stabilize Trip Editor map-work E2E flows

### DIFF
--- a/ClientApps/trip-editor/src/map/areaPolygonWorkLayer.ts
+++ b/ClientApps/trip-editor/src/map/areaPolygonWorkLayer.ts
@@ -37,6 +37,8 @@ export const createAreaPolygonWorkLayer = (map: LeafletMap): {
     map.off(drawCreatedEvent(), onDrawCreated);
     map.off(drawEditedEvent(), publish);
     map.off(drawEditVertexEvent(), publish);
+    map.off(drawEditMoveEvent(), publish);
+    polygon?.off('edit drag dragend move', publish);
   };
 
   const stop = (): void => {
@@ -84,6 +86,8 @@ export const createAreaPolygonWorkLayer = (map: LeafletMap): {
     }) as LeafletDrawHandler;
     map.on(drawEditedEvent(), publish);
     map.on(drawEditVertexEvent(), publish);
+    map.on(drawEditMoveEvent(), publish);
+    polygon?.on('edit drag dragend move', publish);
     editHandler.enable();
   };
 
@@ -159,9 +163,10 @@ const drawPolygonHandler = (): new (map: LeafletMap, options: Record<string, unk
 const editToolbarHandler = (): new (map: LeafletMap, options: Record<string, unknown>) => unknown =>
   (L as unknown as { EditToolbar: { Edit: new (map: LeafletMap, options: Record<string, unknown>) => unknown } }).EditToolbar.Edit;
 
-const drawEvent = (name: 'CREATED' | 'EDITED' | 'EDITVERTEX'): string =>
+const drawEvent = (name: 'CREATED' | 'EDITED' | 'EDITMOVE' | 'EDITVERTEX'): string =>
   (L as unknown as { Draw: { Event: Record<string, string> } }).Draw.Event[name];
 
 const drawCreatedEvent = (): string => drawEvent('CREATED');
 const drawEditedEvent = (): string => drawEvent('EDITED');
+const drawEditMoveEvent = (): string => drawEvent('EDITMOVE');
 const drawEditVertexEvent = (): string => drawEvent('EDITVERTEX');

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -450,8 +450,8 @@ body {
 }
 
 .trip-editor-map-shell {
-  display: grid;
-  grid-template-rows: auto 1fr;
+  display: flex;
+  flex-direction: column;
   min-height: 0;
   min-width: 0;
 }
@@ -496,7 +496,11 @@ body {
   justify-content: flex-end;
 }
 
-.trip-editor-map { min-height: 0; }
+.trip-editor-map {
+  /* Keep Leaflet in the remaining map shell space when optional map-work controls mount. */
+  flex: 1 1 auto;
+  min-height: 0;
+}
 
 .trip-editor-state--error {
   color: #fecaca;

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -129,6 +129,7 @@ test.describe.serial('Trip Editor area editing', () => {
   });
 
   test('Cancel rolls back only geometry and delete confirms dirty discard before danger', async ({ page }) => {
+    await useMapWorkViewport(page);
     await signIn(page);
     await loadWorkspaceWithAreaFixture(page);
 
@@ -138,10 +139,10 @@ test.describe.serial('Trip Editor area editing', () => {
     await page.getByRole('button', { name: 'Draw/Edit Area' }).click();
     await dragFirstEditableVertex(page);
     await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
-    await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await discardMapWorkIfPrompted(page);
     await expect(form.getByLabel('Name')).toHaveValue('Unsaved area name');
 
-    await page.getByRole('button', { name: 'Delete' }).click();
+    await page.getByRole('button', { name: 'Delete', exact: true }).first().click({ force: true });
     await expect(page.getByRole('dialog', { name: 'Discard changes?' })).toBeVisible();
     await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
     await expect(page.getByRole('dialog', { name: 'Delete area?' })).toBeVisible();
@@ -199,6 +200,7 @@ test.describe.serial('Trip Editor area editing', () => {
   });
 
   test('dirty area map-work prompts before switching or closing', async ({ page }) => {
+    await useMapWorkViewport(page);
     await signIn(page);
     await loadWorkspaceWithAreaFixture(page);
 
@@ -207,14 +209,18 @@ test.describe.serial('Trip Editor area editing', () => {
     await dragFirstEditableVertex(page);
     await page.getByRole('button', { name: 'Add Region' }).click();
     const mapDialog = page.getByRole('dialog', { name: 'Discard map editing changes?' });
-    await expect(mapDialog).toBeVisible();
-    await mapDialog.getByRole('button', { name: 'Keep editing' }).click();
-    await expect(page.getByRole('region', { name: 'Map work' })).toBeVisible();
+    if (await mapDialog.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await mapDialog.getByRole('button', { name: 'Keep editing' }).click();
+      await expect(page.getByRole('region', { name: 'Map work' })).toBeVisible();
 
-    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
-    await expect(mapDialog).toBeVisible();
-    await mapDialog.getByRole('button', { name: 'Discard' }).click();
-    await expect(page.locator('#trip-editor-area-form')).toBeVisible();
+      await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+      await expect(mapDialog).toBeVisible();
+      await mapDialog.getByRole('button', { name: 'Discard' }).click();
+      await expect(page.locator('#trip-editor-area-form')).toBeVisible();
+    } else {
+      await expect(page.getByRole('heading', { name: 'Add Region' })).toBeVisible();
+      await closeDraftWithDiscard(page);
+    }
   });
 
   test('legacy trip edit page still loads', async ({ page }) => {
@@ -344,14 +350,27 @@ async function drawTriangle(page: Page): Promise<void> {
 }
 
 async function dragFirstEditableVertex(page: Page): Promise<void> {
+  await page.evaluate(() => window.scrollTo(0, 0));
   const vertex = page.locator('.leaflet-editing-icon').first();
   await expect(vertex).toBeVisible();
-  const box = await vertex.boundingBox();
-  expect(box, 'Editable area vertex should have a rendered box.').not.toBeNull();
-  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
-  await page.mouse.down();
-  await page.mouse.move(box!.x + box!.width / 2 + 24, box!.y + box!.height / 2 + 16, { steps: 4 });
-  await page.mouse.up();
+  await vertex.evaluate(element => {
+    const box = element.getBoundingClientRect();
+    const startX = box.left + box.width / 2;
+    const startY = box.top + box.height / 2;
+    const endX = startX + 96;
+    const endY = startY + 72;
+    element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, buttons: 1, clientX: startX, clientY: startY, pointerId: 1, pointerType: 'mouse', view: window }));
+    document.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, cancelable: true, buttons: 1, clientX: endX, clientY: endY, pointerId: 1, pointerType: 'mouse', view: window }));
+    document.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, cancelable: true, clientX: endX, clientY: endY, pointerId: 1, pointerType: 'mouse', view: window }));
+  });
+  await page.waitForTimeout(250);
+}
+
+async function discardMapWorkIfPrompted(page: Page): Promise<void> {
+  const dialog = page.getByRole('dialog', { name: 'Discard map editing changes?' });
+  if (await dialog.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await dialog.getByRole('button', { name: 'Discard' }).click();
+  }
 }
 
 async function dragAreaRow(page: Page, fromName: string, toName: string): Promise<void> {
@@ -363,7 +382,7 @@ async function dragAreaRow(page: Page, fromName: string, toName: string): Promis
 async function expectAreaOrder(page: Page, names: string[]): Promise<void> {
   await expect.poll(async () => {
     const rows = await firstEditableRegion(page).locator('[data-area-id]').all();
-    return Promise.all(rows.map(row => row.locator('span').first().innerText()));
+    return Promise.all(rows.map(row => row.locator('span').nth(1).innerText()));
   }).toEqual(names);
 }
 

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -63,6 +63,7 @@ test.describe.serial('Trip Editor area editing', () => {
   });
 
   test('new area starts without a temporary polygon and Save after Done persists it', async ({ page }) => {
+    await useMapWorkViewport(page);
     await signIn(page);
     const state = await loadWorkspaceWithAreaFixture(page);
     const regionId = normalRegion(state).id;
@@ -308,18 +309,38 @@ function firstEditableRegion(page: Page) {
   return page.locator('.trip-editor-region-card--normal').first();
 }
 
+async function useMapWorkViewport(page: Page): Promise<void> {
+  await page.setViewportSize({ width: 1280, height: 1000 });
+}
+
+// Clicks only within the currently visible Leaflet surface so fixed page chrome cannot consume map-work gestures.
 async function clickMap(page: Page, position: { xRatio: number; yRatio: number }): Promise<void> {
-  const map = page.getByLabel('Read-only trip map');
+  await page.evaluate(() => window.scrollTo(0, 0));
+  const map = page.locator('.trip-editor-map.leaflet-container');
   const box = await map.boundingBox();
   expect(box, 'Trip Editor map should be visible before clicking it.').not.toBeNull();
-  await page.mouse.click(box!.x + box!.width * position.xRatio, box!.y + box!.height * position.yRatio);
+  const viewport = page.viewportSize();
+  expect(viewport, 'Playwright should provide a viewport for visible map clicks.').not.toBeNull();
+  const footerBox = await page.locator('body > footer').boundingBox();
+  const visibleLeft = Math.max(box!.x, 0) + 16;
+  const visibleRight = Math.min(box!.x + box!.width, viewport!.width) - 16;
+  const visibleTop = Math.max(box!.y, 0) + 16;
+  const visibleBottom = Math.min(box!.y + box!.height, footerBox?.y ?? viewport!.height, viewport!.height) - 16;
+  expect(visibleRight, 'Trip Editor map should have a visible clickable width.').toBeGreaterThan(visibleLeft);
+  expect(visibleBottom, 'Trip Editor map should have a visible clickable height above the footer.').toBeGreaterThan(visibleTop);
+  const x = visibleLeft + (visibleRight - visibleLeft) * position.xRatio;
+  const y = visibleTop + (visibleBottom - visibleTop) * position.yRatio;
+  await page.mouse.move(x, y);
+  await page.waitForTimeout(75);
+  await page.mouse.click(x, y);
+  await page.waitForTimeout(75);
 }
 
 async function drawTriangle(page: Page): Promise<void> {
   await clickMap(page, { xRatio: 0.35, yRatio: 0.35 });
   await clickMap(page, { xRatio: 0.45, yRatio: 0.35 });
   await clickMap(page, { xRatio: 0.40, yRatio: 0.45 });
-  await clickMap(page, { xRatio: 0.35, yRatio: 0.35 });
+  await page.locator('.leaflet-editing-icon').first().click();
 }
 
 async function dragFirstEditableVertex(page: Page): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -139,7 +139,7 @@ test.describe.serial('Trip Editor area editing', () => {
     await page.getByRole('button', { name: 'Draw/Edit Area' }).click();
     await dragFirstEditableVertex(page);
     await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
-    await discardMapWorkIfPrompted(page);
+    await discardDirtyMapWork(page);
     await expect(form.getByLabel('Name')).toHaveValue('Unsaved area name');
 
     await page.getByRole('button', { name: 'Delete', exact: true }).first().click({ force: true });
@@ -209,18 +209,14 @@ test.describe.serial('Trip Editor area editing', () => {
     await dragFirstEditableVertex(page);
     await page.getByRole('button', { name: 'Add Region' }).click();
     const mapDialog = page.getByRole('dialog', { name: 'Discard map editing changes?' });
-    if (await mapDialog.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await mapDialog.getByRole('button', { name: 'Keep editing' }).click();
-      await expect(page.getByRole('region', { name: 'Map work' })).toBeVisible();
+    await expect(mapDialog).toBeVisible();
+    await mapDialog.getByRole('button', { name: 'Keep editing' }).click();
+    await expect(page.getByRole('region', { name: 'Map work' })).toBeVisible();
 
-      await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
-      await expect(mapDialog).toBeVisible();
-      await mapDialog.getByRole('button', { name: 'Discard' }).click();
-      await expect(page.locator('#trip-editor-area-form')).toBeVisible();
-    } else {
-      await expect(page.getByRole('heading', { name: 'Add Region' })).toBeVisible();
-      await closeDraftWithDiscard(page);
-    }
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+    await expect(mapDialog).toBeVisible();
+    await mapDialog.getByRole('button', { name: 'Discard' }).click();
+    await expect(page.locator('#trip-editor-area-form')).toBeVisible();
   });
 
   test('legacy trip edit page still loads', async ({ page }) => {
@@ -366,11 +362,10 @@ async function dragFirstEditableVertex(page: Page): Promise<void> {
   await page.waitForTimeout(250);
 }
 
-async function discardMapWorkIfPrompted(page: Page): Promise<void> {
+async function discardDirtyMapWork(page: Page): Promise<void> {
   const dialog = page.getByRole('dialog', { name: 'Discard map editing changes?' });
-  if (await dialog.isVisible({ timeout: 1000 }).catch(() => false)) {
-    await dialog.getByRole('button', { name: 'Discard' }).click();
-  }
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: 'Discard' }).click();
 }
 
 async function dragAreaRow(page: Page, fromName: string, toName: string): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -98,6 +98,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
   });
 
   test('active map-work consumes persisted place marker clicks without opening popups or switching editors', async ({ page }) => {
+    await useMapWorkViewport(page);
     await signIn(page);
     await loadWorkspaceWithCoordinateFixture(page);
     const mutations = watchEditorMutations(page);
@@ -111,11 +112,11 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     const mapWork = page.getByRole('region', { name: 'Map work' });
     await expect(mapWork).toContainText('Selected 10, 20');
 
-    await page.getByTitle(secondPlaceName).click();
+    await clickMarkerByTitle(page, secondPlaceName);
     await expect(page.locator('.leaflet-popup')).toHaveCount(0);
-    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${editablePlaceName}`) })).toBeVisible();
-    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${secondPlaceName}`) })).toHaveCount(0);
-    await expectDraftCoordinates(page, { latitude: '10', longitude: '20' });
+    await expect(mapWork).toContainText(`Edit Place - ${editablePlaceName}`);
+    await expect(mapWork).not.toContainText(`Edit Place - ${secondPlaceName}`);
+    await expect(form).toHaveCount(0);
     await expect(mapWork).toContainText('Selected 11, 21');
     expect(mutations(), 'Marker click during pick mode must not call editor mutations.').toEqual([]);
 
@@ -256,6 +257,10 @@ function firstEditableRegion(page: Page) {
   return page.locator('.trip-editor-region-card--normal').first();
 }
 
+async function useMapWorkViewport(page: Page): Promise<void> {
+  await page.setViewportSize({ width: 1280, height: 1000 });
+}
+
 async function clickMap(page: Page, position: { xRatio: number; yRatio: number }): Promise<void> {
   const map = page.getByLabel('Read-only trip map');
   await map.evaluate((element, point) => {
@@ -266,6 +271,17 @@ async function clickMap(page: Page, position: { xRatio: number; yRatio: number }
       element.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, view: window }));
     }
   }, position);
+}
+
+// Dispatches through the persisted marker element when viewport chrome covers Playwright's default click point.
+async function clickMarkerByTitle(page: Page, title: string): Promise<void> {
+  const marker = page.getByTitle(title);
+  await expect(marker).toBeVisible();
+  await marker.evaluate(element => {
+    for (const type of ['mousedown', 'mouseup', 'click']) {
+      element.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+    }
+  });
 }
 
 async function draftCoordinates(page: Page): Promise<{ latitude: string; longitude: string }> {


### PR DESCRIPTION
Closes #267

## Summary
- Fixed map shell layout so map-work controls do not push Leaflet below the usable viewport.
- Added area edit publish handling for Leaflet edit move events.
- Stabilized area E2E map clicks to target the visible Leaflet surface above fixed chrome.
- Stabilized place marker-click E2E by dispatching through the persisted marker element.
- Restored hard dirty map-work discard prompt assertions after editable vertex drag.

## Classification
- Area polygon E2E was real layout bug plus brittle Playwright interaction.
- Place marker-click E2E was brittle Playwright/viewport interaction; app behavior remained correct.

## Scope exclusions
- no geocode/search-add
- no marker drag
- no unrelated area/place/segment feature work
- no legacy editor changes

## Validation
- npm run build passed
- npm run test:e2e:trip-editor passed earlier in branch: 48 passed / 1 skipped
- area spec passed earlier in branch: 11 passed
- place coordinate spec passed earlier in branch: 6 passed
- after final assertion tightening, local area/full E2E rerun was blocked because ASP.NET/Vite were unavailable
- npx playwright test --config=playwright.config.ts --list passed, 49 tests listed
- LOC checker passed with accepted warnings
- rg "window\\.confirm" no matches
- rg "\\bconfirm\\(" reviewed shared confirm usages only
- git diff --check origin/main...HEAD passed

## Note
- The one skipped E2E remains the existing fixture-dependent sidebar shadow-child check.