### PR TITLE
Add Trip Editor geocode search

### DIFF
--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -30,6 +30,7 @@ public sealed partial class TripEditorController : ControllerBase
     private readonly TripEditorPlaceMutationService _placeMutations;
     private readonly TripEditorAreaMutationService _areaMutations;
     private readonly TripEditorSegmentMutationService _segmentMutations;
+    private readonly ITripEditorGeocodeSearchService? _geocodeSearch;
     private readonly ILogger<TripEditorController> _logger;
 
     /// <summary>
@@ -46,7 +47,8 @@ public sealed partial class TripEditorController : ControllerBase
         TripEditorPlaceMutationService placeMutations,
         TripEditorAreaMutationService areaMutations,
         TripEditorSegmentMutationService segmentMutations,
-        ILogger<TripEditorController> logger)
+        ILogger<TripEditorController> logger,
+        ITripEditorGeocodeSearchService? geocodeSearch = null)
     {
         _dbContext = dbContext;
         _environment = environment;
@@ -58,6 +60,7 @@ public sealed partial class TripEditorController : ControllerBase
         _placeMutations = placeMutations;
         _areaMutations = areaMutations;
         _segmentMutations = segmentMutations;
+        _geocodeSearch = geocodeSearch;
         _logger = logger;
     }
 
@@ -293,6 +296,58 @@ public sealed partial class TripEditorController : ControllerBase
         return ToActionResult(outcome);
     }
 
+    /// <summary>
+    /// Searches public geocoding through the authenticated Trip Editor backend proxy.
+    /// </summary>
+    [HttpGet("geocode/search")]
+    public async Task<IActionResult> SearchGeocode(Guid tripId, [FromQuery(Name = "q")] string? query, [FromQuery] int? limit, CancellationToken cancellationToken)
+    {
+        var authFailure = RequireEditorUser(out var userId);
+        if (authFailure != null)
+        {
+            return authFailure;
+        }
+
+        var trip = await _dbContext.Trips
+            .AsNoTracking()
+            .Where(t => t.Id == tripId)
+            .Select(t => new { t.UserId })
+            .FirstOrDefaultAsync(cancellationToken);
+        if (trip == null)
+        {
+            return NotFound();
+        }
+
+        if (!string.Equals(trip.UserId, userId, StringComparison.Ordinal))
+        {
+            return StatusCode(StatusCodes.Status403Forbidden);
+        }
+
+        var normalizedQuery = query?.Trim() ?? string.Empty;
+        var validationErrors = ValidateGeocodeSearch(normalizedQuery, limit, BuildOptions().Limits.NominatimSearchLimit, out var clampedLimit);
+        if (validationErrors.Count > 0)
+        {
+            return ValidationError(validationErrors);
+        }
+
+        if (_geocodeSearch == null)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable);
+        }
+
+        var outcome = await _geocodeSearch.SearchAsync(normalizedQuery, clampedLimit, cancellationToken);
+        return outcome.Status switch
+        {
+            TripEditorGeocodeSearchStatus.Success => Ok(outcome.Response),
+            TripEditorGeocodeSearchStatus.LocalRateLimited => StatusCode(StatusCodes.Status429TooManyRequests),
+            TripEditorGeocodeSearchStatus.ProviderRateLimited => StatusCode(StatusCodes.Status429TooManyRequests),
+            TripEditorGeocodeSearchStatus.ProviderMalformed => StatusCode(StatusCodes.Status502BadGateway),
+            TripEditorGeocodeSearchStatus.ProviderUnavailable => StatusCode(StatusCodes.Status503ServiceUnavailable),
+            TripEditorGeocodeSearchStatus.ProviderTimeout => StatusCode(StatusCodes.Status504GatewayTimeout),
+            _ => StatusCode(StatusCodes.Status503ServiceUnavailable)
+        };
+    }
+
     private EditorOptionsDto BuildOptions()
     {
         var colors = _iconColorProvider.GetAvailableColors();
@@ -413,6 +468,27 @@ public sealed partial class TripEditorController : ControllerBase
         {
             ContentTypes = { "application/problem+json" }
         };
+    }
+
+    private static Dictionary<string, string[]> ValidateGeocodeSearch(string query, int? limit, int maxLimit, out int clampedLimit)
+    {
+        var errors = new Dictionary<string, string[]>();
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            errors["q"] = new[] { "Search query is required." };
+        }
+        else if (query.Length < 3)
+        {
+            errors["q"] = new[] { "Search query must be at least 3 characters." };
+        }
+
+        if (limit.HasValue && limit.Value < 1)
+        {
+            errors["limit"] = new[] { "Limit must be at least 1." };
+        }
+
+        clampedLimit = Math.Clamp(limit ?? maxLimit, 1, maxLimit);
+        return errors;
     }
 
 }

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { loadEditorState } from './api/tripEditorApi';
 import ConfirmDialog from './components/ConfirmDialog.vue';
+import MapSearchControl from './components/MapSearchControl.vue';
 import MapWorkToolbar from './components/MapWorkToolbar.vue';
 import TripSidebar from './components/TripSidebar.vue';
 import { disposeConfirmDialogHost, setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
 import { useEditorSurface } from './composables/useEditorSurface';
 import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type AreaPolygonWorkOptions, type CoordinatePickOptions, type FocusActiveEntityResult, type SegmentRouteWorkOptions } from './map/leafletAdapter';
-import type { BootstrapConfig, EditorMutationResult, EditorSegment, EditorTripMetadata, EditorTripState } from './types';
+import type { BootstrapConfig, EditorGeocodeSearchResult, EditorMutationResult, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from './types';
 
 const props = defineProps<{ config: BootstrapConfig }>();
 
@@ -19,6 +20,7 @@ const workspaceElement = ref<HTMLElement | null>(null);
 const mapElement = ref<HTMLElement | null>(null);
 const navigationStatus = ref<string | null>(null);
 const hiddenSegmentIds = ref<Set<string>>(new Set());
+const pendingSearchAdd = ref<{ result: EditorGeocodeSearchResult; regionId: Guid; requestId: number } | null>(null);
 const editorSurface = useEditorSurface();
 let mapAdapter: ReturnType<typeof createTripEditorMap> | null = null;
 const coordinatePicker = {
@@ -47,6 +49,12 @@ const toolbarContext = computed(() => {
 const canFitAllGeometry = computed(() => Boolean(state.value && hasAnyGeometry(state.value)));
 const canRecenterSavedView = computed(() => Boolean(state.value && hasSavedTripView(state.value.metadata)));
 const canFocusTarget = computed(() => Boolean(state.value && canFocusActiveEntity(state.value, editorSurface.activeTarget.value)));
+const activeEditorTarget = computed(() => editorSurface.activeTarget.value);
+
+watch(
+  () => editorSurface.activeTarget.value?.identity,
+  () => mapAdapter?.clearSearchPreview()
+);
 
 onMounted(async () => {
   setConfirmDialogFocusFallback(workspaceElement.value);
@@ -112,6 +120,29 @@ const focusActiveEntity = (): void => {
   const target = editorSurface.activeTarget.value;
   const result = mapAdapter.focusActiveEntity(state.value, target);
   navigationStatus.value = focusStatusText(result, target);
+};
+
+/// Shows a temporary provider-result marker without entering coordinate-pick map-work.
+const previewSearchResult = (result: EditorGeocodeSearchResult): void => {
+  mapAdapter?.showSearchPreview({ latitude: result.latitude, longitude: result.longitude }, result.name);
+};
+
+/// Clears the temporary map-search preview marker.
+const clearSearchPreview = (): void => {
+  mapAdapter?.clearSearchPreview();
+};
+
+/// Requests that the sidebar open the existing Add Place draft for a provider result.
+const requestSearchAddPlace = (request: { result: EditorGeocodeSearchResult; regionId: Guid; requestId: number }): void => {
+  pendingSearchAdd.value = request;
+};
+
+/// Clears the preview marker only after the existing Add Place draft actually opens.
+const handleSearchAddOpened = (requestId: number): void => {
+  if (pendingSearchAdd.value?.requestId === requestId) {
+    clearSearchPreview();
+    pendingSearchAdd.value = null;
+  }
 };
 
 /// Tracks region draft changes that live inside the sidebar child component.
@@ -268,6 +299,7 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
         :trip-index-url="props.config.tripIndexUrl"
         :has-region-draft-changes="hasRegionDraftChanges"
         :hidden-segment-ids="hiddenSegmentIds"
+        :pending-search-add="pendingSearchAdd"
         :coordinate-picker="coordinatePicker"
         :polygon-editor="polygonEditor"
         :route-editor="routeEditor"
@@ -275,6 +307,7 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
         @mutation-applied="applyMutation"
         @region-draft-dirty-changed="setRegionDraftChanges"
         @hidden-segment-ids-changed="updateHiddenSegmentIds"
+        @search-add-opened="handleSearchAddOpened"
       />
       <main class="trip-editor-map-shell">
         <header class="trip-editor-toolbar">
@@ -296,6 +329,15 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
           </div>
         </header>
         <MapWorkToolbar :controller="editorSurface" />
+        <MapSearchControl
+          v-if="!isMapWorkActive"
+          :active-target="activeEditorTarget"
+          :editor-endpoint="props.config.editorEndpoint"
+          :state="state"
+          @add-place="requestSearchAddPlace"
+          @clear-preview="clearSearchPreview"
+          @preview="previewSearchResult"
+        />
         <div ref="mapElement" class="trip-editor-map" aria-label="Read-only trip map"></div>
       </main>
     </template>

--- a/ClientApps/trip-editor/src/api/tripEditorApi.ts
+++ b/ClientApps/trip-editor/src/api/tripEditorApi.ts
@@ -1,5 +1,6 @@
 import type {
   EditorMutationResult,
+  EditorGeocodeSearchResponse,
   EditorArea,
   EditorAreaDeleteResult,
   EditorAreaOrderRequest,
@@ -50,6 +51,39 @@ export const loadEditorState = async (endpoint: string): Promise<EditorTripState
   }
 
   return (await response.json()) as EditorTripState;
+};
+
+/// Searches geocode results through the same-origin Trip Editor proxy only.
+export const searchGeocode = async (
+  endpoint: string,
+  query: string,
+  limit: number,
+  signal?: AbortSignal
+): Promise<EditorGeocodeSearchResponse> => {
+  const url = `${endpoint}/geocode/search?q=${encodeURIComponent(query)}&limit=${encodeURIComponent(String(limit))}`;
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json' },
+    credentials: 'same-origin',
+    signal
+  });
+
+  if (response.status === 400) {
+    throw new EditorValidationError((await response.json()) as ValidationProblemDetails);
+  }
+
+  if (response.status === 429) {
+    throw new Error('geocode-rate-limited');
+  }
+
+  if (response.status === 503) {
+    throw new Error('geocode-provider-unavailable');
+  }
+
+  if (!response.ok) {
+    throw new Error(`Trip Editor geocode search returned ${response.status}`);
+  }
+
+  return (await response.json()) as EditorGeocodeSearchResponse;
 };
 
 export const patchMetadata = async (

--- a/ClientApps/trip-editor/src/components/MapSearchControl.vue
+++ b/ClientApps/trip-editor/src/components/MapSearchControl.vue
@@ -33,7 +33,7 @@ let addSequence = 0;
 const trimmedQuery = computed(() => query.value.trim());
 const minChars = 3;
 const limit = computed(() => props.state.options.limits.nominatimSearchLimit);
-const canSearch = computed(() => trimmedQuery.value.length >= minChars && status.value !== 'loading');
+const canSearch = computed(() => trimmedQuery.value.length >= minChars);
 const eligibleRegions = computed(() => props.state.regionOrder
   .map(id => props.state.regionsById[id])
   .filter((region): region is EditorRegion => Boolean(region) && !region.isShadow && props.state.permissions.canEditPlaces && region.capabilities.canAddChildren));
@@ -97,7 +97,8 @@ const submitSearch = async (): Promise<void> => {
   }
 
   controller?.abort();
-  controller = new AbortController();
+  const searchController = new AbortController();
+  controller = searchController;
   const sequence = ++requestSequence;
   submittedQuery.value = submitted;
   status.value = 'loading';
@@ -106,8 +107,8 @@ const submitSearch = async (): Promise<void> => {
   emit('clearPreview');
 
   try {
-    const response = await searchGeocode(props.editorEndpoint, submitted, limit.value, controller.signal);
-    if (sequence !== requestSequence) {
+    const response = await searchGeocode(props.editorEndpoint, submitted, limit.value, searchController.signal);
+    if (searchController.signal.aborted || sequence !== requestSequence) {
       return;
     }
 
@@ -121,7 +122,7 @@ const submitSearch = async (): Promise<void> => {
     attribution.value = response.attribution;
     status.value = results.value.length === 0 ? 'no-results' : 'success';
   } catch (error) {
-    if (controller.signal.aborted || sequence !== requestSequence) {
+    if (searchController.signal.aborted || sequence !== requestSequence) {
       return;
     }
 
@@ -134,6 +135,10 @@ const submitSearch = async (): Promise<void> => {
       status.value = 'provider-unavailable';
     } else {
       status.value = 'error';
+    }
+  } finally {
+    if (sequence === requestSequence && controller === searchController) {
+      controller = null;
     }
   }
 };
@@ -158,6 +163,7 @@ const addAsPlace = (): void => {
 const clearResults = (): void => {
   controller?.abort();
   controller = null;
+  requestSequence += 1;
   status.value = 'idle';
   errorText.value = null;
   attribution.value = null;

--- a/ClientApps/trip-editor/src/components/MapSearchControl.vue
+++ b/ClientApps/trip-editor/src/components/MapSearchControl.vue
@@ -92,7 +92,7 @@ watch(eligibleRegions, regions => {
 
 const submitSearch = async (): Promise<void> => {
   const submitted = trimmedQuery.value;
-  if (submitted.length < minChars || status.value === 'loading') {
+  if (submitted.length < minChars) {
     return;
   }
 
@@ -107,7 +107,12 @@ const submitSearch = async (): Promise<void> => {
 
   try {
     const response = await searchGeocode(props.editorEndpoint, submitted, limit.value, controller.signal);
-    if (sequence !== requestSequence || response.query !== submittedQuery.value) {
+    if (sequence !== requestSequence) {
+      return;
+    }
+
+    if (response.query !== submittedQuery.value || response.query !== trimmedQuery.value) {
+      status.value = 'idle';
       return;
     }
 

--- a/ClientApps/trip-editor/src/components/MapSearchControl.vue
+++ b/ClientApps/trip-editor/src/components/MapSearchControl.vue
@@ -1,0 +1,218 @@
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from 'vue';
+import { EditorValidationError, searchGeocode } from '../api/tripEditorApi';
+import type { EditorTarget } from '../composables/useEditorSurface';
+import type { EditorGeocodeSearchResult, EditorRegion, EditorTripState, Guid } from '../types';
+
+const props = defineProps<{
+  activeTarget: EditorTarget | null;
+  editorEndpoint: string;
+  state: EditorTripState;
+}>();
+
+const emit = defineEmits<{
+  addPlace: [request: { result: EditorGeocodeSearchResult; regionId: Guid; requestId: number }];
+  clearPreview: [];
+  preview: [result: EditorGeocodeSearchResult];
+}>();
+
+type SearchStatus = 'idle' | 'loading' | 'no-results' | 'validation' | 'provider-unavailable' | 'rate-limit' | 'error' | 'success';
+
+const query = ref('');
+const selectedResultId = ref<string | null>(null);
+const selectedRegionId = ref<Guid | ''>('');
+const status = ref<SearchStatus>('idle');
+const errorText = ref<string | null>(null);
+const attribution = ref<string | null>(null);
+const results = ref<EditorGeocodeSearchResult[]>([]);
+const submittedQuery = ref('');
+let controller: AbortController | null = null;
+let requestSequence = 0;
+let addSequence = 0;
+
+const trimmedQuery = computed(() => query.value.trim());
+const minChars = 3;
+const limit = computed(() => props.state.options.limits.nominatimSearchLimit);
+const canSearch = computed(() => trimmedQuery.value.length >= minChars && status.value !== 'loading');
+const eligibleRegions = computed(() => props.state.regionOrder
+  .map(id => props.state.regionsById[id])
+  .filter((region): region is EditorRegion => Boolean(region) && !region.isShadow && props.state.permissions.canEditPlaces && region.capabilities.canAddChildren));
+const selectedResult = computed(() => results.value.find(result => result.id === selectedResultId.value) ?? null);
+const canAdd = computed(() => Boolean(selectedResult.value && selectedRegionId.value));
+const helperText = computed(() => eligibleRegions.value.length === 0 ? 'No editable region is available for this search result.' : null);
+const statusText = computed(() => {
+  if (status.value === 'loading') {
+    return 'Searching map...';
+  }
+
+  if (status.value === 'no-results') {
+    return 'No map search results.';
+  }
+
+  if (status.value === 'validation') {
+    return errorText.value ?? 'Search query must be at least 3 characters.';
+  }
+
+  if (status.value === 'provider-unavailable') {
+    return 'Map search provider is unavailable.';
+  }
+
+  if (status.value === 'rate-limit') {
+    return 'Map search is rate limited. Try again shortly.';
+  }
+
+  if (status.value === 'error') {
+    return 'Map search failed.';
+  }
+
+  return null;
+});
+
+watch(query, value => {
+  if (value.trim().length === 0) {
+    clearResults();
+  }
+});
+
+watch(eligibleRegions, regions => {
+  if (regions.length === 1) {
+    selectedRegionId.value = regions[0].id;
+    return;
+  }
+
+  if (regions.length > 1 && props.activeTarget?.kind === 'place' && props.activeTarget.parentRegionId && regions.some(region => region.id === props.activeTarget?.parentRegionId)) {
+    selectedRegionId.value = props.activeTarget.parentRegionId;
+    return;
+  }
+
+  if (!regions.some(region => region.id === selectedRegionId.value)) {
+    selectedRegionId.value = '';
+  }
+}, { immediate: true });
+
+const submitSearch = async (): Promise<void> => {
+  const submitted = trimmedQuery.value;
+  if (submitted.length < minChars || status.value === 'loading') {
+    return;
+  }
+
+  controller?.abort();
+  controller = new AbortController();
+  const sequence = ++requestSequence;
+  submittedQuery.value = submitted;
+  status.value = 'loading';
+  errorText.value = null;
+  selectedResultId.value = null;
+  emit('clearPreview');
+
+  try {
+    const response = await searchGeocode(props.editorEndpoint, submitted, limit.value, controller.signal);
+    if (sequence !== requestSequence || response.query !== submittedQuery.value) {
+      return;
+    }
+
+    results.value = response.results.slice(0, limit.value);
+    attribution.value = response.attribution;
+    status.value = results.value.length === 0 ? 'no-results' : 'success';
+  } catch (error) {
+    if (controller.signal.aborted || sequence !== requestSequence) {
+      return;
+    }
+
+    if (error instanceof EditorValidationError) {
+      status.value = 'validation';
+      errorText.value = Object.values(error.errors).flat()[0] ?? error.message;
+    } else if (error instanceof Error && error.message === 'geocode-rate-limited') {
+      status.value = 'rate-limit';
+    } else if (error instanceof Error && error.message === 'geocode-provider-unavailable') {
+      status.value = 'provider-unavailable';
+    } else {
+      status.value = 'error';
+    }
+  }
+};
+
+const onSubmit = async (): Promise<void> => {
+  await submitSearch();
+};
+
+const selectResult = (result: EditorGeocodeSearchResult): void => {
+  selectedResultId.value = result.id;
+  emit('preview', result);
+};
+
+const addAsPlace = (): void => {
+  if (!selectedResult.value || !selectedRegionId.value) {
+    return;
+  }
+
+  emit('addPlace', { result: selectedResult.value, regionId: selectedRegionId.value, requestId: ++addSequence });
+};
+
+const clearResults = (): void => {
+  controller?.abort();
+  controller = null;
+  status.value = 'idle';
+  errorText.value = null;
+  attribution.value = null;
+  results.value = [];
+  selectedResultId.value = null;
+  submittedQuery.value = '';
+  emit('clearPreview');
+};
+
+const resultMeta = (result: EditorGeocodeSearchResult): string =>
+  [result.type, result.category].filter(Boolean).join(' / ');
+
+const roundedCoordinate = (value: number): string => value.toFixed(5);
+
+onUnmounted(() => {
+  clearResults();
+});
+</script>
+
+<template>
+  <section class="trip-editor-map-search" aria-label="Map search">
+    <form class="trip-editor-map-search__form" @submit.prevent="onSubmit">
+      <label class="trip-editor-map-search__label" for="trip-editor-map-search-input">Map search</label>
+      <input
+        id="trip-editor-map-search-input"
+        v-model="query"
+        type="search"
+        autocomplete="off"
+        placeholder="Search address or place"
+      />
+      <button type="submit" class="btn btn-primary btn-sm" :disabled="!canSearch">Search</button>
+    </form>
+
+    <p v-if="statusText" class="trip-editor-map-search__status" :role="status === 'loading' ? 'status' : 'alert'">{{ statusText }}</p>
+
+    <div v-if="results.length > 0" class="trip-editor-map-search__results">
+      <button
+        v-for="result in results"
+        :key="result.id"
+        type="button"
+        class="trip-editor-map-search__result"
+        :class="{ 'trip-editor-map-search__result--selected': selectedResultId === result.id }"
+        @click="selectResult(result)"
+      >
+        <strong>{{ result.name }}</strong>
+        <span>{{ result.address || result.displayName }}</span>
+        <small>{{ resultMeta(result) || 'geocode result' }} · {{ roundedCoordinate(result.latitude) }}, {{ roundedCoordinate(result.longitude) }}</small>
+      </button>
+      <small v-if="attribution" class="trip-editor-map-search__attribution">{{ attribution }}</small>
+    </div>
+
+    <div v-if="selectedResult" class="trip-editor-map-search__add-panel">
+      <label>
+        <span>Target region</span>
+        <select v-model="selectedRegionId" :disabled="eligibleRegions.length <= 1">
+          <option v-if="eligibleRegions.length !== 1" value="">Select region</option>
+          <option v-for="region in eligibleRegions" :key="region.id" :value="region.id">{{ region.name }}</option>
+        </select>
+      </label>
+      <p v-if="helperText" class="trip-editor-map-search__helper">{{ helperText }}</p>
+      <button type="button" class="btn btn-success btn-sm" :disabled="!canAdd" @click="addAsPlace">Add as place</button>
+    </div>
+  </section>
+</template>

--- a/ClientApps/trip-editor/src/components/MapSearchControl.vue
+++ b/ClientApps/trip-editor/src/components/MapSearchControl.vue
@@ -33,7 +33,8 @@ let addSequence = 0;
 const trimmedQuery = computed(() => query.value.trim());
 const minChars = 3;
 const limit = computed(() => props.state.options.limits.nominatimSearchLimit);
-const canSearch = computed(() => trimmedQuery.value.length >= minChars);
+const isSearching = computed(() => status.value === 'loading');
+const canSearch = computed(() => trimmedQuery.value.length >= minChars && !isSearching.value);
 const eligibleRegions = computed(() => props.state.regionOrder
   .map(id => props.state.regionsById[id])
   .filter((region): region is EditorRegion => Boolean(region) && !region.isShadow && props.state.permissions.canEditPlaces && region.capabilities.canAddChildren));
@@ -92,7 +93,7 @@ watch(eligibleRegions, regions => {
 
 const submitSearch = async (): Promise<void> => {
   const submitted = trimmedQuery.value;
-  if (submitted.length < minChars) {
+  if (!canSearch.value) {
     return;
   }
 

--- a/ClientApps/trip-editor/src/components/MapSearchControl.vue
+++ b/ClientApps/trip-editor/src/components/MapSearchControl.vue
@@ -111,7 +111,8 @@ const submitSearch = async (): Promise<void> => {
       return;
     }
 
-    if (response.query !== submittedQuery.value || response.query !== trimmedQuery.value) {
+    const responseQuery = normalizeQuery(response.query);
+    if (responseQuery !== normalizeQuery(submittedQuery.value) || responseQuery !== normalizeQuery(trimmedQuery.value)) {
       status.value = 'idle';
       return;
     }
@@ -170,6 +171,9 @@ const resultMeta = (result: EditorGeocodeSearchResult): string =>
   [result.type, result.category].filter(Boolean).join(' / ');
 
 const roundedCoordinate = (value: number): string => value.toFixed(5);
+
+const normalizeQuery = (value: string): string =>
+  value.trim().split(/\s+/u).filter(Boolean).join(' ').toLowerCase();
 
 onUnmounted(() => {
   clearResults();

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -14,7 +14,7 @@ import { usePlaceEditorActions } from './placeEditorActions';
 import { useRegionEditorActions } from './regionEditorActions';
 import { stopPlaceCoordinatePick, type PlaceCoordinateMapWorkState, type PlaceCoordinatePicker } from './placeCoordinateMapWork';
 import { useEditorMutationFeedback } from './useEditorMutationFeedback';
-import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
+import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorGeocodeSearchResult, EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
 
 const props = defineProps<{
   state: EditorTripState;
@@ -25,6 +25,7 @@ const props = defineProps<{
   searchRegions: EditorRegion[];
   searchPlaceIdsByRegionId: Record<Guid, Guid[]>;
   searchAreaIdsByRegionId: Record<Guid, Guid[]>;
+  pendingSearchAdd: { result: EditorGeocodeSearchResult; regionId: Guid; requestId: number } | null;
   coordinatePicker: PlaceCoordinatePicker;
   polygonEditor: AreaPolygonEditor;
 }>();
@@ -32,6 +33,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   mutationApplied: [result: EditorMutationResult<unknown>];
   dirtyStateChanged: [isDirty: boolean];
+  searchAddOpened: [requestId: number];
 }>();
 
 const regionFields = ['name', 'notesHtml', 'coverImage.rawUrl', 'center.latitude', 'center.longitude'];
@@ -168,7 +170,7 @@ const { cancelDraft, deleteDraftRegion, openCreate, openEdit, reorderRegions, re
   resetFeedback,
   restoreRegionOrder
 });
-const { cancelPlaceDraft, deleteDraftPlace, openPlaceCreate, openPlaceEdit, pickPlaceCoordinate, reorderPlaces, resetPlaceDraft, savePlaceDraft } = usePlaceEditorActions({
+const { cancelPlaceDraft, deleteDraftPlace, openPlaceCreate, openPlaceCreateFromSearch, openPlaceEdit, pickPlaceCoordinate, reorderPlaces, resetPlaceDraft, savePlaceDraft } = usePlaceEditorActions({
   activePlace,
   activePlaceTarget,
   applyError,
@@ -215,6 +217,24 @@ watch(
   isDirty,
   value => emit('dirtyStateChanged', value),
   { immediate: true }
+);
+
+watch(
+  () => props.pendingSearchAdd?.requestId,
+  async requestId => {
+    if (!requestId || !props.pendingSearchAdd) {
+      return;
+    }
+
+    const region = props.state.regionsById[props.pendingSearchAdd.regionId];
+    if (!region || region.isShadow || !props.state.permissions.canEditPlaces || !region.capabilities.canAddChildren) {
+      return;
+    }
+
+    if (await openPlaceCreateFromSearch(region, props.pendingSearchAdd.result)) {
+      emit('searchAddOpened', requestId);
+    }
+  }
 );
 
 onMounted(() => {

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import type { EditorArea, EditorMutationResult, EditorPlace, EditorRegion, EditorSegment, EditorTripState, Guid } from '../types';
+import type { EditorArea, EditorGeocodeSearchResult, EditorMutationResult, EditorPlace, EditorRegion, EditorSegment, EditorTripState, Guid } from '../types';
 import type { EditorSurfaceController } from '../composables/useEditorSurface';
 import MetadataEditor from './MetadataEditor.vue';
 import RegionManager from './RegionManager.vue';
@@ -22,6 +22,7 @@ const props = defineProps<{
   tripIndexUrl: string;
   hasRegionDraftChanges: boolean;
   hiddenSegmentIds: ReadonlySet<Guid>;
+  pendingSearchAdd: { result: EditorGeocodeSearchResult; regionId: Guid; requestId: number } | null;
   coordinatePicker: { startCoordinatePick: (options: CoordinatePickOptions) => () => void };
   polygonEditor: { startAreaPolygonWork: (options: AreaPolygonWorkOptions) => () => void };
   routeEditor: {
@@ -35,6 +36,7 @@ const emit = defineEmits<{
   mutationApplied: [result: EditorMutationResult<unknown>];
   regionDraftDirtyChanged: [isDirty: boolean];
   hiddenSegmentIdsChanged: [ids: Set<Guid>];
+  searchAddOpened: [requestId: number];
 }>();
 
 const searchQuery = ref('');
@@ -187,12 +189,14 @@ function normalize(value: string): string {
       :antiforgery-token="antiforgeryToken"
       :coordinate-picker="coordinatePicker"
       :polygon-editor="polygonEditor"
+      :pending-search-add="pendingSearchAdd"
       :search-active="isSearchActive"
       :search-regions="sidebarSearch.regions"
       :search-place-ids-by-region-id="sidebarSearch.placesByRegionId"
       :search-area-ids-by-region-id="sidebarSearch.areasByRegionId"
       @mutation-applied="result => emit('mutationApplied', result)"
       @dirty-state-changed="isDirty => emit('regionDraftDirtyChanged', isDirty)"
+      @search-add-opened="requestId => emit('searchAddOpened', requestId)"
     />
 
     <SegmentManager

--- a/ClientApps/trip-editor/src/components/placeEditorActions.ts
+++ b/ClientApps/trip-editor/src/components/placeEditorActions.ts
@@ -1,5 +1,5 @@
 import { createPlace, deletePlace, orderPlaces, updatePlace } from '../api/tripEditorApi';
-import type { EditorMutationResult, EditorPlace, EditorRegion, Guid } from '../types';
+import type { EditorGeocodeSearchResult, EditorMutationResult, EditorPlace, EditorRegion, Guid } from '../types';
 import { confirm } from '../composables/useConfirmDialog';
 import { buildPlaceCreateTarget, buildPlaceEditTarget } from './regionPlaceEditorTargets';
 import { buildPlaceRequest, emptyAreaDraft, emptyPlaceDraft, emptyRegionDraft, toPlaceDraft, withoutRegionId } from './regionPlaceDrafts';
@@ -8,22 +8,39 @@ import { beginPlaceCoordinateMapWork } from './placeCoordinateMapWork';
 /// Coordinates place-specific editor actions while RegionManager owns shared draft state.
 export function usePlaceEditorActions(context: any) {
   const openPlaceCreate = async (region: EditorRegion): Promise<void> => {
+    await openPlaceCreateDraft(region, null);
+  };
+
+  const openPlaceCreateFromSearch = async (region: EditorRegion, result: EditorGeocodeSearchResult): Promise<boolean> => {
+    return await openPlaceCreateDraft(region, result);
+  };
+
+  const openPlaceCreateDraft = async (region: EditorRegion, result: EditorGeocodeSearchResult | null): Promise<boolean> => {
     const target = buildPlaceCreateTarget(region);
     const isAlreadyActive = context.props.editorSurface.isTargetActive(target);
-    if (region.isShadow || !(await context.props.editorSurface.activateTarget(target)) || isAlreadyActive) {
-      return;
+    if (region.isShadow || !(await context.props.editorSurface.activateTarget(target)) || (isAlreadyActive && !result)) {
+      return false;
+    }
+
+    if (isAlreadyActive && result && context.isDirty.value && !(await context.confirmDiscard('Discard unsaved place changes before adding this search result?'))) {
+      return false;
     }
 
     Object.assign(context.draft, emptyRegionDraft());
     Object.assign(context.placeDraft, emptyPlaceDraft(region.id));
     Object.assign(context.areaDraft, emptyAreaDraft());
-    context.placeDraft.name = 'New Place';
+    context.placeDraft.name = result ? searchResultName(result) : 'New Place';
+    context.placeDraft.address = result?.address || result?.displayName || '';
+    context.placeDraft.latitude = result?.latitude ?? '';
+    context.placeDraft.longitude = result?.longitude ?? '';
     context.placeDraft.iconName = context.props.state.options.iconNames[0] ?? 'marker';
     context.placeDraft.markerColor = context.props.state.options.markerColorClasses[0] ?? 'bg-blue';
+    context.placeDraft.reverseGeocode = false;
     context.regionCreateBaselineRequest.value = null;
     context.placeCreateBaselineRequest.value = buildPlaceRequest(context.placeDraft);
     context.areaCreateBaselineRequest.value = null;
     context.resetFeedback();
+    return true;
   };
 
   const openPlaceEdit = async (place: EditorPlace): Promise<void> => {
@@ -151,5 +168,9 @@ export function usePlaceEditorActions(context: any) {
     }
   };
 
-  return { cancelPlaceDraft, deleteDraftPlace, openPlaceCreate, openPlaceEdit, pickPlaceCoordinate, reorderPlaces, resetPlaceDraft, savePlaceDraft };
+  return { cancelPlaceDraft, deleteDraftPlace, openPlaceCreate, openPlaceCreateFromSearch, openPlaceEdit, pickPlaceCoordinate, reorderPlaces, resetPlaceDraft, savePlaceDraft };
+}
+
+function searchResultName(result: EditorGeocodeSearchResult): string {
+  return result.name || result.displayName.split(',').map(part => part.trim()).find(Boolean) || 'New Place';
 }

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -13,6 +13,7 @@ export type FocusActiveEntityResult = 'moved' | 'missing-target' | 'no-geometry'
 
 interface TripEditorMapAdapter {
   render: (state: EditorTripState, hiddenSegmentIds?: ReadonlySet<Guid>) => void;
+  clearSearchPreview: () => void;
   startCoordinatePick: (options: CoordinatePickOptions) => () => void;
   startAreaPolygonWork: (options: AreaPolygonWorkOptions) => () => void;
   startSegmentRouteWork: (options: SegmentRouteWorkOptions) => () => void;
@@ -20,12 +21,14 @@ interface TripEditorMapAdapter {
   fitAllGeometry: (state: EditorTripState) => FitAllGeometryResult;
   focusSavedTripView: (metadata: EditorTripMetadata) => FocusSavedTripViewResult;
   focusActiveEntity: (state: EditorTripState, target: EditorTarget | null) => FocusActiveEntityResult;
+  showSearchPreview: (coordinate: EditorCoordinate, label: string) => void;
   dispose: () => void;
 }
 
 export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): TripEditorMapAdapter => {
   const map = L.map(element, { zoomControl: true }).setView([20, 0], 2);
   const layers = L.layerGroup().addTo(map);
+  const searchPreview = createSearchPreviewLayer(map);
   const coordinatePick = createCoordinatePickLayer(map);
   const areaPolygonWork = createAreaPolygonWorkLayer(map);
   const segmentRouteWork = createSegmentRouteWorkLayer(map);
@@ -36,6 +39,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
   }).addTo(map);
 
   const render = (state: EditorTripState, hiddenSegmentIds: ReadonlySet<Guid> = new Set()): void => {
+    searchPreview.clear();
     coordinatePick.clearRegisteredMarkers();
     areaPolygonWork.stop();
     segmentRouteWork.stop();
@@ -55,19 +59,60 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string): Tri
 
   return {
     render,
-    startCoordinatePick: options => coordinatePick.start(options),
-    startAreaPolygonWork: options => areaPolygonWork.start(options),
-    startSegmentRouteWork: options => segmentRouteWork.start(options),
+    clearSearchPreview: searchPreview.clear,
+    startCoordinatePick: options => {
+      searchPreview.clear();
+      return coordinatePick.start(options);
+    },
+    startAreaPolygonWork: options => {
+      searchPreview.clear();
+      return areaPolygonWork.start(options);
+    },
+    startSegmentRouteWork: options => {
+      searchPreview.clear();
+      return segmentRouteWork.start(options);
+    },
     setSegmentRouteWorkRoute: route => segmentRouteWork.setRoute(route),
     fitAllGeometry: state => fitAllGeometry(map, state),
     focusSavedTripView: metadata => focusSavedTripView(map, metadata),
     focusActiveEntity: (state, target) => focusActiveEntity(map, state, target),
+    showSearchPreview: searchPreview.show,
     dispose: () => {
+      searchPreview.dispose();
       coordinatePick.dispose();
       areaPolygonWork.dispose();
       segmentRouteWork.dispose();
       map.remove();
     }
+  };
+};
+
+const createSearchPreviewLayer = (map: LeafletMap): {
+  clear: () => void;
+  dispose: () => void;
+  show: (coordinate: EditorCoordinate, label: string) => void;
+} => {
+  const layer = L.layerGroup().addTo(map);
+
+  const clear = (): void => {
+    layer.clearLayers();
+  };
+
+  const show = (coordinate: EditorCoordinate, label: string): void => {
+    clear();
+    L.marker([coordinate.latitude, coordinate.longitude], {
+      interactive: false,
+      keyboard: false,
+      title: `Search result preview: ${label}`,
+      alt: `Search result preview: ${label}`
+    }).addTo(layer);
+    map.setView([coordinate.latitude, coordinate.longitude], Math.max(map.getZoom(), 13));
+  };
+
+  return {
+    clear,
+    dispose: clear,
+    show
   };
 };
 

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -502,6 +502,82 @@ body {
   min-height: 0;
 }
 
+.trip-editor-map-search {
+  background: var(--trip-editor-surface);
+  border-bottom: 1px solid var(--trip-editor-border);
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.65rem 1rem;
+  position: relative;
+  z-index: 2;
+}
+
+.trip-editor-map-search__form,
+.trip-editor-map-search__add-panel {
+  align-items: end;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: auto minmax(14rem, 28rem) auto;
+  justify-content: start;
+}
+
+.trip-editor-map-search__label,
+.trip-editor-map-search__add-panel span {
+  color: var(--trip-editor-muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.trip-editor-map-search input,
+.trip-editor-map-search select {
+  background: var(--trip-editor-field-bg);
+  border: 1px solid var(--trip-editor-field-border);
+  border-radius: 6px;
+  color: var(--trip-editor-text);
+  min-height: 2rem;
+  padding: 0.25rem 0.5rem;
+  width: 100%;
+}
+
+.trip-editor-map-search__status,
+.trip-editor-map-search__helper,
+.trip-editor-map-search__attribution {
+  color: var(--trip-editor-muted);
+  margin: 0;
+}
+
+.trip-editor-map-search__results {
+  display: grid;
+  gap: 0.35rem;
+  max-width: min(760px, 100%);
+}
+
+.trip-editor-map-search__result {
+  background: var(--trip-editor-card);
+  border: 1px solid var(--trip-editor-border);
+  border-radius: 6px;
+  color: var(--trip-editor-text);
+  display: grid;
+  gap: 0.12rem;
+  padding: 0.45rem 0.55rem;
+  text-align: left;
+}
+
+.trip-editor-map-search__result span,
+.trip-editor-map-search__result small {
+  color: var(--trip-editor-muted);
+}
+
+.trip-editor-map-search__result--selected {
+  border-color: var(--trip-editor-accent);
+  box-shadow: 0 0 0 0.12rem color-mix(in srgb, var(--trip-editor-accent) 26%, transparent);
+}
+
+.trip-editor-map-search__add-panel label {
+  display: grid;
+  gap: 0.2rem;
+}
+
 .trip-editor-state--error {
   color: #fecaca;
   flex-direction: column;
@@ -580,6 +656,12 @@ body {
 
   .trip-editor-toolbar__actions {
     justify-content: flex-start;
+  }
+
+  .trip-editor-map-search__form,
+  .trip-editor-map-search__add-panel {
+    align-items: stretch;
+    grid-template-columns: 1fr;
   }
 
 }

--- a/ClientApps/trip-editor/src/types.ts
+++ b/ClientApps/trip-editor/src/types.ts
@@ -126,6 +126,24 @@ export interface EditorOptions {
   limits: { nominatimSearchLimit: number; sidebarSearchMinCharacters: number };
 }
 
+export interface EditorGeocodeSearchResponse {
+  query: string;
+  attribution: string;
+  results: EditorGeocodeSearchResult[];
+}
+
+export interface EditorGeocodeSearchResult {
+  id: string;
+  provider: string;
+  name: string;
+  displayName: string;
+  address: string;
+  category: string | null;
+  type: string | null;
+  latitude: number;
+  longitude: number;
+}
+
 export interface EditorPermissions {
   canEditTrip: boolean;
   canEditMetadata: boolean;

--- a/Models/Dtos/Editor/EditorGeocodeSearchDtos.cs
+++ b/Models/Dtos/Editor/EditorGeocodeSearchDtos.cs
@@ -1,0 +1,23 @@
+namespace Wayfarer.Models.Dtos.Editor;
+
+/// <summary>
+/// Search response returned by the Trip Editor geocode proxy.
+/// </summary>
+public sealed record EditorGeocodeSearchResponseDto(
+    string Query,
+    string Attribution,
+    IReadOnlyList<EditorGeocodeSearchResultDto> Results);
+
+/// <summary>
+/// Single geocode result normalized for Trip Editor search-add.
+/// </summary>
+public sealed record EditorGeocodeSearchResultDto(
+    string Id,
+    string Provider,
+    string Name,
+    string DisplayName,
+    string Address,
+    string? Category,
+    string? Type,
+    double Latitude,
+    double Longitude);

--- a/Models/Dtos/Editor/EditorTripStateMapper.cs
+++ b/Models/Dtos/Editor/EditorTripStateMapper.cs
@@ -251,7 +251,7 @@ public static class EditorTripStateMapper
         region.DisplayOrder == 0 && string.Equals(region.Name, EditorRegionRequestParser.ShadowRegionName, StringComparison.Ordinal);
 
     private static EditorEntityCapabilitiesDto ShadowCapabilities() =>
-        new(false, false, false, false, false, false, true);
+        new(false, false, false, false, false, false, false);
 
     private static EditorEntityCapabilitiesDto EditableRegionCapabilities() =>
         new(true, true, true, true, false, true, true);

--- a/Models/Options/TripEditorGeocodeOptions.cs
+++ b/Models/Options/TripEditorGeocodeOptions.cs
@@ -1,0 +1,25 @@
+namespace Wayfarer.Models.Options;
+
+/// <summary>
+/// Configuration for the Trip Editor geocode search proxy.
+/// </summary>
+public sealed class TripEditorGeocodeOptions
+{
+    /// <summary>Public Nominatim search endpoint.</summary>
+    public string NominatimSearchEndpoint { get; set; } = "https://nominatim.openstreetmap.org/search";
+
+    /// <summary>Application-identifying User-Agent sent to Nominatim.</summary>
+    public string NominatimUserAgent { get; set; } = "Wayfarer/1.0 (contact: noreply@wayfarer.app)";
+
+    /// <summary>Optional referer header sent to Nominatim when configured.</summary>
+    public string? Referer { get; set; }
+
+    /// <summary>Cache lifetime for normalized identical search queries.</summary>
+    public int CacheSeconds { get; set; } = 60;
+
+    /// <summary>Provider HTTP timeout in seconds.</summary>
+    public int TimeoutSeconds { get; set; } = 5;
+
+    /// <summary>Minimum interval between uncached provider requests.</summary>
+    public int MinimumIntervalMilliseconds { get; set; } = 1000;
+}

--- a/Models/Options/TripEditorGeocodeOptions.cs
+++ b/Models/Options/TripEditorGeocodeOptions.cs
@@ -9,7 +9,7 @@ public sealed class TripEditorGeocodeOptions
     public string NominatimSearchEndpoint { get; set; } = "https://nominatim.openstreetmap.org/search";
 
     /// <summary>Application-identifying User-Agent sent to Nominatim.</summary>
-    public string NominatimUserAgent { get; set; } = "Wayfarer/1.0 (contact: noreply@wayfarer.app)";
+    public string NominatimUserAgent { get; set; } = "Wayfarer/1.0";
 
     /// <summary>Optional referer header sent to Nominatim when configured.</summary>
     public string? Referer { get; set; }

--- a/Program.cs
+++ b/Program.cs
@@ -469,11 +469,7 @@ static void ConfigureServices(WebApplicationBuilder builder)
 
     // Register memory cache for application services
     builder.Services.AddMemoryCache();
-    builder.Services.AddSingleton<TileMetadataHotCache>();
-    builder.Services.Configure<TripEditorGeocodeOptions>(builder.Configuration.GetSection("TripEditorGeocode"));
-    builder.Services.AddSingleton<ITripEditorGeocodeClock, SystemTripEditorGeocodeClock>();
-    builder.Services.AddSingleton<TripEditorGeocodeRateLimiter>();
-    builder.Services.AddScoped<ITripEditorGeocodeSearchService, TripEditorGeocodeSearchService>();
+    builder.Services.AddSingleton<TileMetadataHotCache>(); builder.Services.AddTripEditorGeocodeSearch(builder.Configuration);
 
     // Register application services with DI container
     builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
@@ -540,27 +536,6 @@ static void ConfigureServices(WebApplicationBuilder builder)
 
     // Reverse geocoding Mapbox service
     builder.Services.AddHttpClient<ReverseGeocodingService>();
-    builder.Services.AddHttpClient<ITripEditorGeocodeProvider, NominatimTripEditorGeocodeProvider>()
-        .ConfigureHttpClient((sp, client) =>
-        {
-            var options = sp.GetRequiredService<IOptions<TripEditorGeocodeOptions>>().Value;
-            var config = sp.GetRequiredService<IConfiguration>();
-            var contactEmail = config.GetSection("Application:ContactEmail").Value ?? "noreply@wayfarer.app";
-            client.Timeout = TimeSpan.FromSeconds(Math.Max(1, options.TimeoutSeconds));
-            var userAgent = string.IsNullOrWhiteSpace(options.NominatimUserAgent)
-                ? $"Wayfarer/1.0 (contact: {contactEmail})"
-                : options.NominatimUserAgent;
-            if (!client.DefaultRequestHeaders.UserAgent.TryParseAdd(userAgent))
-            {
-                client.DefaultRequestHeaders.UserAgent.TryParseAdd("Wayfarer/1.0");
-            }
-
-            if (!string.IsNullOrWhiteSpace(options.Referer)
-                && Uri.TryCreate(options.Referer, UriKind.Absolute, out var referer))
-            {
-                client.DefaultRequestHeaders.Referrer = referer;
-            }
-        });
 
     // Tile Cache service — typed HttpClient with OSM-compliant headers.
     // Manual redirects are handled in TileCacheService.SendTileRequestAsync.

--- a/Program.cs
+++ b/Program.cs
@@ -470,6 +470,10 @@ static void ConfigureServices(WebApplicationBuilder builder)
     // Register memory cache for application services
     builder.Services.AddMemoryCache();
     builder.Services.AddSingleton<TileMetadataHotCache>();
+    builder.Services.Configure<TripEditorGeocodeOptions>(builder.Configuration.GetSection("TripEditorGeocode"));
+    builder.Services.AddSingleton<ITripEditorGeocodeClock, SystemTripEditorGeocodeClock>();
+    builder.Services.AddSingleton<TripEditorGeocodeRateLimiter>();
+    builder.Services.AddScoped<ITripEditorGeocodeSearchService, TripEditorGeocodeSearchService>();
 
     // Register application services with DI container
     builder.Services.AddScoped<IApplicationSettingsService, ApplicationSettingsService>();
@@ -536,6 +540,27 @@ static void ConfigureServices(WebApplicationBuilder builder)
 
     // Reverse geocoding Mapbox service
     builder.Services.AddHttpClient<ReverseGeocodingService>();
+    builder.Services.AddHttpClient<ITripEditorGeocodeProvider, NominatimTripEditorGeocodeProvider>()
+        .ConfigureHttpClient((sp, client) =>
+        {
+            var options = sp.GetRequiredService<IOptions<TripEditorGeocodeOptions>>().Value;
+            var config = sp.GetRequiredService<IConfiguration>();
+            var contactEmail = config.GetSection("Application:ContactEmail").Value ?? "noreply@wayfarer.app";
+            client.Timeout = TimeSpan.FromSeconds(Math.Max(1, options.TimeoutSeconds));
+            var userAgent = string.IsNullOrWhiteSpace(options.NominatimUserAgent)
+                ? $"Wayfarer/1.0 (contact: {contactEmail})"
+                : options.NominatimUserAgent;
+            if (!client.DefaultRequestHeaders.UserAgent.TryParseAdd(userAgent))
+            {
+                client.DefaultRequestHeaders.UserAgent.TryParseAdd("Wayfarer/1.0");
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.Referer)
+                && Uri.TryCreate(options.Referer, UriKind.Absolute, out var referer))
+            {
+                client.DefaultRequestHeaders.Referrer = referer;
+            }
+        });
 
     // Tile Cache service — typed HttpClient with OSM-compliant headers.
     // Manual redirects are handled in TileCacheService.SendTileRequestAsync.

--- a/Services/TripEditorGeocodeSearchService.cs
+++ b/Services/TripEditorGeocodeSearchService.cs
@@ -1,0 +1,333 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Wayfarer.Models.Dtos.Editor;
+using Wayfarer.Models.Options;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Search-only geocode provider abstraction used by the Trip Editor proxy.
+/// </summary>
+public interface ITripEditorGeocodeProvider
+{
+    /// <summary>Searches the external provider for a normalized address query.</summary>
+    Task<TripEditorGeocodeProviderResult> SearchAsync(string query, int limit, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Application-level Trip Editor geocode search service.
+/// </summary>
+public interface ITripEditorGeocodeSearchService
+{
+    /// <summary>Searches through the configured provider with local cache and rate limiting.</summary>
+    Task<TripEditorGeocodeSearchOutcome> SearchAsync(string query, int limit, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Provides deterministic time for testable geocode rate limiting.
+/// </summary>
+public interface ITripEditorGeocodeClock
+{
+    /// <summary>Gets the current UTC timestamp.</summary>
+    DateTimeOffset UtcNow { get; }
+}
+
+/// <summary>
+/// System clock for Trip Editor geocode rate limiting.
+/// </summary>
+public sealed class SystemTripEditorGeocodeClock : ITripEditorGeocodeClock
+{
+    /// <inheritdoc />
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Serializes uncached provider calls to at most one request per configured interval.
+/// </summary>
+public sealed class TripEditorGeocodeRateLimiter
+{
+    private readonly ITripEditorGeocodeClock _clock;
+    private readonly object _gate = new();
+    private DateTimeOffset _nextAvailableAt = DateTimeOffset.MinValue;
+
+    /// <summary>Initializes the app-wide geocode rate limiter.</summary>
+    public TripEditorGeocodeRateLimiter(ITripEditorGeocodeClock clock)
+    {
+        _clock = clock;
+    }
+
+    /// <summary>Attempts to reserve one provider request without sleeping.</summary>
+    public bool TryAcquire(TimeSpan minimumInterval)
+    {
+        lock (_gate)
+        {
+            var now = _clock.UtcNow;
+            if (now < _nextAvailableAt)
+            {
+                return false;
+            }
+
+            _nextAvailableAt = now.Add(minimumInterval);
+            return true;
+        }
+    }
+}
+
+/// <summary>
+/// Concrete geocode search service that keeps browser traffic on the Wayfarer proxy.
+/// </summary>
+public sealed class TripEditorGeocodeSearchService : ITripEditorGeocodeSearchService
+{
+    private readonly ITripEditorGeocodeProvider _provider;
+    private readonly IMemoryCache _cache;
+    private readonly TripEditorGeocodeRateLimiter _rateLimiter;
+    private readonly TripEditorGeocodeOptions _options;
+
+    /// <summary>Initializes the cached/rate-limited geocode search service.</summary>
+    public TripEditorGeocodeSearchService(
+        ITripEditorGeocodeProvider provider,
+        IMemoryCache cache,
+        TripEditorGeocodeRateLimiter rateLimiter,
+        IOptions<TripEditorGeocodeOptions> options)
+    {
+        _provider = provider;
+        _cache = cache;
+        _rateLimiter = rateLimiter;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public async Task<TripEditorGeocodeSearchOutcome> SearchAsync(string query, int limit, CancellationToken cancellationToken)
+    {
+        var normalized = NormalizeQuery(query);
+        var cacheKey = $"trip-editor-geocode:{normalized}:{limit}";
+        if (_cache.TryGetValue(cacheKey, out EditorGeocodeSearchResponseDto? cached) && cached != null)
+        {
+            return TripEditorGeocodeSearchOutcome.Success(cached);
+        }
+
+        var interval = TimeSpan.FromMilliseconds(Math.Max(1000, _options.MinimumIntervalMilliseconds));
+        if (!_rateLimiter.TryAcquire(interval))
+        {
+            return TripEditorGeocodeSearchOutcome.Failure(TripEditorGeocodeSearchStatus.LocalRateLimited);
+        }
+
+        var providerResult = await _provider.SearchAsync(normalized, limit, cancellationToken);
+        if (providerResult.Status != TripEditorGeocodeProviderStatus.Success || providerResult.Response == null)
+        {
+            return TripEditorGeocodeSearchOutcome.Failure(providerResult.Status switch
+            {
+                TripEditorGeocodeProviderStatus.RateLimited => TripEditorGeocodeSearchStatus.ProviderRateLimited,
+                TripEditorGeocodeProviderStatus.Timeout => TripEditorGeocodeSearchStatus.ProviderTimeout,
+                TripEditorGeocodeProviderStatus.Unavailable => TripEditorGeocodeSearchStatus.ProviderUnavailable,
+                TripEditorGeocodeProviderStatus.Malformed => TripEditorGeocodeSearchStatus.ProviderMalformed,
+                _ => TripEditorGeocodeSearchStatus.ProviderUnavailable
+            });
+        }
+
+        var ttl = TimeSpan.FromSeconds(Math.Max(1, _options.CacheSeconds));
+        _cache.Set(cacheKey, providerResult.Response, ttl);
+        return TripEditorGeocodeSearchOutcome.Success(providerResult.Response);
+    }
+
+    private static string NormalizeQuery(string query) =>
+        string.Join(' ', query.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries)).ToLowerInvariant();
+}
+
+/// <summary>
+/// Public Nominatim-backed geocode search provider.
+/// </summary>
+public sealed class NominatimTripEditorGeocodeProvider : ITripEditorGeocodeProvider
+{
+    private const string ProviderName = "nominatim";
+    private const string Attribution = "Data © OpenStreetMap contributors, ODbL 1.0.";
+    private readonly HttpClient _httpClient;
+    private readonly TripEditorGeocodeOptions _options;
+
+    /// <summary>Initializes a Nominatim search adapter.</summary>
+    public NominatimTripEditorGeocodeProvider(HttpClient httpClient, IOptions<TripEditorGeocodeOptions> options)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+        if (!_httpClient.DefaultRequestHeaders.UserAgent.Any())
+        {
+            _httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(_options.NominatimUserAgent);
+        }
+
+        if (_httpClient.DefaultRequestHeaders.Referrer == null
+            && !string.IsNullOrWhiteSpace(_options.Referer)
+            && Uri.TryCreate(_options.Referer, UriKind.Absolute, out var referer))
+        {
+            _httpClient.DefaultRequestHeaders.Referrer = referer;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<TripEditorGeocodeProviderResult> SearchAsync(string query, int limit, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, BuildSearchUri(query, limit));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                return TripEditorGeocodeProviderResult.Failure(TripEditorGeocodeProviderStatus.RateLimited);
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return TripEditorGeocodeProviderResult.Failure(TripEditorGeocodeProviderStatus.Unavailable);
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            return TripEditorGeocodeProviderResult.Success(new EditorGeocodeSearchResponseDto(
+                query,
+                Attribution,
+                await ParseResultsAsync(stream, cancellationToken)));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            return TripEditorGeocodeProviderResult.Failure(TripEditorGeocodeProviderStatus.Timeout);
+        }
+        catch (HttpRequestException)
+        {
+            return TripEditorGeocodeProviderResult.Failure(TripEditorGeocodeProviderStatus.Unavailable);
+        }
+        catch (JsonException)
+        {
+            return TripEditorGeocodeProviderResult.Failure(TripEditorGeocodeProviderStatus.Malformed);
+        }
+        catch (FormatException)
+        {
+            return TripEditorGeocodeProviderResult.Failure(TripEditorGeocodeProviderStatus.Malformed);
+        }
+    }
+
+    private Uri BuildSearchUri(string query, int limit)
+    {
+        var endpoint = string.IsNullOrWhiteSpace(_options.NominatimSearchEndpoint)
+            ? "https://nominatim.openstreetmap.org/search"
+            : _options.NominatimSearchEndpoint;
+        var builder = new UriBuilder(endpoint);
+        var queryParts = new Dictionary<string, string?>
+        {
+            ["format"] = "jsonv2",
+            ["q"] = query,
+            ["limit"] = limit.ToString(CultureInfo.InvariantCulture),
+            ["addressdetails"] = "1"
+        };
+        builder.Query = string.Join('&', queryParts.Select(pair => $"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(pair.Value ?? string.Empty)}"));
+        return builder.Uri;
+    }
+
+    private static async Task<IReadOnlyList<EditorGeocodeSearchResultDto>> ParseResultsAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        if (document.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new JsonException("Nominatim search response must be an array.");
+        }
+
+        var results = new List<EditorGeocodeSearchResultDto>();
+        foreach (var element in document.RootElement.EnumerateArray())
+        {
+            var displayName = RequiredString(element, "display_name");
+            var latitude = double.Parse(RequiredString(element, "lat"), CultureInfo.InvariantCulture);
+            var longitude = double.Parse(RequiredString(element, "lon"), CultureInfo.InvariantCulture);
+            if (!double.IsFinite(latitude) || !double.IsFinite(longitude))
+            {
+                throw new FormatException("Nominatim coordinates must be finite.");
+            }
+
+            var name = OptionalString(element, "name") ?? displayName.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? displayName;
+            var id = OptionalString(element, "place_id") ??
+                string.Join(':', new[] { OptionalString(element, "osm_type"), OptionalString(element, "osm_id") }.Where(value => !string.IsNullOrWhiteSpace(value)));
+            results.Add(new EditorGeocodeSearchResultDto(
+                string.IsNullOrWhiteSpace(id) ? $"{ProviderName}:{latitude.ToString(CultureInfo.InvariantCulture)}:{longitude.ToString(CultureInfo.InvariantCulture)}" : $"{ProviderName}:{id}",
+                ProviderName,
+                name,
+                displayName,
+                BuildAddress(element) ?? displayName,
+                OptionalString(element, "category"),
+                OptionalString(element, "type"),
+                latitude,
+                longitude));
+        }
+
+        return results;
+    }
+
+    private static string? BuildAddress(JsonElement element)
+    {
+        if (!element.TryGetProperty("address", out var address) || address.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        var parts = new[] { "road", "neighbourhood", "suburb", "city", "town", "village", "state", "country" }
+            .Select(key => OptionalString(address, key))
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+        var text = string.Join(", ", parts);
+        return string.IsNullOrWhiteSpace(text) ? null : text;
+    }
+
+    private static string RequiredString(JsonElement element, string propertyName) =>
+        OptionalString(element, propertyName) ?? throw new JsonException($"Nominatim result missing {propertyName}.");
+
+    private static string? OptionalString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var value) && value.ValueKind != JsonValueKind.Null
+            ? value.ToString()
+            : null;
+}
+
+/// <summary>Status returned by an external geocode provider.</summary>
+public enum TripEditorGeocodeProviderStatus
+{
+    Success,
+    RateLimited,
+    Timeout,
+    Unavailable,
+    Malformed
+}
+
+/// <summary>Status returned by the Trip Editor geocode service.</summary>
+public enum TripEditorGeocodeSearchStatus
+{
+    Success,
+    LocalRateLimited,
+    ProviderRateLimited,
+    ProviderTimeout,
+    ProviderUnavailable,
+    ProviderMalformed
+}
+
+/// <summary>Provider result wrapper for deterministic proxy status mapping.</summary>
+public sealed record TripEditorGeocodeProviderResult(TripEditorGeocodeProviderStatus Status, EditorGeocodeSearchResponseDto? Response)
+{
+    /// <summary>Builds a successful provider result.</summary>
+    public static TripEditorGeocodeProviderResult Success(EditorGeocodeSearchResponseDto response) => new(TripEditorGeocodeProviderStatus.Success, response);
+
+    /// <summary>Builds a failed provider result.</summary>
+    public static TripEditorGeocodeProviderResult Failure(TripEditorGeocodeProviderStatus status) => new(status, null);
+}
+
+/// <summary>Service result wrapper for deterministic controller status mapping.</summary>
+public sealed record TripEditorGeocodeSearchOutcome(TripEditorGeocodeSearchStatus Status, EditorGeocodeSearchResponseDto? Response)
+{
+    /// <summary>Builds a successful search result.</summary>
+    public static TripEditorGeocodeSearchOutcome Success(EditorGeocodeSearchResponseDto response) => new(TripEditorGeocodeSearchStatus.Success, response);
+
+    /// <summary>Builds a failed search result.</summary>
+    public static TripEditorGeocodeSearchOutcome Failure(TripEditorGeocodeSearchStatus status) => new(status, null);
+}

--- a/Services/TripEditorGeocodeSearchService.cs
+++ b/Services/TripEditorGeocodeSearchService.cs
@@ -143,6 +143,7 @@ public sealed class TripEditorGeocodeSearchService : ITripEditorGeocodeSearchSer
 /// </summary>
 public sealed class NominatimTripEditorGeocodeProvider : ITripEditorGeocodeProvider
 {
+    private const string DefaultUserAgent = "Wayfarer/1.0";
     private const string ProviderName = "nominatim";
     private const string Attribution = "Data © OpenStreetMap contributors, ODbL 1.0.";
     private readonly HttpClient _httpClient;
@@ -155,7 +156,13 @@ public sealed class NominatimTripEditorGeocodeProvider : ITripEditorGeocodeProvi
         _options = options.Value;
         if (!_httpClient.DefaultRequestHeaders.UserAgent.Any())
         {
-            _httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(_options.NominatimUserAgent);
+            var userAgent = string.IsNullOrWhiteSpace(_options.NominatimUserAgent)
+                ? DefaultUserAgent
+                : _options.NominatimUserAgent;
+            if (!_httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(userAgent))
+            {
+                _httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(DefaultUserAgent);
+            }
         }
 
         if (_httpClient.DefaultRequestHeaders.Referrer == null

--- a/Services/TripEditorGeocodeServiceCollectionExtensions.cs
+++ b/Services/TripEditorGeocodeServiceCollectionExtensions.cs
@@ -8,6 +8,8 @@ namespace Wayfarer.Services;
 /// </summary>
 public static class TripEditorGeocodeServiceCollectionExtensions
 {
+    private const string DefaultNominatimUserAgent = "Wayfarer/1.0";
+
     /// <summary>Adds the cache, rate limiter, provider, and search service for Trip Editor geocode search.</summary>
     public static IServiceCollection AddTripEditorGeocodeSearch(this IServiceCollection services, IConfiguration configuration)
     {
@@ -19,14 +21,13 @@ public static class TripEditorGeocodeServiceCollectionExtensions
             .ConfigureHttpClient((sp, client) =>
             {
                 var options = sp.GetRequiredService<IOptions<TripEditorGeocodeOptions>>().Value;
-                var contactEmail = sp.GetRequiredService<IConfiguration>().GetSection("Application:ContactEmail").Value ?? "noreply@wayfarer.app";
                 client.Timeout = TimeSpan.FromSeconds(Math.Max(1, options.TimeoutSeconds));
                 var userAgent = string.IsNullOrWhiteSpace(options.NominatimUserAgent)
-                    ? $"Wayfarer/1.0 (contact: {contactEmail})"
+                    ? DefaultNominatimUserAgent
                     : options.NominatimUserAgent;
                 if (!client.DefaultRequestHeaders.UserAgent.TryParseAdd(userAgent))
                 {
-                    client.DefaultRequestHeaders.UserAgent.TryParseAdd("Wayfarer/1.0");
+                    client.DefaultRequestHeaders.UserAgent.TryParseAdd(DefaultNominatimUserAgent);
                 }
 
                 if (!string.IsNullOrWhiteSpace(options.Referer) && Uri.TryCreate(options.Referer, UriKind.Absolute, out var referer))

--- a/Services/TripEditorGeocodeServiceCollectionExtensions.cs
+++ b/Services/TripEditorGeocodeServiceCollectionExtensions.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Options;
+using Wayfarer.Models.Options;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Registers the Trip Editor geocode search proxy dependencies.
+/// </summary>
+public static class TripEditorGeocodeServiceCollectionExtensions
+{
+    /// <summary>Adds the cache, rate limiter, provider, and search service for Trip Editor geocode search.</summary>
+    public static IServiceCollection AddTripEditorGeocodeSearch(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<TripEditorGeocodeOptions>(configuration.GetSection("TripEditorGeocode"));
+        services.AddSingleton<ITripEditorGeocodeClock, SystemTripEditorGeocodeClock>();
+        services.AddSingleton<TripEditorGeocodeRateLimiter>();
+        services.AddScoped<ITripEditorGeocodeSearchService, TripEditorGeocodeSearchService>();
+        services.AddHttpClient<ITripEditorGeocodeProvider, NominatimTripEditorGeocodeProvider>()
+            .ConfigureHttpClient((sp, client) =>
+            {
+                var options = sp.GetRequiredService<IOptions<TripEditorGeocodeOptions>>().Value;
+                var contactEmail = sp.GetRequiredService<IConfiguration>().GetSection("Application:ContactEmail").Value ?? "noreply@wayfarer.app";
+                client.Timeout = TimeSpan.FromSeconds(Math.Max(1, options.TimeoutSeconds));
+                var userAgent = string.IsNullOrWhiteSpace(options.NominatimUserAgent)
+                    ? $"Wayfarer/1.0 (contact: {contactEmail})"
+                    : options.NominatimUserAgent;
+                if (!client.DefaultRequestHeaders.UserAgent.TryParseAdd(userAgent))
+                {
+                    client.DefaultRequestHeaders.UserAgent.TryParseAdd("Wayfarer/1.0");
+                }
+
+                if (!string.IsNullOrWhiteSpace(options.Referer) && Uri.TryCreate(options.Referer, UriKind.Absolute, out var referer))
+                {
+                    client.DefaultRequestHeaders.Referrer = referer;
+                }
+            });
+
+        return services;
+    }
+}

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -195,7 +195,7 @@ public sealed class TripEditorControllerTests : TestBase
         Assert.False(shadow.Capabilities.CanDelete);
         Assert.False(shadow.Capabilities.CanReorder);
         Assert.False(shadow.Capabilities.CanAddChildren);
-        Assert.True(shadow.Capabilities.CanTargetForSearchAdd);
+        Assert.False(shadow.Capabilities.CanTargetForSearchAdd);
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Controllers/TripEditorGeocodeControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorGeocodeControllerTests.cs
@@ -1,0 +1,228 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Wayfarer.Areas.Api.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Models.Dtos.Editor;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Controllers;
+
+/// <summary>
+/// Focused tests for the Trip Editor geocode proxy controller contract.
+/// </summary>
+public sealed class TripEditorGeocodeControllerTests : TestBase
+{
+    [Fact]
+    public async Task SearchGeocodeRequiresAuthenticatedEditorUser()
+    {
+        using var db = CreateDbContext();
+        var controller = BuildController(db, new FakeGeocodeSearchService());
+
+        var result = await controller.SearchGeocode(Guid.NewGuid(), "athens", null, CancellationToken.None);
+
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Fact]
+    public async Task SearchGeocodeReturnsForbiddenForNonOwner()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db, new FakeGeocodeSearchService());
+        ConfigureControllerWithUserRole(controller, "other-user");
+
+        var result = await controller.SearchGeocode(trip.Id, "athens", null, CancellationToken.None);
+
+        var status = Assert.IsType<StatusCodeResult>(result);
+        Assert.Equal(StatusCodes.Status403Forbidden, status.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task SearchGeocodeReturnsQValidationKeyWhenQueryMissing(string? query)
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db, new FakeGeocodeSearchService());
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.SearchGeocode(trip.Id, query, null, CancellationToken.None);
+
+        Assert.Contains("q", AssertValidationProblem(result).Errors.Keys);
+    }
+
+    [Fact]
+    public async Task SearchGeocodeReturnsQValidationKeyWhenQueryTooShort()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db, new FakeGeocodeSearchService());
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.SearchGeocode(trip.Id, "ab", null, CancellationToken.None);
+
+        Assert.Contains("q", AssertValidationProblem(result).Errors.Keys);
+    }
+
+    [Fact]
+    public async Task SearchGeocodeReturnsLimitValidationKeyWhenLimitBelowMinimum()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db, new FakeGeocodeSearchService());
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.SearchGeocode(trip.Id, "athens", 0, CancellationToken.None);
+
+        Assert.Contains("limit", AssertValidationProblem(result).Errors.Keys);
+    }
+
+    [Fact]
+    public async Task SearchGeocodeClampsLimitToEditorLimit()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var service = new FakeGeocodeSearchService();
+        var controller = BuildController(db, service);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.SearchGeocode(trip.Id, "athens", 99, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(6, service.LastLimit);
+    }
+
+    [Fact]
+    public async Task SearchGeocodeReturnsNoResultsAsSuccessfulResponseWithAttribution()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var service = new FakeGeocodeSearchService
+        {
+            Outcome = TripEditorGeocodeSearchOutcome.Success(new EditorGeocodeSearchResponseDto("missing", "Data source", Array.Empty<EditorGeocodeSearchResultDto>()))
+        };
+        var controller = BuildController(db, service);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.SearchGeocode(trip.Id, "missing", null, CancellationToken.None);
+
+        var response = Assert.IsType<EditorGeocodeSearchResponseDto>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.Empty(response.Results);
+        Assert.Equal("Data source", response.Attribution);
+    }
+
+    [Theory]
+    [InlineData(TripEditorGeocodeSearchStatus.LocalRateLimited, StatusCodes.Status429TooManyRequests)]
+    [InlineData(TripEditorGeocodeSearchStatus.ProviderRateLimited, StatusCodes.Status429TooManyRequests)]
+    [InlineData(TripEditorGeocodeSearchStatus.ProviderMalformed, StatusCodes.Status502BadGateway)]
+    [InlineData(TripEditorGeocodeSearchStatus.ProviderUnavailable, StatusCodes.Status503ServiceUnavailable)]
+    [InlineData(TripEditorGeocodeSearchStatus.ProviderTimeout, StatusCodes.Status504GatewayTimeout)]
+    public async Task SearchGeocodeMapsProviderFailures(TripEditorGeocodeSearchStatus serviceStatus, int expectedStatus)
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var service = new FakeGeocodeSearchService { Outcome = TripEditorGeocodeSearchOutcome.Failure(serviceStatus) };
+        var controller = BuildController(db, service);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.SearchGeocode(trip.Id, "athens", null, CancellationToken.None);
+
+        var status = Assert.IsType<StatusCodeResult>(result);
+        Assert.Equal(expectedStatus, status.StatusCode);
+    }
+
+    [Fact]
+    public async Task SearchGeocodePropagatesCallerCancellation()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        using var cancellation = new CancellationTokenSource();
+        var service = new CancelingGeocodeSearchService(cancellation);
+        var controller = BuildController(db, service);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() => controller.SearchGeocode(trip.Id, "athens", null, cancellation.Token));
+    }
+
+    private static TripEditorController BuildController(ApplicationDbContext db, ITripEditorGeocodeSearchService geocodeSearch)
+    {
+        var environment = Mock.Of<IWebHostEnvironment>(e => e.WebRootPath == Path.GetTempPath());
+        return new TripEditorController(
+            db,
+            environment,
+            Mock.Of<IIconColorProvider>(),
+            Mock.Of<ITripMapThumbnailGenerator>(),
+            Mock.Of<ICacheWarmupScheduler>(),
+            Mock.Of<ITripTagService>(),
+            new TripEditorRegionMutationService(db),
+            new TripEditorPlaceMutationService(db, environment, Mock.Of<IIconColorProvider>(), new ReverseGeocodingService(new HttpClient(), Mock.Of<ILogger<BaseApiController>>())),
+            new TripEditorAreaMutationService(db),
+            new TripEditorSegmentMutationService(db),
+            Mock.Of<ILogger<TripEditorController>>(),
+            geocodeSearch);
+    }
+
+    private static void ConfigureControllerWithUserRole(ControllerBase controller, string userId, string role = "User")
+    {
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = BuildHttpContextWithUser(userId, role)
+        };
+    }
+
+    private static ValidationProblemDetails AssertValidationProblem(IActionResult result)
+    {
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("application/problem+json", badRequest.ContentTypes);
+        return Assert.IsType<ValidationProblemDetails>(badRequest.Value);
+    }
+
+    private static Trip SeedTrip(ApplicationDbContext db, string userId)
+    {
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = userId, Name = "Trip", UpdatedAt = DateTime.UtcNow };
+        db.Trips.Add(trip);
+        db.SaveChanges();
+        return trip;
+    }
+
+    private sealed class FakeGeocodeSearchService : ITripEditorGeocodeSearchService
+    {
+        public int LastLimit { get; private set; }
+
+        public TripEditorGeocodeSearchOutcome Outcome { get; init; } =
+            TripEditorGeocodeSearchOutcome.Success(new EditorGeocodeSearchResponseDto("athens", "Data source", new[]
+            {
+                new EditorGeocodeSearchResultDto("nominatim:1", "nominatim", "Athens", "Athens, Greece", "Greece", "place", "city", 37.9838, 23.7275)
+            }));
+
+        public Task<TripEditorGeocodeSearchOutcome> SearchAsync(string query, int limit, CancellationToken cancellationToken)
+        {
+            LastLimit = limit;
+            return Task.FromResult(Outcome);
+        }
+    }
+
+    private sealed class CancelingGeocodeSearchService : ITripEditorGeocodeSearchService
+    {
+        private readonly CancellationTokenSource _cancellation;
+
+        public CancelingGeocodeSearchService(CancellationTokenSource cancellation)
+        {
+            _cancellation = cancellation;
+        }
+
+        public Task<TripEditorGeocodeSearchOutcome> SearchAsync(string query, int limit, CancellationToken cancellationToken)
+        {
+            _cancellation.Cancel();
+            throw new TaskCanceledException("Caller canceled geocode search.");
+        }
+    }
+}

--- a/tests/Wayfarer.Tests/Services/TripEditorGeocodeSearchServiceTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripEditorGeocodeSearchServiceTests.cs
@@ -83,7 +83,7 @@ public sealed class TripEditorGeocodeSearchServiceTests
         var options = Options.Create(new TripEditorGeocodeOptions
         {
             NominatimSearchEndpoint = "https://nominatim.openstreetmap.org/search",
-            NominatimUserAgent = "WayfarerTests/1.0 (contact: tests@example.test)",
+            NominatimUserAgent = "WayfarerTests/1.0",
             Referer = "https://wayfarer.example.test"
         });
         var provider = new NominatimTripEditorGeocodeProvider(new HttpClient(handler), options);
@@ -101,13 +101,13 @@ public sealed class TripEditorGeocodeSearchServiceTests
         var provider = BuildRegisteredNominatimProvider(handler, new Dictionary<string, string?>
         {
             ["TripEditorGeocode:NominatimSearchEndpoint"] = "https://nominatim.openstreetmap.org/search",
-            ["TripEditorGeocode:NominatimUserAgent"] = "WayfarerConfigured/1.0 (contact: configured@example.test)",
+            ["TripEditorGeocode:NominatimUserAgent"] = "WayfarerConfigured/1.0",
             ["Application:ContactEmail"] = "ignored@example.test"
         });
 
         await provider.SearchAsync("athens", 6, CancellationToken.None);
 
-        Assert.Equal("WayfarerConfigured/1.0 (contact: configured@example.test)", handler.LastRequest!.Headers.UserAgent.ToString());
+        Assert.Equal("WayfarerConfigured/1.0", handler.LastRequest!.Headers.UserAgent.ToString());
         Assert.DoesNotContain("ignored@example.test", handler.LastRequest.Headers.UserAgent.ToString());
     }
 
@@ -129,7 +129,21 @@ public sealed class TripEditorGeocodeSearchServiceTests
 
         Assert.Equal("Wayfarer/1.0", handler.LastRequest!.Headers.UserAgent.ToString());
         Assert.DoesNotContain("ignored@example.test", handler.LastRequest.Headers.UserAgent.ToString());
-        Assert.DoesNotContain("noreply@wayfarer.app", handler.LastRequest.Headers.UserAgent.ToString());
+    }
+
+    [Fact]
+    public async Task RegisteredNominatimProviderUsesPlainUserAgentWhenGeocodeOptionsAreUnbound()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "[]");
+        var provider = BuildRegisteredNominatimProvider(handler, new Dictionary<string, string?>
+        {
+            ["Application:ContactEmail"] = "ignored@example.test"
+        });
+
+        await provider.SearchAsync("athens", 6, CancellationToken.None);
+
+        Assert.Equal("Wayfarer/1.0", handler.LastRequest!.Headers.UserAgent.ToString());
+        Assert.DoesNotContain("ignored@example.test", handler.LastRequest.Headers.UserAgent.ToString());
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Services/TripEditorGeocodeSearchServiceTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripEditorGeocodeSearchServiceTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Text;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Wayfarer.Models.Dtos.Editor;
 using Wayfarer.Models.Options;
@@ -93,6 +95,44 @@ public sealed class TripEditorGeocodeSearchServiceTests
     }
 
     [Fact]
+    public async Task RegisteredNominatimProviderSendsConfiguredUserAgent()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "[]");
+        var provider = BuildRegisteredNominatimProvider(handler, new Dictionary<string, string?>
+        {
+            ["TripEditorGeocode:NominatimSearchEndpoint"] = "https://nominatim.openstreetmap.org/search",
+            ["TripEditorGeocode:NominatimUserAgent"] = "WayfarerConfigured/1.0 (contact: configured@example.test)",
+            ["Application:ContactEmail"] = "ignored@example.test"
+        });
+
+        await provider.SearchAsync("athens", 6, CancellationToken.None);
+
+        Assert.Equal("WayfarerConfigured/1.0 (contact: configured@example.test)", handler.LastRequest!.Headers.UserAgent.ToString());
+        Assert.DoesNotContain("ignored@example.test", handler.LastRequest.Headers.UserAgent.ToString());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task RegisteredNominatimProviderUsesPlainUserAgentWhenConfiguredUserAgentMissingOrBlank(string? configuredUserAgent)
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "[]");
+        var provider = BuildRegisteredNominatimProvider(handler, new Dictionary<string, string?>
+        {
+            ["TripEditorGeocode:NominatimSearchEndpoint"] = "https://nominatim.openstreetmap.org/search",
+            ["TripEditorGeocode:NominatimUserAgent"] = configuredUserAgent,
+            ["Application:ContactEmail"] = "ignored@example.test"
+        });
+
+        await provider.SearchAsync("athens", 6, CancellationToken.None);
+
+        Assert.Equal("Wayfarer/1.0", handler.LastRequest!.Headers.UserAgent.ToString());
+        Assert.DoesNotContain("ignored@example.test", handler.LastRequest.Headers.UserAgent.ToString());
+        Assert.DoesNotContain("noreply@wayfarer.app", handler.LastRequest.Headers.UserAgent.ToString());
+    }
+
+    [Fact]
     public async Task NominatimProviderMapsNoResultsToSuccess()
     {
         var provider = BuildNominatimProvider("[]");
@@ -161,6 +201,21 @@ public sealed class TripEditorGeocodeSearchServiceTests
         new(
             new HttpClient(new CapturingHandler(HttpStatusCode.OK, response)),
             Options.Create(new TripEditorGeocodeOptions { NominatimSearchEndpoint = "https://nominatim.openstreetmap.org/search" }));
+
+    private static ITripEditorGeocodeProvider BuildRegisteredNominatimProvider(
+        CapturingHandler handler,
+        Dictionary<string, string?> values)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+        var services = new ServiceCollection();
+        services.AddMemoryCache();
+        services.AddTripEditorGeocodeSearch(configuration);
+        services.AddHttpClient<ITripEditorGeocodeProvider, NominatimTripEditorGeocodeProvider>()
+            .ConfigurePrimaryHttpMessageHandler(() => handler);
+        return services.BuildServiceProvider().GetRequiredService<ITripEditorGeocodeProvider>();
+    }
 
     private sealed class FakeProvider : ITripEditorGeocodeProvider
     {

--- a/tests/Wayfarer.Tests/Services/TripEditorGeocodeSearchServiceTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripEditorGeocodeSearchServiceTests.cs
@@ -1,0 +1,230 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Wayfarer.Models.Dtos.Editor;
+using Wayfarer.Models.Options;
+using Wayfarer.Services;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>
+/// Tests the Trip Editor geocode provider and local cache/rate-limit service.
+/// </summary>
+public sealed class TripEditorGeocodeSearchServiceTests
+{
+    [Fact]
+    public async Task SearchAsyncReturnsCachedResultWithoutSecondProviderCall()
+    {
+        var provider = new FakeProvider();
+        var clock = new FakeClock();
+        var service = BuildService(provider, clock);
+
+        var first = await service.SearchAsync("  Athens   Acropolis ", 6, CancellationToken.None);
+        var second = await service.SearchAsync("athens acropolis", 6, CancellationToken.None);
+
+        Assert.Equal(TripEditorGeocodeSearchStatus.Success, first.Status);
+        Assert.Equal(TripEditorGeocodeSearchStatus.Success, second.Status);
+        Assert.Equal(1, provider.CallCount);
+    }
+
+    [Fact]
+    public async Task SearchAsyncReturnsLocalRateLimitWithoutSleeping()
+    {
+        var provider = new FakeProvider();
+        var clock = new FakeClock();
+        var service = BuildService(provider, clock);
+
+        var first = await service.SearchAsync("athens one", 6, CancellationToken.None);
+        var second = await service.SearchAsync("athens two", 6, CancellationToken.None);
+
+        Assert.Equal(TripEditorGeocodeSearchStatus.Success, first.Status);
+        Assert.Equal(TripEditorGeocodeSearchStatus.LocalRateLimited, second.Status);
+        Assert.Equal(1, provider.CallCount);
+    }
+
+    [Fact]
+    public async Task SearchAsyncAllowsNextProviderCallAfterClockAdvances()
+    {
+        var provider = new FakeProvider();
+        var clock = new FakeClock();
+        var service = BuildService(provider, clock);
+
+        await service.SearchAsync("athens one", 6, CancellationToken.None);
+        clock.Advance(TimeSpan.FromSeconds(1));
+        var second = await service.SearchAsync("athens two", 6, CancellationToken.None);
+
+        Assert.Equal(TripEditorGeocodeSearchStatus.Success, second.Status);
+        Assert.Equal(2, provider.CallCount);
+    }
+
+    [Theory]
+    [InlineData(TripEditorGeocodeProviderStatus.RateLimited, TripEditorGeocodeSearchStatus.ProviderRateLimited)]
+    [InlineData(TripEditorGeocodeProviderStatus.Timeout, TripEditorGeocodeSearchStatus.ProviderTimeout)]
+    [InlineData(TripEditorGeocodeProviderStatus.Unavailable, TripEditorGeocodeSearchStatus.ProviderUnavailable)]
+    [InlineData(TripEditorGeocodeProviderStatus.Malformed, TripEditorGeocodeSearchStatus.ProviderMalformed)]
+    public async Task SearchAsyncMapsProviderFailures(TripEditorGeocodeProviderStatus providerStatus, TripEditorGeocodeSearchStatus expectedStatus)
+    {
+        var provider = new FakeProvider { Result = TripEditorGeocodeProviderResult.Failure(providerStatus) };
+        var service = BuildService(provider, new FakeClock());
+
+        var result = await service.SearchAsync("athens", 6, CancellationToken.None);
+
+        Assert.Equal(expectedStatus, result.Status);
+    }
+
+    [Fact]
+    public async Task NominatimProviderSendsUserAgentAndReferer()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "[]");
+        var options = Options.Create(new TripEditorGeocodeOptions
+        {
+            NominatimSearchEndpoint = "https://nominatim.openstreetmap.org/search",
+            NominatimUserAgent = "WayfarerTests/1.0 (contact: tests@example.test)",
+            Referer = "https://wayfarer.example.test"
+        });
+        var provider = new NominatimTripEditorGeocodeProvider(new HttpClient(handler), options);
+
+        await provider.SearchAsync("athens", 6, CancellationToken.None);
+
+        Assert.Contains("WayfarerTests/1.0", handler.LastRequest!.Headers.UserAgent.ToString());
+        Assert.Equal("https://wayfarer.example.test/", handler.LastRequest.Headers.Referrer?.ToString());
+    }
+
+    [Fact]
+    public async Task NominatimProviderMapsNoResultsToSuccess()
+    {
+        var provider = BuildNominatimProvider("[]");
+
+        var result = await provider.SearchAsync("missing", 6, CancellationToken.None);
+
+        Assert.Equal(TripEditorGeocodeProviderStatus.Success, result.Status);
+        Assert.Empty(result.Response!.Results);
+        Assert.NotEmpty(result.Response.Attribution);
+    }
+
+    [Fact]
+    public async Task NominatimProviderParsesSuccessfulResult()
+    {
+        var provider = BuildNominatimProvider("""
+        [{
+          "place_id": 123,
+          "name": "Acropolis",
+          "display_name": "Acropolis, Athens, Greece",
+          "lat": "37.9715",
+          "lon": "23.7257",
+          "category": "tourism",
+          "type": "attraction",
+          "address": { "city": "Athens", "country": "Greece" }
+        }]
+        """);
+
+        var result = await provider.SearchAsync("acropolis", 6, CancellationToken.None);
+
+        var item = Assert.Single(result.Response!.Results);
+        Assert.Equal("nominatim", item.Provider);
+        Assert.Equal("Acropolis", item.Name);
+        Assert.Equal("Athens, Greece", item.Address);
+        Assert.Equal(37.9715, item.Latitude, 4);
+        Assert.Equal(23.7257, item.Longitude, 4);
+    }
+
+    [Fact]
+    public async Task NominatimProviderMapsMalformedPayload()
+    {
+        var provider = BuildNominatimProvider("""{ "not": "an array" }""");
+
+        var result = await provider.SearchAsync("athens", 6, CancellationToken.None);
+
+        Assert.Equal(TripEditorGeocodeProviderStatus.Malformed, result.Status);
+    }
+
+    [Fact]
+    public async Task NominatimProviderPropagatesCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var handler = new CancelingHandler(cancellation);
+        var provider = new NominatimTripEditorGeocodeProvider(new HttpClient(handler), Options.Create(new TripEditorGeocodeOptions()));
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() => provider.SearchAsync("athens", 6, cancellation.Token));
+    }
+
+    private static TripEditorGeocodeSearchService BuildService(FakeProvider provider, FakeClock clock) =>
+        new(
+            provider,
+            new MemoryCache(new MemoryCacheOptions()),
+            new TripEditorGeocodeRateLimiter(clock),
+            Options.Create(new TripEditorGeocodeOptions { CacheSeconds = 60, MinimumIntervalMilliseconds = 1000 }));
+
+    private static NominatimTripEditorGeocodeProvider BuildNominatimProvider(string response) =>
+        new(
+            new HttpClient(new CapturingHandler(HttpStatusCode.OK, response)),
+            Options.Create(new TripEditorGeocodeOptions { NominatimSearchEndpoint = "https://nominatim.openstreetmap.org/search" }));
+
+    private sealed class FakeProvider : ITripEditorGeocodeProvider
+    {
+        public int CallCount { get; private set; }
+
+        public TripEditorGeocodeProviderResult Result { get; init; } =
+            TripEditorGeocodeProviderResult.Success(new EditorGeocodeSearchResponseDto("athens", "Data source", new[]
+            {
+                new EditorGeocodeSearchResultDto("nominatim:1", "nominatim", "Athens", "Athens, Greece", "Greece", "place", "city", 37.9838, 23.7275)
+            }));
+
+        public Task<TripEditorGeocodeProviderResult> SearchAsync(string query, int limit, CancellationToken cancellationToken)
+        {
+            CallCount += 1;
+            return Task.FromResult(Result);
+        }
+    }
+
+    private sealed class FakeClock : ITripEditorGeocodeClock
+    {
+        public DateTimeOffset UtcNow { get; private set; } = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        public void Advance(TimeSpan value)
+        {
+            UtcNow = UtcNow.Add(value);
+        }
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _response;
+
+        public CapturingHandler(HttpStatusCode statusCode, string response)
+        {
+            _statusCode = statusCode;
+            _response = response;
+        }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_response, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class CancelingHandler : HttpMessageHandler
+    {
+        private readonly CancellationTokenSource _cancellation;
+
+        public CancelingHandler(CancellationTokenSource cancellation)
+        {
+            _cancellation = cancellation;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _cancellation.Cancel();
+            throw new TaskCanceledException("Caller canceled request.");
+        }
+    }
+}

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -349,16 +349,14 @@ async function dragFirstEditableVertex(page: Page): Promise<void> {
   await page.evaluate(() => window.scrollTo(0, 0));
   const vertex = page.locator('.leaflet-editing-icon').first();
   await expect(vertex).toBeVisible();
-  await vertex.evaluate(element => {
-    const box = element.getBoundingClientRect();
-    const startX = box.left + box.width / 2;
-    const startY = box.top + box.height / 2;
-    const endX = startX + 96;
-    const endY = startY + 72;
-    element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, buttons: 1, clientX: startX, clientY: startY, pointerId: 1, pointerType: 'mouse', view: window }));
-    document.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, cancelable: true, buttons: 1, clientX: endX, clientY: endY, pointerId: 1, pointerType: 'mouse', view: window }));
-    document.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, cancelable: true, clientX: endX, clientY: endY, pointerId: 1, pointerType: 'mouse', view: window }));
-  });
+  const box = await vertex.boundingBox();
+  expect(box, 'Editable area vertex should have a browser-visible box before dragging.').not.toBeNull();
+  const startX = box!.x + box!.width / 2;
+  const startY = box!.y + box!.height / 2;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + 96, startY + 72, { steps: 8 });
+  await page.mouse.up();
   await page.waitForTimeout(250);
 }
 

--- a/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
@@ -91,6 +91,82 @@ test.describe('Trip Editor map geocode search', () => {
     await expect(mapSearch).toContainText('Map search provider is unavailable.');
   });
 
+  test('clearing a pending map search aborts without surfacing stale errors', async ({ page }) => {
+    await signIn(page);
+    const pageErrors = collectPageErrors(page);
+    let releaseOldRequest: ((status: number) => void) | null = null;
+    let resolveOldRequest: () => void = () => undefined;
+    const oldRequest = new Promise<void>(resolve => {
+      resolveOldRequest = resolve;
+    });
+    await routeGeocode(page, async route => {
+      resolveOldRequest();
+      const status = await new Promise<number>(release => {
+        releaseOldRequest = release;
+      });
+      await route.fulfill({ status, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+    const mapSearch = page.getByRole('region', { name: 'Map search' });
+
+    await runSearch(page, 'aborted clear search');
+    await oldRequest;
+    await expect(mapSearch).toContainText('Searching map...');
+
+    await page.getByRole('searchbox', { name: 'Map search' }).fill('');
+    releaseOldRequest?.(503);
+    await page.waitForTimeout(100);
+
+    await expect(mapSearch).not.toContainText('Map search provider is unavailable.');
+    await expect(mapSearch).not.toContainText('Map search failed.');
+    await expect(mapSearch.getByText('Stale Clear Result')).toHaveCount(0);
+    expect(pageErrors()).toEqual([]);
+  });
+
+  test('newer map search aborts an older pending request without rendering stale results', async ({ page }) => {
+    await signIn(page);
+    const pageErrors = collectPageErrors(page);
+    let requestCount = 0;
+    let releaseOldRequest: (() => void) | null = null;
+    let resolveOldRequest: () => void = () => undefined;
+    const oldRequest = new Promise<void>(resolve => {
+      resolveOldRequest = resolve;
+    });
+    await routeGeocode(page, async route => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        resolveOldRequest();
+        await new Promise<void>(release => {
+          releaseOldRequest = release;
+        });
+        await fulfillGeocode(route, [result('Stale Older Result')], 'older pending search');
+        return;
+      }
+
+      await fulfillGeocode(route, [result('Current Newer Result')], 'newer replacement search');
+    });
+
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+    const mapSearch = page.getByRole('region', { name: 'Map search' });
+
+    await runSearch(page, 'older pending search');
+    await oldRequest;
+    await expect(mapSearch).toContainText('Searching map...');
+
+    await page.getByRole('searchbox', { name: 'Map search' }).fill('newer replacement search');
+    await page.getByRole('searchbox', { name: 'Map search' }).press('Enter');
+    await expect(mapSearch.getByRole('button', { name: 'Current Newer Result' })).toBeVisible();
+
+    releaseOldRequest?.();
+    await page.waitForTimeout(100);
+    await expect(mapSearch.getByText('Stale Older Result')).toHaveCount(0);
+    await expect(mapSearch).not.toContainText('Map search failed.');
+    expect(pageErrors()).toEqual([]);
+  });
+
   test('map search accepts normalized response query echoes without dropping current results', async ({ page }) => {
     await signIn(page);
     await routeGeocode(page, async route => {
@@ -252,6 +328,14 @@ function collectExternalProviderCalls(page: Page): () => string[] {
     }
   });
   return () => urls;
+}
+
+function collectPageErrors(page: Page): () => string[] {
+  const errors: string[] = [];
+  page.on('pageerror', error => {
+    errors.push(error.message);
+  });
+  return () => errors;
 }
 
 async function loadEditorState(page: Page): Promise<any> {

--- a/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
@@ -72,6 +72,7 @@ test.describe('Trip Editor map geocode search', () => {
     await page.getByRole('searchbox', { name: 'Map search' }).fill('first query');
     await mapSearch.getByRole('button', { name: 'Search' }).click();
     await expect(mapSearch).toContainText('Searching map...');
+    await expect(mapSearch.getByRole('button', { name: 'Search' })).toBeDisabled();
     mode = 'empty';
     await page.getByRole('searchbox', { name: 'Map search' }).fill('second query');
     await expect(mapSearch.getByText('Stale Result')).toHaveCount(0);
@@ -89,6 +90,53 @@ test.describe('Trip Editor map geocode search', () => {
     await page.getByRole('searchbox', { name: 'Map search' }).fill('provider unavailable');
     await page.getByRole('searchbox', { name: 'Map search' }).press('Enter');
     await expect(mapSearch).toContainText('Map search provider is unavailable.');
+  });
+
+  test('in-flight map search blocks duplicate Search and Enter submits until completion', async ({ page }) => {
+    await signIn(page);
+    let proxyCalls = 0;
+    let releaseFirstRequest: (() => void) | null = null;
+    let resolveFirstRequest: () => void = () => undefined;
+    const firstRequest = new Promise<void>(resolve => {
+      resolveFirstRequest = resolve;
+    });
+    await routeGeocode(page, async route => {
+      proxyCalls += 1;
+      const query = new URL(route.request().url()).searchParams.get('q') ?? '';
+      if (proxyCalls === 1) {
+        resolveFirstRequest();
+        await new Promise<void>(release => {
+          releaseFirstRequest = release;
+        });
+      }
+
+      await fulfillGeocode(route, [result(`Result for ${query}`)], query);
+    });
+
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+    const mapSearch = page.getByRole('region', { name: 'Map search' });
+    const searchInput = page.getByRole('searchbox', { name: 'Map search' });
+    const searchButton = mapSearch.getByRole('button', { name: 'Search' });
+
+    await searchInput.fill('first pending query');
+    await searchButton.click();
+    await firstRequest;
+    await expect(searchButton).toBeDisabled();
+
+    await searchInput.press('Enter');
+    await searchButton.click({ force: true });
+    await page.waitForTimeout(100);
+    expect(proxyCalls, 'In-flight Search and Enter submits must not issue another proxy request.').toBe(1);
+
+    releaseFirstRequest?.();
+    await expect(mapSearch.getByRole('button', { name: 'Result for first pending query' })).toBeVisible();
+    await expect(searchButton).toBeEnabled();
+
+    await searchInput.fill('second completed query');
+    await searchInput.press('Enter');
+    await expect(mapSearch.getByRole('button', { name: 'Result for second completed query' })).toBeVisible();
+    expect(proxyCalls).toBe(2);
   });
 
   test('clearing a pending map search aborts without surfacing stale errors', async ({ page }) => {
@@ -125,7 +173,7 @@ test.describe('Trip Editor map geocode search', () => {
     expect(pageErrors()).toEqual([]);
   });
 
-  test('newer map search aborts an older pending request without rendering stale results', async ({ page }) => {
+  test('query changes during a pending map search ignore stale older results before the next search', async ({ page }) => {
     await signIn(page);
     const pageErrors = collectPageErrors(page);
     let requestCount = 0;
@@ -155,15 +203,21 @@ test.describe('Trip Editor map geocode search', () => {
     await runSearch(page, 'older pending search');
     await oldRequest;
     await expect(mapSearch).toContainText('Searching map...');
+    await expect(mapSearch.getByRole('button', { name: 'Search' })).toBeDisabled();
 
     await page.getByRole('searchbox', { name: 'Map search' }).fill('newer replacement search');
     await page.getByRole('searchbox', { name: 'Map search' }).press('Enter');
-    await expect(mapSearch.getByRole('button', { name: 'Current Newer Result' })).toBeVisible();
+    expect(requestCount, 'Enter must not start a replacement request while the first search is pending.').toBe(1);
 
     releaseOldRequest?.();
+    await expect(mapSearch.getByRole('button', { name: 'Search' })).toBeEnabled();
     await page.waitForTimeout(100);
     await expect(mapSearch.getByText('Stale Older Result')).toHaveCount(0);
     await expect(mapSearch).not.toContainText('Map search failed.');
+
+    await page.getByRole('searchbox', { name: 'Map search' }).press('Enter');
+    await expect(mapSearch.getByRole('button', { name: 'Current Newer Result' })).toBeVisible();
+    expect(requestCount).toBe(2);
     expect(pageErrors()).toEqual([]);
   });
 

--- a/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
@@ -91,6 +91,25 @@ test.describe('Trip Editor map geocode search', () => {
     await expect(mapSearch).toContainText('Map search provider is unavailable.');
   });
 
+  test('map search accepts normalized response query echoes without dropping current results', async ({ page }) => {
+    await signIn(page);
+    await routeGeocode(page, async route => {
+      const query = new URL(route.request().url()).searchParams.get('q') ?? '';
+      const normalized = query.trim().split(/\s+/u).join(' ').toLowerCase();
+      await fulfillGeocode(route, [result(`Result for ${normalized}`)], normalized);
+    });
+
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+    const mapSearch = page.getByRole('region', { name: 'Map search' });
+
+    await runSearch(page, 'Athens');
+    await expect(mapSearch.getByRole('button', { name: 'Result for athens' })).toBeVisible();
+
+    await runSearch(page, 'athens   acropolis');
+    await expect(mapSearch.getByRole('button', { name: 'Result for athens acropolis' })).toBeVisible();
+  });
+
   test('result preview marker appears, clears, and search-add opens the existing Add Place draft without saving', async ({ page }) => {
     await signIn(page);
     let saveCalls = 0;

--- a/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
@@ -1,0 +1,277 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+import {
+  absoluteUrl,
+  closeDraftWithDiscard,
+  config,
+  editorApiPath,
+  expectMountedWorkspace,
+  signIn,
+  workspacePath
+} from './tripEditorTestUtils';
+
+const geocodePath = /\/api\/trips\/[^/]+\/editor\/geocode\/search/i;
+const externalProvider = /nominatim\.openstreetmap\.org|photon\.komoot\.io|api\.mapbox\.com|maps\.googleapis\.com/i;
+
+test.describe('Trip Editor map geocode search', () => {
+  test('map search is separate from sidebar search and uses explicit proxy triggers', async ({ page }) => {
+    await signIn(page);
+    const externalCalls = collectExternalProviderCalls(page);
+    let proxyCalls = 0;
+    await routeGeocode(page, async route => {
+      proxyCalls += 1;
+      await fulfillGeocode(route, [result('Mock Acropolis')]);
+    });
+
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    await page.getByLabel('Sidebar search').fill('ath');
+    await expect(page.getByRole('searchbox', { name: 'Map search' })).toBeVisible();
+    expect(proxyCalls, 'Sidebar search and map-search typing should not call the geocode proxy.').toBe(0);
+
+    const mapSearch = page.getByRole('region', { name: 'Map search' });
+    await expect(mapSearch.getByRole('button', { name: 'Search' })).toBeDisabled();
+    await page.getByRole('searchbox', { name: 'Map search' }).fill('ac');
+    await expect(mapSearch.getByRole('button', { name: 'Search' })).toBeDisabled();
+    await page.getByRole('searchbox', { name: 'Map search' }).fill('acropolis');
+    expect(proxyCalls, 'Typing alone should not call the geocode proxy.').toBe(0);
+
+    await mapSearch.getByRole('button', { name: 'Search' }).click();
+    await expect(mapSearch.getByRole('button', { name: 'Mock Acropolis' })).toBeVisible();
+    expect(proxyCalls).toBe(1);
+
+    await page.getByRole('searchbox', { name: 'Map search' }).fill('parthenon');
+    await page.getByRole('searchbox', { name: 'Map search' }).press('Enter');
+    await expect(mapSearch.getByRole('button', { name: 'Mock Acropolis' })).toBeVisible();
+    expect(proxyCalls).toBe(2);
+    expect(externalCalls()).toEqual([]);
+  });
+
+  test('map search renders loading, no-results, rate-limit, unavailable, and stale-response states', async ({ page }) => {
+    await signIn(page);
+    let mode: 'slow' | 'empty' | 'rate' | 'unavailable' = 'slow';
+    await routeGeocode(page, async route => {
+      if (mode === 'slow') {
+        await new Promise(resolve => setTimeout(resolve, 250));
+        await fulfillGeocode(route, [result('Stale Result')], 'first query');
+        return;
+      }
+
+      if (mode === 'empty') {
+        await fulfillGeocode(route, []);
+        return;
+      }
+
+      await route.fulfill({ status: mode === 'rate' ? 429 : 503, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+    const mapSearch = page.getByRole('region', { name: 'Map search' });
+
+    await page.getByRole('searchbox', { name: 'Map search' }).fill('first query');
+    await mapSearch.getByRole('button', { name: 'Search' }).click();
+    await expect(mapSearch).toContainText('Searching map...');
+    mode = 'empty';
+    await page.getByRole('searchbox', { name: 'Map search' }).fill('second query');
+    await expect(mapSearch.getByText('Stale Result')).toHaveCount(0);
+    await expect(mapSearch.getByRole('button', { name: 'Search' })).toBeEnabled();
+    await page.getByRole('searchbox', { name: 'Map search' }).press('Enter');
+    await expect(mapSearch).toContainText('No map search results.');
+    await expect(mapSearch.getByText('Stale Result')).toHaveCount(0);
+
+    mode = 'rate';
+    await page.getByRole('searchbox', { name: 'Map search' }).fill('rate limit');
+    await page.getByRole('searchbox', { name: 'Map search' }).press('Enter');
+    await expect(mapSearch).toContainText('Map search is rate limited.');
+
+    mode = 'unavailable';
+    await page.getByRole('searchbox', { name: 'Map search' }).fill('provider unavailable');
+    await page.getByRole('searchbox', { name: 'Map search' }).press('Enter');
+    await expect(mapSearch).toContainText('Map search provider is unavailable.');
+  });
+
+  test('result preview marker appears, clears, and search-add opens the existing Add Place draft without saving', async ({ page }) => {
+    await signIn(page);
+    let saveCalls = 0;
+    await page.route('**/api/trips/*/editor/regions/*/places', async route => {
+      saveCalls += 1;
+      await route.fallback();
+    });
+    await routeGeocode(page, async route => fulfillGeocode(route, [result('Preview Place')]));
+
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+    await runSearch(page, 'preview place');
+    await page.getByRole('button', { name: 'Preview Place' }).click();
+    await expect(page.locator('img[alt="Search result preview: Preview Place"]')).toBeVisible();
+
+    await page.getByRole('searchbox', { name: 'Map search' }).fill('');
+    await expect(page.locator('img[alt="Search result preview: Preview Place"]')).toHaveCount(0);
+
+    await runSearch(page, 'preview place');
+    await page.getByRole('button', { name: 'Preview Place' }).click();
+    await addSelectedResult(page);
+    await expect(page.getByRole('heading', { name: 'Add Place' })).toBeVisible();
+    await expect(page.getByLabel('Name')).toHaveValue('Preview Place');
+    await expect(page.getByLabel('Address')).toHaveValue('Athens, Greece');
+    await expect(page.getByLabel('Latitude')).toHaveValue('37.9715');
+    await expect(page.getByLabel('Longitude')).toHaveValue('23.7257');
+    await expect(page.getByLabel('Reverse geocode this location on save')).not.toBeChecked();
+    await expect(page.locator('img[alt="Search result preview: Preview Place"]')).toHaveCount(0);
+    expect(saveCalls, 'Search-add should only open a draft; Save Place owns persistence.').toBe(0);
+    await closeDraftWithDiscard(page);
+  });
+
+  test('target region selector excludes shadow regions and handles eligibility defaults', async ({ page }) => {
+    await signIn(page);
+    const baseState = await loadEditorState(page);
+    await routeEditorState(page, withOneEligibleRegion(baseState));
+    await routeGeocode(page, async route => fulfillGeocode(route, [result('Eligible Place')]));
+
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+    await runSearch(page, 'eligible place');
+    await page.getByRole('button', { name: 'Eligible Place' }).click();
+    const select = page.getByLabel('Target region');
+    await expect(select).toBeDisabled();
+    await expect(select).not.toContainText('Unassigned Places');
+
+    await routeEditorState(page, withNoEligibleRegions(baseState));
+    await page.reload();
+    await expectMountedWorkspace(page);
+    await runSearch(page, 'eligible place');
+    await page.getByRole('button', { name: 'Eligible Place' }).click();
+    await expect(page.getByText('No editable region is available for this search result.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add as place' })).toBeDisabled();
+
+    await routeEditorState(page, withTwoEligibleRegions(baseState));
+    await page.reload();
+    await expectMountedWorkspace(page);
+    await runSearch(page, 'eligible place');
+    await page.getByRole('button', { name: 'Eligible Place' }).click();
+    await expect(page.getByLabel('Target region')).toBeEnabled();
+    await expect(page.getByLabel('Target region')).toHaveValue('');
+    await expect(page.getByRole('button', { name: 'Add as place' })).toBeDisabled();
+  });
+
+  test('dirty active draft prompts before search-add opens Add Place', async ({ page }) => {
+    await signIn(page);
+    await routeGeocode(page, async route => fulfillGeocode(route, [result('Prompt Place')]));
+    await page.goto(absoluteUrl(workspacePath));
+    await expectMountedWorkspace(page);
+
+    await page.getByRole('button', { name: 'Add Region' }).click();
+    await page.getByLabel('Name').fill('Dirty draft before search add');
+    await runSearch(page, 'prompt place');
+    await page.getByRole('button', { name: 'Prompt Place' }).click();
+    await addSelectedResult(page);
+
+    const dialog = page.getByRole('dialog', { name: 'Discard changes?' });
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: 'Discard' }).click();
+    await expect(page.getByRole('heading', { name: 'Add Place' })).toBeVisible();
+    await expect(page.getByLabel('Name')).toHaveValue('Prompt Place');
+    await closeDraftWithDiscard(page);
+  });
+});
+
+async function runSearch(page: Page, query: string): Promise<void> {
+  await page.getByRole('searchbox', { name: 'Map search' }).fill(query);
+  await page.getByRole('region', { name: 'Map search' }).getByRole('button', { name: 'Search' }).click();
+}
+
+async function addSelectedResult(page: Page): Promise<void> {
+  const select = page.getByLabel('Target region');
+  if (await select.isEnabled()) {
+    const options = await select.locator('option').evaluateAll(nodes => nodes.map(option => ({ value: (option as HTMLOptionElement).value, text: option.textContent ?? '' })));
+    const normal = options.find(option => option.value);
+    if (normal) {
+      await select.selectOption(normal.value);
+    }
+  }
+
+  await page.getByRole('button', { name: 'Add as place' }).click();
+}
+
+async function routeGeocode(page: Page, handler: (route: Route) => Promise<void>): Promise<void> {
+  await page.route(geocodePath, handler);
+}
+
+async function fulfillGeocode(route: Route, results: unknown[], query?: string): Promise<void> {
+  const echoedQuery = query ?? new URL(route.request().url()).searchParams.get('q') ?? '';
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      query: echoedQuery,
+      attribution: 'Data source attribution',
+      results
+    })
+  });
+}
+
+function result(name: string): unknown {
+  return {
+    id: `nominatim:${name}`,
+    provider: 'nominatim',
+    name,
+    displayName: `${name}, Athens, Greece`,
+    address: 'Athens, Greece',
+    category: 'tourism',
+    type: 'attraction',
+    latitude: 37.9715,
+    longitude: 23.7257
+  };
+}
+
+function collectExternalProviderCalls(page: Page): () => string[] {
+  const urls: string[] = [];
+  page.on('request', request => {
+    if (externalProvider.test(request.url())) {
+      urls.push(request.url());
+    }
+  });
+  return () => urls;
+}
+
+async function loadEditorState(page: Page): Promise<any> {
+  const response = await page.request.get(absoluteUrl(editorApiPath), { headers: { Accept: 'application/json' } });
+  expect(response.ok()).toBeTruthy();
+  return await response.json();
+}
+
+async function routeEditorState(page: Page, state: any): Promise<void> {
+  await page.unroute(`**${editorApiPath}`).catch(() => undefined);
+  await page.route(`**${editorApiPath}`, async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+  });
+}
+
+function withNoEligibleRegions(state: any): any {
+  const clone = structuredClone(state);
+  for (const region of Object.values<any>(clone.regionsById)) {
+    region.capabilities.canAddChildren = false;
+    region.capabilities.canTargetForSearchAdd = false;
+  }
+  return clone;
+}
+
+function withOneEligibleRegion(state: any): any {
+  const clone = withNoEligibleRegions(state);
+  const region = Object.values<any>(clone.regionsById).find(region => !region.isShadow);
+  region.capabilities.canAddChildren = true;
+  region.capabilities.canTargetForSearchAdd = true;
+  return clone;
+}
+
+function withTwoEligibleRegions(state: any): any {
+  const clone = withOneEligibleRegion(state);
+  const first = Object.values<any>(clone.regionsById).find(region => !region.isShadow);
+  const second = { ...first, id: '11111111-1111-4111-8111-111111111111', name: 'Second Search Target', displayOrder: 999 };
+  clone.regionsById[second.id] = second;
+  clone.regionOrder = [...clone.regionOrder, second.id];
+  clone.placeOrderByRegionId[second.id] = [];
+  clone.areaOrderByRegionId[second.id] = [];
+  return clone;
+}


### PR DESCRIPTION
## Summary
- Added authenticated Trip Editor geocode search proxy.
- Added Nominatim provider behind backend abstraction.
- Browser calls only same-origin `/api/trips/{tripId}/editor/geocode/search`.
- Added app-wide rate limiting, short cache, deterministic provider status mapping, attribution, User-Agent/Referer handling, and caller cancellation propagation.
- Removed fake geocode contact identity; default geocode User-Agent is plain `Wayfarer/1.0`, configured `TripEditorGeocode:NominatimUserAgent` wins.
- Updated shadow search-add targeting so shadow/unassigned region is not targetable.
- Added map search UI with explicit Search/Enter trigger, no request on typing, abort/stale-response handling, result states, preview marker, and cleanup.
- Added search-add draft workflow using explicit normal-region selector and existing Add Place draft path.
- Add as place populates name/address/location, keeps default icon/color, sets reverseGeocode false, and does not save until Save Place.

Closes #262

## Scope exclusions
- no browser-direct Nominatim/external provider calls
- no reverse-geocode save behavior changes
- no unrelated area/place/segment behavior changes
- no marker drag
- no final cutover
- no legacy behavior changes
- no mobile/API token contract changes

## Validation
- in-flight Search blocker fixed in ec7d59e
- latest GitHub checks passed
- dotnet build passed, existing ASP0000 warning only
- dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --filter TripEditor passed, 158 tests
- full dotnet test passed earlier in branch, 1588 tests
- npm run build passed
- npx playwright test --config=playwright.config.ts --list passed, 57 tests listed
- focused map-search Playwright spec passed earlier in branch, 8/8
- full npm run test:e2e:trip-editor passed earlier in branch, 56 passed / 1 skipped
- final local browser E2E was not run because ASP.NET/Vite were unavailable in the final review session
- LOC checker passed with accepted warnings
- rg "window\\.confirm" no matches
- rg "\\bconfirm\\(" reviewed shared confirm usages only
- browser-direct provider scan found no Trip Editor frontend direct external provider calls
- git diff --check origin/main...HEAD passed

## Note
- `noreply@wayfarer.app` remains only in pre-existing tile-provider code/tests, not in geocode code/options/tests.
- The one E2E skip is the existing fixture-dependent sidebar shadow-child check.
