### PR TITLE
[Trip Editor] Add rich notes parity

### DIFF
--- a/ClientApps/trip-editor/src/components/AreaEditorForm.vue
+++ b/ClientApps/trip-editor/src/components/AreaEditorForm.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { EditorAreaDraft } from '../types';
+import RichNotesEditor from './RichNotesEditor.vue';
 
 const props = defineProps<{
   draft: EditorAreaDraft;
@@ -32,11 +33,7 @@ const geometryStatus = computed(() => {
       <small v-for="message in props.fieldErrors('name')" :key="message">{{ message }}</small>
     </label>
 
-    <label class="trip-editor-field">
-      <span>Notes HTML</span>
-      <textarea v-model="props.draft.notesHtml" rows="6"></textarea>
-      <small v-for="message in props.fieldErrors('notesHtml')" :key="message">{{ message }}</small>
-    </label>
+    <RichNotesEditor :editor-id="`${props.formId}-notes`" v-model="props.draft.notesHtml" label="Notes" :validation-messages="props.fieldErrors('notesHtml')" />
 
     <div class="trip-editor-grid">
       <label class="trip-editor-field">

--- a/ClientApps/trip-editor/src/components/MetadataEditor.vue
+++ b/ClientApps/trip-editor/src/components/MetadataEditor.vue
@@ -4,6 +4,7 @@ import { EditorValidationError, patchMetadata, patchShareProgress, putTags, sugg
 import { confirm } from '../composables/useConfirmDialog';
 import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
 import EditorSurface from './EditorSurface.vue';
+import RichNotesEditor from './RichNotesEditor.vue';
 import type {
   EditorMutationResult,
   EditorOptions,
@@ -435,11 +436,7 @@ const fieldErrors = (key: string): string[] => validationErrors.value[key] ?? []
           </template>
         </section>
 
-        <label class="trip-editor-field">
-          <span>Notes HTML</span>
-          <textarea v-model="draft.notesHtml" rows="7"></textarea>
-          <small v-for="message in fieldErrors('notesHtml')" :key="message">{{ message }}</small>
-        </label>
+        <RichNotesEditor editor-id="trip-editor-metadata-notes" v-model="draft.notesHtml" label="Notes" :validation-messages="fieldErrors('notesHtml')" />
 
         <label class="trip-editor-field">
           <span>Cover Image URL</span>

--- a/ClientApps/trip-editor/src/components/MetadataEditor.vue
+++ b/ClientApps/trip-editor/src/components/MetadataEditor.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
 import { EditorValidationError, patchMetadata, patchShareProgress, putTags, suggestTags } from '../api/tripEditorApi';
 import { confirm } from '../composables/useConfirmDialog';
 import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
+import { normalizeNotesHtml } from '../notes/notesHtml';
 import EditorSurface from './EditorSurface.vue';
 import RichNotesEditor from './RichNotesEditor.vue';
 import type {
@@ -307,7 +308,7 @@ function toMetadataDraft(metadata: EditorTripMetadata): Omit<MetadataDraft, 'tag
     name: metadata.name,
     isPublic: metadata.isPublic,
     shareProgressEnabled: metadata.isPublic && metadata.shareProgressEnabled,
-    notesHtml: metadata.notesHtml,
+    notesHtml: normalizeNotesHtml(metadata.notesHtml),
     coverImageRawUrl: metadata.coverImage?.rawUrl ?? '',
     centerLatitude: metadata.center ? String(metadata.center.latitude) : '',
     centerLongitude: metadata.center ? String(metadata.center.longitude) : '',
@@ -332,7 +333,7 @@ function buildMetadataRequest(value: MetadataDraft): EditorTripMetadataUpdateReq
 
   return {
     name: value.name,
-    notesHtml: value.notesHtml,
+    notesHtml: normalizeNotesHtml(value.notesHtml),
     isPublic: value.isPublic,
     coverImage: coverImageRawUrl ? { rawUrl: coverImageRawUrl } : null,
     center: hasPartialCenter

--- a/ClientApps/trip-editor/src/components/PlaceEditorForm.vue
+++ b/ClientApps/trip-editor/src/components/PlaceEditorForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { EditorPlace, EditorPlaceDraft, EditorRegion, EditorTripState } from '../types';
+import RichNotesEditor from './RichNotesEditor.vue';
 
 const props = defineProps<{
   activePlace: EditorPlace | null;
@@ -42,11 +43,7 @@ const markerColorLabel = (color: string): string => {
       <small v-for="message in props.fieldErrors('name')" :key="message">{{ message }}</small>
     </label>
 
-    <label class="trip-editor-field">
-      <span>Notes HTML</span>
-      <textarea v-model="props.draft.notesHtml" rows="6"></textarea>
-      <small v-for="message in props.fieldErrors('notesHtml')" :key="message">{{ message }}</small>
-    </label>
+    <RichNotesEditor :editor-id="`${props.formId}-notes`" v-model="props.draft.notesHtml" label="Notes" :validation-messages="props.fieldErrors('notesHtml')" />
 
     <label class="trip-editor-field">
       <span>Address</span>

--- a/ClientApps/trip-editor/src/components/RegionEditorForm.vue
+++ b/ClientApps/trip-editor/src/components/RegionEditorForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { EditorRegion } from '../types';
+import RichNotesEditor from './RichNotesEditor.vue';
 import type { RegionDraft } from './regionPlaceDrafts';
 
 const props = defineProps<{
@@ -28,11 +29,7 @@ const emit = defineEmits<{
       <small v-for="message in props.fieldErrors('name')" :key="message">{{ message }}</small>
     </label>
 
-    <label class="trip-editor-field">
-      <span>Notes HTML</span>
-      <textarea v-model="props.draft.notesHtml" rows="6"></textarea>
-      <small v-for="message in props.fieldErrors('notesHtml')" :key="message">{{ message }}</small>
-    </label>
+    <RichNotesEditor :editor-id="`${props.formId}-notes`" v-model="props.draft.notesHtml" label="Notes" :validation-messages="props.fieldErrors('notesHtml')" />
 
     <label class="trip-editor-field">
       <span>Cover Image URL</span>

--- a/ClientApps/trip-editor/src/components/RichNotesEditor.vue
+++ b/ClientApps/trip-editor/src/components/RichNotesEditor.vue
@@ -262,7 +262,7 @@ function showFeedback(message: string): void {
     <Teleport to="body">
       <div v-if="isImageDialogOpen" class="trip-editor-rich-notes-dialog" role="dialog" aria-modal="true" aria-labelledby="trip-editor-rich-notes-image-title">
         <div class="trip-editor-rich-notes-dialog__backdrop" aria-hidden="true"></div>
-        <form class="trip-editor-rich-notes-dialog__panel" @submit.prevent="insertImageUrl">
+        <form class="trip-editor-rich-notes-dialog__panel" novalidate @submit.prevent="insertImageUrl">
           <h2 id="trip-editor-rich-notes-image-title">Insert image URL</h2>
           <label class="trip-editor-field">
             <span>Image URL</span>

--- a/ClientApps/trip-editor/src/components/RichNotesEditor.vue
+++ b/ClientApps/trip-editor/src/components/RichNotesEditor.vue
@@ -59,6 +59,7 @@ onMounted(() => {
   quill.on('text-change', handleTextChange);
   quill.root.addEventListener('paste', handlePaste);
   quill.root.addEventListener('drop', handleDrop);
+  quill.root.addEventListener('input', handleInput);
 });
 
 onUnmounted(() => {
@@ -72,6 +73,7 @@ onUnmounted(() => {
 
   quill.root.removeEventListener('paste', handlePaste);
   quill.root.removeEventListener('drop', handleDrop);
+  quill.root.removeEventListener('input', handleInput);
   quill.off('selection-change', handleSelectionChange);
   quill.off('text-change', handleTextChange);
   quill = null;
@@ -96,7 +98,7 @@ function loadHtml(value: string): void {
   isLoadingExternalValue = true;
   quill.setContents([], 'silent');
   quill.clipboard.dangerouslyPasteHTML(normalizeHtml(value), 'silent');
-  removeDataImages();
+  removeUnsafeEditorImages();
   isLoadingExternalValue = false;
 }
 
@@ -111,7 +113,7 @@ function handleTextChange(): void {
     return;
   }
 
-  if (removeDataImages()) {
+  if (removeUnsafeEditorImages()) {
     showFeedback('Embedded data images are not allowed. Use an external image URL.');
   }
 
@@ -138,12 +140,19 @@ function handleDrop(event: DragEvent): void {
   showFeedback('Embedded data images are not allowed. Use an external image URL.');
 }
 
+function handleInput(): void {
+  if (removeUnsafeEditorImages()) {
+    emit('update:modelValue', currentHtml());
+    showFeedback('Embedded data images are not allowed. Use an external image URL.');
+  }
+}
+
 function containsDataImage(data: DataTransfer): boolean {
   if (Array.from(data.files).some(file => file.type.startsWith('image/'))) {
     return true;
   }
 
-  return ['text/html', 'text/plain'].some(type => (data.getData(type) ?? '').includes('data:image'));
+  return ['text/html', 'text/plain'].some(type => containsDataImageReference(data.getData(type) ?? ''));
 }
 
 function openImageDialog(): void {
@@ -170,6 +179,12 @@ function insertImageUrl(): void {
   }
 
   const url = imageUrl.value.trim();
+  if (isDataImageSource(url)) {
+    imageUrlError.value = 'Embedded data images are not allowed. Use an external image URL.';
+    showFeedback('Embedded data images are not allowed. Use an external image URL.');
+    return;
+  }
+
   if (!isExternalImageUrl(url)) {
     imageUrlError.value = 'Enter an http or https image URL.';
     return;
@@ -200,15 +215,15 @@ function currentHtml(): string {
   return normalizeHtml(quill.root.innerHTML);
 }
 
-function removeDataImages(): boolean {
+function removeUnsafeEditorImages(): boolean {
   if (!quill) {
     return false;
   }
 
   let removed = false;
   quill.root.querySelectorAll<HTMLImageElement>('img').forEach(image => {
-    const source = image.getAttribute('src') ?? '';
-    if (source.startsWith('data:image')) {
+    const source = canonicalImageSource(image.getAttribute('src') ?? '');
+    if (isUnsafeImageSource(source)) {
       image.remove();
       removed = true;
     }
@@ -219,9 +234,20 @@ function removeDataImages(): boolean {
 function normalizeHtml(value: string): string {
   const template = document.createElement('template');
   template.innerHTML = value.trim();
+
+  // Keep draft storage independent from Quill's raw HTML export quirks.
+  template.content.querySelectorAll('script, style, iframe, object, embed, link, meta, base, form, input, button, textarea, select, option').forEach(element => {
+    element.remove();
+  });
   template.content.querySelectorAll('*').forEach(element => {
     Array.from(element.attributes).forEach(attribute => {
-      if (attribute.name.startsWith('data-') || attribute.name === 'contenteditable') {
+      if (
+        attribute.name.startsWith('data-') ||
+        attribute.name === 'contenteditable' ||
+        attribute.name === 'srcdoc' ||
+        attribute.name.startsWith('on') ||
+        isUnsafeAttributeUrl(element, attribute.name, attribute.value)
+      ) {
         element.removeAttribute(attribute.name);
       }
     });
@@ -229,7 +255,7 @@ function normalizeHtml(value: string): string {
   template.content.querySelectorAll<HTMLImageElement>('img').forEach(image => {
     const source = image.getAttribute('src') ?? '';
     const originalSource = canonicalImageSource(source);
-    if (originalSource.startsWith('data:image')) {
+    if (isUnsafeImageSource(originalSource)) {
       image.remove();
       return;
     }
@@ -246,16 +272,56 @@ function normalizeHtml(value: string): string {
 }
 
 function canonicalImageSource(value: string): string {
-  if (!value.startsWith('/Public/ProxyImage')) {
-    return value;
+  const trimmedValue = stripUrlBoundaryControls(value);
+  if (!trimmedValue.startsWith('/Public/ProxyImage')) {
+    return trimmedValue;
   }
 
   try {
-    const url = new URL(value, window.location.origin);
-    return url.searchParams.get('url') ?? value;
+    const url = new URL(trimmedValue, window.location.origin);
+    return stripUrlBoundaryControls(url.searchParams.get('url') ?? trimmedValue);
   } catch {
-    return value;
+    return trimmedValue;
   }
+}
+
+function containsDataImageReference(value: string): boolean {
+  return compactUrlText(value).includes('data:image');
+}
+
+function isDataImageSource(value: string): boolean {
+  return compactUrlScheme(value).startsWith('data:image');
+}
+
+function isUnsafeImageSource(value: string): boolean {
+  const normalizedValue = compactUrlScheme(value);
+  return normalizedValue.startsWith('javascript:') || normalizedValue.startsWith('data:image');
+}
+
+function compactUrlScheme(value: string): string {
+  return compactUrlText(stripUrlBoundaryControls(value).slice(0, 64));
+}
+
+function compactUrlText(value: string): string {
+  return value.replace(/[\u0000-\u0020\u007f-\u009f]+/g, '').toLowerCase();
+}
+
+function stripUrlBoundaryControls(value: string): string {
+  return value.replace(/^[\u0000-\u0020\u007f-\u009f]+|[\u0000-\u0020\u007f-\u009f]+$/g, '');
+}
+
+function isUnsafeAttributeUrl(element: Element, name: string, value: string): boolean {
+  const normalizedName = name.toLowerCase();
+  if (normalizedName !== 'href' && normalizedName !== 'src' && normalizedName !== 'xlink:href') {
+    return false;
+  }
+
+  if (element instanceof HTMLImageElement && normalizedName === 'src') {
+    return false;
+  }
+
+  const normalizedValue = compactUrlScheme(value);
+  return normalizedValue.startsWith('javascript:') || normalizedValue.startsWith('data:');
 }
 
 function showFeedback(message: string): void {

--- a/ClientApps/trip-editor/src/components/RichNotesEditor.vue
+++ b/ClientApps/trip-editor/src/components/RichNotesEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import Quill, { type Range } from 'quill';
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { canonicalImageSource, containsDataImageReference, isDataImageSource, isUnsafeImageSource, normalizeNotesHtml } from '../notes/notesHtml';
 
 const props = defineProps<{
   editorId: string;
@@ -82,7 +83,7 @@ onUnmounted(() => {
 watch(
   () => props.modelValue,
   value => {
-    if (!quill || normalizeHtml(value) === currentHtml()) {
+    if (!quill || normalizeNotesHtml(value) === currentHtml()) {
       return;
     }
 
@@ -97,7 +98,7 @@ function loadHtml(value: string): void {
 
   isLoadingExternalValue = true;
   quill.setContents([], 'silent');
-  quill.clipboard.dangerouslyPasteHTML(normalizeHtml(value), 'silent');
+  quill.clipboard.dangerouslyPasteHTML(normalizeNotesHtml(value), 'silent');
   removeUnsafeEditorImages();
   isLoadingExternalValue = false;
 }
@@ -209,10 +210,10 @@ function isExternalImageUrl(value: string): boolean {
 
 function currentHtml(): string {
   if (!quill) {
-    return normalizeHtml(props.modelValue);
+    return normalizeNotesHtml(props.modelValue);
   }
 
-  return normalizeHtml(quill.root.innerHTML);
+  return normalizeNotesHtml(quill.root.innerHTML);
 }
 
 function removeUnsafeEditorImages(): boolean {
@@ -229,99 +230,6 @@ function removeUnsafeEditorImages(): boolean {
     }
   });
   return removed;
-}
-
-function normalizeHtml(value: string): string {
-  const template = document.createElement('template');
-  template.innerHTML = value.trim();
-
-  // Keep draft storage independent from Quill's raw HTML export quirks.
-  template.content.querySelectorAll('script, style, iframe, object, embed, link, meta, base, form, input, button, textarea, select, option').forEach(element => {
-    element.remove();
-  });
-  template.content.querySelectorAll('*').forEach(element => {
-    Array.from(element.attributes).forEach(attribute => {
-      if (
-        attribute.name.startsWith('data-') ||
-        attribute.name === 'contenteditable' ||
-        attribute.name === 'srcdoc' ||
-        attribute.name.startsWith('on') ||
-        isUnsafeAttributeUrl(element, attribute.name, attribute.value)
-      ) {
-        element.removeAttribute(attribute.name);
-      }
-    });
-  });
-  template.content.querySelectorAll<HTMLImageElement>('img').forEach(image => {
-    const source = image.getAttribute('src') ?? '';
-    const originalSource = canonicalImageSource(source);
-    if (isUnsafeImageSource(originalSource)) {
-      image.remove();
-      return;
-    }
-
-    image.setAttribute('src', originalSource);
-    image.removeAttribute('class');
-    image.removeAttribute('style');
-    image.removeAttribute('loading');
-    image.removeAttribute('decoding');
-  });
-
-  const html = template.innerHTML.trim();
-  return html === '<p><br></p>' ? '' : html;
-}
-
-function canonicalImageSource(value: string): string {
-  const trimmedValue = stripUrlBoundaryControls(value);
-  if (!trimmedValue.startsWith('/Public/ProxyImage')) {
-    return trimmedValue;
-  }
-
-  try {
-    const url = new URL(trimmedValue, window.location.origin);
-    return stripUrlBoundaryControls(url.searchParams.get('url') ?? trimmedValue);
-  } catch {
-    return trimmedValue;
-  }
-}
-
-function containsDataImageReference(value: string): boolean {
-  return compactUrlText(value).includes('data:image');
-}
-
-function isDataImageSource(value: string): boolean {
-  return compactUrlScheme(value).startsWith('data:image');
-}
-
-function isUnsafeImageSource(value: string): boolean {
-  const normalizedValue = compactUrlScheme(value);
-  return normalizedValue.startsWith('javascript:') || normalizedValue.startsWith('data:image');
-}
-
-function compactUrlScheme(value: string): string {
-  return compactUrlText(stripUrlBoundaryControls(value).slice(0, 64));
-}
-
-function compactUrlText(value: string): string {
-  return value.replace(/[\u0000-\u0020\u007f-\u009f]+/g, '').toLowerCase();
-}
-
-function stripUrlBoundaryControls(value: string): string {
-  return value.replace(/^[\u0000-\u0020\u007f-\u009f]+|[\u0000-\u0020\u007f-\u009f]+$/g, '');
-}
-
-function isUnsafeAttributeUrl(element: Element, name: string, value: string): boolean {
-  const normalizedName = name.toLowerCase();
-  if (normalizedName !== 'href' && normalizedName !== 'src' && normalizedName !== 'xlink:href') {
-    return false;
-  }
-
-  if (element instanceof HTMLImageElement && normalizedName === 'src') {
-    return false;
-  }
-
-  const normalizedValue = compactUrlScheme(value);
-  return normalizedValue.startsWith('javascript:') || normalizedValue.startsWith('data:');
 }
 
 function showFeedback(message: string): void {

--- a/ClientApps/trip-editor/src/components/RichNotesEditor.vue
+++ b/ClientApps/trip-editor/src/components/RichNotesEditor.vue
@@ -1,0 +1,306 @@
+<script setup lang="ts">
+import Quill, { type Range } from 'quill';
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+
+const props = defineProps<{
+  editorId: string;
+  label: string;
+  modelValue: string;
+  validationMessages: string[];
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string];
+}>();
+
+const editorHost = ref<HTMLDivElement | null>(null);
+const feedbackMessage = ref('');
+const isImageDialogOpen = ref(false);
+const imageUrl = ref('');
+const imageUrlError = ref('');
+const imageUrlInput = ref<HTMLInputElement | null>(null);
+const labelId = computed(() => `${props.editorId}-label`);
+const feedbackId = computed(() => `${props.editorId}-feedback`);
+let quill: Quill | null = null;
+let savedRange: Range | null = null;
+let isLoadingExternalValue = false;
+let feedbackTimer: number | null = null;
+
+const toolbarOptions = [
+  [{ header: [1, 2, 3, 4, 5, 6, false] }],
+  ['bold', 'italic', 'underline'],
+  [{ list: 'ordered' }, { list: 'bullet' }],
+  ['link', 'image'],
+  [{ font: [] }],
+  ['clean']
+];
+
+onMounted(() => {
+  if (!editorHost.value) {
+    return;
+  }
+
+  quill = new Quill(editorHost.value, {
+    modules: {
+      clipboard: { matchVisual: false },
+      toolbar: {
+        container: toolbarOptions,
+        handlers: {
+          image: openImageDialog
+        }
+      }
+    },
+    placeholder: 'Add your notes...',
+    theme: 'snow'
+  });
+
+  loadHtml(props.modelValue);
+  quill.on('selection-change', handleSelectionChange);
+  quill.on('text-change', handleTextChange);
+  quill.root.addEventListener('paste', handlePaste);
+  quill.root.addEventListener('drop', handleDrop);
+});
+
+onUnmounted(() => {
+  if (feedbackTimer !== null) {
+    window.clearTimeout(feedbackTimer);
+  }
+
+  if (!quill) {
+    return;
+  }
+
+  quill.root.removeEventListener('paste', handlePaste);
+  quill.root.removeEventListener('drop', handleDrop);
+  quill.off('selection-change', handleSelectionChange);
+  quill.off('text-change', handleTextChange);
+  quill = null;
+});
+
+watch(
+  () => props.modelValue,
+  value => {
+    if (!quill || normalizeHtml(value) === currentHtml()) {
+      return;
+    }
+
+    loadHtml(value);
+  }
+);
+
+function loadHtml(value: string): void {
+  if (!quill) {
+    return;
+  }
+
+  isLoadingExternalValue = true;
+  quill.setContents([], 'silent');
+  quill.clipboard.dangerouslyPasteHTML(normalizeHtml(value), 'silent');
+  removeDataImages();
+  isLoadingExternalValue = false;
+}
+
+function handleSelectionChange(range: Range | null): void {
+  if (range) {
+    savedRange = range;
+  }
+}
+
+function handleTextChange(): void {
+  if (!quill || isLoadingExternalValue) {
+    return;
+  }
+
+  if (removeDataImages()) {
+    showFeedback('Embedded data images are not allowed. Use an external image URL.');
+  }
+
+  emit('update:modelValue', currentHtml());
+}
+
+function handlePaste(event: ClipboardEvent): void {
+  const clipboard = event.clipboardData;
+  if (!clipboard || !containsDataImage(clipboard)) {
+    return;
+  }
+
+  event.preventDefault();
+  showFeedback('Embedded data images are not allowed. Use an external image URL.');
+}
+
+function handleDrop(event: DragEvent): void {
+  const transfer = event.dataTransfer;
+  if (!transfer || !containsDataImage(transfer)) {
+    return;
+  }
+
+  event.preventDefault();
+  showFeedback('Embedded data images are not allowed. Use an external image URL.');
+}
+
+function containsDataImage(data: DataTransfer): boolean {
+  if (Array.from(data.files).some(file => file.type.startsWith('image/'))) {
+    return true;
+  }
+
+  return ['text/html', 'text/plain'].some(type => (data.getData(type) ?? '').includes('data:image'));
+}
+
+function openImageDialog(): void {
+  if (!quill) {
+    return;
+  }
+
+  savedRange = quill.getSelection() ?? savedRange;
+  imageUrl.value = '';
+  imageUrlError.value = '';
+  isImageDialogOpen.value = true;
+  void nextTick(() => imageUrlInput.value?.focus());
+}
+
+function closeImageDialog(): void {
+  isImageDialogOpen.value = false;
+  imageUrl.value = '';
+  imageUrlError.value = '';
+}
+
+function insertImageUrl(): void {
+  if (!quill) {
+    return;
+  }
+
+  const url = imageUrl.value.trim();
+  if (!isExternalImageUrl(url)) {
+    imageUrlError.value = 'Enter an http or https image URL.';
+    return;
+  }
+
+  const index = savedRange ? savedRange.index : Math.max(0, quill.getLength() - 1);
+  quill.setSelection(index, savedRange?.length ?? 0, 'silent');
+  quill.insertEmbed(index, 'image', url, 'user');
+  quill.setSelection(index + 1, 0, 'silent');
+  emit('update:modelValue', currentHtml());
+  closeImageDialog();
+}
+
+function isExternalImageUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function currentHtml(): string {
+  if (!quill) {
+    return normalizeHtml(props.modelValue);
+  }
+
+  return normalizeHtml(quill.root.innerHTML);
+}
+
+function removeDataImages(): boolean {
+  if (!quill) {
+    return false;
+  }
+
+  let removed = false;
+  quill.root.querySelectorAll<HTMLImageElement>('img').forEach(image => {
+    const source = image.getAttribute('src') ?? '';
+    if (source.startsWith('data:image')) {
+      image.remove();
+      removed = true;
+    }
+  });
+  return removed;
+}
+
+function normalizeHtml(value: string): string {
+  const template = document.createElement('template');
+  template.innerHTML = value.trim();
+  template.content.querySelectorAll('*').forEach(element => {
+    Array.from(element.attributes).forEach(attribute => {
+      if (attribute.name.startsWith('data-') || attribute.name === 'contenteditable') {
+        element.removeAttribute(attribute.name);
+      }
+    });
+  });
+  template.content.querySelectorAll<HTMLImageElement>('img').forEach(image => {
+    const source = image.getAttribute('src') ?? '';
+    const originalSource = canonicalImageSource(source);
+    if (originalSource.startsWith('data:image')) {
+      image.remove();
+      return;
+    }
+
+    image.setAttribute('src', originalSource);
+    image.removeAttribute('class');
+    image.removeAttribute('style');
+    image.removeAttribute('loading');
+    image.removeAttribute('decoding');
+  });
+
+  const html = template.innerHTML.trim();
+  return html === '<p><br></p>' ? '' : html;
+}
+
+function canonicalImageSource(value: string): string {
+  if (!value.startsWith('/Public/ProxyImage')) {
+    return value;
+  }
+
+  try {
+    const url = new URL(value, window.location.origin);
+    return url.searchParams.get('url') ?? value;
+  } catch {
+    return value;
+  }
+}
+
+function showFeedback(message: string): void {
+  feedbackMessage.value = message;
+  if (feedbackTimer !== null) {
+    window.clearTimeout(feedbackTimer);
+  }
+
+  feedbackTimer = window.setTimeout(() => {
+    feedbackMessage.value = '';
+    feedbackTimer = null;
+  }, 5000);
+}
+</script>
+
+<template>
+  <div class="trip-editor-field trip-editor-rich-notes" :data-rich-notes-editor="props.editorId">
+    <span :id="labelId">{{ props.label }}</span>
+    <div
+      :id="props.editorId"
+      ref="editorHost"
+      class="trip-editor-rich-notes__editor"
+      role="group"
+      :aria-labelledby="labelId"
+      :aria-describedby="feedbackMessage ? feedbackId : undefined"
+    ></div>
+    <p v-if="feedbackMessage" :id="feedbackId" class="trip-editor-rich-notes__feedback" role="status">{{ feedbackMessage }}</p>
+    <small v-for="message in props.validationMessages" :key="message">{{ message }}</small>
+
+    <Teleport to="body">
+      <div v-if="isImageDialogOpen" class="trip-editor-rich-notes-dialog" role="dialog" aria-modal="true" aria-labelledby="trip-editor-rich-notes-image-title">
+        <div class="trip-editor-rich-notes-dialog__backdrop" aria-hidden="true"></div>
+        <form class="trip-editor-rich-notes-dialog__panel" @submit.prevent="insertImageUrl">
+          <h2 id="trip-editor-rich-notes-image-title">Insert image URL</h2>
+          <label class="trip-editor-field">
+            <span>Image URL</span>
+            <input ref="imageUrlInput" v-model="imageUrl" type="url" autocomplete="off" />
+            <small v-if="imageUrlError">{{ imageUrlError }}</small>
+          </label>
+          <div class="trip-editor-rich-notes-dialog__actions">
+            <button type="submit" class="btn btn-primary btn-sm">Insert Image</button>
+            <button type="button" class="btn btn-outline-secondary btn-sm" @click="closeImageDialog">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/ClientApps/trip-editor/src/components/SegmentEditorForm.vue
+++ b/ClientApps/trip-editor/src/components/SegmentEditorForm.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { EditorRegion, EditorSegmentDraft, EditorTripState, Guid } from '../types';
+import RichNotesEditor from './RichNotesEditor.vue';
 import { fallbackRoute } from './segmentRouteMapWork';
 
 const props = defineProps<{
@@ -80,11 +81,7 @@ function orderedPlaceIds(regionId: Guid): Guid[] {
       </label>
     </div>
 
-    <label class="trip-editor-field">
-      <span>Notes HTML</span>
-      <textarea v-model="draft.notesHtml" rows="4"></textarea>
-      <small v-for="message in fieldErrors('notesHtml')" :key="message">{{ message }}</small>
-    </label>
+    <RichNotesEditor :editor-id="`${formId}-notes`" v-model="draft.notesHtml" label="Notes" :validation-messages="fieldErrors('notesHtml')" />
 
     <div class="trip-editor-field">
       <span>Route</span>

--- a/ClientApps/trip-editor/src/components/regionPlaceDrafts.ts
+++ b/ClientApps/trip-editor/src/components/regionPlaceDrafts.ts
@@ -1,4 +1,5 @@
 import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorCoordinate, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorSegment, EditorSegmentDraft, EditorSegmentSaveRequest } from '../types';
+import { normalizeNotesHtml } from '../notes/notesHtml';
 
 export type RegionDraft = {
   id: string | null;
@@ -21,7 +22,7 @@ export function toRegionDraft(region: EditorRegion | null): RegionDraft {
   return {
     id: region.id,
     name: region.name,
-    notesHtml: region.notesHtml,
+    notesHtml: normalizeNotesHtml(region.notesHtml),
     coverImageRawUrl: region.coverImage?.rawUrl ?? '',
     centerLatitude: coordinateText(region.center, 'latitude'),
     centerLongitude: coordinateText(region.center, 'longitude')
@@ -36,7 +37,7 @@ export function buildRegionRequest(value: RegionDraft): EditorRegionSaveRequest 
 
   return {
     name: value.name,
-    notesHtml: value.notesHtml,
+    notesHtml: normalizeNotesHtml(value.notesHtml),
     coverImage: coverImageRawUrl ? { rawUrl: coverImageRawUrl } : null,
     center: hasPartialCenter ? { latitude: latitude ? Number(latitude) : Number.NaN, longitude: longitude ? Number(longitude) : Number.NaN } : null
   };
@@ -55,7 +56,7 @@ export function toPlaceDraft(place: EditorPlace | null, fallbackRegionId: string
     id: place.id,
     regionId: place.regionId,
     name: place.name,
-    notesHtml: place.notesHtml,
+    notesHtml: normalizeNotesHtml(place.notesHtml),
     address: place.address,
     latitude: coordinateText(place.location, 'latitude'),
     longitude: coordinateText(place.location, 'longitude'),
@@ -72,7 +73,7 @@ export function buildPlaceRequest(value: EditorPlaceDraft): EditorPlaceSaveReque
   return {
     regionId: value.regionId ?? undefined,
     name: value.name,
-    notesHtml: value.notesHtml,
+    notesHtml: normalizeNotesHtml(value.notesHtml),
     address: value.address || null,
     location: hasLocation ? { latitude: latitude ? Number(latitude) : Number.NaN, longitude: longitude ? Number(longitude) : Number.NaN } : null,
     iconName: value.iconName,
@@ -99,7 +100,7 @@ export function toAreaDraft(area: EditorArea | null, fallbackRegionId: string | 
     id: area.id,
     regionId: area.regionId,
     name: area.name,
-    notesHtml: area.notesHtml,
+    notesHtml: normalizeNotesHtml(area.notesHtml),
     fillHex: area.fillHex || fillHex,
     geometry: cloneGeometry(area.geometry)
   };
@@ -108,7 +109,7 @@ export function toAreaDraft(area: EditorArea | null, fallbackRegionId: string | 
 export function buildAreaRequest(value: EditorAreaDraft): EditorAreaSaveRequest {
   return {
     name: value.name,
-    notesHtml: value.notesHtml,
+    notesHtml: normalizeNotesHtml(value.notesHtml),
     fillHex: value.fillHex,
     geometry: cloneGeometry(value.geometry)
   };
@@ -130,7 +131,7 @@ export function toSegmentDraft(segment: EditorSegment | null): EditorSegmentDraf
     mode: segment.mode,
     estimatedDistanceKm: segment.estimatedDistanceKm ?? '',
     estimatedDurationMinutes: segment.estimatedDurationMinutes ?? '',
-    notesHtml: segment.notesHtml,
+    notesHtml: normalizeNotesHtml(segment.notesHtml),
     route: cloneGeometry(segment.route)
   };
 }
@@ -142,7 +143,7 @@ export function buildSegmentRequest(value: EditorSegmentDraft): EditorSegmentSav
     mode: value.mode || null,
     estimatedDistanceKm: nullableNumber(value.estimatedDistanceKm),
     estimatedDurationMinutes: nullableNumber(value.estimatedDurationMinutes),
-    notesHtml: value.notesHtml,
+    notesHtml: normalizeNotesHtml(value.notesHtml),
     route: cloneGeometry(value.route)
   };
 }

--- a/ClientApps/trip-editor/src/main.ts
+++ b/ClientApps/trip-editor/src/main.ts
@@ -1,9 +1,11 @@
 import { createApp } from 'vue';
 import App from './App.vue';
 import type { BootstrapConfig } from './types';
+import 'quill/dist/quill.snow.css';
 import './theme.css';
 import './styles.css';
 import './surfaces.css';
+import './richNotes.css';
 
 const mountElement = document.getElementById('trip-editor-app');
 

--- a/ClientApps/trip-editor/src/notes/notesHtml.ts
+++ b/ClientApps/trip-editor/src/notes/notesHtml.ts
@@ -1,0 +1,135 @@
+const forbiddenElements = 'script, style, iframe, object, embed, link, meta, base, form, input, button, textarea, select, option';
+const allowedQuillFontClasses = new Set(['ql-font-serif', 'ql-font-monospace']);
+
+/// Normalizes Trip Editor notes to the canonical user HTML stored by save payloads.
+export function normalizeNotesHtml(value: string): string {
+  const template = document.createElement('template');
+  template.innerHTML = value.trim();
+
+  template.content.querySelectorAll(forbiddenElements).forEach(element => {
+    element.remove();
+  });
+  template.content.querySelectorAll('span.ql-ui').forEach(element => {
+    element.remove();
+  });
+  template.content.querySelectorAll('*').forEach(element => {
+    normalizeElementAttributes(element);
+  });
+  template.content.querySelectorAll<HTMLImageElement>('img').forEach(image => {
+    const source = canonicalImageSource(image.getAttribute('src') ?? '');
+    if (!isAllowedImageSource(source)) {
+      image.remove();
+      return;
+    }
+
+    image.setAttribute('src', source);
+  });
+
+  const html = template.innerHTML.trim();
+  return html === '<p><br></p>' ? '' : html;
+}
+
+/// Restores proxied display URLs to the original external image URL saved in notes.
+export function canonicalImageSource(value: string): string {
+  const trimmedValue = stripUrlBoundaryControls(value);
+  if (!trimmedValue.startsWith('/Public/ProxyImage')) {
+    return trimmedValue;
+  }
+
+  try {
+    const url = new URL(trimmedValue, window.location.origin);
+    return stripUrlBoundaryControls(url.searchParams.get('url') ?? trimmedValue);
+  } catch {
+    return trimmedValue;
+  }
+}
+
+/// Detects embedded images before Quill can move them into the editor DOM.
+export function containsDataImageReference(value: string): boolean {
+  return compactUrlText(value).includes('data:image');
+}
+
+/// Detects embedded image URLs entered through the image dialog.
+export function isDataImageSource(value: string): boolean {
+  return compactUrlScheme(value).startsWith('data:image');
+}
+
+/// Rejects every non-http(s) image source after canonical proxy URL restoration.
+export function isUnsafeImageSource(value: string): boolean {
+  return !isAllowedImageSource(canonicalImageSource(value));
+}
+
+function normalizeElementAttributes(element: Element): void {
+  Array.from(element.attributes).forEach(attribute => {
+    const name = attribute.name.toLowerCase();
+    if (name === 'class') {
+      normalizeClassAttribute(element);
+      return;
+    }
+
+    if (
+      name === 'style' ||
+      name.startsWith('data-') ||
+      name === 'contenteditable' ||
+      name === 'srcdoc' ||
+      name.startsWith('on') ||
+      isUnsafeAttributeUrl(element, name, attribute.value)
+    ) {
+      element.removeAttribute(attribute.name);
+    }
+  });
+}
+
+function normalizeClassAttribute(element: Element): void {
+  const allowedClasses = Array.from(element.classList).filter(className => isAllowedClass(element, className));
+  if (allowedClasses.length > 0) {
+    element.setAttribute('class', allowedClasses.join(' '));
+    return;
+  }
+
+  element.removeAttribute('class');
+}
+
+function isAllowedClass(element: Element, className: string): boolean {
+  // Quill's font dropdown stores user-visible font choices as span classes.
+  return element.tagName.toLowerCase() === 'span' && allowedQuillFontClasses.has(className);
+}
+
+function isAllowedImageSource(value: string): boolean {
+  const trimmedValue = stripUrlBoundaryControls(value);
+  if (!trimmedValue || !compactUrlScheme(trimmedValue).startsWith('http')) {
+    return false;
+  }
+
+  try {
+    const url = new URL(trimmedValue);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isUnsafeAttributeUrl(element: Element, name: string, value: string): boolean {
+  if (name !== 'href' && name !== 'src' && name !== 'xlink:href') {
+    return false;
+  }
+
+  if (element instanceof HTMLImageElement && name === 'src') {
+    return false;
+  }
+
+  const normalizedValue = compactUrlScheme(value);
+  return normalizedValue.startsWith('javascript:') || normalizedValue.startsWith('data:') || normalizedValue.startsWith('vbscript:');
+}
+
+function compactUrlScheme(value: string): string {
+  return compactUrlText(stripUrlBoundaryControls(value).slice(0, 64));
+}
+
+function compactUrlText(value: string): string {
+  return value.replace(/[\u0000-\u0020\u007f-\u009f]+/g, '').toLowerCase();
+}
+
+function stripUrlBoundaryControls(value: string): string {
+  return value.replace(/^[\u0000-\u0020\u007f-\u009f]+|[\u0000-\u0020\u007f-\u009f]+$/g, '');
+}

--- a/ClientApps/trip-editor/src/notes/notesHtml.ts
+++ b/ClientApps/trip-editor/src/notes/notesHtml.ts
@@ -1,5 +1,6 @@
 const forbiddenElements = 'script, style, iframe, object, embed, link, meta, base, form, input, button, textarea, select, option';
 const allowedQuillFontClasses = new Set(['ql-font-serif', 'ql-font-monospace']);
+const allowedQuillListKinds = new Set(['bullet', 'ordered']);
 
 /// Normalizes Trip Editor notes to the canonical user HTML stored by save payloads.
 export function normalizeNotesHtml(value: string): string {
@@ -90,7 +91,14 @@ function isAllowedClass(element: Element, className: string): boolean {
 
 function isAllowedElementAttribute(element: Element, name: string): boolean {
   const tagName = element.tagName.toLowerCase();
-  return (tagName === 'a' && name === 'href') || (tagName === 'img' && name === 'src');
+  // Quill 2 stores the user-selected list kind on list items.
+  return (tagName === 'a' && name === 'href')
+    || (tagName === 'img' && name === 'src')
+    || (tagName === 'li' && name === 'data-list' && isAllowedQuillListKind(element));
+}
+
+function isAllowedQuillListKind(element: Element): boolean {
+  return allowedQuillListKinds.has(element.getAttribute('data-list') ?? '');
 }
 
 function isAllowedImageSource(value: string): boolean {

--- a/ClientApps/trip-editor/src/notes/notesHtml.ts
+++ b/ClientApps/trip-editor/src/notes/notesHtml.ts
@@ -67,14 +67,7 @@ function normalizeElementAttributes(element: Element): void {
       return;
     }
 
-    if (
-      name === 'style' ||
-      name.startsWith('data-') ||
-      name === 'contenteditable' ||
-      name === 'srcdoc' ||
-      name.startsWith('on') ||
-      isUnsafeAttributeUrl(element, name, attribute.value)
-    ) {
+    if (!isAllowedElementAttribute(element, name) || isUnsafeAttributeUrl(element, name, attribute.value)) {
       element.removeAttribute(attribute.name);
     }
   });
@@ -93,6 +86,11 @@ function normalizeClassAttribute(element: Element): void {
 function isAllowedClass(element: Element, className: string): boolean {
   // Quill's font dropdown stores user-visible font choices as span classes.
   return element.tagName.toLowerCase() === 'span' && allowedQuillFontClasses.has(className);
+}
+
+function isAllowedElementAttribute(element: Element, name: string): boolean {
+  const tagName = element.tagName.toLowerCase();
+  return (tagName === 'a' && name === 'href') || (tagName === 'img' && name === 'src');
 }
 
 function isAllowedImageSource(value: string): boolean {

--- a/ClientApps/trip-editor/src/richNotes.css
+++ b/ClientApps/trip-editor/src/richNotes.css
@@ -1,0 +1,92 @@
+.trip-editor-rich-notes .ql-toolbar,
+.trip-editor-rich-notes__editor {
+  background: var(--trip-editor-field-bg);
+  border: 1px solid var(--trip-editor-field-border);
+  color: var(--trip-editor-text);
+}
+
+.trip-editor-rich-notes .ql-toolbar {
+  background: var(--trip-editor-surface-muted);
+  border-bottom: 0;
+  border-radius: 6px 6px 0 0;
+}
+
+.trip-editor-rich-notes__editor {
+  border-radius: 0 0 6px 6px;
+  overflow: hidden;
+}
+
+.trip-editor-rich-notes__editor.ql-container {
+  color: var(--trip-editor-text);
+  font: inherit;
+  min-height: 9rem;
+}
+
+.trip-editor-rich-notes__editor.ql-container .ql-editor {
+  min-height: 9rem;
+}
+
+.trip-editor-rich-notes .ql-picker,
+.trip-editor-rich-notes .ql-stroke {
+  color: var(--trip-editor-text);
+  stroke: currentColor;
+}
+
+.trip-editor-rich-notes .ql-fill {
+  fill: var(--trip-editor-text);
+}
+
+.trip-editor-rich-notes .ql-picker-options {
+  background: var(--trip-editor-surface);
+  border-color: var(--trip-editor-field-border);
+}
+
+.trip-editor-rich-notes__feedback {
+  background: var(--trip-editor-warning-bg);
+  border-radius: 6px;
+  color: var(--trip-editor-warning-text);
+  margin: 0;
+  padding: 0.45rem 0.55rem;
+}
+
+.trip-editor-rich-notes-dialog {
+  inset: 0;
+  position: fixed;
+  z-index: 1090;
+}
+
+.trip-editor-rich-notes-dialog__backdrop {
+  background: #020617;
+  inset: 0;
+  opacity: 0.72;
+  position: fixed;
+}
+
+.trip-editor-rich-notes-dialog__panel {
+  background: var(--trip-editor-surface);
+  border: 1px solid var(--trip-editor-border);
+  border-radius: 8px;
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.45);
+  color: var(--trip-editor-text);
+  display: grid;
+  gap: 0.8rem;
+  left: 50%;
+  max-width: min(420px, calc(100vw - 2rem));
+  padding: 1rem;
+  position: fixed;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+}
+
+.trip-editor-rich-notes-dialog__panel h2 {
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.trip-editor-rich-notes-dialog__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/leaflet": "1.9.21",
         "@vitejs/plugin-vue": "6.0.3",
         "leaflet": "1.9.4",
+        "quill": "^2.0.3",
         "typescript": "5.9.3",
         "vite": "7.3.3",
         "vue": "3.5.34"
@@ -1075,6 +1076,18 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1112,6 +1125,25 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1138,6 +1170,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/parchment": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1230,6 +1268,35 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/quill": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "lodash-es": "^4.17.21",
+        "parchment": "^3.0.0",
+        "quill-delta": "^5.1.0"
+      },
+      "engines": {
+        "npm": ">=8.2.3"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/rollup": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@types/leaflet": "1.9.21",
         "@vitejs/plugin-vue": "6.0.3",
         "leaflet": "1.9.4",
-        "quill": "^2.0.3",
+        "quill": "2.0.2",
         "typescript": "5.9.3",
         "vite": "7.3.3",
         "vue": "3.5.34"
@@ -1271,9 +1271,9 @@
       }
     },
     "node_modules/quill": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
-      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.2.tgz",
+      "integrity": "sha512-QfazNrhMakEdRG57IoYFwffUIr04LWJxbS/ZkidRFXYCQt63c1gK6Z7IHUXMx/Vh25WgPBU42oBaNzQ0K1R/xw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "eventemitter3": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/leaflet": "1.9.21",
     "@vitejs/plugin-vue": "6.0.3",
     "leaflet": "1.9.4",
+    "quill": "^2.0.3",
     "typescript": "5.9.3",
     "vite": "7.3.3",
     "vue": "3.5.34"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@types/leaflet": "1.9.21",
     "@vitejs/plugin-vue": "6.0.3",
     "leaflet": "1.9.4",
-    "quill": "^2.0.3",
+    "quill": "2.0.2",
     "typescript": "5.9.3",
     "vite": "7.3.3",
     "vue": "3.5.34"

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -320,7 +320,7 @@ async function expectMockupOnlyPlaceControlsAbsent(page: Page): Promise<void> {
   await expect(page.getByRole('tab', { name: /visit progress/i })).toHaveCount(0);
   await expect(page.getByRole('button', { name: /visit progress/i })).toHaveCount(0);
   await expect(page.getByRole('button', { name: /photos?/i })).toHaveCount(0);
-  await expect(page.getByRole('button', { name: /links?|official site/i })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /links|official site/i })).toHaveCount(0);
 
   const placeForm = await openFirstPlaceFormIfAvailable(page);
   if (!placeForm) {

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -320,7 +320,8 @@ async function expectMockupOnlyPlaceControlsAbsent(page: Page): Promise<void> {
   await expect(page.getByRole('tab', { name: /visit progress/i })).toHaveCount(0);
   await expect(page.getByRole('button', { name: /visit progress/i })).toHaveCount(0);
   await expect(page.getByRole('button', { name: /photos?/i })).toHaveCount(0);
-  await expect(page.getByRole('button', { name: /links|official site/i })).toHaveCount(0);
+  await expect(page.locator('button:not(.ql-link)').filter({ hasText: /^links?$/i })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /official site/i })).toHaveCount(0);
 
   const placeForm = await openFirstPlaceFormIfAvailable(page);
   if (!placeForm) {

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -71,20 +71,9 @@ test.describe.serial('Trip Editor rich notes parity', () => {
 
   test('metadata save sanitizes unedited persisted notes when another field changes', async ({ page }) => {
     await signIn(page);
-    const state = await loadWorkspaceWithRichNotesFixture(page);
-    state.metadata.notesHtml = [
-      '<h2 class="trip-img-modal" style="color:red">Unsafe persisted heading</h2>',
-      '<p class="editor-only" style="font-size:30px"><strong>Bold</strong> <em>Italic</em> <u>Underline</u></p>',
-      '<p><a class="unsafe-link" style="color:red" onclick="alert(1)" href="https://example.test/page">Safe link</a></p>',
-      '<p><span class="ql-font-serif trip-img-modal" style="font-family:serif" data-original="ignored">Font note</span></p>',
-      '<p><img class="trip-img-modal" style="width:400px" data-original="ignored" loading="lazy" src="/Public/ProxyImage?url=https%3A%2F%2Fcdn.example.test%2Fproxied.jpg"></p>',
-      '<p><img src="   https://cdn.example.test/direct.jpg   "></p>',
-      '<p><img src="data:text/html,ignored"></p>',
-      '<p><img src="file:///C:/temp/ignored.png"></p>',
-      '<p><img src="vbscript:msgbox(1)"></p>',
-      '<p><img src="java&#x0A;script:alert(1)"></p>',
-      '<p><img src="not a url"></p>'
-    ].join('');
+    const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
+      editorState.metadata.notesHtml = unsafePersistedMetadataNotes();
+    });
     const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
     await routeEditorMutations(page, state, requests);
 
@@ -226,14 +215,31 @@ test.describe.serial('Trip Editor rich notes parity', () => {
   });
 });
 
-async function loadWorkspaceWithRichNotesFixture(page: Page): Promise<MutableEditorState> {
+async function loadWorkspaceWithRichNotesFixture(page: Page, configureState?: (state: MutableEditorState) => void): Promise<MutableEditorState> {
   await page.unroute(editorApiMatcher).catch(() => undefined);
   const state = await loadEditorStateFixture(page) as MutableEditorState;
   prepareRichNotesState(state);
+  configureState?.(state);
   await page.route(editorApiMatcher, async route => routeEditorState(route, state, []));
   await page.goto(absoluteUrl(workspacePath));
   await expectMountedWorkspace(page);
   return state;
+}
+
+function unsafePersistedMetadataNotes(): string {
+  return [
+    '<h2 class="trip-img-modal" style="color:red">Unsafe persisted heading</h2>',
+    '<p class="editor-only" style="font-size:30px"><strong>Bold</strong> <em>Italic</em> <u>Underline</u></p>',
+    '<p><a class="unsafe-link" style="color:red" onclick="alert(1)" href="https://example.test/page">Safe link</a></p>',
+    '<p><span class="ql-font-serif trip-img-modal" style="font-family:serif" data-original="ignored">Font note</span></p>',
+    '<p><img class="trip-img-modal" style="width:400px" data-original="ignored" loading="lazy" src="/Public/ProxyImage?url=https%3A%2F%2Fcdn.example.test%2Fproxied.jpg"></p>',
+    '<p><img src="   https://cdn.example.test/direct.jpg   "></p>',
+    '<p><img src="data:text/html,ignored"></p>',
+    '<p><img src="file:///C:/temp/ignored.png"></p>',
+    '<p><img src="vbscript:msgbox(1)"></p>',
+    '<p><img src="java&#x0A;script:alert(1)"></p>',
+    '<p><img src="not a url"></p>'
+  ].join('');
 }
 
 async function routeEditorMutations(page: Page, state: MutableEditorState, requests: Array<{ method: string; url: string; body: Record<string, any> }>): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -1,0 +1,341 @@
+import { expect, test, type Locator, type Page, type Route } from '@playwright/test';
+import {
+  absoluteUrl,
+  editorApiPath,
+  expectMountedWorkspace,
+  loadEditorStateFixture,
+  signIn,
+  workspacePath
+} from './tripEditorTestUtils';
+
+type MutableEditorState = Record<string, any>;
+
+const regionId = '00000000-0000-0000-0000-000000272001';
+const placeId = '00000000-0000-0000-0000-000000272002';
+const areaId = '00000000-0000-0000-0000-000000272003';
+const segmentId = '00000000-0000-0000-0000-000000272004';
+const regionName = 'PW rich notes region';
+const placeName = 'PW rich notes place';
+const areaName = 'PW rich notes area';
+const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
+
+test.describe.serial('Trip Editor rich notes parity', () => {
+  test('all owner forms render the shared rich notes editor instead of raw notes textareas', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithRichNotesFixture(page);
+
+    await expectRichNotesOwner(page.locator('#trip-editor-metadata-form'), 'trip-editor-metadata-notes');
+    await expect(page.getByText('Notes HTML')).toHaveCount(0);
+
+    await openRegion(page);
+    await expectRichNotesOwner(page.locator('#trip-editor-region-form'), 'trip-editor-region-form-notes');
+    await expect(page.getByText('Notes HTML')).toHaveCount(0);
+
+    await openPlace(page);
+    await expectRichNotesOwner(page.locator('#trip-editor-place-form'), 'trip-editor-place-form-notes');
+    await expect(page.getByText('Notes HTML')).toHaveCount(0);
+
+    await openArea(page);
+    await expectRichNotesOwner(page.locator('#trip-editor-area-form'), 'trip-editor-area-form-notes');
+    await expect(page.getByText('Notes HTML')).toHaveCount(0);
+
+    await openSegment(page);
+    await expectRichNotesOwner(page.locator('#trip-editor-segment-form'), 'trip-editor-segment-form-notes');
+    await expect(page.getByText('Notes HTML')).toHaveCount(0);
+  });
+
+  test('metadata and child owner saves send canonical rich notes through existing mutation endpoints', async ({ page }) => {
+    await signIn(page);
+    const state = await loadWorkspaceWithRichNotesFixture(page);
+    const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
+    await routeEditorMutations(page, state, requests);
+
+    await richEditor(page.locator('#trip-editor-metadata-form')).locator('.ql-editor').click();
+    await page.keyboard.type('Metadata rich note');
+    await insertImageUrl(page.locator('#trip-editor-metadata-form'), 'https://example.com/photo.jpg');
+    await page.getByRole('button', { name: 'Save & Continue' }).click();
+    await expect.poll(() => requests.length).toBe(1);
+    expect(requests[0].method).toBe('PATCH');
+    expect(requests[0].url).toContain('/metadata');
+    expectCanonicalNotes(requests[0].body.notesHtml, ['Metadata rich note', 'https://example.com/photo.jpg']);
+
+    await openRegion(page);
+    await richEditor(page.locator('#trip-editor-region-form')).locator('.ql-editor').fill('');
+    await page.keyboard.type('Region rich note');
+    await page.getByRole('button', { name: 'Save Region' }).click();
+    await expect.poll(() => requests.length).toBe(2);
+    expect(requests[1].method).toBe('PUT');
+    expect(requests[1].url).toContain(`/regions/${regionId}`);
+    expectCanonicalNotes(requests[1].body.notesHtml, ['Region rich note']);
+  });
+
+  test('image dialog inserts URL embeds and data images are blocked with visible feedback', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithRichNotesFixture(page);
+
+    const form = page.locator('#trip-editor-metadata-form');
+    await insertImageUrl(form, 'https://images.example.test/rich-note.png');
+    const image = richEditor(form).locator('.ql-editor img');
+    await expect(image).toHaveAttribute('src', /https:\/\/images\.example\.test\/rich-note\.png$/);
+
+    await pasteDataImage(richEditor(form).locator('.ql-editor'));
+    await expect(form.getByRole('status')).toContainText('Embedded data images are not allowed');
+    await expect(richEditor(form).locator('.ql-editor img[src^="data:image"]')).toHaveCount(0);
+  });
+
+  test('docked and expanded modes keep one active notes draft and shared discard/reset flows', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithRichNotesFixture(page);
+
+    const dockedForm = page.locator('#trip-editor-metadata-form');
+    await richEditor(dockedForm).locator('.ql-editor').click();
+    await page.keyboard.type('Expanded draft note');
+    await page.getByRole('button', { name: 'Expand Editor' }).click();
+
+    const dialog = page.getByRole('dialog', { name: /Edit Trip -/ });
+    await expect(dialog.locator('#trip-editor-metadata-form')).toHaveCount(1);
+    await expect(page.locator('#trip-editor-metadata-form')).toHaveCount(1);
+    await expect(richEditor(dialog.locator('#trip-editor-metadata-form')).locator('.ql-editor')).toContainText('Expanded draft note');
+
+    await dialog.getByRole('button', { name: 'Dock to sidebar' }).click();
+    await expect(page.locator('#trip-editor-metadata-form')).toHaveCount(1);
+    await expect(richEditor(page.locator('#trip-editor-metadata-form')).locator('.ql-editor')).toContainText('Expanded draft note');
+
+    await page.getByRole('button', { name: 'Close' }).click();
+    const discard = page.getByRole('dialog', { name: 'Discard changes?' });
+    await expect(discard).toBeVisible();
+    await discard.getByRole('button', { name: 'Keep editing' }).click();
+    await expect(richEditor(page.locator('#trip-editor-metadata-form')).locator('.ql-editor')).toContainText('Expanded draft note');
+
+    await page.getByRole('button', { name: 'Cancel / Reset' }).click();
+    await expect(richEditor(page.locator('#trip-editor-metadata-form')).locator('.ql-editor')).not.toContainText('Expanded draft note');
+  });
+
+  test('area and segment map-work preserve notes without adding another editor surface', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithRichNotesFixture(page);
+
+    await openArea(page);
+    await richEditor(page.locator('#trip-editor-area-form')).locator('.ql-editor').click();
+    await page.keyboard.type('Area map-work note');
+    await page.getByRole('button', { name: 'Draw/Edit Area' }).click();
+    await expect(page.getByRole('region', { name: 'Map work' })).toBeVisible();
+    await expect(page.locator('.trip-editor-rich-notes')).toHaveCount(0);
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+    await expect(richEditor(page.locator('#trip-editor-area-form')).locator('.ql-editor')).toContainText('Area map-work note');
+    await page.getByRole('button', { name: 'Reset' }).click();
+
+    await openSegment(page);
+    await richEditor(page.locator('#trip-editor-segment-form')).locator('.ql-editor').click();
+    await page.keyboard.type('Segment map-work note');
+    await page.getByRole('button', { name: 'Draw/Edit Route' }).click();
+    await expect(page.getByRole('region', { name: 'Map work' })).toBeVisible();
+    await expect(page.locator('.trip-editor-rich-notes')).toHaveCount(0);
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+    await expect(richEditor(page.locator('#trip-editor-segment-form')).locator('.ql-editor')).toContainText('Segment map-work note');
+  });
+});
+
+async function loadWorkspaceWithRichNotesFixture(page: Page): Promise<MutableEditorState> {
+  await page.unroute(editorApiMatcher).catch(() => undefined);
+  const state = await loadEditorStateFixture(page) as MutableEditorState;
+  prepareRichNotesState(state);
+  await page.route(editorApiMatcher, async route => routeEditorState(route, state, []));
+  await page.goto(absoluteUrl(workspacePath));
+  await expectMountedWorkspace(page);
+  return state;
+}
+
+async function routeEditorMutations(page: Page, state: MutableEditorState, requests: Array<{ method: string; url: string; body: Record<string, any> }>): Promise<void> {
+  await page.unroute(editorApiMatcher);
+  await page.route(editorApiMatcher, async route => routeEditorState(route, state, requests));
+}
+
+async function routeEditorState(route: Route, state: MutableEditorState, requests: Array<{ method: string; url: string; body: Record<string, any> }>): Promise<void> {
+  const request = route.request();
+  if (request.method() === 'GET') {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+    return;
+  }
+
+  const body = request.postDataJSON() as Record<string, any>;
+  requests.push({ method: request.method(), url: request.url(), body });
+  const result = applyMutation(state, request.method(), request.url(), body);
+  await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(result) });
+}
+
+function applyMutation(state: MutableEditorState, method: string, url: string, body: Record<string, any>): Record<string, any> {
+  if (method === 'PATCH' && url.includes('/metadata')) {
+    state.metadata = { ...state.metadata, ...body };
+    return mutationResult(state.metadata, { metadata: state.metadata });
+  }
+
+  if (method === 'PUT' && url.includes(`/regions/${regionId}`)) {
+    state.regionsById[regionId] = { ...state.regionsById[regionId], ...body };
+    return mutationResult(state.regionsById[regionId], { regions: [state.regionsById[regionId]] });
+  }
+
+  throw new Error(`Unexpected rich notes mutation ${method} ${url}`);
+}
+
+function prepareRichNotesState(state: MutableEditorState): void {
+  state.permissions.canEditMetadata = true;
+  state.permissions.canEditRegions = true;
+  state.permissions.canEditPlaces = true;
+  state.permissions.canEditAreas = true;
+  state.permissions.canEditSegments = true;
+
+  state.regionsById[regionId] = {
+    id: regionId,
+    tripId: state.tripId,
+    name: regionName,
+    notesHtml: '<p>Persisted region note</p>',
+    coverImage: null,
+    center: null,
+    displayOrder: 1,
+    isShadow: false,
+    capabilities: editableCapabilities()
+  };
+  state.regionOrder = [regionId, ...state.regionOrder.filter((id: string) => id !== regionId)];
+
+  state.placesById[placeId] = {
+    id: placeId,
+    tripId: state.tripId,
+    regionId,
+    name: placeName,
+    notesHtml: '<p>Persisted place note</p>',
+    address: 'Athens',
+    location: { latitude: 37.9838, longitude: 23.7275 },
+    iconName: state.options.iconNames[0] ?? 'marker',
+    markerColor: state.options.markerColorClasses[0] ?? 'bg-blue',
+    displayOrder: 1,
+    visitSummary: { placeId, visitCount: 0, isVisited: false, firstVisitAt: null, lastVisitAt: null },
+    capabilities: editableCapabilities()
+  };
+  state.placeOrderByRegionId[regionId] = [placeId];
+
+  state.areasById[areaId] = {
+    id: areaId,
+    tripId: state.tripId,
+    regionId,
+    name: areaName,
+    notesHtml: '<p>Persisted area note</p>',
+    fillHex: '#ff6600',
+    geometry: { type: 'Polygon', coordinates: [[[23, 37], [24, 37], [24, 38], [23, 37]]] },
+    displayOrder: 1,
+    capabilities: editableCapabilities()
+  };
+  state.areaOrderByRegionId[regionId] = [areaId];
+
+  state.segmentsById[segmentId] = {
+    id: segmentId,
+    tripId: state.tripId,
+    fromPlaceId: placeId,
+    toPlaceId: placeId,
+    mode: state.options.transportModes[0]?.value ?? 'walk',
+    estimatedDistanceKm: 1,
+    estimatedDurationMinutes: 10,
+    notesHtml: '<p>Persisted segment note</p>',
+    route: { type: 'LineString', coordinates: [[23, 37], [24, 38]] },
+    displayOrder: 1,
+    capabilities: editableCapabilities()
+  };
+  state.segmentOrder = [segmentId];
+}
+
+function editableCapabilities(): Record<string, boolean> {
+  return {
+    canEdit: true,
+    canRename: true,
+    canDelete: true,
+    canReorder: true,
+    canMove: true,
+    canAddChildren: true,
+    canTargetForSearchAdd: true
+  };
+}
+
+function mutationResult(data: Record<string, any>, affected: Record<string, any>): Record<string, any> {
+  return {
+    success: true,
+    data,
+    affected: {
+      metadata: null,
+      regions: [],
+      regionOrder: null,
+      places: [],
+      placeOrdersByRegionId: {},
+      areas: [],
+      areaOrdersByRegionId: {},
+      segments: [],
+      segmentOrder: null,
+      tags: [],
+      tagOrder: null,
+      visitProgress: null,
+      options: null,
+      ...affected
+    },
+    deletedIds: { regions: [], places: [], areas: [], segments: [], tags: [] },
+    warnings: []
+  };
+}
+
+async function expectRichNotesOwner(form: Locator, editorId: string): Promise<void> {
+  await expect(form.locator(`[data-rich-notes-editor="${editorId}"]`)).toBeVisible();
+  await expect(form.getByText('Notes', { exact: true })).toBeVisible();
+  await expect(form.locator('textarea')).toHaveCount(0);
+  await expect(richEditor(form).locator('.ql-editor')).toBeVisible();
+}
+
+function richEditor(form: Locator): Locator {
+  return form.locator('.trip-editor-rich-notes');
+}
+
+async function insertImageUrl(form: Locator, url: string): Promise<void> {
+  await richEditor(form).locator('.ql-image').click();
+  const dialog = form.page().getByRole('dialog', { name: 'Insert image URL' });
+  await expect(dialog).toBeVisible();
+  await dialog.getByLabel('Image URL').fill(url);
+  await dialog.getByRole('button', { name: 'Insert Image' }).click();
+  await expect(dialog).toHaveCount(0);
+}
+
+async function pasteDataImage(editor: Locator): Promise<void> {
+  await editor.evaluate(element => {
+    const data = new DataTransfer();
+    data.setData('text/html', '<p><img src="data:image/png;base64,iVBORw0KGgo="></p>');
+    const event = new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data });
+    element.dispatchEvent(event);
+  });
+}
+
+async function openRegion(page: Page): Promise<void> {
+  await page.locator(`[data-region-id="${regionId}"] .trip-editor-region-card__header`).getByRole('button', { name: 'Edit' }).click();
+  await expect(page.getByRole('heading', { name: `Edit Region - ${regionName}` })).toBeVisible();
+}
+
+async function openPlace(page: Page): Promise<void> {
+  await page.locator(`[data-place-id="${placeId}"]`).getByRole('button', { name: 'Edit' }).click();
+  await expect(page.getByRole('heading', { name: `Edit Place - ${placeName}` })).toBeVisible();
+}
+
+async function openArea(page: Page): Promise<void> {
+  await page.locator(`[data-area-id="${areaId}"]`).getByRole('button', { name: 'Edit' }).click();
+  await expect(page.getByRole('heading', { name: `Edit Area - ${areaName}` })).toBeVisible();
+}
+
+async function openSegment(page: Page): Promise<void> {
+  await page.locator(`[data-segment-id="${segmentId}"] .trip-editor-list-button`).click();
+  await expect(page.getByRole('heading', { name: /Edit Segment -/ })).toBeVisible();
+}
+
+function expectCanonicalNotes(value: string, expectedParts: string[]): void {
+  for (const part of expectedParts) {
+    expect(value).toContain(part);
+  }
+
+  expect(value).not.toContain('/Public/ProxyImage');
+  expect(value).not.toContain('data-original');
+  expect(value).not.toContain('data:image');
+  expect(value).not.toContain('trip-img-modal');
+}

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -69,6 +69,54 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     expectCanonicalNotes(requests[1].body.notesHtml, ['Region rich note']);
   });
 
+  test('metadata save sanitizes unedited persisted notes when another field changes', async ({ page }) => {
+    await signIn(page);
+    const state = await loadWorkspaceWithRichNotesFixture(page);
+    state.metadata.notesHtml = [
+      '<h2 class="trip-img-modal" style="color:red">Unsafe persisted heading</h2>',
+      '<p class="editor-only" style="font-size:30px"><strong>Bold</strong> <em>Italic</em> <u>Underline</u></p>',
+      '<p><a class="unsafe-link" style="color:red" onclick="alert(1)" href="https://example.test/page">Safe link</a></p>',
+      '<p><span class="ql-font-serif trip-img-modal" style="font-family:serif" data-original="ignored">Font note</span></p>',
+      '<p><img class="trip-img-modal" style="width:400px" data-original="ignored" loading="lazy" src="/Public/ProxyImage?url=https%3A%2F%2Fcdn.example.test%2Fproxied.jpg"></p>',
+      '<p><img src="   https://cdn.example.test/direct.jpg   "></p>',
+      '<p><img src="data:text/html,ignored"></p>',
+      '<p><img src="file:///C:/temp/ignored.png"></p>',
+      '<p><img src="vbscript:msgbox(1)"></p>',
+      '<p><img src="java&#x0A;script:alert(1)"></p>',
+      '<p><img src="not a url"></p>'
+    ].join('');
+    const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
+    await routeEditorMutations(page, state, requests);
+
+    await page.locator('#trip-editor-metadata-form').getByLabel('Name').fill('PW rich notes renamed trip');
+    await page.getByRole('button', { name: 'Save & Continue' }).click();
+
+    await expect.poll(() => requests.length).toBe(1);
+    const notesHtml = requests[0].body.notesHtml as string;
+    expectCanonicalNotes(notesHtml, [
+      'Unsafe persisted heading',
+      '<strong>Bold</strong>',
+      '<em>Italic</em>',
+      '<u>Underline</u>',
+      'href="https://example.test/page"',
+      '<span class="ql-font-serif">Font note</span>',
+      'https://cdn.example.test/proxied.jpg',
+      'https://cdn.example.test/direct.jpg'
+    ]);
+    expect(notesHtml).not.toContain('style=');
+    expect(notesHtml).not.toContain('trip-img-modal');
+    expect(notesHtml).not.toContain('editor-only');
+    expect(notesHtml).not.toContain('unsafe-link');
+    expect(notesHtml).not.toContain('onclick');
+    expect(notesHtml).not.toContain('data-original');
+    expect(notesHtml).not.toContain('loading=');
+    expect(notesHtml).not.toContain('data:text');
+    expect(notesHtml).not.toContain('file:');
+    expect(notesHtml).not.toContain('vbscript:');
+    expect(notesHtml).not.toContain('javascript:');
+    expect(notesHtml).not.toContain('not a url');
+  });
+
   test('image dialog inserts URL embeds and data images are blocked with visible feedback', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithRichNotesFixture(page);

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -83,6 +83,48 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     await expect(richEditor(form).locator('.ql-editor img[src^="data:image"]')).toHaveCount(0);
   });
 
+  test('data image blocking handles mixed case and whitespace-padded variants before draft storage', async ({ page }) => {
+    await signIn(page);
+    const state = await loadWorkspaceWithRichNotesFixture(page);
+    const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
+    await routeEditorMutations(page, state, requests);
+
+    const form = page.locator('#trip-editor-metadata-form');
+    const editor = richEditor(form).locator('.ql-editor');
+
+    await pasteDataImage(editor, '<p><img src=" DATA:IMAGE/png;base64,iVBORw0KGgo="></p>');
+    await expect(form.getByRole('status')).toContainText('Embedded data images are not allowed');
+    await expect(editor.locator('img')).toHaveCount(0);
+
+    await dropDataImage(editor, '<p><img src="\r\ndata : image/png;base64,iVBORw0KGgo="></p>');
+    await expect(form.getByRole('status')).toContainText('Embedded data images are not allowed');
+    await expect(editor.locator('img')).toHaveCount(0);
+
+    await rejectImageDialogUrl(form, '\tDaTa : ImAgE/png;base64,iVBORw0KGgo=');
+
+    await editor.evaluate(element => {
+      const image = document.createElement('img');
+      image.setAttribute('src', '\nDATA:\tIMAGE/png;base64,from-export');
+      element.append(image);
+      element.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertFromPaste' }));
+    });
+    await expect(form.getByRole('status')).toContainText('Embedded data images are not allowed');
+    await expect(editor.locator('img')).toHaveCount(0);
+
+    await editor.click();
+    await editor.evaluate(element => {
+      element.insertAdjacentHTML('beforeend', '<script>alert("x")</script><a href="javascript:alert(1)" onclick="alert(2)">Unsafe link</a><img src="javascript:alert(3)" onerror="alert(4)">');
+    });
+    await page.keyboard.type('Normalized rich note');
+    await page.getByRole('button', { name: 'Save & Continue' }).click();
+    await expect.poll(() => requests.length).toBe(1);
+    expectCanonicalNotes(requests[0].body.notesHtml, ['Normalized rich note']);
+    expect(requests[0].body.notesHtml).not.toContain('<script');
+    expect(requests[0].body.notesHtml).not.toContain('javascript:');
+    expect(requests[0].body.notesHtml).not.toContain('onclick');
+    expect(requests[0].body.notesHtml).not.toContain('onerror');
+  });
+
   test('docked and expanded modes keep one active notes draft and shared discard/reset flows', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithRichNotesFixture(page);
@@ -300,13 +342,33 @@ async function insertImageUrl(form: Locator, url: string): Promise<void> {
   await expect(dialog).toHaveCount(0);
 }
 
-async function pasteDataImage(editor: Locator): Promise<void> {
-  await editor.evaluate(element => {
+async function pasteDataImage(editor: Locator, html = '<p><img src="data:image/png;base64,iVBORw0KGgo="></p>'): Promise<void> {
+  await editor.evaluate((element, value) => {
     const data = new DataTransfer();
-    data.setData('text/html', '<p><img src="data:image/png;base64,iVBORw0KGgo="></p>');
+    data.setData('text/html', value);
     const event = new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data });
     element.dispatchEvent(event);
-  });
+  }, html);
+}
+
+async function dropDataImage(editor: Locator, html: string): Promise<void> {
+  await editor.evaluate((element, value) => {
+    const data = new DataTransfer();
+    data.setData('text/html', value);
+    const event = new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: data });
+    element.dispatchEvent(event);
+  }, html);
+}
+
+async function rejectImageDialogUrl(form: Locator, url: string): Promise<void> {
+  await richEditor(form).locator('.ql-image').click();
+  const dialog = form.page().getByRole('dialog', { name: 'Insert image URL' });
+  await expect(dialog).toBeVisible();
+  await dialog.getByLabel('Image URL').fill(url);
+  await dialog.getByRole('button', { name: 'Insert Image' }).click();
+  await expect(dialog.getByText('Embedded data images are not allowed')).toBeVisible();
+  await expect(form.getByRole('status')).toContainText('Embedded data images are not allowed');
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
 }
 
 async function openRegion(page: Page): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -106,6 +106,28 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     expect(notesHtml).not.toContain('not a url');
   });
 
+  test('bullet and ordered lists keep Quill list metadata through reload and save normalization', async ({ page }) => {
+    await signIn(page);
+    const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
+      editorState.metadata.notesHtml = persistedQuillListNotes();
+    });
+    const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
+    await routeEditorMutations(page, state, requests);
+
+    const editor = richEditor(page.locator('#trip-editor-metadata-form')).locator('.ql-editor');
+    await expect(editor.locator('li[data-list="bullet"]')).toContainText('Bullet note');
+    await expect(editor.locator('li[data-list="ordered"]')).toContainText('Ordered note');
+
+    await page.locator('#trip-editor-metadata-form').getByLabel('Name').fill('PW rich notes list trip');
+    await page.getByRole('button', { name: 'Save & Continue' }).click();
+
+    await expect.poll(() => requests.length).toBe(1);
+    const notesHtml = requests[0].body.notesHtml as string;
+    expectCanonicalNotes(notesHtml, ['Bullet note', 'Ordered note', 'data-list="bullet"', 'data-list="ordered"']);
+    expect(notesHtml).not.toContain('data-extra');
+    expect(notesHtml).not.toContain('data-original');
+  });
+
   test('image dialog inserts URL embeds and data images are blocked with visible feedback', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithRichNotesFixture(page);
@@ -239,6 +261,16 @@ function unsafePersistedMetadataNotes(): string {
     '<p><img src="vbscript:msgbox(1)"></p>',
     '<p><img src="java&#x0A;script:alert(1)"></p>',
     '<p><img src="not a url"></p>'
+  ].join('');
+}
+
+function persistedQuillListNotes(): string {
+  return [
+    '<ol data-extra="drop-list-container">',
+    '<li data-list="bullet" data-extra="drop-list-item"><span class="ql-ui" contenteditable="false"></span>Bullet note</li>',
+    '<li data-list="ordered" data-original="drop-list-item"><span class="ql-ui" contenteditable="false"></span>Ordered note</li>',
+    '</ol>',
+    '<p data-extra="drop-paragraph">After list</p>'
   ].join('');
 }
 


### PR DESCRIPTION
Closes #272

## Summary

- Adds a Trip Editor-local Quill wrapper through `RichNotesEditor.vue`, wired into the Vue/Vite dependency graph instead of the legacy Razor `LoadQuill` / `window.Quill` path.
- Upgrades all five notes owners from raw `notesHtml` textarea editing to the shared rich notes editor: trip metadata, region, place, area, and segment.
- Keeps the existing owner draft and save flows intact, including docked/expanded shared editor surfaces and existing mutation endpoints.
- Adds focused Playwright coverage for rich notes owner rendering, editing, image URL insertion, dirty/reset/save behavior, docked/expanded synchronization, and Quill bullet/ordered list preservation.

## Notes Canonicalization / Sanitizer Boundary

- Adds Trip Editor-local notes HTML canonicalization for Quill output so drafts and saves keep canonical user HTML.
- Preserves Quill 2 list formatting through canonical `li[data-list]` metadata for `bullet` and `ordered` lists only.
- Prevents editor-only/proxy-only state from becoming persisted notes content.
- Preserves the intended boundary: no broad frontend sanitizer rewrite was added, no broad `data-*` persistence was re-opened, and existing backend validation remains authoritative for rejected notes HTML such as `data:image` sources.

## Image URL Insertion

- The Quill wrapper owns image URL insertion behavior.
- HTTP/HTTPS image URLs can be inserted into notes content.
- The saved draft value remains the original user image URL rather than a `/Public/ProxyImage` display URL.
- `data:image` image input is blocked or normalized away with visible editor feedback, while server-side validation remains the final enforcement boundary.

## Dependency / Advisory State

- Adds `quill@2.0.2` to the Trip Editor frontend dependency graph.
- `npm audit --json` reports 0 vulnerabilities.

## Validation

- Final head SHA: `47f44aa63a510005ba9574e01e34557bc5b93796`.
- `git status --porcelain=v1` clean before push.
- `git ls-files -- .local playwright-report test-results screenshots traces wwwroot/vite/trip-editor` returned no tracked transient artifacts.
- `git diff --check origin/main...HEAD` passed.
- `npm run build` passed. Vite reported the existing chunk-size warning for the generated main bundle.
- `npm audit --json` passed with 0 vulnerabilities.
- `npm ls quill` passed and resolved `quill@2.0.2`.
- `npx playwright test --config=playwright.config.ts --list` listed 66 Trip Editor tests.
- `npx playwright test --config=playwright.config.ts tests/e2e/trip-editor/tripEditorRichNotes.spec.ts` passed: 8 passed.
- `npm run test:e2e:trip-editor` passed: 65 passed, 1 skipped.
- `dotnet build` passed with 0 warnings and 0 errors.
- `dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --filter TripEditor` passed: 158 passed.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` passed with warnings only.
- `rg "window\\.confirm" ClientApps/trip-editor/src` returned no matches.
- `rg "\\bconfirm\\(" ClientApps/trip-editor/src` returned only shared `useConfirmDialog` usage after manual review.
- `rg "window\\.Quill|LoadQuill" ClientApps/trip-editor/src` returned no matches.
- `rg "Notes HTML" ClientApps/trip-editor/src` returned no matches.

## E2E Server Findings

- Initial TCP checks found `localhost:5012` and `localhost:5173` closed.
- Started ASP.NET with `dotnet run --urls http://localhost:5012`; it listened on `http://localhost:5012` after normal startup and no-op migrations.
- Started Vite with `npm run dev`; it served `http://localhost:5173/`.
- Browser E2E ran against those local servers successfully, then both servers were stopped before .NET build/test validation.

## LOC Warning Decisions

The LOC checker reported warnings, but no hard failures:

- `ClientApps/trip-editor/src/styles.css` at 561 LOC: accepted as existing shared Trip Editor styling accumulation; this PR adds scoped rich notes CSS separately rather than further growing that file.
- `ClientApps/trip-editor/src/map/leafletAdapter.ts` at 453 LOC: accepted as unrelated map adapter scope; no rich notes change belongs there.
- `Areas/Api/Controllers/TripEditorController.cs` at 430 LOC: accepted as unrelated existing API controller scope; this PR does not add backend/API notes behavior.
- `tests/e2e/trip-editor/tripEditorRichNotes.spec.ts` at 424 LOC: warning accepted because the added coverage remains in the focused rich-notes E2E spec and exercises the same reload/save sanitizer contract without introducing a separate harness.
- `ClientApps/trip-editor/src/components/MetadataEditor.vue` at 416 LOC: accepted for this slice because the change is a narrow owner-surface swap from textarea notes to the shared rich notes component.
- `tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts` at 410 LOC: accepted as unrelated existing area coverage; rich notes coverage lives in a focused spec.

## Explicit Non-Scope

No backend/API/storage notes model was added. This PR preserves existing notes persistence through the current metadata, region, place, area, and segment mutation flows.