### PR TITLE
[Trip Editor] Polish responsive UI before cutover

### DIFF
--- a/ClientApps/trip-editor/src/richNotes.css
+++ b/ClientApps/trip-editor/src/richNotes.css
@@ -9,6 +9,7 @@
   background: var(--trip-editor-surface-muted);
   border-bottom: 0;
   border-radius: 6px 6px 0 0;
+  white-space: normal;
 }
 
 .trip-editor-rich-notes__editor {
@@ -39,6 +40,15 @@
 .trip-editor-rich-notes .ql-picker-options {
   background: var(--trip-editor-surface);
   border-color: var(--trip-editor-field-border);
+}
+
+.trip-editor-rich-notes .ql-formats {
+  margin-bottom: 0.25rem;
+}
+
+.trip-editor-rich-notes .ql-tooltip {
+  max-width: calc(100vw - 2rem);
+  white-space: normal;
 }
 
 .trip-editor-rich-notes__feedback {
@@ -77,6 +87,10 @@
   top: 50%;
   transform: translate(-50%, -50%);
   width: 100%;
+}
+
+.trip-editor-rich-notes-dialog__panel input {
+  min-width: 0;
 }
 
 .trip-editor-rich-notes-dialog__panel h2 {

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -20,6 +20,7 @@ body {
   height: calc(100vh - 116px);
   min-height: 560px;
   overflow: hidden;
+  width: 100%;
 }
 
 .trip-editor-sidebar {
@@ -37,12 +38,14 @@ body {
   gap: 1rem;
   justify-content: space-between;
   margin-bottom: 1rem;
+  min-width: 0;
 }
 
 .trip-editor-sidebar__header h1 {
   font-size: 1.35rem;
   line-height: 1.2;
   margin: 0;
+  overflow-wrap: anywhere;
 }
 
 .trip-editor-sidebar__eyebrow,
@@ -60,7 +63,8 @@ body {
   color: var(--trip-editor-text);
   font-size: 0.8rem;
   padding: 0.25rem 0.55rem;
-  white-space: nowrap;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .trip-editor-panel {
@@ -109,8 +113,9 @@ body {
 
 .trip-editor-save-state {
   color: var(--trip-editor-accent);
+  flex: 0 1 auto;
   font-size: 0.8rem;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .trip-editor-field {
@@ -265,6 +270,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
+  min-width: 0;
 }
 
 .trip-editor-settings-group {
@@ -304,6 +310,7 @@ body {
   display: grid;
   gap: 0.5rem;
   grid-template-columns: minmax(0, 1fr) auto;
+  min-width: 0;
 }
 
 .trip-editor-tag-suggestions {
@@ -461,8 +468,10 @@ body {
   background: var(--trip-editor-bg);
   border-bottom: 1px solid var(--trip-editor-border);
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   justify-content: space-between;
+  min-width: 0;
   padding: 0.75rem 1rem;
 }
 
@@ -519,6 +528,7 @@ body {
   gap: 0.5rem;
   grid-template-columns: auto minmax(14rem, 28rem) auto;
   justify-content: start;
+  min-width: 0;
 }
 
 .trip-editor-map-search__label,
@@ -576,6 +586,7 @@ body {
 .trip-editor-map-search__add-panel label {
   display: grid;
   gap: 0.2rem;
+  min-width: 0;
 }
 
 .trip-editor-state--error {
@@ -664,4 +675,36 @@ body {
     grid-template-columns: 1fr;
   }
 
+}
+
+@media (max-width: 520px) {
+  .trip-editor-workspace {
+    grid-template-rows: minmax(240px, 48vh) minmax(360px, 1fr);
+  }
+
+  .trip-editor-sidebar {
+    padding: 0.75rem;
+  }
+
+  .trip-editor-sidebar__header,
+  .trip-editor-panel__line,
+  .trip-editor-visit-progress-entry {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .trip-editor-grid,
+  .trip-editor-tag-entry {
+    grid-template-columns: 1fr;
+  }
+
+  .trip-editor-tag-entry .btn {
+    justify-self: start;
+  }
+
+  .trip-editor-map-search,
+  .trip-editor-toolbar {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
 }

--- a/ClientApps/trip-editor/src/surfaces.css
+++ b/ClientApps/trip-editor/src/surfaces.css
@@ -2,8 +2,10 @@
 .trip-editor-surface-context {
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   justify-content: space-between;
+  min-width: 0;
 }
 
 .trip-editor-surface,
@@ -24,8 +26,21 @@
 .trip-editor-surface__header {
   align-items: flex-start;
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   justify-content: space-between;
+  min-width: 0;
+}
+
+.trip-editor-surface__header > div:first-child,
+.trip-editor-surface-context > div:first-child {
+  min-width: 0;
+}
+
+.trip-editor-surface__header h2,
+.trip-editor-surface-context strong,
+.trip-editor-map-work-toolbar strong {
+  overflow-wrap: anywhere;
 }
 
 .trip-editor-surface__header h2,
@@ -60,10 +75,18 @@
   flex-wrap: wrap;
   gap: 0.5rem;
   justify-content: flex-end;
+  min-width: 0;
 }
 
 .trip-editor-surface__body {
   min-width: 0;
+}
+
+.trip-editor-workspace .btn,
+.trip-editor-expanded .btn,
+.trip-editor-map-work-toolbar .btn {
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .trip-editor-surface__footer {
@@ -120,8 +143,10 @@
   background: var(--trip-editor-surface);
   border-bottom: 1px solid var(--trip-editor-border);
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   justify-content: space-between;
+  min-width: 0;
   padding: 0.75rem 1rem;
   position: relative;
   z-index: 2;
@@ -130,6 +155,7 @@
 .trip-editor-map-work-toolbar > div:first-child {
   display: grid;
   gap: 0.15rem;
+  min-width: 0;
 }
 
 @media (max-width: 900px) {
@@ -148,5 +174,29 @@
     top: auto;
     transform: none;
     width: calc(100vw - 1.5rem);
+  }
+
+  .trip-editor-surface__controls,
+  .trip-editor-surface__footer,
+  .trip-editor-map-work-toolbar__actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 520px) {
+  .trip-editor-expanded__dialog {
+    bottom: 0.5rem;
+    left: 0.5rem;
+    max-height: calc(100vh - 1rem);
+    max-width: calc(100vw - 1rem);
+    width: calc(100vw - 1rem);
+  }
+
+  .trip-editor-expanded__header,
+  .trip-editor-expanded__body,
+  .trip-editor-expanded__footer,
+  .trip-editor-map-work-toolbar {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
   }
 }

--- a/ClientApps/trip-editor/src/visitProgress.css
+++ b/ClientApps/trip-editor/src/visitProgress.css
@@ -84,8 +84,10 @@
 .trip-editor-visit-history-row {
   align-items: flex-start;
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
   justify-content: space-between;
+  min-width: 0;
 }
 
 .trip-editor-visit-place-row header small,
@@ -139,4 +141,21 @@
 .trip-editor-visit-history-row dl {
   flex: 1 1 auto;
   grid-template-columns: repeat(3, minmax(0, 1fr));
+  min-width: min(24rem, 100%);
+}
+
+@media (max-width: 700px) {
+  .trip-editor-visit-place-row__summary,
+  .trip-editor-visit-history-row dl {
+    grid-template-columns: 1fr;
+  }
+
+  .trip-editor-visit-history-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .trip-editor-visit-history-row dl {
+    min-width: 0;
+  }
 }

--- a/tests/e2e/trip-editor/tripEditorVisualPolish.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorVisualPolish.spec.ts
@@ -249,8 +249,32 @@ async function setTheme(page: Page, theme: 'dark' | 'light'): Promise<void> {
 }
 
 async function expectNoPageOverflow(page: Page): Promise<void> {
-  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
-  expect(overflow, 'Trip Editor should not introduce horizontal page overflow.').toBeLessThanOrEqual(2);
+  const overflow = await page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth;
+    const documentOverflow = document.documentElement.scrollWidth - viewportWidth;
+    const bodyOverflow = document.body ? document.body.scrollWidth - viewportWidth : 0;
+    const stableContainerSelectors = ['#trip-editor-app', '.trip-editor-shell', '.trip-editor-workspace'];
+    const containerOverflow = stableContainerSelectors
+      .map(selector => {
+        const element = document.querySelector<HTMLElement>(selector);
+        if (!element) {
+          return { selector, overflow: 0 };
+        }
+
+        const bounds = element.getBoundingClientRect();
+        return {
+          selector,
+          overflow: Math.max(0, bounds.right - viewportWidth)
+        };
+      })
+      .filter(result => result.overflow > 2);
+
+    return { documentOverflow, bodyOverflow, containerOverflow };
+  });
+
+  expect(overflow.documentOverflow, 'Trip Editor should not introduce horizontal document overflow.').toBeLessThanOrEqual(2);
+  expect(overflow.bodyOverflow, 'Trip Editor should not introduce horizontal body overflow.').toBeLessThanOrEqual(2);
+  expect(overflow.containerOverflow, 'Stable Trip Editor containers should fit within the viewport.').toEqual([]);
 }
 
 async function expectDialogFitsViewport(page: Page): Promise<void> {
@@ -265,6 +289,7 @@ async function expectDialogFitsViewport(page: Page): Promise<void> {
 }
 
 async function capture(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  await expectNoPageOverflow(page);
   await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
 }
 

--- a/tests/e2e/trip-editor/tripEditorVisualPolish.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorVisualPolish.spec.ts
@@ -1,0 +1,273 @@
+import { expect, test, type Page, type Route, type TestInfo } from '@playwright/test';
+import {
+  absoluteUrl,
+  editorApiPath,
+  expectMountedWorkspace,
+  loadEditorStateFixture,
+  signIn,
+  workspacePath
+} from './tripEditorTestUtils';
+
+type MutableEditorState = Record<string, any>;
+
+const regionId = '00000000-0000-0000-0000-000000275101';
+const placeId = '00000000-0000-0000-0000-000000275201';
+const secondPlaceId = '00000000-0000-0000-0000-000000275202';
+const areaId = '00000000-0000-0000-0000-000000275301';
+const segmentId = '00000000-0000-0000-0000-000000275401';
+const visitId = '00000000-0000-0000-0000-000000275501';
+const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
+const matrixViewports = [
+  { name: 'desktop-wide', width: 1440, height: 1000 },
+  { name: 'laptop', width: 1280, height: 800 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'phone-smoke', width: 390, height: 900 }
+];
+
+test.describe.serial('Trip Editor issue 275 visual polish evidence', () => {
+  test.setTimeout(120000);
+
+  for (const viewport of matrixViewports) {
+    test(`metadata, search, visits, confirmations, and map-work evidence at ${viewport.name}`, async ({ page }, testInfo) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await signIn(page);
+      await loadWorkspaceWithVisualFixture(page);
+
+      await setTheme(page, 'light');
+      await expectNoPageOverflow(page);
+      await capture(page, testInfo, `${viewport.name}-light-docked-metadata`);
+      note(testInfo, 'docked metadata, tags/share progress, map navigation toolbar', viewport.name, 'light', 'data-bs-theme', 'pass');
+
+      await page.getByRole('button', { name: 'Expand Editor' }).click();
+      await expect(page.getByRole('dialog', { name: /Edit Trip -/ })).toBeVisible();
+      await expectDialogFitsViewport(page);
+      await capture(page, testInfo, `${viewport.name}-light-expanded-metadata`);
+      note(testInfo, 'expanded metadata and rich notes', viewport.name, 'light', 'data-bs-theme', 'pass');
+
+      await setTheme(page, 'dark');
+      await expectDialogFitsViewport(page);
+      await capture(page, testInfo, `${viewport.name}-dark-expanded-metadata`);
+      note(testInfo, 'expanded metadata dark theme', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await page.getByRole('dialog', { name: /Edit Trip -/ }).getByRole('button', { name: 'Dock to sidebar' }).click();
+
+      await setTheme(page, 'dark');
+      await page.getByLabel('Sidebar search').fill('not-a-visual-match');
+      await expect(page.getByText('No matching regions, places, areas, or segments.')).toBeVisible();
+      await capture(page, testInfo, `${viewport.name}-dark-sidebar-no-match`);
+      note(testInfo, 'sidebar search no-match state', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await page.getByLabel('Sidebar search').fill('');
+
+      await routeGeocode(page);
+      await page.getByRole('searchbox', { name: 'Map search' }).fill('visual place');
+      await page.getByRole('region', { name: 'Map search' }).getByRole('button', { name: 'Search' }).click();
+      await page.getByRole('button', { name: 'Visual Search Place' }).click();
+      await capture(page, testInfo, `${viewport.name}-dark-map-search-add`);
+      note(testInfo, 'map search/search-add', viewport.name, 'dark', 'data-bs-theme', 'pass');
+
+      await page.getByRole('button', { name: 'Visits' }).click();
+      await expect(page.getByRole('dialog', { name: 'Visit progress and history' })).toBeVisible();
+      await expectDialogFitsViewport(page);
+      await capture(page, testInfo, `${viewport.name}-dark-visit-progress`);
+      note(testInfo, 'visit progress/history', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await page.getByRole('dialog', { name: 'Visit progress and history' }).getByRole('button', { name: 'Close' }).click();
+
+      await openPlace(page);
+      await capture(page, testInfo, `${viewport.name}-dark-place-edit-docked`);
+      note(testInfo, 'child entity edit docked', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await page.getByRole('button', { name: 'Expand Editor' }).click();
+      await expectDialogFitsViewport(page);
+      await capture(page, testInfo, `${viewport.name}-dark-place-edit-expanded`);
+      note(testInfo, 'child entity edit expanded', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await page.getByRole('dialog', { name: /Edit Place -/ }).getByRole('button', { name: 'Dock to sidebar' }).click();
+
+      await page.getByRole('button', { name: 'Pick on map' }).click();
+      await capture(page, testInfo, `${viewport.name}-dark-place-coordinate-map-work`);
+      note(testInfo, 'place coordinate map-work', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await clickMap(page, { xRatio: 0.48, yRatio: 0.42 });
+      await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+      await expect(page.getByRole('dialog', { name: 'Discard map editing changes?' })).toBeVisible();
+      await capture(page, testInfo, `${viewport.name}-dark-map-work-confirm`);
+      note(testInfo, 'map-work cancel/discard confirmation', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
+
+      await openArea(page);
+      await page.getByRole('button', { name: 'Draw/Edit Area' }).click();
+      await capture(page, testInfo, `${viewport.name}-dark-area-polygon-map-work`);
+      note(testInfo, 'area polygon map-work', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+
+      await openSegment(page);
+      await page.getByRole('button', { name: 'Draw/Edit Route' }).click();
+      await capture(page, testInfo, `${viewport.name}-dark-segment-route-map-work`);
+      note(testInfo, 'segment route map-work', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+
+      await openPlace(page);
+      await page.locator('#trip-editor-place-form').getByLabel('Name').fill('Unsaved visual place');
+      await page.getByRole('button', { name: 'Close' }).click();
+      await expect(page.getByRole('dialog', { name: 'Discard changes?' })).toBeVisible();
+      await capture(page, testInfo, `${viewport.name}-dark-dirty-discard-confirm`);
+      note(testInfo, 'dirty-discard confirmation', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
+
+      await openPlace(page);
+      await page.getByRole('button', { name: 'Delete', exact: true }).click();
+      await expect(page.getByRole('dialog', { name: 'Delete place?' })).toBeVisible();
+      await capture(page, testInfo, `${viewport.name}-dark-delete-confirm`);
+      note(testInfo, 'delete confirmation', viewport.name, 'dark', 'data-bs-theme', 'pass');
+      await page.getByRole('dialog', { name: 'Delete place?' }).getByRole('button', { name: 'Keep place' }).click();
+
+      await page.locator('#trip-editor-place-form').getByLabel('Name').fill('Unsaved navigation guard');
+      await openVisits(page);
+      await page.getByRole('link', { name: 'Manage visit' }).click();
+      await expect(page.getByRole('dialog', { name: 'Discard changes?' })).toBeVisible();
+      await capture(page, testInfo, `${viewport.name}-dark-navigation-confirm`);
+      note(testInfo, 'navigation confirmation', viewport.name, 'dark', 'data-bs-theme', 'pass');
+    });
+  }
+});
+
+async function loadWorkspaceWithVisualFixture(page: Page): Promise<void> {
+  await page.unroute(editorApiMatcher).catch(() => undefined);
+  const state = await loadEditorStateFixture(page) as MutableEditorState;
+  prepareVisualState(state);
+  await page.route(editorApiMatcher, async route => routeReadOnlyEditor(route, state));
+  await page.goto(absoluteUrl(workspacePath));
+  await expectMountedWorkspace(page);
+}
+
+async function routeReadOnlyEditor(route: Route, state: MutableEditorState): Promise<void> {
+  if (route.request().method() !== 'GET') {
+    throw new Error(`Unexpected visual evidence mutation ${route.request().method()} ${route.request().url()}`);
+  }
+
+  await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+}
+
+function prepareVisualState(state: MutableEditorState): void {
+  state.permissions.canEditMetadata = true;
+  state.permissions.canEditRegions = true;
+  state.permissions.canEditPlaces = true;
+  state.permissions.canEditAreas = true;
+  state.permissions.canEditSegments = true;
+  state.permissions.canReadVisitProgress = true;
+  state.metadata.isPublic = true;
+  state.metadata.shareProgressEnabled = true;
+  state.metadata.progressPublicUrl ||= '/Public/Trips/visual-progress';
+  state.tagOrder = ['visual'];
+  state.tagsBySlug = { visual: { slug: 'visual', name: 'Visual QA' } };
+
+  state.regionsById[regionId] = regionFixture(state);
+  state.regionOrder = [regionId];
+  state.placesById[placeId] = placeFixture(state, placeId, 'Visual Place', { latitude: 37.9838, longitude: 23.7275 });
+  state.placesById[secondPlaceId] = placeFixture(state, secondPlaceId, 'Visual Second Place', { latitude: 37.99, longitude: 23.74 });
+  state.placeOrderByRegionId = { [regionId]: [placeId, secondPlaceId] };
+  state.areasById = { [areaId]: areaFixture(state) };
+  state.areaOrderByRegionId = { [regionId]: [areaId] };
+  state.segmentsById = { [segmentId]: segmentFixture(state) };
+  state.segmentOrder = [segmentId];
+  state.visitProgress = {
+    totalPlaces: 2,
+    visitedPlaces: 1,
+    percentVisited: 50,
+    placeSummariesByPlaceId: {
+      [placeId]: { placeId, visitCount: 1, isVisited: true, firstVisitAt: '2026-01-01T08:00:00.000Z', lastVisitAt: '2026-01-01T08:45:00.000Z' },
+      [secondPlaceId]: { placeId: secondPlaceId, visitCount: 0, isVisited: false, firstVisitAt: null, lastVisitAt: null }
+    },
+    historyRows: [{ visitId, placeId, regionId, startedAt: '2026-01-01T08:00:00.000Z', endedAt: '2026-01-01T08:45:00.000Z', durationMinutes: 45 }]
+  };
+}
+
+function regionFixture(state: MutableEditorState): Record<string, any> {
+  return { id: regionId, tripId: state.tripId, name: 'Visual Region', notesHtml: '<p>Region notes</p>', coverImage: null, center: null, displayOrder: 1, isShadow: false, capabilities: editableCapabilities() };
+}
+
+function placeFixture(state: MutableEditorState, id: string, name: string, location: Record<string, number>): Record<string, any> {
+  return { id, tripId: state.tripId, regionId, name, notesHtml: '<p>Place notes</p>', address: 'Athens, Greece', location, iconName: state.options.iconNames[0] ?? 'marker', markerColor: state.options.markerColorClasses[0] ?? 'bg-blue', displayOrder: 1, visitSummary: { placeId: id, visitCount: id === placeId ? 1 : 0, isVisited: id === placeId, firstVisitAt: null, lastVisitAt: null }, capabilities: editableCapabilities() };
+}
+
+function areaFixture(state: MutableEditorState): Record<string, any> {
+  return { id: areaId, tripId: state.tripId, regionId, name: 'Visual Area', notesHtml: '<p>Area notes</p>', fillHex: '#0d6efd', geometry: { type: 'Polygon', coordinates: [[[23.72, 37.98], [23.73, 37.98], [23.73, 37.99], [23.72, 37.98]]] }, displayOrder: 1, capabilities: editableCapabilities() };
+}
+
+function segmentFixture(state: MutableEditorState): Record<string, any> {
+  return { id: segmentId, tripId: state.tripId, fromPlaceId: placeId, toPlaceId: secondPlaceId, mode: state.options.transportModes[0]?.value ?? 'walk', estimatedDistanceKm: 2, estimatedDurationMinutes: 30, notesHtml: '<p>Segment notes</p>', route: { type: 'LineString', coordinates: [[23.7275, 37.9838], [23.74, 37.99]] }, displayOrder: 1, capabilities: editableCapabilities() };
+}
+
+function editableCapabilities(): Record<string, boolean> {
+  return { canEdit: true, canRename: true, canDelete: true, canReorder: true, canMove: true, canAddChildren: true, canTargetForSearchAdd: true };
+}
+
+async function routeGeocode(page: Page): Promise<void> {
+  await page.route(/\/api\/trips\/[^/]+\/editor\/geocode\/search/i, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        query: 'visual place',
+        attribution: 'Visual evidence provider',
+        results: [{ id: 'visual:place', provider: 'visual', name: 'Visual Search Place', displayName: 'Visual Search Place, Athens', address: 'Athens, Greece', category: 'tourism', type: 'attraction', latitude: 37.9715, longitude: 23.7257 }]
+      })
+    });
+  });
+}
+
+async function openPlace(page: Page): Promise<void> {
+  await page.locator(`[data-place-id="${placeId}"]`).getByRole('button', { name: 'Edit', exact: true }).click();
+  await expect(page.getByRole('heading', { name: /Edit Place - Visual Place/ })).toBeVisible();
+}
+
+async function openArea(page: Page): Promise<void> {
+  await page.locator(`[data-area-id="${areaId}"]`).getByRole('button', { name: 'Edit', exact: true }).click();
+  await expect(page.getByRole('heading', { name: /Edit Area - Visual Area/ })).toBeVisible();
+}
+
+async function openSegment(page: Page): Promise<void> {
+  await page.locator(`[data-segment-id="${segmentId}"] .trip-editor-list-button`).click();
+  await expect(page.getByRole('heading', { name: /Edit Segment -/ })).toBeVisible();
+}
+
+async function openVisits(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Visits' }).click();
+  await expect(page.getByRole('dialog', { name: 'Visit progress and history' })).toBeVisible();
+}
+
+async function clickMap(page: Page, position: { xRatio: number; yRatio: number }): Promise<void> {
+  const map = page.getByLabel('Read-only trip map');
+  await map.evaluate((element, point) => {
+    const box = element.getBoundingClientRect();
+    const clientX = box.left + box.width * point.xRatio;
+    const clientY = box.top + box.height * point.yRatio;
+    for (const type of ['mousedown', 'mouseup', 'click']) {
+      element.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, view: window }));
+    }
+  }, position);
+}
+
+async function setTheme(page: Page, theme: 'dark' | 'light'): Promise<void> {
+  await page.evaluate(value => document.documentElement.setAttribute('data-bs-theme', value), theme);
+}
+
+async function expectNoPageOverflow(page: Page): Promise<void> {
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(overflow, 'Trip Editor should not introduce horizontal page overflow.').toBeLessThanOrEqual(2);
+}
+
+async function expectDialogFitsViewport(page: Page): Promise<void> {
+  const dialog = page.locator('.trip-editor-expanded__dialog:visible').first();
+  const [box, viewport] = await Promise.all([dialog.boundingBox(), page.viewportSize()]);
+  expect(box, 'Expanded dialog should have a rendered box.').not.toBeNull();
+  expect(viewport, 'Viewport should be available for dialog fit check.').not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(-1);
+  expect(box!.y).toBeGreaterThanOrEqual(-1);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
+}
+
+async function capture(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
+}
+
+function note(testInfo: TestInfo, state: string, viewport: string, theme: string, themeSource: string, result: string): void {
+  testInfo.annotations.push({ type: 'issue-275-evidence', description: `${state} | ${viewport} | ${theme} | ${themeSource} | ${result}` });
+}


### PR DESCRIPTION
Closes #275

## Summary
- Applies CSS-only Trip Editor polish for the responsive workspace shell, sidebar, toolbar, and dense/mobile states before route cutover.
- Adds/uses visual evidence coverage for the requested responsive, theme, overflow, and confirmation-dialog states.

## Scope
No backend/Razor/API/project/shared build, route cutover, legacy cleanup, import/export/backfill, or new feature work is included in this slice.

## Evidence matrix summary
- States reviewed: workspace shell/sidebar/toolbar responsive states, dense content/overflow states, map/editor surface alignment, and confirmation dialog presentation.
- Viewport/theme combinations: desktop and mobile responsive coverage across light and dark theme modes.
- Evidence artifact location: Playwright visual polish artifacts under the repo-local ignored evidence/output locations from the focused Trip Editor visual polish run.
- Pass/limitation notes: focused visual polish coverage passed; manual/browser evidence depends on the ASP.NET and Vite dev servers running locally.
- Theme mechanism used: Trip Editor theme class/data-state mechanism exercised through Playwright rather than backend or Razor changes.
- Confirmation dialog evidence: shared Trip Editor confirmation dialog path was exercised; raw window.confirm usage remains excluded.

## Validation
- `npm run build` passed.
- `npx playwright test --config=playwright.config.ts --list` passed, 79 tests.
- Focused visual polish spec passed, 4 tests.
- `npm run test:e2e:trip-editor` passed, 78 passed / 1 skipped.
- LOC checker passed with warnings.
- Confirm scans clean/shared-dialog only.
- `git diff --check origin/main...HEAD` passed.
- Tracked artifact scan clean.

## E2E server timeline
- Initial focused run failed with `ERR_CONNECTION_REFUSED` before ASP.NET was started.
- After starting ASP.NET on `http://localhost:5012` and Vite on `http://localhost:5173`, focused and full E2E passed.

## LOC decision
`styles.css` at 598 LOC is accepted for this slice because changed rules remain cohesive Trip Editor shell/sidebar/toolbar/responsive styling; next base-style growth should split before crossing hard cap.
