### PR TITLE
[Trip Editor] Cut over Edit route to Vue workspace

### DIFF
--- a/Areas/User/Controllers/TripController.cs
+++ b/Areas/User/Controllers/TripController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 using Wayfarer.Models;
+using Wayfarer.Models.ViewModels;
 using Wayfarer.Services;
 using Wayfarer.Util;
 
@@ -181,59 +182,38 @@ namespace Wayfarer.Areas.User.Controllers
             return View(model);
         }
 
-        // GET: /User/Trip/Edit/{id}
+        /// <summary>
+        /// Shows the canonical Vue Trip Editor shell for an owned trip.
+        /// </summary>
         public async Task<IActionResult> Edit(Guid id)
         {
             SetPageTitle("Edit Trip");
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
 
-            // 1) Eager-load Regions → Places, Areas and Segments
-            var trip = await _dbContext.Trips.Where(t => t.Id == id)
-                .Include(t => t.Regions)
-                .ThenInclude(r => r.Places)
-                .Include(t => t.Regions!).ThenInclude(a => a.Areas)
-                .Include(t => t.Segments)
-                .Include(t => t.Tags)
-                .FirstOrDefaultAsync(t => t.Id == id && t.UserId == userId);
+            var trip = await _dbContext.Trips
+                .AsNoTracking()
+                .Where(t => t.Id == id && t.UserId == userId)
+                .Select(t => new { t.Id, t.Name })
+                .FirstOrDefaultAsync();
 
             if (trip == null)
             {
-                SetAlert("Trip not found.", "warning");
-                return RedirectToAction(nameof(Index));
+                return NotFound();
             }
 
+            ViewData["Title"] = "Trip Editor";
+            ViewData["BodyClass"] = "container-fluid";
+            ViewData["LoadLeaflet"] = false;
+            ViewData["LoadQuill"] = false;
 
-            // 2) Materialize to concrete Lists
-            trip.Regions = trip.Regions?.ToList() ?? new List<Region>();
-            foreach (var region in trip.Regions)
+            return View("~/Areas/User/Views/Trip/Workspace.cshtml", new TripEditorWorkspaceViewModel
             {
-                region.Places = region.Places?.ToList() ?? new List<Place>();
-            }
-
-            trip.Segments = trip.Segments?.ToList() ?? new List<Segment>();
-
-            // 3) Calculate visit progress for this trip
-            var allPlaceIds = trip.Regions
-                .SelectMany(r => r.Places ?? Enumerable.Empty<Place>())
-                .Select(p => p.Id)
-                .ToList();
-
-            // Get visit events per place (a place can be visited multiple times)
-            var visitEvents = await _dbContext.PlaceVisitEvents
-                .Where(v => v.UserId == userId && v.PlaceId != null && allPlaceIds.Contains(v.PlaceId.Value))
-                .OrderByDescending(v => v.ArrivedAtUtc)
-                .ToListAsync();
-
-            var placeVisitCounts = visitEvents
-                .GroupBy(v => v.PlaceId!.Value)
-                .ToDictionary(g => g.Key, g => g.Count());
-
-            ViewBag.TotalPlaces = allPlaceIds.Count;
-            ViewBag.VisitedPlaces = placeVisitCounts.Count;
-            ViewBag.PlaceVisitCounts = placeVisitCounts;
-            ViewBag.VisitEvents = visitEvents; // Pass flat list, group in view
-
-            return View(trip);
+                TripId = trip.Id,
+                TripName = trip.Name,
+                EditorEndpointUrl = $"/api/trips/{trip.Id}/editor",
+                TripIndexUrl = Url?.Action(nameof(Index), "Trip", new { area = "User" }) ?? "/User/Trip/Index",
+                TilesUrl = "/Public/tiles/{z}/{x}/{y}.png"
+            });
         }
 
         // POST: /User/Trip/Edit/{id}

--- a/Areas/User/Controllers/TripController.cs
+++ b/Areas/User/Controllers/TripController.cs
@@ -241,7 +241,9 @@ namespace Wayfarer.Areas.User.Controllers
             ModelState.Remove(nameof(model.User));
 
             if (!ValidateModelState())
-                return View(model);
+            {
+                return BadRequest(ModelState);
+            }
 
             try
             {
@@ -293,7 +295,7 @@ namespace Wayfarer.Areas.User.Controllers
             catch (Exception ex)
             {
                 HandleError(ex);
-                return View(model);
+                return StatusCode(500);
             }
         }
 

--- a/Areas/User/Controllers/TripController.cs
+++ b/Areas/User/Controllers/TripController.cs
@@ -162,7 +162,7 @@ namespace Wayfarer.Areas.User.Controllers
                         // Redirect to Edit for further configuration
                         return RedirectToAction(
                             actionName: nameof(Edit),
-                            controllerName: ControllerContext.ActionDescriptor.ControllerName,
+                            controllerName: "Trip",
                             routeValues: new { area = "User", id = model.Id }
                         );
                     }

--- a/Areas/User/Controllers/TripWorkspaceController.cs
+++ b/Areas/User/Controllers/TripWorkspaceController.cs
@@ -16,7 +16,7 @@ public sealed class TripWorkspaceController : Controller
     private readonly ApplicationDbContext _dbContext;
 
     /// <summary>
-    /// Initializes a new workspace shell controller.
+    /// Initializes a new workspace redirect controller.
     /// </summary>
     public TripWorkspaceController(ApplicationDbContext dbContext)
     {

--- a/Areas/User/Controllers/TripWorkspaceController.cs
+++ b/Areas/User/Controllers/TripWorkspaceController.cs
@@ -3,12 +3,11 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Wayfarer.Models;
-using Wayfarer.Models.ViewModels;
 
 namespace Wayfarer.Areas.User.Controllers;
 
 /// <summary>
-/// MVC shell controller for the Vue/Vite Trip Editor workspace spike.
+/// Temporary redirect controller for the former Trip Editor workspace URL.
 /// </summary>
 [Area("User")]
 [Authorize(Roles = "User")]
@@ -25,7 +24,7 @@ public sealed class TripWorkspaceController : Controller
     }
 
     /// <summary>
-    /// Shows the Trip Editor workspace shell for an owned trip.
+    /// Redirects owned-trip workspace requests to the canonical Trip Editor route.
     /// </summary>
     [HttpGet]
     public async Task<IActionResult> Workspace(Guid id)
@@ -47,18 +46,6 @@ public sealed class TripWorkspaceController : Controller
             return NotFound();
         }
 
-        ViewData["Title"] = "Trip Editor Workspace";
-        ViewData["BodyClass"] = "container-fluid";
-        ViewData["LoadLeaflet"] = false;
-        ViewData["LoadQuill"] = false;
-
-        return View("~/Areas/User/Views/Trip/Workspace.cshtml", new TripEditorWorkspaceViewModel
-        {
-            TripId = trip.Id,
-            TripName = trip.Name,
-            EditorEndpointUrl = $"/api/trips/{trip.Id}/editor",
-            TripIndexUrl = Url.Action("Index", "Trip", new { area = "User" }) ?? "/User/Trip/Index",
-            TilesUrl = "/Public/tiles/{z}/{x}/{y}.png"
-        });
+        return RedirectToAction("Edit", "Trip", new { area = "User", id = trip.Id });
     }
 }

--- a/Areas/User/Views/Trip/Workspace.cshtml
+++ b/Areas/User/Views/Trip/Workspace.cshtml
@@ -4,7 +4,7 @@
 
 @{
     Layout = "~/Views/Shared/_Layout.cshtml";
-    ViewData["Title"] = "Trip Editor Workspace";
+    ViewData["Title"] = "Trip Editor";
     var manifestPath = System.IO.Path.Combine(Environment.WebRootPath, "vite", "trip-editor", ".vite", "manifest.json");
     var entryScript = "/ClientApps/trip-editor/src/main.ts";
 }
@@ -60,7 +60,7 @@
      data-tiles-url="@Model.TilesUrl">
     <div class="trip-editor-shell-loading">
         <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>
-        Loading trip editor workspace...
+        Loading trip editor...
     </div>
 </div>
 

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -282,7 +282,7 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
   <div ref="workspaceElement" class="trip-editor-workspace" tabindex="-1">
     <div v-if="isLoading" class="trip-editor-state trip-editor-state--loading">
       <div class="spinner-border" role="status" aria-label="Loading"></div>
-      <span>Loading trip editor workspace...</span>
+      <span>Loading trip editor...</span>
     </div>
 
     <div v-else-if="error" class="trip-editor-state trip-editor-state--error">
@@ -325,7 +325,6 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
               </button>
               <button type="button" class="btn btn-outline-light btn-sm" :disabled="!canFocusTarget" @click="focusActiveEntity">Focus Active Entity</button>
             </template>
-            <a v-if="!isMapWorkActive" class="btn btn-outline-light btn-sm" :href="`/User/Trip/Edit/${state.tripId}`">Legacy editor</a>
           </div>
         </header>
         <MapWorkToolbar :controller="editorSurface" />

--- a/tests/Wayfarer.Tests/Controllers/TripControllerCreateRedirectTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripControllerCreateRedirectTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Wayfarer.Areas.User.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Controllers;
+
+/// <summary>
+/// Create-flow redirect coverage for canonical Trip Editor entry points.
+/// </summary>
+public class TripControllerCreateRedirectTests : TestBase
+{
+    [Fact]
+    public async Task Create_Post_RedirectsToCanonicalEdit_WhenSaveEditRequested()
+    {
+        var db = CreateDbContext();
+        var user = TestDataFixtures.CreateUser(id: "creator");
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+        var controller = BuildController(db, user.Id);
+        var tripId = Guid.NewGuid();
+        var model = new Trip
+        {
+            Id = tripId,
+            Name = "New Trip",
+            IsPublic = false,
+            Notes = string.Empty
+        };
+
+        var result = await controller.Create(model, "save-edit");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(TripController.Edit), redirect.ActionName);
+        Assert.Equal("Trip", redirect.ControllerName);
+        Assert.Equal("User", redirect.RouteValues?["area"]);
+        Assert.Equal(tripId, redirect.RouteValues?["id"]);
+    }
+
+    private static TripController BuildController(ApplicationDbContext db, string userId)
+    {
+        var httpContext = BuildHttpContextWithUser(userId);
+        var controller = new TripController(
+            NullLogger<TripController>.Instance,
+            db,
+            Mock.Of<ITripMapThumbnailGenerator>(),
+            Mock.Of<ITripTagService>(),
+            Mock.Of<ICacheWarmupScheduler>());
+
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        controller.TempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
+        return controller;
+    }
+}

--- a/tests/Wayfarer.Tests/Controllers/TripControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripControllerTests.cs
@@ -10,6 +10,7 @@ using Moq;
 using NetTopologySuite.Geometries;
 using Wayfarer.Areas.User.Controllers;
 using Wayfarer.Models;
+using Wayfarer.Models.ViewModels;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
 using Xunit;
@@ -393,7 +394,7 @@ public class TripControllerTests : TestBase
     }
 
     [Fact]
-    public async Task Edit_Get_RedirectsWithAlert_WhenTripMissing()
+    public async Task Edit_Get_ReturnsNotFound_WhenTripMissing()
     {
         var db = CreateDbContext();
         var user = TestDataFixtures.CreateUser(id: "user-1");
@@ -404,35 +405,16 @@ public class TripControllerTests : TestBase
 
         var result = await controller.Edit(Guid.NewGuid());
 
-        var redirect = Assert.IsType<RedirectToActionResult>(result);
-        Assert.Equal(nameof(TripController.Index), redirect.ActionName);
-        Assert.Equal("Trip not found.", controller.TempData["AlertMessage"]);
+        Assert.IsType<NotFoundResult>(result);
     }
 
     [Fact]
-    public async Task Edit_Get_ReturnsView_WithLoadedCollections()
+    public async Task Edit_Get_ReturnsCanonicalVueShell_WhenTripOwned()
     {
         var db = CreateDbContext();
         var user = TestDataFixtures.CreateUser(id: "owner");
         db.Users.Add(user);
         var trip = TestDataFixtures.CreateTrip(user, "Owned Trip");
-        var region = new Region
-        {
-            Id = Guid.NewGuid(),
-            TripId = trip.Id,
-            UserId = user.Id,
-            Name = "Region",
-            Places = new List<Place> { new() { Id = Guid.NewGuid(), UserId = user.Id, RegionId = Guid.NewGuid(), Name = "Place" } }
-        };
-        var segment = new Segment
-        {
-            Id = Guid.NewGuid(),
-            TripId = trip.Id,
-            UserId = user.Id,
-            Mode = "walk"
-        };
-        trip.Regions = new List<Region> { region };
-        trip.Segments = new List<Segment> { segment };
         db.Trips.Add(trip);
         await db.SaveChangesAsync();
 
@@ -441,13 +423,12 @@ public class TripControllerTests : TestBase
         var result = await controller.Edit(trip.Id);
 
         var view = Assert.IsType<ViewResult>(result);
-        var model = Assert.IsType<Trip>(view.Model);
-        Assert.NotNull(model.Regions);
-        Assert.Single(model.Regions);
-        Assert.NotNull(model.Regions.First().Places);
-        Assert.Single(model.Regions.First().Places);
-        Assert.NotNull(model.Segments);
-        Assert.Single(model.Segments);
+        Assert.Equal("~/Areas/User/Views/Trip/Workspace.cshtml", view.ViewName);
+        var model = Assert.IsType<TripEditorWorkspaceViewModel>(view.Model);
+        Assert.Equal(trip.Id, model.TripId);
+        Assert.Equal("Owned Trip", model.TripName);
+        Assert.Equal($"/api/trips/{trip.Id}/editor", model.EditorEndpointUrl);
+        Assert.Equal("/User/Trip/Index", model.TripIndexUrl);
     }
 
     [Fact]
@@ -690,6 +671,31 @@ public class TripControllerTests : TestBase
 
         // Assert: non-immediate (debounced) warmup scheduled
         warmupMock.Verify(w => w.ScheduleWarmupAsync(trip.Id, false), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_Post_RedirectsToCanonicalEdit_WhenSaveEditRequested()
+    {
+        var db = CreateDbContext();
+        var user = TestDataFixtures.CreateUser(id: "creator");
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+        var controller = BuildControllerWithUser(db, user.Id);
+        var tripId = Guid.NewGuid();
+        var model = new Trip
+        {
+            Id = tripId,
+            Name = "New Trip",
+            IsPublic = false
+        };
+
+        var result = await controller.Create(model, "save-edit");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(TripController.Edit), redirect.ActionName);
+        Assert.Equal("Trip", redirect.ControllerName);
+        Assert.Equal("User", redirect.RouteValues?["area"]);
+        Assert.Equal(tripId, redirect.RouteValues?["id"]);
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Controllers/TripControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripControllerTests.cs
@@ -674,32 +674,6 @@ public class TripControllerTests : TestBase
     }
 
     [Fact]
-    public async Task Create_Post_RedirectsToCanonicalEdit_WhenSaveEditRequested()
-    {
-        var db = CreateDbContext();
-        var user = TestDataFixtures.CreateUser(id: "creator");
-        db.Users.Add(user);
-        await db.SaveChangesAsync();
-        var controller = BuildControllerWithUser(db, user.Id);
-        var tripId = Guid.NewGuid();
-        var model = new Trip
-        {
-            Id = tripId,
-            Name = "New Trip",
-            IsPublic = false,
-            Notes = string.Empty
-        };
-
-        var result = await controller.Create(model, "save-edit");
-
-        var redirect = Assert.IsType<RedirectToActionResult>(result);
-        Assert.Equal(nameof(TripController.Edit), redirect.ActionName);
-        Assert.Equal("Trip", redirect.ControllerName);
-        Assert.Equal("User", redirect.RouteValues?["area"]);
-        Assert.Equal(tripId, redirect.RouteValues?["id"]);
-    }
-
-    [Fact]
     public async Task Create_Post_DoesNotScheduleWarmup_WhenNoImages()
     {
         // Arrange

--- a/tests/Wayfarer.Tests/Controllers/TripControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripControllerTests.cs
@@ -559,7 +559,6 @@ public class TripControllerTests : TestBase
         var result = await controller.Edit(trip.Id, model, submitAction: null!);
 
         Assert.IsType<BadRequestObjectResult>(result);
-        Assert.IsNotType<ViewResult>(result);
         Assert.Equal("Original", db.Trips.Find(trip.Id)!.Name);
     }
 
@@ -584,7 +583,6 @@ public class TripControllerTests : TestBase
 
         var status = Assert.IsType<StatusCodeResult>(result);
         Assert.Equal(500, status.StatusCode);
-        Assert.IsNotType<ViewResult>(result);
     }
 
     private TripController BuildController(ApplicationDbContext db)

--- a/tests/Wayfarer.Tests/Controllers/TripControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripControllerTests.cs
@@ -686,7 +686,8 @@ public class TripControllerTests : TestBase
         {
             Id = tripId,
             Name = "New Trip",
-            IsPublic = false
+            IsPublic = false,
+            Notes = string.Empty
         };
 
         var result = await controller.Create(model, "save-edit");

--- a/tests/Wayfarer.Tests/Controllers/TripControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripControllerTests.cs
@@ -543,7 +543,7 @@ public class TripControllerTests : TestBase
     }
 
     [Fact]
-    public async Task Edit_Post_ReturnsView_WhenModelInvalid()
+    public async Task Edit_Post_ReturnsBadRequest_WhenModelInvalid()
     {
         var db = CreateDbContext();
         var user = TestDataFixtures.CreateUser(id: "owner");
@@ -558,9 +558,33 @@ public class TripControllerTests : TestBase
 
         var result = await controller.Edit(trip.Id, model, submitAction: null!);
 
-        var view = Assert.IsType<ViewResult>(result);
-        Assert.Same(model, view.Model);
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.IsNotType<ViewResult>(result);
         Assert.Equal("Original", db.Trips.Find(trip.Id)!.Name);
+    }
+
+    [Fact]
+    public async Task Edit_Post_ReturnsServerError_WhenLegacyUpdateThrows()
+    {
+        var db = CreateDbContext();
+        var user = TestDataFixtures.CreateUser(id: "owner");
+        db.Users.Add(user);
+        var trip = TestDataFixtures.CreateTrip(user, "Original");
+        db.Trips.Add(trip);
+        await db.SaveChangesAsync();
+
+        var thumbnailMock = new Mock<ITripMapThumbnailGenerator>();
+        thumbnailMock
+            .Setup(t => t.InvalidateThumbnails(trip.Id, It.IsAny<DateTime>()))
+            .Throws(new InvalidOperationException("Legacy POST failure."));
+        var controller = BuildControllerWithUser(db, user.Id, thumbnailMock);
+        var model = new Trip { Id = trip.Id, Name = "Updated" };
+
+        var result = await controller.Edit(trip.Id, model, submitAction: null!);
+
+        var status = Assert.IsType<StatusCodeResult>(result);
+        Assert.Equal(500, status.StatusCode);
+        Assert.IsNotType<ViewResult>(result);
     }
 
     private TripController BuildController(ApplicationDbContext db)

--- a/tests/Wayfarer.Tests/Controllers/TripImportControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripImportControllerTests.cs
@@ -30,17 +30,19 @@ public class TripImportControllerTests : TestBase
         Assert.Equal("File missing", bad.Value);
     }
 
-    [Fact]
-    public async Task Import_RedirectsToTripEdit_OnSuccess()
+    [Theory]
+    [InlineData(TripImportMode.Auto)]
+    [InlineData(TripImportMode.CreateNew)]
+    public async Task Import_RedirectsToCanonicalTripEdit_OnSuccess(TripImportMode mode)
     {
         var importSvc = new Mock<ITripImportService>();
-        importSvc.Setup(s => s.ImportWayfarerKmlAsync(It.IsAny<Stream>(), "u1", TripImportMode.Auto))
+        importSvc.Setup(s => s.ImportWayfarerKmlAsync(It.IsAny<Stream>(), "u1", mode))
             .ReturnsAsync(Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
         var controller = BuildController(importSvc.Object);
         ConfigureControllerWithUser(controller, "u1");
         var file = CreateFormFile("content");
 
-        var result = await controller.Import(file);
+        var result = await controller.Import(file, mode);
 
         var redirect = Assert.IsType<RedirectToActionResult>(result);
         Assert.Equal("Edit", redirect.ActionName);

--- a/tests/Wayfarer.Tests/Controllers/TripWorkspaceControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripWorkspaceControllerTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Wayfarer.Areas.User.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Controllers;
+
+/// <summary>
+/// Temporary Trip Editor workspace route behavior after the canonical Edit cutover.
+/// </summary>
+public class TripWorkspaceControllerTests : TestBase
+{
+    [Fact]
+    public void Controller_RequiresUserRole()
+    {
+        var authorize = typeof(TripWorkspaceController)
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .Cast<AuthorizeAttribute>()
+            .Single();
+
+        Assert.Equal("User", authorize.Roles);
+    }
+
+    [Fact]
+    public async Task Workspace_RedirectsToCanonicalEdit_WhenTripOwned()
+    {
+        var db = CreateDbContext();
+        var user = TestDataFixtures.CreateUser(id: "owner");
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = user.Id, Name = "Owned Trip" };
+        db.Users.Add(user);
+        db.Trips.Add(trip);
+        await db.SaveChangesAsync();
+        var controller = BuildController(db, user.Id);
+
+        var result = await controller.Workspace(trip.Id);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Edit", redirect.ActionName);
+        Assert.Equal("Trip", redirect.ControllerName);
+        Assert.Equal("User", redirect.RouteValues?["area"]);
+        Assert.Equal(trip.Id, redirect.RouteValues?["id"]);
+        Assert.False(redirect.Permanent);
+    }
+
+    [Fact]
+    public async Task Workspace_ReturnsNotFound_WhenTripMissing()
+    {
+        var db = CreateDbContext();
+        var user = TestDataFixtures.CreateUser(id: "owner");
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+        var controller = BuildController(db, user.Id);
+
+        var result = await controller.Workspace(Guid.NewGuid());
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Workspace_ReturnsNotFound_WhenTripNotOwned()
+    {
+        var db = CreateDbContext();
+        var owner = TestDataFixtures.CreateUser(id: "owner");
+        var other = TestDataFixtures.CreateUser(id: "other");
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = owner.Id, Name = "Owned Trip" };
+        db.Users.AddRange(owner, other);
+        db.Trips.Add(trip);
+        await db.SaveChangesAsync();
+        var controller = BuildController(db, other.Id);
+
+        var result = await controller.Workspace(trip.Id);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    private static TripWorkspaceController BuildController(ApplicationDbContext db, string userId)
+    {
+        var controller = new TripWorkspaceController(db);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = BuildHttpContextWithUser(userId)
+        };
+        return controller;
+    }
+}

--- a/tests/Wayfarer.Tests/Controllers/UserTripControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/UserTripControllerTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Wayfarer.Areas.User.Controllers;
 using Wayfarer.Models;
+using Wayfarer.Models.ViewModels;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
 using Xunit;
@@ -63,12 +64,14 @@ public class UserTripControllerTests : TestBase
         var result = await controller.Edit(trip.Id);
 
         var view = Assert.IsType<ViewResult>(result);
-        var model = Assert.IsType<Trip>(view.Model);
-        Assert.Equal(trip.Id, model.Id);
+        Assert.Equal("~/Areas/User/Views/Trip/Workspace.cshtml", view.ViewName);
+        var model = Assert.IsType<TripEditorWorkspaceViewModel>(view.Model);
+        Assert.Equal(trip.Id, model.TripId);
+        Assert.Equal($"/api/trips/{trip.Id}/editor", model.EditorEndpointUrl);
     }
 
     [Fact]
-    public async Task Edit_Get_RedirectsToIndex_WhenNotOwned()
+    public async Task Edit_Get_ReturnsNotFound_WhenNotOwned()
     {
         var db = CreateDbContext();
         db.Users.AddRange(
@@ -81,8 +84,7 @@ public class UserTripControllerTests : TestBase
 
         var result = await controller.Edit(trip.Id);
 
-        var redirect = Assert.IsType<RedirectToActionResult>(result);
-        Assert.Equal("Index", redirect.ActionName);
+        Assert.IsType<NotFoundResult>(result);
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Controllers/UserTripControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/UserTripControllerTests.cs
@@ -180,7 +180,7 @@ public class UserTripControllerTests : TestBase
     }
 
     [Fact]
-    public async Task Edit_Post_ReturnsView_WhenModelInvalid()
+    public async Task Edit_Post_ReturnsBadRequest_WhenModelInvalid()
     {
         var db = CreateDbContext();
         var userId = "u1";
@@ -197,7 +197,8 @@ public class UserTripControllerTests : TestBase
             Name = ""
         }, null);
 
-        var view = Assert.IsType<ViewResult>(result);
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.IsNotType<ViewResult>(result);
         Assert.False(controller.ModelState.IsValid);
     }
 

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -9,23 +9,23 @@ import {
   expectMountedWorkspace,
   firstRegionWithChildren,
   firstVisibleAddPlace,
-  legacyEditPath,
+  editorPath,
   pathRegex,
   regionEditButton,
   signIn,
   uniqueName,
-  workspacePath
+  workspaceRedirectPath
 } from './tripEditorTestUtils';
 
 test.describe.serial('Trip Editor dev verification', () => {
   test('login succeeds', async ({ page }) => {
     await signIn(page);
 
-    await expect(page).toHaveURL(pathRegex(workspacePath));
+    await expect(page).toHaveURL(pathRegex(editorPath));
     await expectActiveMetadataSurface(page);
   });
 
-  test('workspace, editor API, and legacy editor load', async ({ page }) => {
+  test('canonical editor, editor API, and temporary workspace redirect load', async ({ page }) => {
     await signIn(page);
 
     const apiResponse = await page.request.get(absoluteUrl(editorApiPath), {
@@ -35,18 +35,22 @@ test.describe.serial('Trip Editor dev verification', () => {
     expect(apiResponse.headers()['content-type']).toMatch(/application\/json/i);
     expect(String((await apiResponse.json()).tripId).toLowerCase()).toBe(config.tripId.toLowerCase());
 
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
-    const legacyResponse = await page.goto(absoluteUrl(legacyEditPath));
-    expect(legacyResponse?.ok(), `GET ${legacyEditPath} returned ${legacyResponse?.status() ?? 'no response'}`).toBeTruthy();
-    await expect(page).toHaveURL(pathRegex(legacyEditPath));
-    await expect(page.getByText('Trip Settings')).toBeVisible();
+    const workspaceResponse = await page.request.get(absoluteUrl(workspaceRedirectPath), { maxRedirects: 0 });
+    expect(workspaceResponse.status(), `GET ${workspaceRedirectPath} should return a temporary redirect.`).toBe(302);
+    expect(workspaceResponse.headers().location).toBe(editorPath);
+
+    const editResponse = await page.goto(absoluteUrl(editorPath));
+    expect(editResponse?.ok(), `GET ${editorPath} returned ${editResponse?.status() ?? 'no response'}`).toBeTruthy();
+    await expect(page).toHaveURL(pathRegex(editorPath));
+    await expectMountedWorkspace(page);
   });
 
   test('metadata surfaces work in docked and expanded dark/light states', async ({ page }, testInfo) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     await setTheme(page, 'dark');
@@ -71,7 +75,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
   test('region edit and place create surfaces validate, save temporary data, and clean up', async ({ page }, testInfo) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     const unique = uniqueName('PW matrix');
@@ -121,7 +125,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
   test('draft values survive dock-expanded-dock and dirty close prompts use the shared dialog', async ({ page }, testInfo) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     const draftName = uniqueName('Unsaved metadata');
@@ -149,7 +153,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
   test('dirty target switch prompts and clean target switch does not', async ({ page }) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     await page.getByRole('button', { name: 'Add Region' }).click();
@@ -172,7 +176,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
   test('region hierarchy and unavailable #249 mockup controls remain correct', async ({ page }) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     await expectTripLevelTagsOnly(page);
@@ -191,7 +195,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
   test('trip tags are editable in docked settings and update the sidebar', async ({ page }) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     const tagName = uniqueName('pw-docked-tag');
@@ -207,7 +211,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
   test('trip tags are editable in expanded settings', async ({ page }) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     const tagName = uniqueName('pw-expanded-tag');
@@ -225,7 +229,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
   test('share progress toggle is visible and private draft disables it', async ({ page }) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     const surface = page.locator('.trip-editor-surface--docked');
@@ -241,7 +245,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
   test('Save & Exit stays on workspace when tag save fails', async ({ page }) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
     await page.route('**/api/trips/*/editor/tags', async route => {
       await route.fulfill({
@@ -258,7 +262,7 @@ test.describe.serial('Trip Editor dev verification', () => {
     await addTagInActiveSettings(page, uniqueName('pw-failed-tag'));
     await page.getByRole('button', { name: 'Save & Exit' }).click();
 
-    await expect(page).toHaveURL(pathRegex(workspacePath));
+    await expect(page).toHaveURL(pathRegex(editorPath));
     await expect(page.getByRole('alert')).toContainText('One or more validation errors occurred.');
     await expect(page.locator('.trip-editor-surface--docked')).toContainText('Injected tag save failure.');
   });
@@ -266,7 +270,7 @@ test.describe.serial('Trip Editor dev verification', () => {
   test('responsive narrow workspace remains usable', async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 900 });
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     await expect(page.locator('.trip-editor-sidebar')).toBeVisible();
@@ -279,7 +283,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
   test('safe reorder coverage is documented unless suitable rows exist', async ({ page }) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     const regionHandles = page.getByRole('button', { name: 'Drag to reorder region' });
@@ -414,7 +418,7 @@ async function addTagInSurface(surface: Locator, tagName: string): Promise<void>
 
 async function removeTagIfPresent(page: Page, tagName: string): Promise<void> {
   await page.unroute('**/api/trips/*/editor/tags').catch(() => undefined);
-  await page.goto(absoluteUrl(workspacePath));
+  await page.goto(absoluteUrl(editorPath));
   await expectMountedWorkspace(page);
   const remove = page.locator('.trip-editor-surface--docked').getByRole('button', { name: `Remove tag ${tagName}` });
   if ((await remove.count()) === 0) {

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -7,12 +7,14 @@ import {
   escapeRegex,
   expectActiveMetadataSurface,
   expectMountedWorkspace,
+  expectNoLegacyEditorAction,
   firstRegionWithChildren,
   firstVisibleAddPlace,
   editorPath,
   pathRegex,
   regionEditButton,
   signIn,
+  signInAs,
   uniqueName,
   workspaceRedirectPath
 } from './tripEditorTestUtils';
@@ -25,7 +27,12 @@ test.describe.serial('Trip Editor dev verification', () => {
     await expectActiveMetadataSurface(page);
   });
 
-  test('canonical editor, editor API, and temporary workspace redirect load', async ({ page }) => {
+  test('canonical editor, editor API, and temporary workspace auth matrix load', async ({ page }) => {
+    const unauthenticatedWorkspaceResponse = await page.request.get(absoluteUrl(workspaceRedirectPath), { maxRedirects: 0 });
+    expect(unauthenticatedWorkspaceResponse.status(), `GET ${workspaceRedirectPath} should challenge anonymous users.`).toBe(302);
+    expect(unauthenticatedWorkspaceResponse.headers().location).toContain('/Identity/Account/Login');
+    expect(unauthenticatedWorkspaceResponse.headers().location).toContain(encodeURIComponent(workspaceRedirectPath));
+
     await signIn(page);
 
     const apiResponse = await page.request.get(absoluteUrl(editorApiPath), {
@@ -46,6 +53,16 @@ test.describe.serial('Trip Editor dev verification', () => {
     expect(editResponse?.ok(), `GET ${editorPath} returned ${editResponse?.status() ?? 'no response'}`).toBeTruthy();
     await expect(page).toHaveURL(pathRegex(editorPath));
     await expectMountedWorkspace(page);
+    await expectNoLegacyEditorAction(page);
+  });
+
+  test('temporary workspace denies authenticated accounts without User role', async ({ page }) => {
+    await signInAs(page, 'admin', 'Admin1!', workspaceRedirectPath);
+
+    const workspaceResponse = await page.request.get(absoluteUrl(workspaceRedirectPath), { maxRedirects: 0 });
+    expect(workspaceResponse.status(), `GET ${workspaceRedirectPath} should deny authenticated non-User roles.`).toBe(302);
+    expect(workspaceResponse.headers().location).toContain('/Identity/Account/AccessDenied');
+    expect(workspaceResponse.headers().location).toContain(encodeURIComponent(workspaceRedirectPath));
   });
 
   test('metadata surfaces work in docked and expanded dark/light states', async ({ page }, testInfo) => {

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -243,7 +243,7 @@ test.describe.serial('Trip Editor dev verification', () => {
     await expect(surface.getByRole('link', { name: 'Open progress URL' })).toHaveCount(0);
   });
 
-  test('Save & Exit stays on workspace when tag save fails', async ({ page }) => {
+  test('Save & Exit stays on the editor when tag save fails', async ({ page }) => {
     await signIn(page);
     await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
@@ -267,7 +267,7 @@ test.describe.serial('Trip Editor dev verification', () => {
     await expect(page.locator('.trip-editor-surface--docked')).toContainText('Injected tag save failure.');
   });
 
-  test('responsive narrow workspace remains usable', async ({ page }, testInfo) => {
+  test('responsive narrow editor remains usable', async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 900 });
     await signIn(page);
     await page.goto(absoluteUrl(editorPath));

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -6,6 +6,7 @@ import {
   editorApiPath,
   escapeRegex,
   expectActiveMetadataSurface,
+  expectAuthRedirect,
   expectMountedWorkspace,
   expectNoLegacyEditorAction,
   firstRegionWithChildren,
@@ -28,10 +29,7 @@ test.describe.serial('Trip Editor dev verification', () => {
   });
 
   test('canonical editor, editor API, and temporary workspace auth matrix load', async ({ page }) => {
-    const unauthenticatedWorkspaceResponse = await page.request.get(absoluteUrl(workspaceRedirectPath), { maxRedirects: 0 });
-    expect(unauthenticatedWorkspaceResponse.status(), `GET ${workspaceRedirectPath} should challenge anonymous users.`).toBe(302);
-    expect(unauthenticatedWorkspaceResponse.headers().location).toContain('/Identity/Account/Login');
-    expect(unauthenticatedWorkspaceResponse.headers().location).toContain(encodeURIComponent(workspaceRedirectPath));
+    await expectAuthRedirect(page, workspaceRedirectPath, '/Identity/Account/Login', `GET ${workspaceRedirectPath} should challenge anonymous users.`);
 
     await signIn(page);
 
@@ -58,11 +56,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
   test('temporary workspace denies authenticated accounts without User role', async ({ page }) => {
     await signInAs(page, 'admin', 'Admin1!', workspaceRedirectPath);
-
-    const workspaceResponse = await page.request.get(absoluteUrl(workspaceRedirectPath), { maxRedirects: 0 });
-    expect(workspaceResponse.status(), `GET ${workspaceRedirectPath} should deny authenticated non-User roles.`).toBe(302);
-    expect(workspaceResponse.headers().location).toContain('/Identity/Account/AccessDenied');
-    expect(workspaceResponse.headers().location).toContain(encodeURIComponent(workspaceRedirectPath));
+    await expectAuthRedirect(page, workspaceRedirectPath, '/Identity/Account/AccessDenied', `GET ${workspaceRedirectPath} should deny authenticated non-User roles.`);
   });
 
   test('metadata surfaces work in docked and expanded dark/light states', async ({ page }, testInfo) => {

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -5,10 +5,9 @@ import {
   editorApiPath,
   expectMountedWorkspace,
   expectNoSearchAddUi,
-  legacyEditPath,
   loadEditorStateFixture,
   signIn,
-  workspacePath
+  editorPath
 } from './tripEditorTestUtils';
 
 type MutableEditorState = Record<string, any>;
@@ -221,7 +220,7 @@ test.describe.serial('Trip Editor area editing', () => {
 
   test('legacy trip edit page still loads', async ({ page }) => {
     await signIn(page);
-    await page.goto(absoluteUrl(legacyEditPath));
+    await page.goto(absoluteUrl(editorPath));
     await expect(page).toHaveURL(new RegExp(`/User/Trip/Edit/${configTripIdPattern()}$`, 'i'));
     await expect(page.locator('body')).not.toContainText('Trip Editor development server is not available');
   });
@@ -249,7 +248,7 @@ async function loadWorkspaceWithAreaFixture(page: Page, configure?: (state: Muta
   prepareAreaState(state);
   configure?.(state);
   await page.route(editorApiMatcher, async route => routeEditorReadOnly(route, state));
-  await page.goto(absoluteUrl(workspacePath));
+  await page.goto(absoluteUrl(editorPath));
   await expectMountedWorkspace(page);
   return state;
 }

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -218,11 +218,11 @@ test.describe.serial('Trip Editor area editing', () => {
     await expect(page.locator('#trip-editor-area-form')).toBeVisible();
   });
 
-  test('legacy trip edit page still loads', async ({ page }) => {
+  test('canonical trip edit page mounts the Vue editor shell', async ({ page }) => {
     await signIn(page);
     await page.goto(absoluteUrl(editorPath));
     await expect(page).toHaveURL(new RegExp(`/User/Trip/Edit/${configTripIdPattern()}$`, 'i'));
-    await expect(page.locator('body')).not.toContainText('Trip Editor development server is not available');
+    await expectMountedWorkspace(page);
   });
 
   test('map and marker clicks outside area map-work do not mutate area geometry', async ({ page }) => {

--- a/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
@@ -9,7 +9,7 @@ import {
   regionCard,
   regionEditButton,
   signIn,
-  workspacePath
+  editorPath
 } from './tripEditorTestUtils';
 
 type MutableEditorState = Record<string, any>;
@@ -17,7 +17,7 @@ type MutableEditorState = Record<string, any>;
 test.describe.serial('Trip Editor map navigation toolbar', () => {
   test('renders real commands without mutating metadata drafts', async ({ page }) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     const toolbar = page.locator('.trip-editor-toolbar');
@@ -187,7 +187,7 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
 
   test('defers to map-work toolbar', async ({ page }) => {
     await signIn(page);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     await enterMapWorkFromE2e(page);
@@ -217,7 +217,7 @@ async function loadWorkspaceWithEditorState<T>(page: Page, mutate: (state: Mutab
 
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
   });
-  await page.goto(absoluteUrl(workspacePath));
+  await page.goto(absoluteUrl(editorPath));
   await expectMountedWorkspace(page);
   return result;
 }

--- a/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
@@ -6,7 +6,7 @@ import {
   editorApiPath,
   expectMountedWorkspace,
   signIn,
-  workspacePath
+  editorPath
 } from './tripEditorTestUtils';
 
 const geocodePath = /\/api\/trips\/[^/]+\/editor\/geocode\/search/i;
@@ -22,7 +22,7 @@ test.describe('Trip Editor map geocode search', () => {
       await fulfillGeocode(route, [result('Mock Acropolis')]);
     });
 
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     await page.getByLabel('Sidebar search').fill('ath');
@@ -65,7 +65,7 @@ test.describe('Trip Editor map geocode search', () => {
       await route.fulfill({ status: mode === 'rate' ? 429 : 503, contentType: 'application/json', body: '{}' });
     });
 
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
     const mapSearch = page.getByRole('region', { name: 'Map search' });
 
@@ -113,7 +113,7 @@ test.describe('Trip Editor map geocode search', () => {
       await fulfillGeocode(route, [result(`Result for ${query}`)], query);
     });
 
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
     const mapSearch = page.getByRole('region', { name: 'Map search' });
     const searchInput = page.getByRole('searchbox', { name: 'Map search' });
@@ -155,7 +155,7 @@ test.describe('Trip Editor map geocode search', () => {
       await route.fulfill({ status, contentType: 'application/json', body: '{}' });
     });
 
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
     const mapSearch = page.getByRole('region', { name: 'Map search' });
 
@@ -196,7 +196,7 @@ test.describe('Trip Editor map geocode search', () => {
       await fulfillGeocode(route, [result('Current Newer Result')], 'newer replacement search');
     });
 
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
     const mapSearch = page.getByRole('region', { name: 'Map search' });
 
@@ -229,7 +229,7 @@ test.describe('Trip Editor map geocode search', () => {
       await fulfillGeocode(route, [result(`Result for ${normalized}`)], normalized);
     });
 
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
     const mapSearch = page.getByRole('region', { name: 'Map search' });
 
@@ -249,7 +249,7 @@ test.describe('Trip Editor map geocode search', () => {
     });
     await routeGeocode(page, async route => fulfillGeocode(route, [result('Preview Place')]));
 
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
     await runSearch(page, 'preview place');
     await page.getByRole('button', { name: 'Preview Place' }).click();
@@ -278,7 +278,7 @@ test.describe('Trip Editor map geocode search', () => {
     await routeEditorState(page, withOneEligibleRegion(baseState));
     await routeGeocode(page, async route => fulfillGeocode(route, [result('Eligible Place')]));
 
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
     await runSearch(page, 'eligible place');
     await page.getByRole('button', { name: 'Eligible Place' }).click();
@@ -307,7 +307,7 @@ test.describe('Trip Editor map geocode search', () => {
   test('dirty active draft prompts before search-add opens Add Place', async ({ page }) => {
     await signIn(page);
     await routeGeocode(page, async route => fulfillGeocode(route, [result('Prompt Place')]));
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     await page.getByRole('button', { name: 'Add Region' }).click();

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -6,7 +6,7 @@ import {
   expectNoSearchAddUi,
   loadEditorStateFixture,
   signIn,
-  workspacePath
+  editorPath
 } from './tripEditorTestUtils';
 
 type MutableEditorState = Record<string, any>;
@@ -196,7 +196,7 @@ async function loadWorkspaceWithCoordinateFixture(page: Page): Promise<void> {
   const state = await loadEditorStateFixture(page) as MutableEditorState;
   prepareCoordinateState(state);
   await page.route(editorApiMatcher, async route => routeEditorReadOnly(route, state));
-  await page.goto(absoluteUrl(workspacePath));
+  await page.goto(absoluteUrl(editorPath));
   await expectMountedWorkspace(page);
 }
 

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -5,7 +5,7 @@ import {
   expectMountedWorkspace,
   loadEditorStateFixture,
   signIn,
-  workspacePath
+  editorPath
 } from './tripEditorTestUtils';
 
 type MutableEditorState = Record<string, any>;
@@ -243,7 +243,7 @@ async function loadWorkspaceWithRichNotesFixture(page: Page, configureState?: (s
   prepareRichNotesState(state);
   configureState?.(state);
   await page.route(editorApiMatcher, async route => routeEditorState(route, state, []));
-  await page.goto(absoluteUrl(workspacePath));
+  await page.goto(absoluteUrl(editorPath));
   await expectMountedWorkspace(page);
   return state;
 }

--- a/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
@@ -6,7 +6,7 @@ import {
   expectNoSearchAddUi,
   loadEditorStateFixture,
   signIn,
-  workspacePath
+  editorPath
 } from './tripEditorTestUtils';
 
 type MutableEditorState = Record<string, any>;
@@ -53,18 +53,18 @@ test.describe.serial('Trip Editor segment editing', () => {
     });
 
     await openEditableSegment(page);
-    await expect(page.getByRole('link', { name: 'Legacy editor' })).toBeVisible();
+    await expect(page.locator('.trip-editor-toolbar a[href^="/User/Trip/Edit/"]')).toHaveCount(0);
     await page.getByRole('button', { name: 'Draw/Edit Route' }).click();
     const mapWork = page.getByRole('region', { name: 'Map work' });
     await expect(mapWork).toContainText('Draw segment route');
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
     await expect(page.locator('.trip-editor-toolbar').getByRole('button', { name: 'Fit All' })).toHaveCount(0);
-    await expect(page.getByRole('link', { name: 'Legacy editor' })).toHaveCount(0);
+    await expect(page.locator('.trip-editor-toolbar a[href^="/User/Trip/Edit/"]')).toHaveCount(0);
     await expect(page.getByRole('button', { name: /pick on map|draw\/edit area|geocode|search.?add|marker drag/i })).toHaveCount(0);
     await expectNoSearchAddUi(page);
 
     await mapWork.getByRole('button', { name: 'Done' }).click();
-    await expect(page.getByRole('link', { name: 'Legacy editor' })).toBeVisible();
+    await expect(page.locator('.trip-editor-toolbar a[href^="/User/Trip/Edit/"]')).toHaveCount(0);
     expect(savedRequests, 'Done must not call the segment save endpoint.').toEqual([]);
     await expect(page.locator('#trip-editor-segment-form')).toContainText('2 custom route points');
 
@@ -163,7 +163,7 @@ async function loadWorkspaceWithSegmentFixture(page: Page): Promise<MutableEdito
   const state = await loadEditorStateFixture(page) as MutableEditorState;
   prepareSegmentState(state);
   await page.route(editorApiMatcher, async route => routeEditorReadOnly(route, state));
-  await page.goto(absoluteUrl(workspacePath));
+  await page.goto(absoluteUrl(editorPath));
   await expectMountedWorkspace(page);
   return state;
 }

--- a/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
@@ -3,6 +3,7 @@ import {
   absoluteUrl,
   editorApiPath,
   expectMountedWorkspace,
+  expectNoLegacyEditorAction,
   expectNoSearchAddUi,
   loadEditorStateFixture,
   signIn,
@@ -53,18 +54,18 @@ test.describe.serial('Trip Editor segment editing', () => {
     });
 
     await openEditableSegment(page);
-    await expect(page.locator('.trip-editor-toolbar a[href^="/User/Trip/Edit/"]')).toHaveCount(0);
+    await expectNoLegacyEditorAction(page);
     await page.getByRole('button', { name: 'Draw/Edit Route' }).click();
     const mapWork = page.getByRole('region', { name: 'Map work' });
     await expect(mapWork).toContainText('Draw segment route');
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
     await expect(page.locator('.trip-editor-toolbar').getByRole('button', { name: 'Fit All' })).toHaveCount(0);
-    await expect(page.locator('.trip-editor-toolbar a[href^="/User/Trip/Edit/"]')).toHaveCount(0);
+    await expectNoLegacyEditorAction(page);
     await expect(page.getByRole('button', { name: /pick on map|draw\/edit area|geocode|search.?add|marker drag/i })).toHaveCount(0);
     await expectNoSearchAddUi(page);
 
     await mapWork.getByRole('button', { name: 'Done' }).click();
-    await expect(page.locator('.trip-editor-toolbar a[href^="/User/Trip/Edit/"]')).toHaveCount(0);
+    await expectNoLegacyEditorAction(page);
     expect(savedRequests, 'Done must not call the segment save endpoint.').toEqual([]);
     await expect(page.locator('#trip-editor-segment-form')).toContainText('2 custom route points');
 

--- a/tests/e2e/trip-editor/tripEditorSidebarSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSidebarSearch.spec.ts
@@ -13,7 +13,7 @@ import {
   sidebarSearchFixture,
   signIn,
   uniqueName,
-  workspacePath
+  editorPath
 } from './tripEditorTestUtils';
 
 test.describe.serial('Trip Editor sidebar search verification', () => {
@@ -21,7 +21,7 @@ test.describe.serial('Trip Editor sidebar search verification', () => {
     await signIn(page);
     const state = await loadEditorStateFixture(page);
     const fixture = sidebarSearchFixture(state);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     const requests = collectForbiddenSidebarSearchRequests(page);
@@ -71,7 +71,7 @@ test.describe.serial('Trip Editor sidebar search verification', () => {
     await signIn(page);
     const state = await loadEditorStateFixture(page);
     const fixture = sidebarSearchFixture(state);
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     const card = regionCard(page, fixture.place.regionName);
@@ -99,7 +99,7 @@ test.describe.serial('Trip Editor sidebar search verification', () => {
     const state = await loadEditorStateFixture(page);
     const fixture = sidebarSearchFixture(state);
     test.skip(!fixture.area, 'Configured Trip Editor fixture has no loaded area rows to verify sidebar area search.');
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     await page.getByLabel('Sidebar search').fill(fixture.area!.name);
@@ -113,7 +113,7 @@ test.describe.serial('Trip Editor sidebar search verification', () => {
     const state = await loadEditorStateFixture(page);
     const fixture = sidebarSearchFixture(state);
     test.skip(!fixture.segment, 'Configured Trip Editor fixture has no loaded segment rows to verify sidebar segment search.');
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     await page.getByLabel('Sidebar search').fill(fixture.segment!.query);
@@ -126,7 +126,7 @@ test.describe.serial('Trip Editor sidebar search verification', () => {
     const state = await loadEditorStateFixture(page);
     const fixture = shadowChildFixture(state);
     test.skip(!fixture, 'Configured Trip Editor fixture has no loaded shadow-region child row to verify shadow search behavior.');
-    await page.goto(absoluteUrl(workspacePath));
+    await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
     await page.getByLabel('Sidebar search').fill(fixture!.childName);

--- a/tests/e2e/trip-editor/tripEditorTestUtils.ts
+++ b/tests/e2e/trip-editor/tripEditorTestUtils.ts
@@ -71,6 +71,14 @@ export async function signInAs(page: Page, username: string, password: string, r
   ]);
 }
 
+// Exercises authentication middleware redirects without following them.
+export async function expectAuthRedirect(page: Page, path: string, expectedPath: string, message: string): Promise<void> {
+  const response = await page.request.get(absoluteUrl(path), { maxRedirects: 0 });
+  expect(response.status(), message).toBe(302);
+  expect(response.headers().location).toContain(expectedPath);
+  expect(response.headers().location).toContain(encodeURIComponent(path));
+}
+
 // Waits for the Vue editor to replace the Razor loading shell.
 export async function expectMountedWorkspace(page: Page): Promise<void> {
   const app = page.locator('#trip-editor-app');

--- a/tests/e2e/trip-editor/tripEditorTestUtils.ts
+++ b/tests/e2e/trip-editor/tripEditorTestUtils.ts
@@ -57,9 +57,14 @@ export function uniqueName(prefix: string): string {
 
 // Signs in through the real Identity page without logging credential values.
 export async function signIn(page: Page): Promise<void> {
-  await page.goto(absoluteUrl(`/Identity/Account/Login?ReturnUrl=${encodeURIComponent(editorPath)}`));
-  await page.getByLabel('Username').fill(config.username);
-  await page.getByLabel('Password').fill(config.password);
+  await signInAs(page, config.username, config.password, editorPath);
+}
+
+// Signs in with explicit credentials for route/auth smoke coverage.
+export async function signInAs(page: Page, username: string, password: string, returnPath: string): Promise<void> {
+  await page.goto(absoluteUrl(`/Identity/Account/Login?ReturnUrl=${encodeURIComponent(returnPath)}`));
+  await page.getByLabel('Username').fill(username);
+  await page.getByLabel('Password').fill(password);
   await Promise.all([
     page.waitForURL(url => !url.pathname.includes('/Identity/Account/Login')),
     page.getByRole('button', { name: 'Log in' }).click()
@@ -196,6 +201,13 @@ export async function closeDraftWithDiscard(page: Page): Promise<void> {
 export async function expectNoSearchAddUi(page: Page): Promise<void> {
   await expect(page.getByRole('button', { name: /search.?add|add from search/i })).toHaveCount(0);
   await expect(page.getByRole('link', { name: /search.?add|add from search/i })).toHaveCount(0);
+}
+
+// Confirms the old editor escape hatch is not exposed after final cutover.
+export async function expectNoLegacyEditorAction(page: Page): Promise<void> {
+  await expect(page.getByText('Legacy editor', { exact: true })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /^Legacy editor$/i })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /^Legacy editor$/i })).toHaveCount(0);
 }
 
 function segmentSearchFixture(state: EditorTripFixture, segment: EditorTripFixture['segmentsById'][string]): { query: string; label: string } {

--- a/tests/e2e/trip-editor/tripEditorTestUtils.ts
+++ b/tests/e2e/trip-editor/tripEditorTestUtils.ts
@@ -2,8 +2,8 @@ import { expect, test, type Locator, type Page } from '@playwright/test';
 import { loadTripEditorConfig } from './tripEditorConfig';
 
 export const config = loadTripEditorConfig();
-export const workspacePath = `/User/Trip/Workspace/${config.tripId}`;
-export const legacyEditPath = `/User/Trip/Edit/${config.tripId}`;
+export const editorPath = `/User/Trip/Edit/${config.tripId}`;
+export const workspaceRedirectPath = `/User/Trip/Workspace/${config.tripId}`;
 export const editorApiPath = `/api/trips/${config.tripId}/editor`;
 
 const forbiddenSidebarSearchRequest = /nominatim|geosearch|search-add|searchadd|\/search(?:[/?#]|$)/i;
@@ -57,7 +57,7 @@ export function uniqueName(prefix: string): string {
 
 // Signs in through the real Identity page without logging credential values.
 export async function signIn(page: Page): Promise<void> {
-  await page.goto(absoluteUrl(`/Identity/Account/Login?ReturnUrl=${encodeURIComponent(workspacePath)}`));
+  await page.goto(absoluteUrl(`/Identity/Account/Login?ReturnUrl=${encodeURIComponent(editorPath)}`));
   await page.getByLabel('Username').fill(config.username);
   await page.getByLabel('Password').fill(config.password);
   await Promise.all([
@@ -66,7 +66,7 @@ export async function signIn(page: Page): Promise<void> {
   ]);
 }
 
-// Waits for the Vue workspace to replace the Razor loading shell.
+// Waits for the Vue editor to replace the Razor loading shell.
 export async function expectMountedWorkspace(page: Page): Promise<void> {
   const app = page.locator('#trip-editor-app');
   await expect(app).toBeVisible();

--- a/tests/e2e/trip-editor/tripEditorVisitProgress.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorVisitProgress.spec.ts
@@ -5,7 +5,7 @@ import {
   expectMountedWorkspace,
   loadEditorStateFixture,
   signIn,
-  workspacePath
+  editorPath
 } from './tripEditorTestUtils';
 
 type MutableEditorState = Record<string, any>;
@@ -82,7 +82,7 @@ test.describe.serial('Trip Editor visit progress and history', () => {
     await expect(discard).toBeVisible();
     await discard.getByRole('button', { name: 'Keep editing' }).click();
 
-    await expect(page).toHaveURL(new RegExp(`${workspacePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/?$`));
+    await expect(page).toHaveURL(new RegExp(`${editorPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/?$`));
     await expect(visitDialog(page)).toBeVisible();
     await expect(page.locator('#trip-editor-metadata-form').getByLabel('Name')).toHaveValue('Unsaved visit guard trip');
   });
@@ -102,7 +102,7 @@ test.describe.serial('Trip Editor visit progress and history', () => {
     await expect(mapDiscard).toBeVisible();
     await mapDiscard.getByRole('button', { name: 'Keep editing' }).click();
 
-    await expect(page).toHaveURL(new RegExp(`${workspacePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/?$`));
+    await expect(page).toHaveURL(new RegExp(`${editorPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/?$`));
     await expect(page.getByRole('region', { name: 'Map work' })).toBeVisible();
   });
 
@@ -119,7 +119,7 @@ test.describe.serial('Trip Editor visit progress and history', () => {
     await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
 
     await expect(page).toHaveURL(url => {
-      return url.pathname === `/User/Visit/Edit/${newerVisitId}` && url.searchParams.get('returnUrl') === workspacePath;
+      return url.pathname === `/User/Visit/Edit/${newerVisitId}` && url.searchParams.get('returnUrl') === editorPath;
     });
   });
 
@@ -161,7 +161,7 @@ async function loadWorkspaceWithVisitFixture(page: Page, prepare: (state: Mutabl
   prepareBaseState(state);
   prepare(state);
   await page.route(editorApiMatcher, async route => routeEditorReadOnly(route, state));
-  await page.goto(absoluteUrl(workspacePath));
+  await page.goto(absoluteUrl(editorPath));
   await expectMountedWorkspace(page);
   return state;
 }

--- a/tests/e2e/trip-editor/tripEditorVisualPolish.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorVisualPolish.spec.ts
@@ -5,7 +5,7 @@ import {
   expectMountedWorkspace,
   loadEditorStateFixture,
   signIn,
-  workspacePath
+  editorPath
 } from './tripEditorTestUtils';
 
 type MutableEditorState = Record<string, any>;
@@ -132,7 +132,7 @@ async function loadWorkspaceWithVisualFixture(page: Page): Promise<void> {
   const state = await loadEditorStateFixture(page) as MutableEditorState;
   prepareVisualState(state);
   await page.route(editorApiMatcher, async route => routeReadOnlyEditor(route, state));
-  await page.goto(absoluteUrl(workspacePath));
+  await page.goto(absoluteUrl(editorPath));
   await expectMountedWorkspace(page);
 }
 


### PR DESCRIPTION
Closes #277

## Summary
- `/User/Trip/Edit/{id}` now serves Vue shell directly
- `/User/Trip/Workspace/{id}` redirects to `/User/Trip/Edit/{id}`
- missing/non-owned `/Edit` returns 404
- Vue toolbar Legacy editor link removed
- E2E helpers/specs now use `/Edit` canonical route
- no hidden legacy fallback route added
- legacy files/scripts preserved for #279 cleanup

## Scope statement
- no broad legacy cleanup/deletion
- no import/export/backfill migration
- no new editor capabilities
- no mobile/API changes
- no #279 cleanup

## Rollback
- latest stable release tag/reference: v1.2.28
- rollback by redeploy/revert to v1.2.28
- asset-only rollback by redeploying last known-good `wwwroot/vite/trip-editor` manifest/assets

## Validation
- dotnet build passed
- dotnet test passed, 1595 tests
- focused controller tests passed, 39 tests
- npm run build passed with existing Vite chunk warning
- Playwright --list passed, 80 tests listed
- LOC checker passed with warnings only
- confirm scans clean/shared-dialog only
- route/text scan reviewed
- git diff --check passed
- tracked artifact scan clean
- live focused browser E2E passed on head c7786bd695d059bc911c4087247ee60abed3c686: `npx playwright test --config=playwright.config.ts tests/e2e/trip-editor/tripEditor.spec.ts` (14 passed)
- live full browser E2E passed on head c7786bd695d059bc911c4087247ee60abed3c686: `npm run test:e2e:trip-editor` (79 passed, 1 skipped)
