### PR TITLE
Fix Trip Editor production manifest entry

### DIFF
--- a/Areas/User/Views/Trip/Edit.cshtml
+++ b/Areas/User/Views/Trip/Edit.cshtml
@@ -6,7 +6,7 @@
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Trip Editor";
     var manifestPath = System.IO.Path.Combine(Environment.WebRootPath, "vite", "trip-editor", ".vite", "manifest.json");
-    var entryScript = "/ClientApps/trip-editor/src/main.ts";
+    var entryScript = "ClientApps/trip-editor/src/main.ts";
 }
 
 @functions {


### PR DESCRIPTION
## Summary
- Fix Trip Editor production manifest lookup to use Vite's emitted `ClientApps/trip-editor/src/main.ts` key.
- Leave Development dev-server script URLs unchanged.

## Root Cause
Vite emits the Trip Editor manifest entry as `ClientApps/trip-editor/src/main.ts`, but the Razor shell looked up `/ClientApps/trip-editor/src/main.ts` with a leading slash. In non-Development, that lookup missed and rendered the existing missing-assets message.

## Validation
- [x] `npm run build` - passed; manifest contains `ClientApps/trip-editor/src/main.ts`, JS `assets/main-C_zZkZYD.js`, CSS `assets/main-B5zf2fhr.css`.
- [x] Production BundleTest smoke - passed; `/User/Trip/Edit/{tripId}` requested `/vite/trip-editor/assets/main-C_zZkZYD.js` and `/vite/trip-editor/assets/main-B5zf2fhr.css`; `localhost:5173/@vite/client` request count was 0.
- [x] Development smoke with Vite running - passed for asset behavior; requested `http://localhost:5173/@vite/client` and `http://localhost:5173/ClientApps/trip-editor/src/main.ts`. Existing delayed hint timer can still appear before/alongside the eventual Vue mount on this local run, but the Razor shell URLs are unchanged.
- [x] Development smoke with Vite stopped - passed; existing “Trip Editor development server is not available. Run npm run dev.” hint appears.
- [x] MvcFrontendKit/shared frontend impact check - no diff in `Program.cs`, `_ViewImports.cshtml`, root `package.json`, `frontend.config.yaml`, or `vite.config.ts`.
- [x] `dotnet build` - passed, 0 warnings/errors.
- [x] `dotnet test` - passed, 1535 tests.
- [x] `npm run build` - passed again; Vite chunk-size advisory only.
- [x] `npx playwright test --config=playwright.config.ts --list` - passed, listed 84 tests.
- [x] `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` - passed with existing Trip Editor warning-threshold files only.
- [x] `git diff --check origin/main...HEAD` - passed.
- [x] `git ls-files -- .local playwright-report test-results screenshots traces wwwroot/vite/trip-editor` - no tracked artifacts.

## Tests
No new unit test was added because the changed logic is a private Razor-local manifest key constant; extracting it solely for this one-line fix would add more surface area than the bug fix.

## Merge Note
Do not merge until production-bundle and development smoke evidence above remains acceptable.