### PR TITLE
Fix generated frontend bundle compression regression

### DIFF
--- a/Wayfarer.csproj
+++ b/Wayfarer.csproj
@@ -7,7 +7,7 @@
         <UserSecretsId>aspnet-Wayfarer-61e4bfbb-7b73-4610-9e19-3a5a901d3bdd</UserSecretsId>
         <!-- Generated frontend bundles are served from wwwroot by UseStaticFiles so their
              compressed variants cannot drift from static-web-asset endpoint metadata. -->
-        <StaticWebAssetEndpointExclusionPattern>$(StaticWebAssetEndpointExclusionPattern);wwwroot/dist/**;wwwroot/vite/trip-editor/**</StaticWebAssetEndpointExclusionPattern>
+        <StaticWebAssetEndpointExclusionPattern>$(StaticWebAssetEndpointExclusionPattern);dist/**;vite/trip-editor/**;wwwroot/dist/**;wwwroot/vite/trip-editor/**</StaticWebAssetEndpointExclusionPattern>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Wayfarer.csproj
+++ b/Wayfarer.csproj
@@ -5,6 +5,9 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>aspnet-Wayfarer-61e4bfbb-7b73-4610-9e19-3a5a901d3bdd</UserSecretsId>
+        <!-- Generated frontend bundles are served from wwwroot by UseStaticFiles so their
+             compressed variants cannot drift from static-web-asset endpoint metadata. -->
+        <StaticWebAssetEndpointExclusionPattern>$(StaticWebAssetEndpointExclusionPattern);wwwroot/dist/**;wwwroot/vite/trip-editor/**</StaticWebAssetEndpointExclusionPattern>
     </PropertyGroup>
 
     <ItemGroup>

--- a/docs/14-Setup.md
+++ b/docs/14-Setup.md
@@ -26,7 +26,7 @@ Frontend Development
   - Configuration: `frontend.config.yaml`
   - Convention: JS files in `wwwroot/js/Areas/{Area}/{Controller}/{Action}.js` auto-link to matching views.
   - Development: runs unbundled for debugging.
-  - Production: run `dotnet mvcfrontendkit build` to generate minified bundles in `/dist`.
+  - Production: run `dotnet frontend build` to generate minified bundles in `/dist`.
 - **Trip Editor**: Vue/Vite builds static assets under `wwwroot/vite/trip-editor`.
   - Run `npm ci` and `npm run build` before publishing when building on the server.
   - Generated Vite output is not committed. Production still runs as one ASP.NET Core app with no Node runtime service or SSR server.


### PR DESCRIPTION
## Summary
- Exclude generated MvcFrontendKit `/dist/**` and Trip Editor Vite `/vite/trip-editor/**` bundle routes from ASP.NET Core static-web-asset endpoint mapping.
- Keep `UseStaticFiles()`, `UseResponseCompression()`, MvcFrontendKit, and Vite production bundle behavior intact.
- Update setup docs to use `dotnet frontend build` for MvcFrontendKit bundles.

## Root cause
Current main introduced/generated Trip Editor Vite bundle output beside MvcFrontendKit bundles under `wwwroot`, while `MapStaticAssets()` still generated compressed endpoints for those externally generated bundle folders. The stable tag `v1.2.28` did not include the Vite bundle output path or the current server-build Trip Editor asset flow. When the frontend build cleaned the SDK compressed cache, browser-like gzip requests could hit static-web-asset compressed endpoints that returned `HTTP 200` with an empty body. Excluding only the generated bundle routes forces them back through physical `UseStaticFiles()` serving.

## Validation
- `git fetch --tags --prune origin`
- `git tag --sort=-creatordate | Select-Object -First 10` confirmed `v1.2.28` is the latest stable tag.
- `git diff v1.2.28..main -- Program.cs Wayfarer.csproj Areas/User/Views/Trip/Edit.cshtml Views/Shared/_Layout.cshtml frontend.config.yaml package.json vite.config.ts deployment docs`
- `rg "UseResponseCompression|AddResponseCompression|UseStaticFiles|MapStaticAssets|MapStatic|Frontend|vite/trip-editor|dist/" Program.cs <resolved csproj files> Views Areas docs deployment -n`
- `dotnet build` passed with existing `ASP0000` warning.
- `dotnet test` passed: 1535 passed, 0 failed.
- `dotnet frontend build` passed.
- `npm run build` passed; Vite reported the existing >500 kB chunk warning.
- `npx playwright test --config=playwright.config.ts --list` passed: 84 tests listed.
- Static-web-assets endpoint metadata check: representative `/dist` and `/vite/trip-editor` bundle routes had `endpoints=0` after the fix.
- Production-like HTTPS smoke with `ASPNETCORE_ENVIRONMENT=Production`, local DB connection string, and `https://localhost:5001` passed.
- Focused production-like Trip Editor browser smoke passed with local self-signed TLS workaround: `login succeeds` and `canonical editor, editor API, and removed workspace route behavior load`.
- Development-mode Trip Editor smoke passed with ASP.NET on `http://localhost:5012` and Vite on `http://localhost:5173`: same focused tests passed.
- Normal MVC browser smoke passed: home page loaded MvcFrontendKit `/dist/css/global.999f878a.css` and `/dist/js/global.275d33bf.js` with 200 responses and applied styles.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` completed with existing Trip Editor LOC warnings only; no touched file warned.
- `git diff --check` passed.
- `git ls-files -- .local playwright-report test-results screenshots traces wwwroot/vite/trip-editor` returned no tracked transient/generated artifacts.

## Representative asset curl results after fix
- `curl.exe -k -i -H "Accept-Encoding: gzip" https://localhost:5001/dist/css/global.999f878a.css?v=asset-check`: `HTTP/1.1 200 OK`, `Content-Type: text/css`, `Content-Encoding: gzip`, `Transfer-Encoding: chunked`, non-empty body.
- `curl.exe -k -i -H "Accept-Encoding: gzip" https://localhost:5001/dist/js/global.275d33bf.js?v=asset-check`: `HTTP/1.1 200 OK`, `Content-Type: text/javascript`, `Content-Encoding: gzip`, `Transfer-Encoding: chunked`, non-empty body.
- `curl.exe -k -i -H "Accept-Encoding: gzip" https://localhost:5001/vite/trip-editor/assets/main-B5zf2fhr.css?v=asset-check`: `HTTP/1.1 200 OK`, `Content-Type: text/css`, `Content-Encoding: gzip`, `Transfer-Encoding: chunked`, non-empty body.
- `curl.exe -k -i -H "Accept-Encoding: identity" https://localhost:5001/dist/css/global.999f878a.css?v=asset-check`: `HTTP/1.1 200 OK`, `Content-Length: 39256`, `Content-Type: text/css`, non-empty body.

## Notes
- First non-launch-profile production run failed until the local DB connection string was supplied explicitly; the rerun used the same local DB as Development with `ASPNETCORE_ENVIRONMENT=Production`.
- Do not merge yet.
