### PR TITLE
docs: clarify production-like asset acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,11 @@ See `docs/22-Testing.md` for the required variables, local file format, and
 browser install command. Do not reset passwords or create users for this harness
 unless that is explicitly approved.
 
-Production and deployment builds still use `npm ci` and `npm run build` to emit
-static Trip Editor assets served by ASP.NET Core.
+Production-like bundle acceptance should build frontend prerequisites with
+`dotnet frontend build`, `npm ci`, and `npm run build` before `dotnet publish`.
+Run the published output rather than source-tree
+`ASPNETCORE_ENVIRONMENT=Production dotnet run`; published output is the supported
+layout for scoped CSS, MvcFrontendKit bundles, and Trip Editor Vite assets.
 
 1. Sign in with the seeded `admin` / `Admin1!` account and change the password.
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -214,13 +214,20 @@ For the current server-build deployment model, `install.sh` installs or verifies
 Node.js/npm on the build host. Node/npm are build-host tooling only; no Node
 runtime service is installed or configured.
 
-During deployment, `deploy.sh` runs the frontend build before `dotnet publish`:
+During deployment, `deploy.sh` runs the Trip Editor frontend build before
+`dotnet publish`:
 
 ```bash
 npm ci
 npm run build
 dotnet publish
 ```
+
+For production-like local acceptance, also run `dotnet frontend build` before
+publishing so MvcFrontendKit bundles are freshly generated, then run the
+published output. Source-tree `ASPNETCORE_ENVIRONMENT=Production dotnet run` is
+not the supported bundle acceptance path because local scoped CSS static web
+assets are generated outside `wwwroot`.
 
 If builds later move to CI or another artifact builder, Node/npm are required on
 that build host only. The production runtime remains the ASP.NET Core app serving

--- a/docs/14-Setup.md
+++ b/docs/14-Setup.md
@@ -26,15 +26,27 @@ Frontend Development
   - Configuration: `frontend.config.yaml`
   - Convention: JS files in `wwwroot/js/Areas/{Area}/{Controller}/{Action}.js` auto-link to matching views.
   - Development: runs unbundled for debugging.
-  - Production: run `dotnet frontend build` to generate minified bundles in `/dist`.
+  - Production prerequisite: run `dotnet frontend build` to generate minified bundles in `/dist`.
 - **Trip Editor**: Vue/Vite builds static assets under `wwwroot/vite/trip-editor`.
-  - Run `npm ci` and `npm run build` before publishing when building on the server.
+  - Production prerequisite: run `npm ci` and `npm run build` before publishing when building on the server.
   - Generated Vite output is not committed. Production still runs as one ASP.NET Core app with no Node runtime service or SSR server.
 - **State Management**: Trip editing state is owned by the Vue Trip Editor under `ClientApps/trip-editor/src`.
   - Key files: `ClientApps/trip-editor/src/App.vue`, `ClientApps/trip-editor/src/api/tripEditorApi.ts`
 - **Map Icons**: [wayfarer-map-icons](https://github.com/stef-k/wayfarer-map-icons) provides consistent marker icons.
   - Location: `wwwroot/icons/wayfarer-map-icons/`
 - Global assets: `site.js` and `site.css` load on every page.
+
+Production-like Bundle Acceptance
+- Build frontend prerequisites first: `dotnet frontend build`, then `npm ci` and `npm run build`.
+- Publish and run the published output:
+
+```bash
+dotnet publish Wayfarer.csproj -c Release -o ./out
+cd ./out
+ASPNETCORE_ENVIRONMENT=Production dotnet Wayfarer.dll --urls=http://localhost:5000
+```
+
+- Do not use source-tree `ASPNETCORE_ENVIRONMENT=Production dotnet run` as a bundle acceptance path. Razor scoped CSS such as `Wayfarer.styles.css` is produced as a static web asset outside `wwwroot` during local builds, and published output is the supported production-like asset layout.
 
 Mobile App (Separate Repo)
 - Location: `WayfarerMobile`.

--- a/docs/20-Deployment.md
+++ b/docs/20-Deployment.md
@@ -271,14 +271,23 @@ sudo find /var/www/wayfarer -type f -exec chmod 644 {} \;
 sudo -u wayfarer bash
 cd /var/www/wayfarer
 
-# Restore and build
+# Restore and build frontend prerequisites
 dotnet restore
-dotnet build -c Release
+dotnet frontend build
+npm ci
+npm run build
 
-# Test run
+# Publish and run the production-like output
+dotnet publish Wayfarer.csproj -c Release -o ./out
+cd ./out
 export ASPNETCORE_ENVIRONMENT=Production
-dotnet run --urls=http://localhost:5000
+dotnet Wayfarer.dll --urls=http://localhost:5000
 ```
+
+Run production-like bundle acceptance from the published output. Do not use
+source-tree `ASPNETCORE_ENVIRONMENT=Production dotnet run` for this check:
+local scoped CSS such as `Wayfarer.styles.css` is a static web asset generated
+outside `wwwroot`, while publish produces the supported production asset layout.
 
 **What happens on first run:**
 - Database tables created automatically
@@ -398,6 +407,7 @@ sudo -u postgres pg_dump wayfarer > wayfarer-backup-$(date +%Y%m%d).sql
 # Pull and build
 cd /home/youruser/Wayfarer
 git pull origin main
+dotnet frontend build
 npm ci
 npm run build
 dotnet publish -c Release -o ./out


### PR DESCRIPTION
## Summary
- Documents that production-like bundle acceptance must run from `dotnet publish` output rather than source-tree Production `dotnet run`.
- Separates Development, frontend prerequisite builds, and published-output acceptance paths.
- Leaves runtime behavior unchanged after proving published output serves scoped CSS correctly.

## Root Cause
`Wayfarer.styles.css` is Razor scoped CSS generated as a static web asset outside `wwwroot` during local source builds. Published output copies it into the supported production asset layout. Source-tree `ASPNETCORE_ENVIRONMENT=Production dotnet run` can therefore fail locally when static web assets are not enabled, while real published output serves the file correctly.

## Validation
- `dotnet frontend build` passed.
- `npm run build` passed.
- `dotnet build` passed with existing `ASP0000` warning in `Program.cs`.
- `dotnet test` passed: 1535 passed, 0 failed.
- `dotnet publish Wayfarer.csproj -c Release -o .local\publish-smoke` passed with existing `ASP0000` warning.
- Published-output smoke on `https://localhost:5001` served:
  - `/Wayfarer.styles.css?v=publish-smoke`: 200, `Content-Type: text/css`, `Content-Length: 2223`.
  - `/Wayfarer.styles.css?v=publish-smoke` with `Accept-Encoding: gzip`: 200, `Content-Type: text/css`, `Content-Encoding: gzip`, `Content-Length: 604`.
  - `/dist/css/global.999f878a.css`: 200, `Content-Type: text/css`, `Content-Length: 39256`.
  - `/dist/js/global.275d33bf.js`: 200, `Content-Type: text/javascript`, `Content-Length: 9040`.
  - `/vite/trip-editor/assets/main-B5zf2fhr.css`: 200, `Content-Type: text/css`, `Content-Length: 76649`.
- Browser smoke against published output passed for `My Trips - Wayfarer` and `/User/Trip/Edit/15993426-552d-40e5-bd74-86dea34a3bf8` (`Trip Editor - Wayfarer`) with no failed `/dist`, `/vite`, or `Wayfarer.styles.css` responses observed.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` passed; remaining warnings are pre-existing Trip Editor warning-threshold files not touched here.
- `git diff --check HEAD` passed.
- `git status --short --untracked-files=all` clean.

## Notes
- Source-tree non-Development `dotnet run` is now documented as unsupported for bundle acceptance.
- No runtime code, deployment script behavior, MvcFrontendKit registration, Trip Editor Vite asset handling, or PR #285 static asset exclusions were changed.