### PR TITLE
Fix Trip Editor manifest in published output

### DIFF
--- a/Areas/User/Views/Trip/Edit.cshtml
+++ b/Areas/User/Views/Trip/Edit.cshtml
@@ -5,7 +5,7 @@
 @{
     Layout = "~/Views/Shared/_Layout.cshtml";
     ViewData["Title"] = "Trip Editor";
-    var manifestPath = System.IO.Path.Combine(Environment.WebRootPath, "vite", "trip-editor", ".vite", "manifest.json");
+    var manifestPath = System.IO.Path.Combine(Environment.WebRootPath, "vite", "trip-editor", "manifest.json");
     var entryScript = "ClientApps/trip-editor/src/main.ts";
 }
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Production-like bundle acceptance should build frontend prerequisites with
 Run the published output rather than source-tree
 `ASPNETCORE_ENVIRONMENT=Production dotnet run`; published output is the supported
 layout for scoped CSS, MvcFrontendKit bundles, and Trip Editor Vite assets.
+The Trip Editor publish output must include
+`wwwroot/vite/trip-editor/manifest.json` and the CSS/JS files referenced by that
+manifest.
 
 1. Sign in with the seeded `admin` / `Admin1!` account and change the password.
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -206,9 +206,11 @@ REF=v1.3.0 ./deployment/deploy.sh
 ### Frontend Build Requirement
 
 The Vue/Vite Trip Editor workspace is built into local static assets under
-`wwwroot/vite/trip-editor`. These generated files are build output and are not
-committed. Production remains a single ASP.NET Core app; it does not run a Node
-service or SSR process.
+`wwwroot/vite/trip-editor`. The production shell reads
+`wwwroot/vite/trip-editor/manifest.json` and then loads the CSS/JS assets listed
+by that manifest from the same folder. These generated files are build output
+and are not committed. Production remains a single ASP.NET Core app; it does not
+run a Node service or SSR process.
 
 For the current server-build deployment model, `install.sh` installs or verifies
 Node.js/npm on the build host. Node/npm are build-host tooling only; no Node
@@ -228,6 +230,9 @@ publishing so MvcFrontendKit bundles are freshly generated, then run the
 published output. Source-tree `ASPNETCORE_ENVIRONMENT=Production dotnet run` is
 not the supported bundle acceptance path because local scoped CSS static web
 assets are generated outside `wwwroot`.
+The published output must include
+`wwwroot/vite/trip-editor/manifest.json` plus the CSS/JS files referenced by
+that manifest.
 
 If builds later move to CI or another artifact builder, Node/npm are required on
 that build host only. The production runtime remains the ASP.NET Core app serving

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -150,9 +150,9 @@ echo "  npm:  $(npm --version)"
 npm ci
 npm run build
 
-if [ ! -f "$APP_DIR/wwwroot/vite/trip-editor/.vite/manifest.json" ]; then
+if [ ! -f "$APP_DIR/wwwroot/vite/trip-editor/manifest.json" ]; then
   echo "✖ Error: Trip Editor Vite manifest was not generated." >&2
-  echo "  Expected: $APP_DIR/wwwroot/vite/trip-editor/.vite/manifest.json" >&2
+  echo "  Expected: $APP_DIR/wwwroot/vite/trip-editor/manifest.json" >&2
   exit 1
 fi
 

--- a/docs/14-Setup.md
+++ b/docs/14-Setup.md
@@ -29,6 +29,7 @@ Frontend Development
   - Production prerequisite: run `dotnet frontend build` to generate minified bundles in `/dist`.
 - **Trip Editor**: Vue/Vite builds static assets under `wwwroot/vite/trip-editor`.
   - Production prerequisite: run `npm ci` and `npm run build` before publishing when building on the server.
+  - Production output must include `wwwroot/vite/trip-editor/manifest.json` and the CSS/JS files referenced by that manifest.
   - Generated Vite output is not committed. Production still runs as one ASP.NET Core app with no Node runtime service or SSR server.
 - **State Management**: Trip editing state is owned by the Vue Trip Editor under `ClientApps/trip-editor/src`.
   - Key files: `ClientApps/trip-editor/src/App.vue`, `ClientApps/trip-editor/src/api/tripEditorApi.ts`
@@ -47,6 +48,7 @@ ASPNETCORE_ENVIRONMENT=Production dotnet Wayfarer.dll --urls=http://localhost:50
 ```
 
 - Do not use source-tree `ASPNETCORE_ENVIRONMENT=Production dotnet run` as a bundle acceptance path. Razor scoped CSS such as `Wayfarer.styles.css` is produced as a static web asset outside `wwwroot` during local builds, and published output is the supported production-like asset layout.
+- Confirm the published output contains `wwwroot/vite/trip-editor/manifest.json` plus the referenced Trip Editor CSS/JS files before treating the bundle acceptance as complete.
 
 Mobile App (Separate Repo)
 - Location: `WayfarerMobile`.

--- a/docs/15-Architecture.md
+++ b/docs/15-Architecture.md
@@ -217,8 +217,11 @@ Two-tier caching strategy:
 
 The Trip Editor uses Vue/Vite and builds static assets under
 `wwwroot/vite/trip-editor`. That Vite output is generated during deployment and
-is not committed. Production remains a single ASP.NET Core app serving local
-static assets; there is no Node runtime service and no SSR server.
+is not committed. The production Razor shell reads
+`wwwroot/vite/trip-editor/manifest.json` and serves the CSS/JS assets referenced
+by that manifest from the same local folder. Production remains a single
+ASP.NET Core app serving local static assets; there is no Node runtime service
+and no SSR server.
 
 ### State Management
 

--- a/docs/20-Deployment.md
+++ b/docs/20-Deployment.md
@@ -288,6 +288,9 @@ Run production-like bundle acceptance from the published output. Do not use
 source-tree `ASPNETCORE_ENVIRONMENT=Production dotnet run` for this check:
 local scoped CSS such as `Wayfarer.styles.css` is a static web asset generated
 outside `wwwroot`, while publish produces the supported production asset layout.
+The Trip Editor published output must include
+`wwwroot/vite/trip-editor/manifest.json` plus the CSS/JS files referenced by
+that manifest.
 
 **What happens on first run:**
 - Database tables created automatically

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   build: {
     outDir: 'wwwroot/vite/trip-editor',
     emptyOutDir: true,
-    manifest: true,
+    manifest: 'manifest.json',
     rollupOptions: {
       input: 'ClientApps/trip-editor/src/main.ts'
     }


### PR DESCRIPTION
## Summary
- move the Trip Editor Vite manifest from hidden `.vite/manifest.json` to explicit `wwwroot/vite/trip-editor/manifest.json`
- update the Razor shell and deployment validation to read the non-hidden manifest path
- document the published-output contract for the manifest and referenced CSS/JS assets

## Root Cause
Current Vite config used `manifest: true`, which emits `.vite/manifest.json` in Vite 7. The source tree had that hidden manifest after `npm run build`, but `dotnet publish` did not carry the hidden `.vite` folder into publish output. The production Razor shell therefore could not find the manifest and showed the missing-assets fallback even though the CSS/JS assets were published.

## Validation
- `dotnet build` - passed, 0 warnings/errors
- `dotnet test` - passed, 1535 passed
- `dotnet frontend build` - passed
- `npm ci` - passed, 0 vulnerabilities
- `npm run build` - passed; emitted `wwwroot/vite/trip-editor/manifest.json`
- `dotnet publish Wayfarer.csproj -c Release -o .local\publish-smoke` - passed
- publish output contained `wwwroot/vite/trip-editor/manifest.json` (451 bytes) and referenced CSS/JS assets (76,649 bytes / 627,246 bytes)
- published app smoke from `.local\publish-smoke` in Production - passed
- curl checks for `Wayfarer.styles.css`, `/dist/css/global.999f878a.css`, and manifest-referenced Trip Editor CSS/JS - all 200, correct content types, non-empty; compressed checks had no `Content-Length: 0`
- published browser smoke - passed; normal MVC page styled, Trip Editor mounted, no missing-assets message, no failed watched asset requests, no `localhost:5173`, expand/dock interaction worked
- Development smoke - passed; Trip Editor loaded from Vite via `http://localhost:5173/@vite/client` and `/ClientApps/trip-editor/src/main.ts`; missing-dev-server hint appeared after Vite stopped
- `npx playwright test --config=playwright.config.ts --list` - passed, 84 tests listed
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` - passed after removing generated `.local/publish-smoke`; remaining warnings are existing Trip Editor files not touched by this fix
- `git diff --check` - passed
- artifact hygiene: `git ls-files -- .local playwright-report test-results screenshots traces wwwroot/vite/trip-editor wwwroot/dist wwwroot/frontend.manifest.json` returned no tracked generated artifacts

## Notes
- `.gitignore` still ignores `wwwroot/vite/trip-editor/`, so source-tree generated Vite output remains untracked while publish output includes the manifest.
- This does not reintroduce `/User/Trip/Workspace/{id}`, any legacy editor fallback, or changes to MvcFrontendKit/static-web-asset exclusions.