### PR TITLE
Fix Trip Editor selection/status sync

### DIFF
--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -39,13 +39,49 @@ const updatedLabel = computed(() =>
   state.value ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(state.value.metadata.updatedAt)) : ''
 );
 const isMapWorkActive = computed(() => editorSurface.isMapWorkActive.value);
-const toolbarContext = computed(() => {
+const selectedPlace = computed(() => selectedPlaceId.value && state.value ? state.value.placesById[selectedPlaceId.value] ?? null : null);
+const selectedPlaceRegionName = computed(() => selectedPlace.value && state.value ? state.value.regionsById[selectedPlace.value.regionId]?.name ?? null : null);
+const toolbarEyebrow = computed(() => {
   if (editorSurface.mapWork.value) {
-    const status = editorSurface.mapWork.value.statusText;
-    return `${editorSurface.mapWork.value.modeName}: ${typeof status === 'function' ? status() : status}`;
+    return 'Map work';
   }
 
-  return editorSurface.activeTarget.value?.title ?? 'Trip map';
+  if (selectedPlace.value) {
+    return 'Selected place';
+  }
+
+  if (editorSurface.activeTarget.value) {
+    return `${editorSurface.activeTarget.value.mode === 'add' ? 'New' : 'Editing'} ${editorSurface.activeTarget.value.kind}`;
+  }
+
+  return 'Map status';
+});
+const toolbarTitle = computed(() => {
+  if (editorSurface.mapWork.value) {
+    return editorSurface.mapWork.value.modeName;
+  }
+
+  return selectedPlace.value?.name ?? editorSurface.activeTarget.value?.title ?? 'Trip map';
+});
+const toolbarDetail = computed(() => {
+  if (editorSurface.mapWork.value) {
+    const status = editorSurface.mapWork.value.statusText;
+    return typeof status === 'function' ? status() : status;
+  }
+
+  if (navigationStatus.value) {
+    return navigationStatus.value;
+  }
+
+  if (selectedPlace.value) {
+    return selectedPlaceRegionName.value ? `In ${selectedPlaceRegionName.value}` : 'Selected on the map and sidebar';
+  }
+
+  if (editorSurface.activeTarget.value?.subtitle) {
+    return editorSurface.activeTarget.value.subtitle;
+  }
+
+  return `Updated ${updatedLabel.value}`;
 });
 const canFitAllGeometry = computed(() => Boolean(state.value && hasAnyGeometry(state.value)));
 const canRecenterSavedView = computed(() => Boolean(state.value && hasSavedTripView(state.value.metadata)));
@@ -100,7 +136,7 @@ const applyMetadata = (metadata: EditorTripMetadata): void => {
   mapAdapter?.render(state.value, hiddenSegmentIds.value, selectedPlaceId.value);
 };
 
-/// Updates UI-only place selection shared by the sidebar and map marker halo after guarded editor cleanup.
+/// Updates UI-only place selection shared by the sidebar, toolbar, and map marker halo after guarded editor cleanup.
 const selectPlace = async (placeId: Guid, options: { focusMap?: boolean; openPopup?: boolean } = {}): Promise<boolean> => {
   if (!state.value) {
     selectedPlaceId.value = null;
@@ -113,20 +149,29 @@ const selectPlace = async (placeId: Guid, options: { focusMap?: boolean; openPop
     return false;
   }
 
-  if (!(await closeActivePlaceEditBeforeSelection(placeId))) {
+  if (!(await closeActiveEditorBeforeSelection(placeId))) {
     return false;
   }
 
   selectedPlaceId.value = placeId;
   mapAdapter?.selectPlace(state.value, placeId, { focus: options.focusMap, openPopup: options.openPopup });
+  navigationStatus.value = `Selected place: ${state.value.placesById[placeId].name}`;
   return true;
 };
 
-/// Runs the shared dirty-discard flow before selection hides a different active place editor.
-async function closeActivePlaceEditBeforeSelection(placeId: Guid): Promise<boolean> {
+/// Runs the shared dirty-discard flow before selection hides a different active editor.
+async function closeActiveEditorBeforeSelection(placeId: Guid): Promise<boolean> {
   const target = editorSurface.activeTarget.value;
-  if (target?.kind !== 'place' || target.mode !== 'edit' || target.entityId === placeId) {
+  if (!target) {
     return true;
+  }
+
+  if (target.kind === 'place' && target.mode === 'edit' && target.entityId === placeId) {
+    return true;
+  }
+
+  if (target.kind !== 'place' || target.mode !== 'edit') {
+    return await editorSurface.closeActiveTarget('Discard unsaved editor changes before selecting a place?');
   }
 
   return await editorSurface.closeActiveTarget('Discard unsaved place changes before selecting another place?');
@@ -267,6 +312,7 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
 
   if (selectedPlaceId.value && !next.placesById[selectedPlaceId.value]) {
     selectedPlaceId.value = null;
+    navigationStatus.value = null;
   }
 
   state.value = next;
@@ -359,10 +405,9 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
       <main class="trip-editor-map-shell">
         <header class="trip-editor-toolbar">
           <div class="trip-editor-toolbar__context">
-            <span>{{ state.metadata.isPublic ? 'Public trip' : 'Private trip' }}</span>
-            <strong>Updated {{ updatedLabel }}</strong>
-            <small>{{ toolbarContext }}</small>
-            <small v-if="navigationStatus" class="trip-editor-toolbar__status" role="status">{{ navigationStatus }}</small>
+            <span>{{ toolbarEyebrow }}</span>
+            <strong>{{ toolbarTitle }}</strong>
+            <small class="trip-editor-toolbar__status" role="status">{{ toolbarDetail }}</small>
           </div>
           <div class="trip-editor-toolbar__actions">
             <template v-if="!isMapWorkActive">

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -149,6 +149,15 @@ const selectPlace = async (placeId: Guid, options: { focusMap?: boolean; openPop
     return false;
   }
 
+  if (selectedPlaceId.value === placeId) {
+    const target = editorSurface.activeTarget.value;
+    if (target?.kind === 'place' && target.mode === 'edit' && target.entityId === placeId) {
+      return true;
+    }
+
+    return await clearSelectedPlace();
+  }
+
   if (!(await closeActiveEditorBeforeSelection(placeId))) {
     return false;
   }
@@ -180,6 +189,26 @@ async function closeActiveEditorBeforeSelection(placeId: Guid): Promise<boolean>
 
   return await editorSurface.closeActiveTarget('Discard unsaved place changes before selecting another place?');
 }
+
+/// Clears selected-place context, closing the selected place editor first when that editor owns the selection.
+const clearSelectedPlace = async (): Promise<boolean> => {
+  if (!state.value || !selectedPlaceId.value) {
+    return true;
+  }
+
+  const placeId = selectedPlaceId.value;
+  const target = editorSurface.activeTarget.value;
+  if (target?.kind === 'place' && target.mode === 'edit' && target.entityId === placeId) {
+    if (!(await editorSurface.closeActiveTarget('Discard unsaved place changes?'))) {
+      return false;
+    }
+  }
+
+  selectedPlaceId.value = null;
+  navigationStatus.value = null;
+  mapAdapter?.selectPlace(state.value, null);
+  return true;
+};
 
 /// Runs a navigation-only adapter command without mutating editor drafts or metadata.
 const fitAllGeometry = (): void => {
@@ -404,6 +433,7 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
         @region-draft-dirty-changed="setRegionDraftChanges"
         @hidden-segment-ids-changed="updateHiddenSegmentIds"
         :select-place="placeId => selectPlace(placeId, { focusMap: true })"
+        :clear-selected-place="clearSelectedPlace"
         @search-add-opened="handleSearchAddOpened"
       />
       <main class="trip-editor-map-shell">
@@ -420,6 +450,7 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
                 Recenter Saved Trip View
               </button>
               <button type="button" class="btn btn-outline-light btn-sm" :disabled="!canFocusTarget" @click="focusActiveEntity">Focus Active Entity</button>
+              <button v-if="selectedPlace" type="button" class="btn btn-outline-light btn-sm" @click="clearSelectedPlace">Clear Selection</button>
             </template>
           </div>
         </header>

--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -170,8 +170,12 @@ async function closeActiveEditorBeforeSelection(placeId: Guid): Promise<boolean>
     return true;
   }
 
-  if (target.kind !== 'place' || target.mode !== 'edit') {
-    return await editorSurface.closeActiveTarget('Discard unsaved editor changes before selecting a place?');
+  if (target.kind !== 'place') {
+    return true;
+  }
+
+  if (target.mode === 'add') {
+    return await editorSurface.closeActiveTarget('Discard unsaved place changes before selecting another place?');
   }
 
   return await editorSurface.closeActiveTarget('Discard unsaved place changes before selecting another place?');

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -30,6 +30,7 @@ const props = defineProps<{
   coordinatePicker: PlaceCoordinatePicker;
   polygonEditor: AreaPolygonEditor;
   selectPlace: (placeId: Guid) => Promise<boolean>;
+  clearSelectedPlace: () => Promise<boolean>;
 }>();
 
 const emit = defineEmits<{

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -64,6 +64,7 @@ const orderedRegions = computed(() => props.state.regionOrder.map(id => props.st
 const activeRegion = computed(() => (draft.id ? props.state.regionsById[draft.id] ?? null : null));
 const activePlace = computed(() => (placeDraft.id ? props.state.placesById[placeDraft.id] ?? null : null));
 const activeArea = computed(() => (areaDraft.id ? props.state.areasById[areaDraft.id] ?? null : null));
+const activePlaceEditorId = computed(() => (activePlace.value && isPlaceEditOpen(activePlace.value) ? activePlace.value.id : null));
 const isDraftOpen = computed(() => draft.id !== null || Boolean(draft.name || draft.notesHtml || draft.coverImageRawUrl || draft.centerLatitude || draft.centerLongitude));
 const isPlaceDraftOpen = computed(() => placeDraft.regionId !== null || Boolean(placeDraft.name || placeDraft.notesHtml || placeDraft.address || placeDraft.latitude || placeDraft.longitude));
 const isAreaDraftOpen = computed(() => areaDraft.regionId !== null || Boolean(areaDraft.name || areaDraft.notesHtml || areaDraft.geometry));
@@ -115,7 +116,10 @@ const renderedAreaIdsByRegionId = computed(() => {
 
   return result;
 });
-const forcedExpandedRegionIds = computed(() => new Set(props.searchActive ? renderedRegions.value.map(region => region.id) : []));
+const forcedExpandedRegionIds = computed(() => {
+  const ids = props.searchActive ? renderedRegions.value.map(region => region.id) : activeContextRegions().map(region => region.id);
+  return new Set(ids);
+});
 const regionBaselineRequest = computed(() => draft.id ? buildRegionRequest(toRegionDraft(activeRegion.value)) : regionCreateBaselineRequest.value ?? buildRegionRequest(emptyRegionDraft()));
 const placeBaselineRequest = computed(() => placeDraft.id ? placeEditBaselineRequest.value ?? buildPlaceRequest(toPlaceDraft(activePlace.value, placeDraft.regionId)) : placeCreateBaselineRequest.value ?? buildPlaceRequest(emptyPlaceDraft(placeDraft.regionId)));
 const areaBaselineRequest = computed(() => areaDraft.id ? buildAreaRequest(toAreaDraft(activeArea.value, areaDraft.regionId, props.state.options.areaDefaults.fillHex)) : areaCreateBaselineRequest.value ?? buildAreaRequest(emptyAreaDraft(areaDraft.regionId, props.state.options.areaDefaults.fillHex)));
@@ -432,7 +436,7 @@ async function selectAndOpenPlaceEdit(place: EditorPlace): Promise<void> {
 
     <RegionEditorSurface v-if="isDraftOpen && !draft.id" :active-region="activeRegion" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="regionFormId" :form-summary-errors="formSummaryErrors" :is-dirty="regionDirty" :is-saving="isSaving" :status-text="statusText" :target="activeRegionTarget" @cancel="cancelDraft" @delete="deleteDraftRegion" @reset="resetDraft" @save="saveDraft" />
 
-    <RegionPlaceList :key="regionListKey" :active-area-id="activeArea?.id ?? null" :active-place-id="selectedPlaceId" :active-region-id="activeRegion?.id ?? null" :force-expanded-region-ids="forcedExpandedRegionIds" :is-ordering="isOrdering" :is-saving="isSaving" :place-ids-by-region-id="renderedPlaceIdsByRegionId" :area-ids-by-region-id="renderedAreaIdsByRegionId" :regions="renderedRegions" :search-active="searchActive" :state="state" @add-area="openAreaCreate" @add-place="openPlaceCreate" @area-reorder="reorderAreas" @edit-area="openAreaEdit" @edit-place="selectAndOpenPlaceEdit" @edit-region="openEdit" @place-reorder="reorderPlaces" @region-reorder="reorderRegions" @select-place="selectPlace">
+    <RegionPlaceList :key="regionListKey" :active-area-id="activeArea?.id ?? null" :active-place-editor-id="activePlaceEditorId" :active-place-id="selectedPlaceId" :active-region-id="activeRegion?.id ?? null" :force-expanded-region-ids="forcedExpandedRegionIds" :is-ordering="isOrdering" :is-saving="isSaving" :place-ids-by-region-id="renderedPlaceIdsByRegionId" :area-ids-by-region-id="renderedAreaIdsByRegionId" :regions="renderedRegions" :search-active="searchActive" :state="state" @add-area="openAreaCreate" @add-place="openPlaceCreate" @area-reorder="reorderAreas" @edit-area="openAreaEdit" @edit-place="selectAndOpenPlaceEdit" @edit-region="openEdit" @place-reorder="reorderPlaces" @region-reorder="reorderRegions" @select-place="selectPlace">
       <template #region-editor="{ region }">
         <RegionEditorSurface v-if="isRegionEditOpen(region)" :active-region="activeRegion" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="regionFormId" :form-summary-errors="formSummaryErrors" :is-dirty="regionDirty" :is-saving="isSaving" :status-text="statusText" :target="activeRegionTarget" @cancel="cancelDraft" @delete="deleteDraftRegion" @reset="resetDraft" @save="saveDraft" />
       </template>

--- a/ClientApps/trip-editor/src/components/RegionPlaceList.vue
+++ b/ClientApps/trip-editor/src/components/RegionPlaceList.vue
@@ -315,7 +315,7 @@ function toggleRegion(regionId: Guid): void {
         <li v-if="orderedAreas(region.id).length > 0" class="trip-editor-child-section">
           <span>Areas</span>
         </li>
-        <li v-show="!isCollapsed(region.id)" :data-area-list-region-id="region.id" class="trip-editor-area-list">
+        <li v-if="orderedAreas(region.id).length > 0" v-show="!isCollapsed(region.id)" :data-area-list-region-id="region.id" class="trip-editor-area-list">
           <template v-for="area in orderedAreas(region.id)" :key="area.id">
             <div
               class="trip-editor-area-row"

--- a/ClientApps/trip-editor/src/components/RegionPlaceList.vue
+++ b/ClientApps/trip-editor/src/components/RegionPlaceList.vue
@@ -13,6 +13,7 @@ declare global {
 
 const props = defineProps<{
   activePlaceId: Guid | null;
+  activePlaceEditorId: Guid | null;
   activeAreaId: Guid | null;
   activeRegionId: Guid | null;
   areaIdsByRegionId: Record<Guid, Guid[]>;
@@ -307,7 +308,7 @@ function toggleRegion(regionId: Guid): void {
             </span>
             <button type="button" class="btn btn-outline-light btn-sm" :disabled="props.isSaving || props.isOrdering" @click.stop="emit('editPlace', place)">Edit</button>
           </li>
-          <li v-if="props.activePlaceId === place.id" class="trip-editor-place-editor-row" aria-live="polite">
+          <li v-if="props.activePlaceEditorId === place.id" class="trip-editor-place-editor-row" aria-live="polite">
             <slot name="place-editor" :place="place"></slot>
           </li>
         </template>

--- a/ClientApps/trip-editor/src/components/RegionPlaceList.vue
+++ b/ClientApps/trip-editor/src/components/RegionPlaceList.vue
@@ -342,12 +342,14 @@ function toggleRegion(regionId: Guid): void {
           </template>
         </li>
       </ul>
-      <button v-if="!region.isShadow" type="button" class="btn btn-outline-light btn-sm" :disabled="props.isSaving || props.isOrdering" @click="emit('addPlace', region)">
-        Add Place
-      </button>
-      <button v-if="canAddArea(region)" type="button" class="btn btn-outline-light btn-sm" :disabled="props.isSaving || props.isOrdering" @click="emit('addArea', region)">
-        Add Area
-      </button>
+      <div v-if="!region.isShadow || canAddArea(region)" class="trip-editor-region-card__add-actions">
+        <button v-if="!region.isShadow" type="button" class="btn btn-outline-light btn-sm" :disabled="props.isSaving || props.isOrdering" @click="emit('addPlace', region)">
+          Add Place
+        </button>
+        <button v-if="canAddArea(region)" type="button" class="btn btn-outline-light btn-sm" :disabled="props.isSaving || props.isOrdering" @click="emit('addArea', region)">
+          Add Area
+        </button>
+      </div>
       <slot name="add-place-editor" :region="region"></slot>
       <slot name="add-area-editor" :region="region"></slot>
     </article>

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -32,6 +32,7 @@ const props = defineProps<{
     startSegmentRouteWork: (options: SegmentRouteWorkOptions) => () => void;
   };
   selectPlace: (placeId: Guid) => Promise<boolean>;
+  clearSelectedPlace: () => Promise<boolean>;
 }>();
 
 const emit = defineEmits<{
@@ -211,6 +212,7 @@ function normalize(value: string): string {
       :search-place-ids-by-region-id="sidebarSearch.placesByRegionId"
       :search-area-ids-by-region-id="sidebarSearch.areasByRegionId"
       :select-place="selectPlace"
+      :clear-selected-place="clearSelectedPlace"
       @mutation-applied="result => emit('mutationApplied', result)"
       @dirty-state-changed="isDirty => emit('regionDraftDirtyChanged', isDirty)"
       @search-add-opened="requestId => emit('searchAddOpened', requestId)"

--- a/ClientApps/trip-editor/src/components/placeEditorActions.ts
+++ b/ClientApps/trip-editor/src/components/placeEditorActions.ts
@@ -84,6 +84,11 @@ export function usePlaceEditorActions(context: any) {
   };
 
   const cancelPlaceDraft = async (): Promise<void> => {
+    if (context.placeDraft.id && context.props.selectedPlaceId === context.placeDraft.id) {
+      await context.props.clearSelectedPlace();
+      return;
+    }
+
     await context.props.editorSurface.closeActiveTarget('Discard unsaved place changes?');
   };
 

--- a/ClientApps/trip-editor/src/map.css
+++ b/ClientApps/trip-editor/src/map.css
@@ -21,6 +21,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
+  flex: 1 1 16rem;
   min-width: 0;
 }
 
@@ -41,6 +42,7 @@
 
 .trip-editor-toolbar__actions {
   align-items: center;
+  flex: 0 1 auto;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -59,17 +61,7 @@
 }
 
 .trip-editor-map-marker__halo {
-  border: 3px solid #0d6efd;
-  border-radius: 999px;
-  box-shadow: 0 0 0.75rem rgba(13, 110, 253, 0.8);
   display: none;
-  height: 3rem;
-  left: 50%;
-  pointer-events: none;
-  position: absolute;
-  top: 50%;
-  transform: translate(-50%, -62%);
-  width: 3rem;
 }
 
 .trip-editor-map-marker__image {
@@ -81,7 +73,14 @@
 }
 
 .trip-editor-map-marker--selected .trip-editor-map-marker__halo {
-  display: block;
+  display: none;
+}
+
+.trip-editor-map-marker--selected .trip-editor-map-marker__image {
+  filter:
+    drop-shadow(0 0 3px var(--trip-editor-selected-marker-color, #0d6efd))
+    drop-shadow(0 0 5px var(--trip-editor-selected-marker-color, #0d6efd));
+  transform: translateY(-2px);
 }
 
 .trip-editor-map-marker__badge {

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -99,6 +99,9 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
     selectPlace: (state, placeId, selectOptions = {}) => {
       selectedPlaceId = placeId && state.placesById[placeId] ? placeId : null;
       applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
+      if (!selectOptions.openPopup) {
+        map.closePopup();
+      }
       if (selectedPlaceId) {
         focusSelectedPlace(map, state, placeMarkers, selectedPlaceId, selectOptions);
       }

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -45,8 +45,16 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
   const areaPolygonWork = createAreaPolygonWorkLayer(map);
   const segmentRouteWork = createSegmentRouteWorkLayer(map);
   const placeMarkers = new Map<Guid, L.Marker>();
+  const updateMapViewDataset = (): void => {
+    const center = map.getCenter();
+    element.dataset.tripEditorMapLat = center.lat.toFixed(6);
+    element.dataset.tripEditorMapLng = center.lng.toFixed(6);
+    element.dataset.tripEditorMapZoom = String(map.getZoom());
+  };
   let selectedPlaceId: Guid | null = null;
   let initialViewApplied = false;
+
+  map.on('moveend zoomend', updateMapViewDataset);
 
   L.tileLayer(tilesUrl, {
     attribution: window.wayfarerTileConfig?.attribution ?? '&copy; OpenStreetMap contributors',
@@ -81,6 +89,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
       initialViewApplied = true;
       applyInitialMapView(map, state);
     }
+    updateMapViewDataset();
     applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
   };
 
@@ -116,6 +125,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
       coordinatePick.dispose();
       areaPolygonWork.dispose();
       segmentRouteWork.dispose();
+      map.off('moveend zoomend', updateMapViewDataset);
       map.remove();
     }
   };
@@ -625,9 +635,16 @@ const isFiniteCoordinate = (coordinate: EditorCoordinate): boolean =>
 
 const readUrlMapView = (search: string): { center: EditorCoordinate; zoom: number } | null => {
   const parameters = new URLSearchParams(search);
-  const latitude = Number(parameters.get('lat'));
-  const longitude = Number(parameters.get('lng'));
-  const zoom = Number(parameters.get('zoom'));
+  const latitudeValue = parameters.get('lat');
+  const longitudeValue = parameters.get('lng');
+  const zoomValue = parameters.get('zoom');
+  if (latitudeValue === null || longitudeValue === null || zoomValue === null) {
+    return null;
+  }
+
+  const latitude = Number(latitudeValue);
+  const longitude = Number(longitudeValue);
+  const zoom = Number(zoomValue);
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude) || !Number.isFinite(zoom) || zoom < 0 || zoom > 19) {
     return null;
   }

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -11,6 +11,7 @@ export type { SegmentRouteWorkOptions } from './segmentRouteWorkLayer';
 export type FitAllGeometryResult = 'moved' | 'no-geometry';
 export type FocusSavedTripViewResult = 'moved' | 'missing-view';
 export type FocusActiveEntityResult = 'moved' | 'missing-target' | 'no-geometry' | 'unsupported-target';
+export type InitialMapViewSource = 'url' | 'saved' | 'fit-bounds' | 'fallback';
 
 interface TripEditorMapAdapter {
   render: (state: EditorTripState, hiddenSegmentIds?: ReadonlySet<Guid>, selectedPlaceId?: Guid | null) => void;
@@ -45,6 +46,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
   const segmentRouteWork = createSegmentRouteWorkLayer(map);
   const placeMarkers = new Map<Guid, L.Marker>();
   let selectedPlaceId: Guid | null = null;
+  let initialViewApplied = false;
 
   L.tileLayer(tilesUrl, {
     attribution: window.wayfarerTileConfig?.attribution ?? '&copy; OpenStreetMap contributors',
@@ -75,7 +77,10 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
       }
     });
 
-    fitMapToState(map, state);
+    if (!initialViewApplied) {
+      initialViewApplied = true;
+      applyInitialMapView(map, state);
+    }
     applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
   };
 
@@ -313,7 +318,7 @@ const placeMarkerIcon = (place: EditorPlace): L.DivIcon => {
 
   return L.divIcon({
     className: 'trip-editor-map-marker',
-    html: `<span class="trip-editor-map-marker__halo" aria-hidden="true"></span><img class="trip-editor-map-marker__image" src="${placeMarkerIconUrl(place.iconName, place.markerColor)}" width="28" height="45" alt="${escapeHtml(placeMarkerLabel(place))}" data-place-marker-icon="${escapeHtml(place.id)}">${visitBadge}`,
+    html: `<span class="trip-editor-map-marker__halo" aria-hidden="true"></span><img class="trip-editor-map-marker__image" src="${placeMarkerIconUrl(place.iconName, place.markerColor)}" width="28" height="45" alt="${escapeHtml(placeMarkerLabel(place))}" style="--trip-editor-selected-marker-color: ${markerSelectionColor(place.markerColor)}" data-place-marker-icon="${escapeHtml(place.id)}">${visitBadge}`,
     iconSize: [36, 50],
     iconAnchor: [18, 50],
     popupAnchor: [0, -45]
@@ -386,13 +391,22 @@ const fallbackSegmentCoordinates = (segment: EditorSegment, state: EditorTripSta
   return from && to ? [[from.longitude, from.latitude], [to.longitude, to.latitude]] : null;
 };
 
-// Preserves the existing render-time auto-fit while toolbar commands remain explicit navigation calls.
-const fitMapToState = (map: LeafletMap, state: EditorTripState): void => {
-  if (fitBounds(map, allGeometryBounds(state)) === 'moved') {
-    return;
+const applyInitialMapView = (map: LeafletMap, state: EditorTripState): InitialMapViewSource => {
+  const urlView = readUrlMapView(window.location.search);
+  if (urlView) {
+    map.setView([urlView.center.latitude, urlView.center.longitude], urlView.zoom);
+    return 'url';
   }
 
-  focusRenderFallbackView(map, state.metadata);
+  if (focusSavedTripView(map, state.metadata) === 'moved') {
+    return 'saved';
+  }
+
+  if (fitAllGeometry(map, state) === 'moved') {
+    return 'fit-bounds';
+  }
+
+  return 'fallback';
 };
 
 const fitAllGeometry = (map: LeafletMap, state: EditorTripState): FitAllGeometryResult =>
@@ -405,14 +419,6 @@ const focusSavedTripView = (map: LeafletMap, metadata: EditorTripMetadata): Focu
 
   map.setView([metadata.center.latitude, metadata.center.longitude], metadata.zoom);
   return 'moved';
-};
-
-const focusRenderFallbackView = (map: LeafletMap, metadata: EditorTripMetadata): void => {
-  if (!metadata.center || !isFiniteCoordinate(metadata.center)) {
-    return;
-  }
-
-  map.setView([metadata.center.latitude, metadata.center.longitude], metadata.zoom ?? 8);
 };
 
 const focusActiveEntity = (map: LeafletMap, state: EditorTripState, target: EditorTarget | null): FocusActiveEntityResult => {
@@ -616,6 +622,32 @@ const extendLongitudeLatitude = (bounds: L.LatLngBounds, [longitude, latitude]: 
 
 const isFiniteCoordinate = (coordinate: EditorCoordinate): boolean =>
   Number.isFinite(coordinate.latitude) && Number.isFinite(coordinate.longitude);
+
+const readUrlMapView = (search: string): { center: EditorCoordinate; zoom: number } | null => {
+  const parameters = new URLSearchParams(search);
+  const latitude = Number(parameters.get('lat'));
+  const longitude = Number(parameters.get('lng'));
+  const zoom = Number(parameters.get('zoom'));
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude) || !Number.isFinite(zoom) || zoom < 0 || zoom > 19) {
+    return null;
+  }
+
+  const center = { latitude, longitude };
+  return isFiniteCoordinate(center) ? { center, zoom } : null;
+};
+
+const markerSelectionColor = (markerColor: string | null | undefined): string => ({
+  'bg-blue': '#0d6efd',
+  'bg-cyan': '#0dcaf0',
+  'bg-green': '#198754',
+  'bg-indigo': '#6610f2',
+  'bg-orange': '#fd7e14',
+  'bg-pink': '#d63384',
+  'bg-purple': '#6f42c1',
+  'bg-red': '#dc3545',
+  'bg-teal': '#20c997',
+  'bg-yellow': '#ffc107'
+})[markerColor ?? ''] ?? '#0d6efd';
 
 const segmentLabel = (segment: EditorSegment, state: EditorTripState): string => {
   const fromName = segment.fromPlaceId ? state.placesById[segment.fromPlaceId]?.name : null;

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -406,8 +406,9 @@ body {
 
 .trip-editor-region-card--active,
 .trip-editor-place-row--active {
-  border-color: rgba(13, 110, 253, 0.45);
-  box-shadow: inset 0 0 0 1px rgba(13, 110, 253, 0.25);
+  background: color-mix(in srgb, var(--trip-editor-accent) 14%, var(--trip-editor-card-strong));
+  border-color: color-mix(in srgb, var(--trip-editor-accent) 58%, var(--trip-editor-border));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--trip-editor-accent) 34%, transparent);
 }
 
 .trip-editor-region-card__header {

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -439,7 +439,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
-  margin-top: 0.4rem;
+  margin-top: 0.55rem;
 }
 
 .trip-editor-icon-button {
@@ -487,12 +487,16 @@ body {
 
 .trip-editor-place-row {
   cursor: pointer;
-  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  display: flex;
 }
 
 .trip-editor-place-row:focus-visible {
   outline: 2px solid #93c5fd;
   outline-offset: 2px;
+}
+
+.trip-editor-place-row .trip-editor-place-drag-handle {
+  flex: 0 0 2rem;
 }
 
 .trip-editor-place-row > span,
@@ -504,8 +508,10 @@ body {
 .trip-editor-place-row__icon {
   align-items: end;
   display: inline-flex;
+  flex: 0 0 1.75rem;
   height: 2.55rem;
   justify-content: flex-start;
+  min-width: 1.75rem;
   position: relative;
   width: 1.75rem;
 }
@@ -531,6 +537,7 @@ body {
 
 .trip-editor-place-row__content {
   display: grid;
+  flex: 1 1 auto;
   gap: 0.1rem;
   min-width: 0;
 }

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -435,6 +435,13 @@ body {
   justify-content: flex-end;
 }
 
+.trip-editor-region-card__add-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
+}
+
 .trip-editor-icon-button {
   align-items: center;
   background: var(--trip-editor-field-bg);
@@ -498,7 +505,7 @@ body {
   align-items: end;
   display: inline-flex;
   height: 2.55rem;
-  justify-content: center;
+  justify-content: flex-start;
   position: relative;
   width: 1.75rem;
 }

--- a/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
@@ -85,8 +85,8 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
       preparePlaceLocationFocusState(state);
       state.metadata.center = { latitude: -33.8688, longitude: 151.2093 };
       state.metadata.zoom = 4;
-    }, `${editorPath}?lat=12.3456&lng=45.6789&zoom=7`);
-    await expectMapViewNear(page, { latitude: 12.3456, longitude: 45.6789, zoom: 7 });
+    }, `${editorPath}?lat=12.3456&lng=45.6789&zoom=2`);
+    await expectMapViewNear(page, { latitude: 12.3456, longitude: 45.6789, zoom: 2 });
 
     await loadWorkspaceWithEditorState(page, state => {
       preparePlaceLocationFocusState(state);

--- a/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
@@ -79,6 +79,33 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
     await expect(toolbar.getByRole('button', { name: 'Focus Active Entity' })).toBeDisabled();
   });
 
+  test('initial map load uses URL view before saved view and fit-bounds fallback', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithEditorState(page, state => {
+      preparePlaceLocationFocusState(state);
+      state.metadata.center = { latitude: -33.8688, longitude: 151.2093 };
+      state.metadata.zoom = 4;
+    }, `${editorPath}?lat=12.3456&lng=45.6789&zoom=7`);
+    await expectMapViewNear(page, { latitude: 12.3456, longitude: 45.6789, zoom: 7 });
+
+    await loadWorkspaceWithEditorState(page, state => {
+      preparePlaceLocationFocusState(state);
+      state.metadata.center = { latitude: 37.9838, longitude: 23.7275 };
+      state.metadata.zoom = 9;
+    });
+    await expectMapViewNear(page, { latitude: 37.9838, longitude: 23.7275, zoom: 9 });
+
+    await loadWorkspaceWithEditorState(page, state => {
+      clearNavigationGeometry(state);
+      state.metadata.center = null;
+      state.metadata.zoom = null;
+      const region = normalRegion(state);
+      test.skip(!region, 'Configured Trip Editor fixture has no normal region for fit-bounds fallback coverage.');
+      addAreaGeometry(state, region!.id, '00000000-0000-0000-0000-000000260104', 'PW initial fit fallback area');
+    });
+    await expectMapCenterInRange(page, { minLatitude: 36.8, maxLatitude: 38.2, minLongitude: 22.8, maxLongitude: 24.2 });
+  });
+
   test('metadata focus falls back to Fit All when saved trip view is missing', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithEditorState(page, state => {
@@ -205,7 +232,7 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
   });
 });
 
-async function loadWorkspaceWithEditorState<T>(page: Page, mutate: (state: MutableEditorState) => T): Promise<T> {
+async function loadWorkspaceWithEditorState<T>(page: Page, mutate: (state: MutableEditorState) => T, path = editorPath): Promise<T> {
   await page.unroute(`**${editorApiPath}`).catch(() => undefined);
   const state = await loadEditorStateFixture(page) as MutableEditorState;
   const result = mutate(state);
@@ -217,7 +244,7 @@ async function loadWorkspaceWithEditorState<T>(page: Page, mutate: (state: Mutab
 
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
   });
-  await page.goto(absoluteUrl(editorPath));
+  await page.goto(absoluteUrl(path));
   await expectMountedWorkspace(page);
   return result;
 }
@@ -410,6 +437,31 @@ async function readMapView(page: Page): Promise<MapViewSnapshot> {
       tilePaneTransform: readTransform('.leaflet-tile-pane')
     };
   });
+}
+
+async function readMapViewCoordinates(page: Page): Promise<{ latitude: number; longitude: number; zoom: number }> {
+  await expectUsableMapView(page);
+  return await page.getByLabel('Read-only trip map').evaluate(map => ({
+    latitude: Number((map as HTMLElement).dataset.tripEditorMapLat),
+    longitude: Number((map as HTMLElement).dataset.tripEditorMapLng),
+    zoom: Number((map as HTMLElement).dataset.tripEditorMapZoom)
+  }));
+}
+
+async function expectMapViewNear(page: Page, expected: { latitude: number; longitude: number; zoom: number }): Promise<void> {
+  await expect.poll(async () => readMapViewCoordinates(page)).toEqual({
+    latitude: expect.closeTo(expected.latitude, 0.0001),
+    longitude: expect.closeTo(expected.longitude, 0.0001),
+    zoom: expected.zoom
+  });
+}
+
+async function expectMapCenterInRange(page: Page, expected: { minLatitude: number; maxLatitude: number; minLongitude: number; maxLongitude: number }): Promise<void> {
+  const view = await readMapViewCoordinates(page);
+  expect(view.latitude).toBeGreaterThanOrEqual(expected.minLatitude);
+  expect(view.latitude).toBeLessThanOrEqual(expected.maxLatitude);
+  expect(view.longitude).toBeGreaterThanOrEqual(expected.minLongitude);
+  expect(view.longitude).toBeLessThanOrEqual(expected.maxLongitude);
 }
 
 async function expectMapViewChanged(page: Page, before: MapViewSnapshot, message: string): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
 import {
   absoluteUrl,
   editorApiPath,
@@ -79,7 +79,7 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
     await expect(toolbar.getByRole('button', { name: 'Focus Active Entity' })).toBeDisabled();
   });
 
-  test('initial map load uses URL view before saved view and fit-bounds fallback', async ({ page }) => {
+  test('initial map load uses URL view before saved view and fit-bounds fallback', async ({ page }, testInfo) => {
     await signIn(page);
     await loadWorkspaceWithEditorState(page, state => {
       preparePlaceLocationFocusState(state);
@@ -94,6 +94,7 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
       state.metadata.zoom = 9;
     });
     await expectMapViewNear(page, { latitude: 37.9838, longitude: 23.7275, zoom: 9 });
+    await captureEvidence(page, testInfo, 'saved-view-load');
 
     await loadWorkspaceWithEditorState(page, state => {
       clearNavigationGeometry(state);
@@ -104,6 +105,7 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
       addAreaGeometry(state, region!.id, '00000000-0000-0000-0000-000000260104', 'PW initial fit fallback area');
     });
     await expectMapCenterInRange(page, { minLatitude: 36.8, maxLatitude: 38.2, minLongitude: 22.8, maxLongitude: 24.2 });
+    await captureEvidence(page, testInfo, 'fit-bounds-fallback-load');
   });
 
   test('metadata focus falls back to Fit All when saved trip view is missing', async ({ page }) => {
@@ -462,6 +464,10 @@ async function expectMapCenterInRange(page: Page, expected: { minLatitude: numbe
   expect(view.latitude).toBeLessThanOrEqual(expected.maxLatitude);
   expect(view.longitude).toBeGreaterThanOrEqual(expected.minLongitude);
   expect(view.longitude).toBeLessThanOrEqual(expected.maxLongitude);
+}
+
+async function captureEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
 }
 
 async function expectMapViewChanged(page: Page, before: MapViewSnapshot, message: string): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page, type Route } from '@playwright/test';
+import { expect, test, type Locator, type Page, type Route, type TestInfo } from '@playwright/test';
 import {
   absoluteUrl,
   editorApiPath,
@@ -20,7 +20,7 @@ const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]
 const tinyPng = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=', 'base64');
 
 test.describe.serial('Trip Editor marker and notes parity', () => {
-  test('keeps map markers, sidebar rows, popups, and selection synchronized both directions', async ({ page }) => {
+  test('keeps map markers, sidebar rows, popups, and selection synchronized both directions', async ({ page }, testInfo) => {
     await signIn(page);
     await loadWorkspaceWithMarkerFixture(page);
 
@@ -35,6 +35,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(0);
     await expect(page.locator('.leaflet-popup')).toContainText(firstPlaceName);
     await expect(page.locator('.leaflet-popup')).toContainText('Marker popup rich note');
+    await captureEvidence(page, testInfo, 'map-click-selects-sidebar-status');
 
     await sidebarRow(page, secondPlaceId).click();
     await expectSelectedPlace(page, secondPlaceId);
@@ -42,6 +43,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expect(page.locator('.trip-editor-toolbar')).toContainText(secondPlaceName);
     await expect(page.locator('.trip-editor-toolbar__status')).toContainText(`Selected place: ${secondPlaceName}`);
     await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(0);
+    await captureEvidence(page, testInfo, 'sidebar-click-selects-map-status');
 
     await sidebarRow(page, firstPlaceId).getByRole('button', { name: 'Edit', exact: true }).click();
     await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(firstPlaceName)}`) })).toBeVisible();
@@ -63,7 +65,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expectSelectedPlace(page, firstPlaceId);
   });
 
-  test('guards marker and sidebar place selection while a place editor is dirty', async ({ page }) => {
+  test('guards marker and sidebar place selection while a place editor is dirty', async ({ page }, testInfo) => {
     await signIn(page);
     await loadWorkspaceWithMarkerFixture(page);
 
@@ -83,6 +85,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expectNotSelected(page, secondPlaceId);
     await expect(page.locator('.trip-editor-toolbar')).toContainText(firstPlaceName);
     await expect(page.locator('.leaflet-popup')).toHaveCount(0);
+    await captureEvidence(page, testInfo, 'dirty-marker-selection-cancel-keeps-editor');
 
     await sidebarRow(page, secondPlaceId).click();
     const sidebarDiscard = page.getByRole('dialog', { name: 'Discard changes?' });
@@ -284,6 +287,10 @@ async function clickMarker(page: Page, placeId: string): Promise<void> {
   await markerImage(page, placeId).evaluate(element => {
     element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
   });
+}
+
+async function captureEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
 }
 
 async function expectPlaceRowDoesNotOverlapEdit(page: Page, placeId: string): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -27,20 +27,27 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expectLoadedImages(mapMarkerImages(page));
     await expectLoadedImages(page.locator('[data-sidebar-place-icon]'));
 
-    await markerImage(page, firstPlaceId).click();
+    await clickMarker(page, firstPlaceId);
     await expectSelectedPlace(page, firstPlaceId);
     await expect(sidebarRow(page, firstPlaceId)).toBeInViewport();
+    await expect(page.locator('.trip-editor-toolbar')).toContainText(firstPlaceName);
+    await expect(page.locator('.trip-editor-toolbar__status')).toContainText(`Selected place: ${firstPlaceName}`);
+    await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(0);
     await expect(page.locator('.leaflet-popup')).toContainText(firstPlaceName);
     await expect(page.locator('.leaflet-popup')).toContainText('Marker popup rich note');
 
     await sidebarRow(page, secondPlaceId).click();
     await expectSelectedPlace(page, secondPlaceId);
     await expectNotSelected(page, firstPlaceId);
+    await expect(page.locator('.trip-editor-toolbar')).toContainText(secondPlaceName);
+    await expect(page.locator('.trip-editor-toolbar__status')).toContainText(`Selected place: ${secondPlaceName}`);
+    await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(0);
 
     await sidebarRow(page, firstPlaceId).getByRole('button', { name: 'Edit', exact: true }).click();
     await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(firstPlaceName)}`) })).toBeVisible();
     await expectSelectedPlace(page, firstPlaceId);
     await expectNotSelected(page, secondPlaceId);
+    await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(1);
 
     await page.getByLabel('Sidebar search').fill('second place');
     await expectSelectedPlace(page, firstPlaceId);
@@ -65,7 +72,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await page.locator('#trip-editor-place-form').getByLabel('Address').fill('Unsaved dirty marker guard address');
     await expectSelectedPlace(page, firstPlaceId);
 
-    await markerImage(page, secondPlaceId).click();
+    await clickMarker(page, secondPlaceId);
     const markerDiscard = page.getByRole('dialog', { name: 'Discard changes?' });
     await expect(markerDiscard).toBeVisible();
     await markerDiscard.getByRole('button', { name: 'Keep editing' }).click();
@@ -74,6 +81,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expect(page.locator('#trip-editor-place-form').getByLabel('Address')).toHaveValue('Unsaved dirty marker guard address');
     await expectSelectedPlace(page, firstPlaceId);
     await expectNotSelected(page, secondPlaceId);
+    await expect(page.locator('.trip-editor-toolbar')).toContainText(firstPlaceName);
     await expect(page.locator('.leaflet-popup')).toHaveCount(0);
 
     await sidebarRow(page, secondPlaceId).click();
@@ -86,7 +94,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expectSelectedPlace(page, firstPlaceId);
     await expectNotSelected(page, secondPlaceId);
 
-    await markerImage(page, secondPlaceId).click();
+    await clickMarker(page, secondPlaceId);
     const confirmDiscard = page.getByRole('dialog', { name: 'Discard changes?' });
     await expect(confirmDiscard).toBeVisible();
     await confirmDiscard.getByRole('button', { name: 'Discard' }).click();
@@ -164,6 +172,8 @@ async function routeEditorState(route: Route, state: MutableEditorState, request
 function prepareMarkerState(state: MutableEditorState): void {
   state.permissions.canEditRegions = true;
   state.permissions.canEditPlaces = true;
+  state.metadata.center = null;
+  state.metadata.zoom = null;
   state.regionsById = {
     [regionId]: {
       id: regionId,
@@ -180,7 +190,7 @@ function prepareMarkerState(state: MutableEditorState): void {
   state.regionOrder = [regionId];
   state.placesById = {
     [firstPlaceId]: placeFixture(state, firstPlaceId, firstPlaceName, 'camera', 'bg-blue', { latitude: 37.9838, longitude: 23.7275 }, true),
-    [secondPlaceId]: placeFixture(state, secondPlaceId, secondPlaceName, 'star', 'bg-red', { latitude: 37.99, longitude: 23.74 }, false)
+    [secondPlaceId]: placeFixture(state, secondPlaceId, secondPlaceName, 'star', 'bg-red', { latitude: 38.2, longitude: 24.05 }, false)
   };
   state.placeOrderByRegionId = { [regionId]: [firstPlaceId, secondPlaceId] };
   state.areasById = {};
@@ -267,6 +277,13 @@ async function expectLoadedImages(images: Locator): Promise<void> {
   for (let index = 0; index < count; index += 1) {
     await expect.poll(async () => images.nth(index).evaluate(image => image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0)).toBe(true);
   }
+}
+
+async function clickMarker(page: Page, placeId: string): Promise<void> {
+  await expect(markerImage(page, placeId)).toBeVisible();
+  await markerImage(page, placeId).evaluate(element => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+  });
 }
 
 async function expectPlaceRowDoesNotOverlapEdit(page: Page, placeId: string): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -43,7 +43,13 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expect(page.locator('.trip-editor-toolbar')).toContainText(secondPlaceName);
     await expect(page.locator('.trip-editor-toolbar__status')).toContainText(`Selected place: ${secondPlaceName}`);
     await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(0);
+    await expect(page.locator('.leaflet-popup')).toHaveCount(0);
     await captureEvidence(page, testInfo, 'sidebar-click-selects-map-status');
+
+    await sidebarRow(page, secondPlaceId).click();
+    await expectNoSelectedPlace(page);
+    await expect(page.locator('.leaflet-popup')).toHaveCount(0);
+    await captureEvidence(page, testInfo, 'selected-place-row-click-clears-selection');
 
     await sidebarRow(page, firstPlaceId).getByRole('button', { name: 'Edit', exact: true }).click();
     await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(firstPlaceName)}`) })).toBeVisible();
@@ -62,7 +68,10 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expectSelectedPlace(page, firstPlaceId);
 
     await page.getByRole('button', { name: 'Cancel' }).click();
-    await expectSelectedPlace(page, firstPlaceId);
+    await expectNoSelectedPlace(page);
+    await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(0);
+    await expect(page.locator('.leaflet-popup')).toHaveCount(0);
+    await captureEvidence(page, testInfo, 'clean-edit-cancel-clears-selection');
   });
 
   test('guards marker and sidebar place selection while a place editor is dirty', async ({ page }, testInfo) => {
@@ -106,6 +115,65 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expectSelectedPlace(page, secondPlaceId);
     await expectNotSelected(page, firstPlaceId);
     await expect(page.locator('.leaflet-popup')).toContainText(secondPlaceName);
+    await captureEvidence(page, testInfo, 'dirty-marker-selection-discard-selects-target');
+  });
+
+  test('clear selection follows the selected place editor dirty contract', async ({ page }, testInfo) => {
+    await signIn(page);
+    await loadWorkspaceWithMarkerFixture(page);
+
+    await clickMarker(page, firstPlaceId);
+    await expectSelectedPlace(page, firstPlaceId);
+    await expect(page.locator('.leaflet-popup')).toContainText(firstPlaceName);
+
+    await page.getByRole('button', { name: 'Clear Selection' }).click();
+    await expectNoSelectedPlace(page);
+    await expect(page.locator('.leaflet-popup')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Clear Selection' })).toHaveCount(0);
+    await captureEvidence(page, testInfo, 'selected-place-clear-action-clears-surfaces');
+
+    await sidebarRow(page, firstPlaceId).getByRole('button', { name: 'Edit', exact: true }).click();
+    await expect(expectPlaceEditor(page, firstPlaceName)).toBeVisible();
+    await page.locator('#trip-editor-place-form').getByLabel('Address').fill('Unsaved dirty clear selection address');
+
+    await page.getByRole('button', { name: 'Clear Selection' }).click();
+    const keepDialog = page.getByRole('dialog', { name: 'Discard changes?' });
+    await expect(keepDialog).toBeVisible();
+    await keepDialog.getByRole('button', { name: 'Keep editing' }).click();
+
+    await expect(expectPlaceEditor(page, firstPlaceName)).toBeVisible();
+    await expect(page.locator('#trip-editor-place-form').getByLabel('Address')).toHaveValue('Unsaved dirty clear selection address');
+    await expectSelectedPlace(page, firstPlaceId);
+    await captureEvidence(page, testInfo, 'dirty-clear-selection-keep-editing');
+
+    await page.getByRole('button', { name: 'Clear Selection' }).click();
+    const discardDialog = page.getByRole('dialog', { name: 'Discard changes?' });
+    await expect(discardDialog).toBeVisible();
+    await discardDialog.getByRole('button', { name: 'Discard' }).click();
+
+    await expect(expectPlaceEditor(page, firstPlaceName)).toHaveCount(0);
+    await expectNoSelectedPlace(page);
+    await expect(page.locator('.leaflet-popup')).toHaveCount(0);
+    await captureEvidence(page, testInfo, 'dirty-clear-selection-discard');
+  });
+
+  test('docked return from expanded place editor preserves the selected owning row', async ({ page }, testInfo) => {
+    await signIn(page);
+    await loadWorkspaceWithMarkerFixture(page);
+
+    await sidebarRow(page, firstPlaceId).getByRole('button', { name: 'Edit', exact: true }).click();
+    await expectSelectedPlace(page, firstPlaceId);
+    await page.locator('.trip-editor-place-editor-row .trip-editor-surface--docked').getByRole('button', { name: 'Expand Editor' }).click();
+
+    const expanded = page.getByRole('dialog', { name: new RegExp(`Edit Place - ${escapeRegex(firstPlaceName)}`) });
+    await expect(expanded).toBeVisible();
+    await captureEvidence(page, testInfo, 'expanded-selected-place-editor');
+
+    await expanded.getByRole('button', { name: 'Dock to sidebar' }).click();
+    await expect(page.locator('.trip-editor-place-editor-row .trip-editor-surface--docked')).toBeVisible();
+    await expect(sidebarRow(page, firstPlaceId)).toBeInViewport();
+    await expectSelectedPlace(page, firstPlaceId);
+    await captureEvidence(page, testInfo, 'expanded-docked-selected-place-preserved');
   });
 
   test('shows icon choices and keeps long place names from overlapping actions', async ({ page }) => {
@@ -272,6 +340,14 @@ async function expectSelectedPlace(page: Page, placeId: string): Promise<void> {
 async function expectNotSelected(page: Page, placeId: string): Promise<void> {
   await expect(sidebarRow(page, placeId)).not.toHaveClass(/trip-editor-place-row--active/);
   await expect(markerImage(page, placeId).locator('xpath=ancestor::*[contains(@class, "trip-editor-map-marker")]')).not.toHaveClass(/trip-editor-map-marker--selected/);
+}
+
+async function expectNoSelectedPlace(page: Page): Promise<void> {
+  await expect(sidebarRow(page, firstPlaceId)).not.toHaveClass(/trip-editor-place-row--active/);
+  await expect(sidebarRow(page, secondPlaceId)).not.toHaveClass(/trip-editor-place-row--active/);
+  await expect(markerImage(page, firstPlaceId).locator('xpath=ancestor::*[contains(@class, "trip-editor-map-marker")]')).not.toHaveClass(/trip-editor-map-marker--selected/);
+  await expect(markerImage(page, secondPlaceId).locator('xpath=ancestor::*[contains(@class, "trip-editor-map-marker")]')).not.toHaveClass(/trip-editor-map-marker--selected/);
+  await expect(page.locator('.trip-editor-toolbar')).not.toContainText('Selected place');
 }
 
 async function expectLoadedImages(images: Locator): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -406,23 +406,31 @@ async function expectRegionAddActionsAttached(page: Page): Promise<void> {
 }
 
 async function expectPlaceIconColumnAligned(page: Page): Promise<void> {
-  const firstIcon = sidebarRow(page, firstPlaceId).locator('.trip-editor-place-row__icon');
-  const secondIcon = sidebarRow(page, secondPlaceId).locator('.trip-editor-place-row__icon');
+  const firstRow = sidebarRow(page, firstPlaceId);
+  const secondRow = sidebarRow(page, secondPlaceId);
+  const firstIcon = firstRow.locator('.trip-editor-place-row__icon');
+  const secondIcon = secondRow.locator('.trip-editor-place-row__icon');
   const firstImage = firstIcon.locator('img[data-sidebar-place-icon]');
   const secondImage = secondIcon.locator('img[data-sidebar-place-icon]');
-  const [firstIconBox, secondIconBox, firstImageBox, secondImageBox] = await Promise.all([
+  const [firstRowBox, secondRowBox, firstIconBox, secondIconBox, firstImageBox, secondImageBox] = await Promise.all([
+    firstRow.boundingBox(),
+    secondRow.boundingBox(),
     firstIcon.boundingBox(),
     secondIcon.boundingBox(),
     firstImage.boundingBox(),
     secondImage.boundingBox()
   ]);
+  expect(firstRowBox, 'First place row should have a rendered bounding box.').not.toBeNull();
+  expect(secondRowBox, 'Second place row should have a rendered bounding box.').not.toBeNull();
   expect(firstIconBox, 'First place icon column should have a rendered bounding box.').not.toBeNull();
   expect(secondIconBox, 'Second place icon column should have a rendered bounding box.').not.toBeNull();
   expect(firstImageBox, 'First place icon should have a rendered bounding box.').not.toBeNull();
   expect(secondImageBox, 'Second place icon should have a rendered bounding box.').not.toBeNull();
 
   const tolerance = 2;
-  expect(Math.abs(firstIconBox!.x - secondIconBox!.x), 'Place icon columns should align consistently across rows.').toBeLessThanOrEqual(tolerance);
+  const firstColumnOffset = firstIconBox!.x - firstRowBox!.x;
+  const secondColumnOffset = secondIconBox!.x - secondRowBox!.x;
+  expect(Math.abs(firstColumnOffset - secondColumnOffset), 'Place icon columns should align consistently within their rows.').toBeLessThanOrEqual(tolerance);
   expect(Math.abs(firstImageBox!.x - firstIconBox!.x), 'First place icon should be left-aligned inside its icon column.').toBeLessThanOrEqual(tolerance);
   expect(Math.abs(secondImageBox!.x - secondIconBox!.x), 'Second place icon should be left-aligned inside its icon column.').toBeLessThanOrEqual(tolerance);
 }

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -33,6 +33,8 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expect(page.locator('.trip-editor-toolbar')).toContainText(firstPlaceName);
     await expect(page.locator('.trip-editor-toolbar__status')).toContainText(`Selected place: ${firstPlaceName}`);
     await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(0);
+    await expect(regionCard(page).locator('.trip-editor-area-list')).toHaveCount(0);
+    await expectRegionAddActionsAttached(page);
     await expect(page.locator('.leaflet-popup')).toContainText(firstPlaceName);
     await expect(page.locator('.leaflet-popup')).toContainText('Marker popup rich note');
     await captureEvidence(page, testInfo, 'map-click-selects-sidebar-status');
@@ -43,6 +45,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expect(page.locator('.trip-editor-toolbar')).toContainText(secondPlaceName);
     await expect(page.locator('.trip-editor-toolbar__status')).toContainText(`Selected place: ${secondPlaceName}`);
     await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(0);
+    await expectRegionAddActionsAttached(page);
     await expect(page.locator('.leaflet-popup')).toHaveCount(0);
     await captureEvidence(page, testInfo, 'sidebar-click-selects-map-status');
 
@@ -56,6 +59,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expectSelectedPlace(page, firstPlaceId);
     await expectNotSelected(page, secondPlaceId);
     await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(1);
+    await expectNonEmptyPlaceEditorRow(page);
 
     await page.getByLabel('Sidebar search').fill('second place');
     await expectSelectedPlace(page, firstPlaceId);
@@ -171,6 +175,8 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
 
     await expanded.getByRole('button', { name: 'Dock to sidebar' }).click();
     await expect(page.locator('.trip-editor-place-editor-row .trip-editor-surface--docked')).toBeVisible();
+    await expectNonEmptyPlaceEditorRow(page);
+    await expectEditorRowUnderPlace(page, firstPlaceId);
     await expect(sidebarRow(page, firstPlaceId)).toBeInViewport();
     await expectSelectedPlace(page, firstPlaceId);
     await captureEvidence(page, testInfo, 'expanded-docked-selected-place-preserved');
@@ -320,6 +326,10 @@ function sidebarRow(page: Page, placeId: string): Locator {
   return page.locator(`[data-place-id="${placeId}"]`);
 }
 
+function regionCard(page: Page): Locator {
+  return page.locator(`[data-region-id="${regionId}"]`);
+}
+
 function markerImage(page: Page, placeId: string): Locator {
   return page.locator(`[data-place-marker-icon="${placeId}"]`);
 }
@@ -377,6 +387,37 @@ async function expectPlaceRowDoesNotOverlapEdit(page: Page, placeId: string): Pr
   expect(nameBox).not.toBeNull();
   expect(editBox).not.toBeNull();
   expect(nameBox!.x + nameBox!.width, 'Place name must not overlap the Edit button.').toBeLessThanOrEqual(editBox!.x);
+}
+
+async function expectRegionAddActionsAttached(page: Page): Promise<void> {
+  const lastChildRow = sidebarRow(page, secondPlaceId);
+  const addPlaceButton = regionCard(page).getByRole('button', { name: 'Add Place' });
+  await expect(lastChildRow).toBeVisible();
+  await expect(addPlaceButton).toBeVisible();
+
+  const [rowBox, addBox] = await Promise.all([lastChildRow.boundingBox(), addPlaceButton.boundingBox()]);
+  expect(rowBox, 'Last visible child row should have a rendered bounding box.').not.toBeNull();
+  expect(addBox, 'Add Place button should have a rendered bounding box.').not.toBeNull();
+  expect(addBox!.y - (rowBox!.y + rowBox!.height), 'Add actions should stay visually attached to region children without a blank panel gap.').toBeLessThanOrEqual(28);
+}
+
+async function expectNonEmptyPlaceEditorRow(page: Page): Promise<void> {
+  const editorRow = page.locator('.trip-editor-place-editor-row');
+  await expect(editorRow).toHaveCount(1);
+  await expect(editorRow.locator('.trip-editor-surface--docked')).toBeVisible();
+  await expect(editorRow.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(firstPlaceName)}`) })).toBeVisible();
+}
+
+async function expectEditorRowUnderPlace(page: Page, placeId: string): Promise<void> {
+  const selectedRow = sidebarRow(page, placeId);
+  const editorRow = page.locator('.trip-editor-place-editor-row');
+  const followingRow = sidebarRow(page, secondPlaceId);
+  const [selectedBox, editorBox, followingBox] = await Promise.all([selectedRow.boundingBox(), editorRow.boundingBox(), followingRow.boundingBox()]);
+  expect(selectedBox, 'Selected place row should have a rendered bounding box.').not.toBeNull();
+  expect(editorBox, 'Docked editor row should have a rendered bounding box.').not.toBeNull();
+  expect(followingBox, 'Following place row should have a rendered bounding box.').not.toBeNull();
+  expect(editorBox!.y, 'Docked editor row should render below its owning selected place row.').toBeGreaterThanOrEqual(selectedBox!.y + selectedBox!.height);
+  expect(followingBox!.y, 'Docked editor row should stay before the next place row.').toBeGreaterThanOrEqual(editorBox!.y + editorBox!.height);
 }
 
 function escapeRegex(value: string): string {

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -35,6 +35,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(0);
     await expect(regionCard(page).locator('.trip-editor-area-list')).toHaveCount(0);
     await expectRegionAddActionsAttached(page);
+    await expectPlaceIconColumnAligned(page);
     await expect(page.locator('.leaflet-popup')).toContainText(firstPlaceName);
     await expect(page.locator('.leaflet-popup')).toContainText('Marker popup rich note');
     await captureEvidence(page, testInfo, 'map-click-selects-sidebar-status');
@@ -46,6 +47,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expect(page.locator('.trip-editor-toolbar__status')).toContainText(`Selected place: ${secondPlaceName}`);
     await expect(page.locator('.trip-editor-place-editor-row')).toHaveCount(0);
     await expectRegionAddActionsAttached(page);
+    await expectPlaceIconColumnAligned(page);
     await expect(page.locator('.leaflet-popup')).toHaveCount(0);
     await captureEvidence(page, testInfo, 'sidebar-click-selects-map-status');
 
@@ -398,7 +400,31 @@ async function expectRegionAddActionsAttached(page: Page): Promise<void> {
   const [rowBox, addBox] = await Promise.all([lastChildRow.boundingBox(), addPlaceButton.boundingBox()]);
   expect(rowBox, 'Last visible child row should have a rendered bounding box.').not.toBeNull();
   expect(addBox, 'Add Place button should have a rendered bounding box.').not.toBeNull();
-  expect(addBox!.y - (rowBox!.y + rowBox!.height), 'Add actions should stay visually attached to region children without a blank panel gap.').toBeLessThanOrEqual(28);
+  const addActionGap = addBox!.y - (rowBox!.y + rowBox!.height);
+  expect(addActionGap, 'Add actions should have compact breathing room above the buttons.').toBeGreaterThanOrEqual(4);
+  expect(addActionGap, 'Add actions should stay visually attached to region children without a blank panel gap.').toBeLessThanOrEqual(28);
+}
+
+async function expectPlaceIconColumnAligned(page: Page): Promise<void> {
+  const firstIcon = sidebarRow(page, firstPlaceId).locator('.trip-editor-place-row__icon');
+  const secondIcon = sidebarRow(page, secondPlaceId).locator('.trip-editor-place-row__icon');
+  const firstImage = firstIcon.locator('img[data-sidebar-place-icon]');
+  const secondImage = secondIcon.locator('img[data-sidebar-place-icon]');
+  const [firstIconBox, secondIconBox, firstImageBox, secondImageBox] = await Promise.all([
+    firstIcon.boundingBox(),
+    secondIcon.boundingBox(),
+    firstImage.boundingBox(),
+    secondImage.boundingBox()
+  ]);
+  expect(firstIconBox, 'First place icon column should have a rendered bounding box.').not.toBeNull();
+  expect(secondIconBox, 'Second place icon column should have a rendered bounding box.').not.toBeNull();
+  expect(firstImageBox, 'First place icon should have a rendered bounding box.').not.toBeNull();
+  expect(secondImageBox, 'Second place icon should have a rendered bounding box.').not.toBeNull();
+
+  const tolerance = 2;
+  expect(Math.abs(firstIconBox!.x - secondIconBox!.x), 'Place icon columns should align consistently across rows.').toBeLessThanOrEqual(tolerance);
+  expect(Math.abs(firstImageBox!.x - firstIconBox!.x), 'First place icon should be left-aligned inside its icon column.').toBeLessThanOrEqual(tolerance);
+  expect(Math.abs(secondImageBox!.x - secondIconBox!.x), 'Second place icon should be left-aligned inside its icon column.').toBeLessThanOrEqual(tolerance);
 }
 
 async function expectNonEmptyPlaceEditorRow(page: Page): Promise<void> {


### PR DESCRIPTION
## Summary
- Fixes Batch 1 of #288: Trip Editor map/sidebar/status selection synchronization.
- Restores initial map view precedence: URL lat/lng/zoom, saved trip center/zoom, then fit-bounds fallback.
- Synchronizes map marker clicks, sidebar row/edit clicks, toolbar status text, selected sidebar highlighting, selected marker styling, and dirty selection guards.
- Suppresses empty selected place panels by only rendering inline editor content when a real place editor is active.
- Removes the empty no-area sortable/list panel that created a blank child-sized gap before Add Place/Add Area in regions without areas.

## Design translation
- Preserved legacy behavior: selected marker feedback, sidebar/map two-way selection, saved-view-first map load behavior, fit-bounds fallback, and dirty guard protection before switching away from a dirty place editor.
- Vue-native translation: the active map toolbar now presents the current selection context instead of duplicating trip metadata; selected rows use the current theme accent; selected markers use a color-aware marker image halo/drop-shadow that fits the existing Vue map design.
- Intentionally not copied from legacy UI: legacy route/fallback behavior, old status/banner duplication, exact legacy marker CSS mechanics, popup expansion, attribution styling, region marker rendering, pick/search preview visuals, and icon selector behavior.
- Usability result: equivalent behavior with clearer current-selection feedback, no empty selected panel, and responsive status/action placement without competing metadata/status surfaces.

## Backend/API
- No backend or API changes. Existing editor read state was sufficient.

## Validation
- `npm run build` passed. Vite chunk-size warning only.
- `dotnet build` initially failed while the already-running local Wayfarer validation server locked `bin/Debug/net10.0/Wayfarer.exe`; after stopping PID 22844, rerun passed with 0 warnings and 0 errors.
- `dotnet test` passed: 1535 passed, 0 failed, 0 skipped.
- `npx playwright test --config=playwright.config.ts --list` passed: 87 tests listed.
- Focused Batch 1 specs passed: `npx playwright test --config=playwright.config.ts tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts` passed: 6 passed.
- Visual polish spec passed.
- Full `npm run test:e2e:trip-editor` passed: 86 passed, 1 skipped.
- Published-output smoke passed from `dotnet publish Wayfarer.csproj -c Release` output against `/User/Trip/Edit/{id}`.
- Development smoke passed with ASP.NET on `http://localhost:5012` and Vite on `http://127.0.0.1:5173`.
- Screenshot evidence captured for saved view load, fit-bounds fallback, map-click selection sync, sidebar-click selection sync, and dirty selection cancel.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` initially failed because ignored `.local/publish-manual-pr289-cc06711` publish output was present; rerun with ignored `.local` temporarily moved out of the repo passed with existing warnings only.
- `git diff --check origin/main...HEAD` passed.
- Tracked artifact scan passed: no tracked `.local`, `playwright-report`, `test-results`, `screenshots`, `traces`, `wwwroot/vite/trip-editor`, or `wwwroot/dist` artifacts.

## Notes
- Batch 1 manual layout follow-up in 994a07f: root cause was an always-rendered empty `.trip-editor-area-list` child container, not a stale `.trip-editor-place-editor-row`; marker parity coverage now asserts no empty editor row, compact child-to-add-button spacing, one non-empty real editor row, and expanded-to-docked owning-row preservation.
- The first full E2E run exposed one Batch 1 regression where marker selection closed a non-place editor. This PR narrows the dirty selection guard so place selection no longer closes unrelated editors.
- One rich-notes assertion flaked once during the first full E2E run and passed unchanged on focused rerun and final full rerun.


