### PR TITLE
Fix Trip Editor marker popup presentation parity

### DIFF
--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -8,7 +8,7 @@ import TripSidebar from './components/TripSidebar.vue';
 import { disposeConfirmDialogHost, setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
 import { useEditorSurface } from './composables/useEditorSurface';
 import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type AreaPolygonWorkOptions, type CoordinatePickOptions, type FocusActiveEntityResult, type SegmentRouteWorkOptions } from './map/leafletAdapter';
-import type { BootstrapConfig, EditorGeocodeSearchResult, EditorMutationResult, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from './types';
+import type { BootstrapConfig, EditorCoordinate, EditorGeocodeSearchResult, EditorMutationResult, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from './types';
 
 const props = defineProps<{ config: BootstrapConfig }>();
 
@@ -25,6 +25,7 @@ const pendingSearchAdd = ref<{ result: EditorGeocodeSearchResult; regionId: Guid
 const editorSurface = useEditorSurface();
 let mapAdapter: ReturnType<typeof createTripEditorMap> | null = null;
 const coordinatePicker = {
+  applyPlaceDraftCoordinate: (placeId: Guid, coordinate: EditorCoordinate): void => mapAdapter?.applyPlaceDraftCoordinate(placeId, coordinate),
   startCoordinatePick: (options: CoordinatePickOptions): (() => void) => mapAdapter?.startCoordinatePick(options) ?? (() => undefined)
 };
 const polygonEditor = {

--- a/ClientApps/trip-editor/src/components/EditorSurface.vue
+++ b/ClientApps/trip-editor/src/components/EditorSurface.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue';
 import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
+import { mutationFeedbackClass } from './useEditorMutationFeedback';
 
 const props = defineProps<{
   controller: EditorSurfaceController;
@@ -11,9 +12,13 @@ const props = defineProps<{
 const closeButton = ref<HTMLButtonElement | null>(null);
 const titleId = computed(() => `trip-editor-surface-title-${props.target.identity.replace(/[^a-z0-9_-]/gi, '-')}`);
 const isActive = computed(() => props.controller.isTargetActive(props.target));
-const isDocked = computed(() => isActive.value && props.controller.surfaceMode.value === 'docked');
+const isDockedMapWork = computed(() => isActive.value &&
+  props.target.kind === 'place' &&
+  props.controller.surfaceMode.value === 'map-work' &&
+  props.controller.mapWork.value?.previousSurface === 'docked' &&
+  props.controller.mapWork.value.modeName === 'Pick place location');
+const isDocked = computed(() => isActive.value && (props.controller.surfaceMode.value === 'docked' || isDockedMapWork.value));
 const isExpanded = computed(() => isActive.value && props.controller.surfaceMode.value === 'expanded');
-
 watch(isExpanded, async expanded => {
   if (!expanded) {
     return;
@@ -25,7 +30,7 @@ watch(isExpanded, async expanded => {
 </script>
 
 <template>
-  <section v-if="isDocked" class="trip-editor-surface trip-editor-surface--docked" :aria-labelledby="titleId">
+  <section v-if="isDocked" class="trip-editor-surface trip-editor-surface--docked" :class="{ 'trip-editor-surface--map-work': isDockedMapWork }" :aria-labelledby="titleId">
     <header class="trip-editor-surface__header">
       <div>
         <p class="trip-editor-surface__eyebrow">{{ target.mode === 'add' ? 'New' : 'Editing' }} {{ target.kind }}</p>
@@ -33,9 +38,9 @@ watch(isExpanded, async expanded => {
         <small v-if="target.subtitle">{{ target.subtitle }}</small>
       </div>
       <div class="trip-editor-surface__controls">
-        <span class="trip-editor-save-state">{{ statusText }}</span>
-        <button type="button" class="btn btn-outline-light btn-sm" @click="controller.expand(target)">Expand Editor</button>
-        <button type="button" class="btn btn-outline-secondary btn-sm" @click="controller.closeActiveTarget()">Close</button>
+        <span class="trip-editor-save-state" :class="mutationFeedbackClass(statusText)" role="status">{{ statusText }}</span>
+        <button type="button" class="btn btn-outline-light btn-sm" :disabled="isDockedMapWork" @click="controller.expand(target)">Expand Editor</button>
+        <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="isDockedMapWork" @click="controller.closeActiveTarget()">Close</button>
       </div>
     </header>
     <div class="trip-editor-surface__body">
@@ -72,7 +77,7 @@ watch(isExpanded, async expanded => {
             <small v-if="target.subtitle">{{ target.subtitle }}</small>
           </div>
           <div class="trip-editor-surface__controls">
-            <span class="trip-editor-save-state">{{ statusText }}</span>
+            <span class="trip-editor-save-state" :class="mutationFeedbackClass(statusText)" role="status">{{ statusText }}</span>
             <button type="button" class="btn btn-outline-light btn-sm" @click="controller.dock(target)">Dock to sidebar</button>
             <button ref="closeButton" type="button" class="btn btn-outline-secondary btn-sm" @click="controller.closeActiveTarget()">Close</button>
           </div>

--- a/ClientApps/trip-editor/src/components/MapWorkToolbar.vue
+++ b/ClientApps/trip-editor/src/components/MapWorkToolbar.vue
@@ -32,7 +32,7 @@ watch(
     }
 
     await nextTick();
-    doneButton.value?.focus();
+    doneButton.value?.focus({ preventScroll: true });
   }
 );
 </script>

--- a/ClientApps/trip-editor/src/components/PlaceEditorSurface.vue
+++ b/ClientApps/trip-editor/src/components/PlaceEditorSurface.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
 import type { EditorPlace, EditorPlaceDraft, EditorRegion, EditorTripState } from '../types';
 import EditorSurface from './EditorSurface.vue';
 import PlaceEditorForm from './PlaceEditorForm.vue';
 
-defineProps<{
+const props = defineProps<{
   activePlace: EditorPlace | null;
   controller: EditorSurfaceController;
   draft: EditorPlaceDraft;
@@ -18,6 +19,8 @@ defineProps<{
   statusText: string;
   target: EditorTarget;
 }>();
+
+const isMapWorkActive = computed(() => props.controller.isMapWorkActive.value);
 
 defineEmits<{
   cancel: [];
@@ -45,13 +48,13 @@ defineEmits<{
     </template>
 
     <template #footer>
-      <button v-if="activePlace?.capabilities.canDelete" type="button" class="btn btn-outline-danger btn-sm me-auto" :disabled="isSaving" @click="$emit('delete')">
+      <button v-if="activePlace?.capabilities.canDelete" type="button" class="btn btn-outline-danger btn-sm me-auto" :disabled="isSaving || isMapWorkActive" @click="$emit('delete')">
         Delete
       </button>
       <button
         type="button"
         class="btn btn-outline-light btn-sm"
-        :disabled="isSaving"
+        :disabled="isSaving || isMapWorkActive"
         title="Pick this place's latitude and longitude on the map"
         :aria-describedby="`${formId}-pick-help`"
         @click="$emit('pickCoordinate')"
@@ -59,9 +62,9 @@ defineEmits<{
         Pick on map
         <span :id="`${formId}-pick-help`" class="visually-hidden">Use the map to choose this place's latitude and longitude.</span>
       </button>
-      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="$emit('cancel')">Cancel</button>
-      <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="isSaving || !isDirty" @click="$emit('reset')">Reset</button>
-      <button type="submit" :form="formId" class="btn btn-primary btn-sm" :disabled="isSaving">Save Place</button>
+      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving || isMapWorkActive" @click="$emit('cancel')">Cancel</button>
+      <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="isSaving || isMapWorkActive || !isDirty" @click="$emit('reset')">Reset</button>
+      <button type="submit" :form="formId" class="btn btn-primary btn-sm" :disabled="isSaving || isMapWorkActive">Save Place</button>
     </template>
   </EditorSurface>
 </template>

--- a/ClientApps/trip-editor/src/components/PlaceEditorSurface.vue
+++ b/ClientApps/trip-editor/src/components/PlaceEditorSurface.vue
@@ -48,7 +48,17 @@ defineEmits<{
       <button v-if="activePlace?.capabilities.canDelete" type="button" class="btn btn-outline-danger btn-sm me-auto" :disabled="isSaving" @click="$emit('delete')">
         Delete
       </button>
-      <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="$emit('pickCoordinate')">Pick on map</button>
+      <button
+        type="button"
+        class="btn btn-outline-light btn-sm"
+        :disabled="isSaving"
+        title="Pick this place's latitude and longitude on the map"
+        :aria-describedby="`${formId}-pick-help`"
+        @click="$emit('pickCoordinate')"
+      >
+        Pick on map
+        <span :id="`${formId}-pick-help`" class="visually-hidden">Use the map to choose this place's latitude and longitude.</span>
+      </button>
       <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving" @click="$emit('cancel')">Cancel</button>
       <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="isSaving || !isDirty" @click="$emit('reset')">Reset</button>
       <button type="submit" :form="formId" class="btn btn-primary btn-sm" :disabled="isSaving">Save Place</button>

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -13,7 +13,7 @@ import { useAreaEditorActions } from './areaEditorActions';
 import { usePlaceEditorActions } from './placeEditorActions';
 import { useRegionEditorActions } from './regionEditorActions';
 import { stopPlaceCoordinatePick, type PlaceCoordinateMapWorkState, type PlaceCoordinatePicker } from './placeCoordinateMapWork';
-import { useEditorMutationFeedback } from './useEditorMutationFeedback';
+import { mutationFeedbackClass, useEditorMutationFeedback } from './useEditorMutationFeedback';
 import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorGeocodeSearchResult, EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
 
 const props = defineProps<{
@@ -427,7 +427,7 @@ async function selectAndOpenPlaceEdit(place: EditorPlace): Promise<void> {
   <section class="trip-editor-panel trip-editor-regions">
     <div class="trip-editor-panel__line">
       <h2>Regions &amp; Places</h2>
-      <span class="trip-editor-save-state">{{ statusText }}</span>
+      <span class="trip-editor-save-state" :class="mutationFeedbackClass(statusText)" role="status">{{ statusText }}</span>
     </div>
 
     <div v-if="saveError" class="trip-editor-form-error" role="alert">{{ saveError }}</div>

--- a/ClientApps/trip-editor/src/components/SegmentManager.vue
+++ b/ClientApps/trip-editor/src/components/SegmentManager.vue
@@ -8,6 +8,7 @@ import { buildSegmentCreateTarget, buildSegmentEditTarget, segmentDraftKey } fro
 import { buildSegmentRequest, emptySegmentDraft, toSegmentDraft } from './regionPlaceDrafts';
 import SegmentEditorSurface from './SegmentEditorSurface.vue';
 import { beginSegmentRouteMapWork, stopSegmentRouteEdit, type SegmentRouteEditor, type SegmentRouteMapWorkState } from './segmentRouteMapWork';
+import { mutationFeedbackClass } from './useEditorMutationFeedback';
 
 declare global {
   interface Window {
@@ -342,7 +343,7 @@ function modeText(segment: EditorSegment): string {
   <section class="trip-editor-panel">
     <div class="trip-editor-panel__line">
       <h2>Segments</h2>
-      <span class="trip-editor-save-state">{{ statusText }}</span>
+      <span class="trip-editor-save-state" :class="mutationFeedbackClass(statusText)" role="status">{{ statusText }}</span>
     </div>
     <div v-if="saveError" class="trip-editor-form-error" role="alert">{{ saveError }}</div>
     <button type="button" class="btn btn-primary btn-sm trip-editor-add-button" :disabled="isSaving || isOrdering" @click="openCreate">Add Segment</button>

--- a/ClientApps/trip-editor/src/components/placeCoordinateMapWork.ts
+++ b/ClientApps/trip-editor/src/components/placeCoordinateMapWork.ts
@@ -1,8 +1,9 @@
 import type { EditorSurfaceController } from '../composables/useEditorSurface';
 import type { CoordinatePickOptions } from '../map/leafletAdapter';
-import type { EditorCoordinate, EditorPlaceDraft } from '../types';
+import type { EditorCoordinate, EditorPlaceDraft, Guid } from '../types';
 
 export type PlaceCoordinatePicker = {
+  applyPlaceDraftCoordinate?: (placeId: Guid, coordinate: EditorCoordinate) => void;
   startCoordinatePick: (options: CoordinatePickOptions) => () => void;
 };
 
@@ -47,6 +48,9 @@ export function beginPlaceCoordinateMapWork(
       if (isValidCoordinate(state.coordinate)) {
         draft.latitude = state.coordinate.latitude;
         draft.longitude = state.coordinate.longitude;
+        if (draft.id) {
+          coordinatePicker.applyPlaceDraftCoordinate?.(draft.id, state.coordinate);
+        }
       }
       stopPlaceCoordinatePick(state);
     },

--- a/ClientApps/trip-editor/src/components/placeEditorActions.ts
+++ b/ClientApps/trip-editor/src/components/placeEditorActions.ts
@@ -109,7 +109,7 @@ export function usePlaceEditorActions(context: any) {
       context.placeCreateBaselineRequest.value = null;
       context.placeEditBaselineRequest.value = buildPlaceRequest(context.placeDraft);
       context.props.editorSurface.replaceActiveTarget(context.activePlaceTarget.value);
-      context.markSaved(result.warnings.map((warning: { message: string }) => warning.message));
+      context.markSaved(result.warnings.map((warning: { message: string }) => warning.message), 'Place saved');
     } catch (error) {
       context.applyError(error, 'Place save failed.');
     } finally {

--- a/ClientApps/trip-editor/src/components/useEditorMutationFeedback.ts
+++ b/ClientApps/trip-editor/src/components/useEditorMutationFeedback.ts
@@ -18,6 +18,7 @@ export function useEditorMutationFeedback(options: FeedbackOptions) {
   const saveWarning = ref<string | null>(null);
   const validationErrors = ref<Record<string, string[]>>({});
   const lastSavedAt = ref<string | null>(null);
+  const lastSavedLabel = ref('Saved');
 
   const statusText = computed(() => {
     if (options.isSaving.value) {
@@ -33,14 +34,14 @@ export function useEditorMutationFeedback(options: FeedbackOptions) {
     }
 
     if (saveWarning.value) {
-      return lastSavedAt.value ? `Saved ${lastSavedAt.value} with warning` : 'Saved with warning';
+      return lastSavedAt.value ? `${lastSavedLabel.value} ${lastSavedAt.value} with warning` : `${lastSavedLabel.value} with warning`;
     }
 
     if (options.isDirty.value) {
       return 'Unsaved changes';
     }
 
-    return lastSavedAt.value ? `Saved ${lastSavedAt.value}` : 'Saved';
+    return lastSavedAt.value ? `${lastSavedLabel.value} ${lastSavedAt.value}` : lastSavedLabel.value;
   });
 
   const formSummaryErrors = computed(() => {
@@ -64,8 +65,9 @@ export function useEditorMutationFeedback(options: FeedbackOptions) {
     return validationErrors.value[key] ?? [];
   }
 
-  function markSaved(warningMessages: string[] = []): void {
+  function markSaved(warningMessages: string[] = [], savedLabel = 'Saved'): void {
     lastSavedAt.value = new Intl.DateTimeFormat(undefined, { timeStyle: 'short' }).format(new Date());
+    lastSavedLabel.value = savedLabel;
     saveError.value = null;
     saveWarning.value = warningMessages.length > 0 ? warningMessages.join(' ') : null;
   }

--- a/ClientApps/trip-editor/src/components/useEditorMutationFeedback.ts
+++ b/ClientApps/trip-editor/src/components/useEditorMutationFeedback.ts
@@ -12,6 +12,23 @@ type FeedbackOptions = {
   regionFields: string[];
 };
 
+/// Maps mutation status text onto existing Bootstrap/app feedback color semantics.
+export function mutationFeedbackClass(statusText: string): string {
+  if (/save failed/i.test(statusText)) {
+    return 'text-bg-danger trip-editor-save-state--danger';
+  }
+
+  if (/warning/i.test(statusText)) {
+    return 'text-bg-warning trip-editor-save-state--warning';
+  }
+
+  if (/^place saved\b/i.test(statusText) || /^saved\s+\S+/i.test(statusText)) {
+    return 'text-bg-success trip-editor-save-state--success';
+  }
+
+  return '';
+}
+
 /// Tracks mutation feedback shared by region and place editor forms.
 export function useEditorMutationFeedback(options: FeedbackOptions) {
   const saveError = ref<string | null>(null);

--- a/ClientApps/trip-editor/src/displayHelpers.ts
+++ b/ClientApps/trip-editor/src/displayHelpers.ts
@@ -2,10 +2,12 @@ import { canonicalImageSource, normalizeNotesHtml } from './notes/notesHtml';
 import type { EditorPlace } from './types';
 
 const iconBasePath = '/icons/wayfarer-map-icons/dist/png/marker';
+const defaultMarkerColor = 'bg-blue';
+const defaultMarkerIcon = 'marker';
 
 /// Builds the static PNG marker path used by the legacy editor and public trip views.
 export function placeMarkerIconUrl(iconName: string | null | undefined, markerColor: string | null | undefined): string {
-  return `${iconBasePath}/${safePathSegment(markerColor || 'bg-blue')}/${safePathSegment(iconName || 'marker')}.png`;
+  return `${iconBasePath}/${safePathSegment(markerColor, defaultMarkerColor)}/${safePathSegment(iconName, defaultMarkerIcon)}.png`;
 }
 
 /// Converts canonical external notes image URLs to the display-only proxy endpoint.
@@ -74,6 +76,6 @@ function isExternalHttpUrl(value: string): boolean {
   }
 }
 
-function safePathSegment(value: string): string {
-  return encodeURIComponent(value.trim() || 'marker');
+function safePathSegment(value: string | null | undefined, fallback: string): string {
+  return encodeURIComponent(value?.trim() || fallback);
 }

--- a/ClientApps/trip-editor/src/map.css
+++ b/ClientApps/trip-editor/src/map.css
@@ -99,8 +99,7 @@
   max-height: min(22rem, 52vh);
   max-width: min(24rem, 72vw);
   min-width: min(18rem, 68vw);
-  overflow-y: auto;
-  padding-right: 0.15rem;
+  overflow: hidden;
 }
 
 .trip-editor-place-popup__header {
@@ -113,6 +112,14 @@
 .trip-editor-place-popup__footer {
   color: var(--trip-editor-muted);
   font-size: 0.82rem;
+}
+
+.trip-editor-place-popup__body {
+  display: grid;
+  gap: 0.45rem;
+  max-height: min(14rem, 34vh);
+  overflow-y: auto;
+  padding-right: 0.15rem;
 }
 
 .trip-editor-place-popup__meta span,
@@ -145,14 +152,14 @@
   background: color-mix(in srgb, var(--trip-editor-surface) 92%, transparent);
   border: 1px solid var(--trip-editor-border);
   border-radius: 6px 0 0 0;
-  color: var(--trip-editor-muted);
+  color: color-mix(in srgb, var(--trip-editor-text) 78%, transparent);
   line-height: 1.35;
   max-width: min(32rem, calc(100vw - 2rem));
   white-space: normal;
 }
 
 .trip-editor-map .leaflet-control-attribution a {
-  color: var(--trip-editor-accent);
+  color: color-mix(in srgb, var(--trip-editor-accent) 72%, var(--trip-editor-text));
 }
 
 .trip-editor-map-search {

--- a/ClientApps/trip-editor/src/map.css
+++ b/ClientApps/trip-editor/src/map.css
@@ -210,7 +210,11 @@
 .trip-editor-map-search__results {
   display: grid;
   gap: 0.35rem;
+  max-height: min(18rem, 42vh);
   max-width: min(760px, 100%);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 0.2rem;
 }
 
 .trip-editor-map-search__result {

--- a/ClientApps/trip-editor/src/map.css
+++ b/ClientApps/trip-editor/src/map.css
@@ -60,6 +60,10 @@
   border: 0;
 }
 
+.trip-editor-map-marker--preview {
+  opacity: 0.95;
+}
+
 .trip-editor-map-marker__halo {
   display: none;
 }
@@ -91,14 +95,36 @@
 
 .trip-editor-place-popup__content {
   display: grid;
-  gap: 0.35rem;
-  max-width: 18rem;
+  gap: 0.45rem;
+  max-height: min(22rem, 52vh);
+  max-width: min(24rem, 72vw);
+  min-width: min(18rem, 68vw);
+  overflow-y: auto;
+  padding-right: 0.15rem;
+}
+
+.trip-editor-place-popup__header {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.trip-editor-place-popup__header span,
+.trip-editor-place-popup__meta,
+.trip-editor-place-popup__footer {
+  color: var(--trip-editor-muted);
+  font-size: 0.82rem;
+}
+
+.trip-editor-place-popup__meta span,
+.trip-editor-place-popup__notes > span {
+  color: var(--trip-editor-text);
+  font-weight: 700;
 }
 
 .trip-editor-place-popup__notes {
   border-top: 1px solid var(--trip-editor-border);
-  max-height: 7rem;
-  overflow: hidden;
+  display: grid;
+  gap: 0.25rem;
   padding-top: 0.35rem;
 }
 
@@ -108,6 +134,25 @@
   margin-top: 0.25rem;
   max-height: 4rem;
   max-width: 100%;
+}
+
+.trip-editor-place-popup__footer {
+  border-top: 1px solid var(--trip-editor-border);
+  padding-top: 0.35rem;
+}
+
+.trip-editor-map .leaflet-control-attribution {
+  background: color-mix(in srgb, var(--trip-editor-surface) 92%, transparent);
+  border: 1px solid var(--trip-editor-border);
+  border-radius: 6px 0 0 0;
+  color: var(--trip-editor-muted);
+  line-height: 1.35;
+  max-width: min(32rem, calc(100vw - 2rem));
+  white-space: normal;
+}
+
+.trip-editor-map .leaflet-control-attribution a {
+  color: var(--trip-editor-accent);
 }
 
 .trip-editor-map-search {

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -61,7 +61,9 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
     attribution: providerAttribution(window.wayfarerTileConfig?.attribution),
     maxZoom: 19
   }).addTo(map);
-  map.attributionControl.setPrefix('&copy; <a href="https://wayfarer.stefk.me" title="Powered by Wayfarer" target="_blank" rel="noopener">Wayfarer</a> | <a href="https://stefk.me" title="Stef K" target="_blank" rel="noopener">Stef K</a> | &copy; <a href="https://leafletjs.com/" target="_blank" rel="noopener">Leaflet</a>');
+  map.attributionControl.setPrefix('&copy; <a href="https://wayfarer.stefk.me" title="Powered by Wayfarer, made by Stef" target="_blank" rel="noopener">Wayfarer</a> | <a href="https://stefk.me" title="Check my blog" target="_blank" rel="noopener">Stef K</a> | &copy; <a href="https://leafletjs.com/" target="_blank" rel="noopener">Leaflet</a>');
+  map.attributionControl.getContainer()?.setAttribute('aria-label', 'Map attribution');
+  map.attributionControl.getContainer()?.setAttribute('title', 'Map attribution');
 
   const render = (state: EditorTripState, hiddenSegmentIds: ReadonlySet<Guid> = new Set(), nextSelectedPlaceId: Guid | null = selectedPlaceId): void => {
     searchPreview.clear();
@@ -192,7 +194,8 @@ const createCoordinatePickLayer = (map: LeafletMap): {
       icon: previewMarkerIcon('coordinate', 'Selected place location preview'),
       interactive: false,
       keyboard: false,
-      title: 'Selected place location preview'
+      title: 'Selected place location preview',
+      alt: 'Selected place location preview'
     }).addTo(layer);
   };
 

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -58,7 +58,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
   map.on('moveend zoomend', updateMapViewDataset);
 
   L.tileLayer(tilesUrl, {
-    attribution: window.wayfarerTileConfig?.attribution ?? '&copy; OpenStreetMap contributors',
+    attribution: providerAttribution(window.wayfarerTileConfig?.attribution),
     maxZoom: 19
   }).addTo(map);
   map.attributionControl.setPrefix('&copy; <a href="https://wayfarer.stefk.me" title="Powered by Wayfarer" target="_blank" rel="noopener">Wayfarer</a> | <a href="https://stefk.me" title="Stef K" target="_blank" rel="noopener">Stef K</a> | &copy; <a href="https://leafletjs.com/" target="_blank" rel="noopener">Leaflet</a>');
@@ -634,6 +634,24 @@ const readUrlMapView = (search: string): { center: EditorCoordinate; zoom: numbe
 
   const center = { latitude, longitude };
   return isFiniteCoordinate(center) ? { center, zoom } : null;
+};
+
+/// Preserves configured provider attribution while ensuring OpenStreetMap remains linked.
+const providerAttribution = (configuredAttribution: string | null | undefined): string => {
+  const attribution = configuredAttribution?.trim() || '&copy; OpenStreetMap contributors';
+  if (/openstreetmap\.org/i.test(attribution)) {
+    return attribution;
+  }
+
+  if (/OpenStreetMap contributors/i.test(attribution)) {
+    return attribution.replace(/OpenStreetMap contributors/gi, '<a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> contributors');
+  }
+
+  if (/OpenStreetMap/i.test(attribution)) {
+    return attribution.replace(/OpenStreetMap/gi, '<a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a>');
+  }
+
+  return `${attribution} | &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> contributors`;
 };
 
 const segmentLabel = (segment: EditorSegment, state: EditorTripState): string => {

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -16,6 +16,7 @@ export type InitialMapViewSource = 'url' | 'saved' | 'fit-bounds' | 'fallback';
 
 interface TripEditorMapAdapter {
   render: (state: EditorTripState, hiddenSegmentIds?: ReadonlySet<Guid>, selectedPlaceId?: Guid | null) => void;
+  applyPlaceDraftCoordinate: (placeId: Guid, coordinate: EditorCoordinate) => void;
   clearSearchPreview: () => void;
   selectPlace: (state: EditorTripState, placeId: Guid | null, options?: SelectPlaceOptions) => void;
   startCoordinatePick: (options: CoordinatePickOptions) => () => void;
@@ -99,6 +100,16 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
 
   return {
     render,
+    applyPlaceDraftCoordinate: (placeId, coordinate) => {
+      const marker = placeMarkers.get(placeId);
+      if (!marker) {
+        return;
+      }
+
+      marker.setLatLng([coordinate.latitude, coordinate.longitude]);
+      applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
+      updateMapViewDataset();
+    },
     clearSearchPreview: searchPreview.clear,
     selectPlace: (state, placeId, selectOptions = {}) => {
       selectedPlaceId = placeId && state.placesById[placeId] ? placeId : null;

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -1,9 +1,10 @@
 import L, { type LayerGroup, type LeafletMouseEvent, type Map as LeafletMap } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import type { EditorTarget } from '../composables/useEditorSurface';
-import { placeMarkerIconUrl, placeMarkerLabel, placeNotesPreviewHtml } from '../displayHelpers';
 import type { EditorArea, EditorCoordinate, EditorPlace, EditorRegion, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from '../types';
 import { createAreaPolygonWorkLayer } from './areaPolygonWorkLayer';
+import { placeMarkerIcon, previewMarkerIcon, regionMarkerIcon } from './markerRendering';
+import { placePopupHtml } from './placePopupRendering';
 import { createSegmentRouteWorkLayer } from './segmentRouteWorkLayer';
 export type { AreaPolygonWorkOptions } from './areaPolygonWorkLayer';
 export type { SegmentRouteWorkOptions } from './segmentRouteWorkLayer';
@@ -60,6 +61,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
     attribution: window.wayfarerTileConfig?.attribution ?? '&copy; OpenStreetMap contributors',
     maxZoom: 19
   }).addTo(map);
+  map.attributionControl.setPrefix('&copy; <a href="https://wayfarer.stefk.me" title="Powered by Wayfarer" target="_blank" rel="noopener">Wayfarer</a> | <a href="https://stefk.me" title="Stef K" target="_blank" rel="noopener">Stef K</a> | &copy; <a href="https://leafletjs.com/" target="_blank" rel="noopener">Leaflet</a>');
 
   const render = (state: EditorTripState, hiddenSegmentIds: ReadonlySet<Guid> = new Set(), nextSelectedPlaceId: Guid | null = selectedPlaceId): void => {
     searchPreview.clear();
@@ -72,7 +74,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
 
     Object.values(state.regionsById).forEach(region => renderRegion(region, layers));
     Object.values(state.areasById).forEach(area => renderArea(area, layers));
-    Object.values(state.placesById).forEach(place => renderPlace(place, layers, coordinatePick, placeMarkers, () => {
+    Object.values(state.placesById).forEach(place => renderPlace(place, state, layers, coordinatePick, placeMarkers, () => {
       if (coordinatePick.isActive()) {
         return false;
       }
@@ -148,6 +150,7 @@ const createSearchPreviewLayer = (map: LeafletMap): {
   const show = (coordinate: EditorCoordinate, label: string): void => {
     clear();
     L.marker([coordinate.latitude, coordinate.longitude], {
+      icon: previewMarkerIcon('search', `Search result preview: ${label}`),
       interactive: false,
       keyboard: false,
       title: `Search result preview: ${label}`,
@@ -186,6 +189,7 @@ const createCoordinatePickLayer = (map: LeafletMap): {
   const setPreview = (coordinate: EditorCoordinate): void => {
     layer.clearLayers();
     L.marker([coordinate.latitude, coordinate.longitude], {
+      icon: previewMarkerIcon('coordinate', 'Selected place location preview'),
       interactive: false,
       keyboard: false,
       title: 'Selected place location preview'
@@ -278,16 +282,18 @@ const renderRegion = (region: EditorRegion, layers: LayerGroup): void => {
     return;
   }
 
-  L.circleMarker([region.center.latitude, region.center.longitude], {
-    radius: region.isShadow ? 5 : 7,
-    color: region.isShadow ? '#64748b' : '#2563eb',
-    weight: 2,
-    fillOpacity: 0.7
+  L.marker([region.center.latitude, region.center.longitude], {
+    icon: regionMarkerIcon(region),
+    interactive: !region.isShadow,
+    keyboard: !region.isShadow,
+    title: `${region.name} region center`,
+    alt: `${region.name} region center`
   }).bindTooltip(escapeHtml(region.name)).addTo(layers);
 };
 
 const renderPlace = (
   place: EditorPlace,
+  state: EditorTripState,
   layers: LayerGroup,
   coordinatePick: ReturnType<typeof createCoordinatePickLayer>,
   placeMarkers: Map<Guid, L.Marker>,
@@ -299,8 +305,8 @@ const renderPlace = (
 
   const marker = L.marker([place.location.latitude, place.location.longitude], {
     icon: placeMarkerIcon(place),
-    title: placeMarkerLabel(place),
-    alt: placeMarkerLabel(place)
+    title: place.name,
+    alt: place.name
   });
   marker.on('click', async event => {
     if (event.originalEvent) {
@@ -312,7 +318,7 @@ const renderPlace = (
       marker.openPopup();
     }
   });
-  marker.bindPopup(placePopupHtml(place), { className: 'trip-editor-place-popup' });
+  marker.bindPopup(placePopupHtml(place, state.regionsById[place.regionId]?.name), { className: 'trip-editor-place-popup' });
   // Leaflet auto-opens bound popups on marker click; selection must finish first so dirty-discard cancel keeps the old popup/halo.
   const popupMarker = marker as L.Marker & { _openPopup?: (event: LeafletMouseEvent) => void };
   if (popupMarker._openPopup) {
@@ -321,32 +327,6 @@ const renderPlace = (
   coordinatePick.registerMarker(marker, place.location);
   marker.addTo(layers);
   placeMarkers.set(place.id, marker);
-};
-
-/// Uses the static Wayfarer marker PNGs instead of Leaflet defaults so Vite cannot break image paths.
-const placeMarkerIcon = (place: EditorPlace): L.DivIcon => {
-  const visitBadge = place.visitSummary.isVisited
-    ? `<span class="trip-editor-map-marker__badge" title="${escapeHtml(place.visitSummary.visitCount === 1 ? 'Visited' : `Visited ${place.visitSummary.visitCount} times`)}">${escapeHtml(place.visitSummary.visitCount === 1 ? '✓' : String(place.visitSummary.visitCount))}</span>`
-    : '';
-
-  return L.divIcon({
-    className: 'trip-editor-map-marker',
-    html: `<span class="trip-editor-map-marker__halo" aria-hidden="true"></span><img class="trip-editor-map-marker__image" src="${placeMarkerIconUrl(place.iconName, place.markerColor)}" width="28" height="45" alt="${escapeHtml(placeMarkerLabel(place))}" style="--trip-editor-selected-marker-color: ${markerSelectionColor(place.markerColor)}" data-place-marker-icon="${escapeHtml(place.id)}">${visitBadge}`,
-    iconSize: [36, 50],
-    iconAnchor: [18, 50],
-    popupAnchor: [0, -45]
-  });
-};
-
-const placePopupHtml = (place: EditorPlace): string => {
-  const visitText = place.visitSummary.isVisited ? ` · ${place.visitSummary.visitCount} visit(s)` : '';
-  const notesHtml = placeNotesPreviewHtml(place.notesHtml);
-  return [
-    '<div class="trip-editor-place-popup__content">',
-    `<strong>${escapeHtml(place.name)}</strong>${escapeHtml(visitText)}`,
-    notesHtml ? `<div class="trip-editor-place-popup__notes">${notesHtml}</div>` : '',
-    '</div>'
-  ].join('');
 };
 
 function applySelectedPlaceMarker(placeMarkers: Map<Guid, L.Marker>, selectedPlaceId: Guid | null): void {
@@ -655,19 +635,6 @@ const readUrlMapView = (search: string): { center: EditorCoordinate; zoom: numbe
   const center = { latitude, longitude };
   return isFiniteCoordinate(center) ? { center, zoom } : null;
 };
-
-const markerSelectionColor = (markerColor: string | null | undefined): string => ({
-  'bg-blue': '#0d6efd',
-  'bg-cyan': '#0dcaf0',
-  'bg-green': '#198754',
-  'bg-indigo': '#6610f2',
-  'bg-orange': '#fd7e14',
-  'bg-pink': '#d63384',
-  'bg-purple': '#6f42c1',
-  'bg-red': '#dc3545',
-  'bg-teal': '#20c997',
-  'bg-yellow': '#ffc107'
-})[markerColor ?? ''] ?? '#0d6efd';
 
 const segmentLabel = (segment: EditorSegment, state: EditorTripState): string => {
   const fromName = segment.fromPlaceId ? state.placesById[segment.fromPlaceId]?.name : null;

--- a/ClientApps/trip-editor/src/map/markerRendering.ts
+++ b/ClientApps/trip-editor/src/map/markerRendering.ts
@@ -1,0 +1,107 @@
+import L from 'leaflet';
+import { placeMarkerIconUrl, placeMarkerLabel } from '../displayHelpers';
+import type { EditorPlace, EditorRegion } from '../types';
+
+const markerWidth = 28;
+const markerHeight = 45;
+
+/// Builds app marker icons from static Wayfarer PNGs so Leaflet default image paths are never used.
+export function placeMarkerIcon(place: EditorPlace): L.DivIcon {
+  const visitBadge = place.visitSummary.isVisited
+    ? `<span class="trip-editor-map-marker__badge" title="${escapeHtml(place.visitSummary.visitCount === 1 ? 'Visited' : `Visited ${place.visitSummary.visitCount} times`)}">${escapeHtml(place.visitSummary.visitCount === 1 ? '✓' : String(place.visitSummary.visitCount))}</span>`
+    : '';
+
+  return appMarkerIcon({
+    className: 'trip-editor-map-marker',
+    imageClassName: 'trip-editor-map-marker__image',
+    src: placeMarkerIconUrl(place.iconName, place.markerColor),
+    alt: placeMarkerLabel(place),
+    dataAttribute: `data-place-marker-icon="${escapeHtml(place.id)}"`,
+    style: `--trip-editor-selected-marker-color: ${markerSelectionColor(place.markerColor)}`,
+    extraHtml: visitBadge,
+    iconSize: [36, 50],
+    iconAnchor: [18, 50],
+    popupAnchor: [0, -45]
+  });
+}
+
+/// Builds the legacy-equivalent red map marker used for region centers.
+export function regionMarkerIcon(region: EditorRegion): L.DivIcon {
+  return appMarkerIcon({
+    className: 'trip-editor-map-marker trip-editor-map-marker--region',
+    imageClassName: 'trip-editor-map-marker__image',
+    src: placeMarkerIconUrl('map', 'bg-red'),
+    alt: `${region.name} region center`,
+    dataAttribute: `data-region-marker-icon="${escapeHtml(region.id)}"`,
+    iconSize: [markerWidth, markerHeight],
+    iconAnchor: [14, 45],
+    popupAnchor: [0, -45]
+  });
+}
+
+/// Builds temporary preview markers for coordinate picking and map search.
+export function previewMarkerIcon(kind: 'coordinate' | 'search', label: string): L.DivIcon {
+  const markerColor = kind === 'search' ? 'bg-black' : 'bg-blue';
+  const markerName = kind === 'search' ? 'map' : 'marker';
+  return appMarkerIcon({
+    className: `trip-editor-map-marker trip-editor-map-marker--preview trip-editor-map-marker--preview-${kind}`,
+    imageClassName: 'trip-editor-map-marker__image',
+    src: placeMarkerIconUrl(markerName, markerColor),
+    alt: label,
+    dataAttribute: `data-${kind}-preview-marker="true"`,
+    iconSize: [markerWidth, markerHeight],
+    iconAnchor: [14, 45],
+    popupAnchor: [0, -45]
+  });
+}
+
+interface AppMarkerIconOptions {
+  alt: string;
+  className: string;
+  dataAttribute: string;
+  extraHtml?: string;
+  iconAnchor: [number, number];
+  iconSize: [number, number];
+  imageClassName: string;
+  popupAnchor: [number, number];
+  src: string;
+  style?: string;
+}
+
+function appMarkerIcon(options: AppMarkerIconOptions): L.DivIcon {
+  const style = options.style ? ` style="${escapeHtml(options.style)}"` : '';
+  return L.divIcon({
+    className: options.className,
+    html: `<span class="trip-editor-map-marker__halo" aria-hidden="true"></span><img class="${options.imageClassName}" src="${options.src}" width="${markerWidth}" height="${markerHeight}" alt="${escapeHtml(options.alt)}"${style} ${options.dataAttribute}>${options.extraHtml ?? ''}`,
+    iconSize: options.iconSize,
+    iconAnchor: options.iconAnchor,
+    popupAnchor: options.popupAnchor
+  });
+}
+
+function markerSelectionColor(markerColor: string | null | undefined): string {
+  return ({
+    'bg-blue': '#0d6efd',
+    'bg-cyan': '#0dcaf0',
+    'bg-red': '#dc3545',
+    'bg-green': '#198754',
+    'bg-indigo': '#6610f2',
+    'bg-yellow': '#ffc107',
+    'bg-orange': '#fd7e14',
+    'bg-purple': '#6f42c1',
+    'bg-pink': '#d63384',
+    'bg-teal': '#20c997',
+    'bg-gray': '#6c757d',
+    'bg-black': '#212529',
+    'bg-white': '#adb5bd'
+  })[markerColor ?? ''] ?? '#0d6efd';
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}

--- a/ClientApps/trip-editor/src/map/markerRendering.ts
+++ b/ClientApps/trip-editor/src/map/markerRendering.ts
@@ -41,12 +41,10 @@ export function regionMarkerIcon(region: EditorRegion): L.DivIcon {
 
 /// Builds temporary preview markers for coordinate picking and map search.
 export function previewMarkerIcon(kind: 'coordinate' | 'search', label: string): L.DivIcon {
-  const markerColor = kind === 'search' ? 'bg-black' : 'bg-blue';
-  const markerName = kind === 'search' ? 'map' : 'marker';
   return appMarkerIcon({
     className: `trip-editor-map-marker trip-editor-map-marker--preview trip-editor-map-marker--preview-${kind}`,
     imageClassName: 'trip-editor-map-marker__image',
-    src: placeMarkerIconUrl(markerName, markerColor),
+    src: placeMarkerIconUrl('marker', 'bg-blue'),
     alt: label,
     dataAttribute: `data-${kind}-preview-marker="true"`,
     iconSize: [markerWidth, markerHeight],

--- a/ClientApps/trip-editor/src/map/placePopupRendering.ts
+++ b/ClientApps/trip-editor/src/map/placePopupRendering.ts
@@ -1,0 +1,42 @@
+import { placeNotesPreviewHtml } from '../displayHelpers';
+import type { EditorPlace } from '../types';
+
+/// Builds sanitized place popup HTML from existing editor state only.
+export function placePopupHtml(place: EditorPlace, regionName: string | null | undefined): string {
+  const notesHtml = placeNotesPreviewHtml(place.notesHtml, 220);
+  return [
+    '<div class="trip-editor-place-popup__content">',
+    '<div class="trip-editor-place-popup__header">',
+    `<strong>${escapeHtml(place.name || 'Unnamed Place')}</strong>`,
+    regionName ? `<span>${escapeHtml(regionName)}</span>` : '',
+    '</div>',
+    place.location ? `<div class="trip-editor-place-popup__meta"><span>Lat:</span> ${formatCoordinate(place.location.latitude)} <span>Lon:</span> ${formatCoordinate(place.location.longitude)}</div>` : '',
+    place.address ? `<div class="trip-editor-place-popup__meta"><span>Address:</span> ${escapeHtml(place.address)}</div>` : '',
+    visitSummaryHtml(place),
+    notesHtml ? `<div class="trip-editor-place-popup__notes"><span>Notes:</span><div>${notesHtml}</div></div>` : '',
+    '<div class="trip-editor-place-popup__footer">Click marker to select this place</div>',
+    '</div>'
+  ].join('');
+}
+
+function visitSummaryHtml(place: EditorPlace): string {
+  if (!place.visitSummary.isVisited) {
+    return '<div class="trip-editor-place-popup__meta"><span>Visits:</span> Not visited yet</div>';
+  }
+
+  const count = place.visitSummary.visitCount;
+  return `<div class="trip-editor-place-popup__meta"><span>Visits:</span> ${escapeHtml(count === 1 ? '1 visit' : `${count} visits`)}</div>`;
+}
+
+function formatCoordinate(value: number): string {
+  return Number.isFinite(value) ? value.toFixed(5) : '';
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}

--- a/ClientApps/trip-editor/src/map/placePopupRendering.ts
+++ b/ClientApps/trip-editor/src/map/placePopupRendering.ts
@@ -10,10 +10,12 @@ export function placePopupHtml(place: EditorPlace, regionName: string | null | u
     `<strong>${escapeHtml(place.name || 'Unnamed Place')}</strong>`,
     regionName ? `<span>${escapeHtml(regionName)}</span>` : '',
     '</div>',
+    '<div class="trip-editor-place-popup__body">',
     place.location ? `<div class="trip-editor-place-popup__meta"><span>Lat:</span> ${formatCoordinate(place.location.latitude)} <span>Lon:</span> ${formatCoordinate(place.location.longitude)}</div>` : '',
     place.address ? `<div class="trip-editor-place-popup__meta"><span>Address:</span> ${escapeHtml(place.address)}</div>` : '',
     visitSummaryHtml(place),
     notesHtml ? `<div class="trip-editor-place-popup__notes"><span>Notes:</span><div>${notesHtml}</div></div>` : '',
+    '</div>',
     '<div class="trip-editor-place-popup__footer">Click marker to select this place</div>',
     '</div>'
   ].join('');

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -26,6 +26,7 @@ body {
 .trip-editor-sidebar {
   background: var(--trip-editor-surface);
   border-right: 1px solid var(--trip-editor-border);
+  contain: layout paint;
   min-height: 0;
   overflow: auto;
   overflow-x: hidden;

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -112,13 +112,6 @@ body {
   margin: 0;
 }
 
-.trip-editor-save-state {
-  color: var(--trip-editor-accent);
-  flex: 0 1 auto;
-  font-size: 0.8rem;
-  overflow-wrap: anywhere;
-}
-
 .trip-editor-field {
   display: grid;
   gap: 0.35rem;

--- a/ClientApps/trip-editor/src/surfaces.css
+++ b/ClientApps/trip-editor/src/surfaces.css
@@ -82,11 +82,42 @@
   min-width: 0;
 }
 
+.trip-editor-save-state {
+  border-radius: 999px;
+  color: var(--trip-editor-accent);
+  flex: 0 1 auto;
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+  padding: 0.2rem 0.5rem;
+}
+
+.trip-editor-save-state--success {
+  background-color: var(--bs-success-bg-subtle);
+  border: 1px solid var(--bs-success-border-subtle);
+  color: var(--bs-success-text-emphasis);
+}
+
+.trip-editor-save-state--danger {
+  background-color: var(--bs-danger-bg-subtle);
+  border: 1px solid var(--bs-danger-border-subtle);
+  color: var(--bs-danger-text-emphasis);
+}
+
+.trip-editor-save-state--warning {
+  background-color: var(--bs-warning-bg-subtle);
+  border: 1px solid var(--bs-warning-border-subtle);
+  color: var(--bs-warning-text-emphasis);
+}
+
 .trip-editor-place-editor-row .trip-editor-surface--docked {
   contain: layout paint;
   grid-template-rows: auto minmax(0, 1fr) auto;
   height: min(42rem, calc(100vh - 10rem));
   overflow: hidden;
+}
+
+.trip-editor-place-editor-row .trip-editor-surface--map-work {
+  border-style: dashed;
 }
 
 .trip-editor-place-editor-row .trip-editor-surface__body {

--- a/ClientApps/trip-editor/src/surfaces.css
+++ b/ClientApps/trip-editor/src/surfaces.css
@@ -82,6 +82,25 @@
   min-width: 0;
 }
 
+.trip-editor-place-editor-row .trip-editor-surface--docked {
+  contain: layout paint;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  height: min(42rem, calc(100vh - 10rem));
+  overflow: hidden;
+}
+
+.trip-editor-place-editor-row .trip-editor-surface__body {
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.trip-editor-place-editor-row .trip-editor-surface-context--map-work {
+  align-content: start;
+  height: min(42rem, calc(100vh - 10rem));
+  overflow: hidden;
+}
+
 .trip-editor-workspace .btn,
 .trip-editor-expanded .btn,
 .trip-editor-map-work-toolbar .btn {

--- a/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page, type Route } from '@playwright/test';
+import { expect, test, type Locator, type Page, type Route } from '@playwright/test';
 import {
   absoluteUrl,
   closeDraftWithDiscard,
@@ -254,6 +254,8 @@ test.describe('Trip Editor map geocode search', () => {
     await runSearch(page, 'preview place');
     await page.getByRole('button', { name: 'Preview Place' }).click();
     await expect(page.locator('img[alt="Search result preview: Preview Place"]')).toBeVisible();
+    await expectLoadedImages(page.locator('[data-search-preview-marker]'));
+    await expect(page.locator('[data-search-preview-marker]')).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-black\/map\.png$/);
 
     await page.getByRole('searchbox', { name: 'Map search' }).fill('');
     await expect(page.locator('img[alt="Search result preview: Preview Place"]')).toHaveCount(0);
@@ -341,6 +343,14 @@ async function addSelectedResult(page: Page): Promise<void> {
   }
 
   await page.getByRole('button', { name: 'Add as place' }).click();
+}
+
+async function expectLoadedImages(images: Locator): Promise<void> {
+  const count = await images.count();
+  expect(count, 'Expected at least one image to validate.').toBeGreaterThan(0);
+  for (let index = 0; index < count; index += 1) {
+    await expect.poll(async () => images.nth(index).evaluate(image => image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0)).toBe(true);
+  }
 }
 
 async function routeGeocode(page: Page, handler: (route: Route) => Promise<void>): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page, type Route } from '@playwright/test';
+import { expect, test, type Locator, type Page, type Route, type TestInfo } from '@playwright/test';
 import {
   absoluteUrl,
   closeDraftWithDiscard,
@@ -240,7 +240,7 @@ test.describe('Trip Editor map geocode search', () => {
     await expect(mapSearch.getByRole('button', { name: 'Result for athens acropolis' })).toBeVisible();
   });
 
-  test('result preview marker appears, clears, and search-add opens the existing Add Place draft without saving', async ({ page }) => {
+  test('result preview marker appears, clears, and search-add opens the existing Add Place draft without saving', async ({ page }, testInfo) => {
     await signIn(page);
     let saveCalls = 0;
     await page.route('**/api/trips/*/editor/regions/*/places', async route => {
@@ -256,6 +256,7 @@ test.describe('Trip Editor map geocode search', () => {
     await expect(page.locator('img[alt="Search result preview: Preview Place"]')).toBeVisible();
     await expectLoadedImages(page.locator('[data-search-preview-marker]'));
     await expect(page.locator('[data-search-preview-marker]')).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-black\/map\.png$/);
+    await captureEvidence(page, testInfo, 'map-search-preview-marker');
 
     await page.getByRole('searchbox', { name: 'Map search' }).fill('');
     await expect(page.locator('img[alt="Search result preview: Preview Place"]')).toHaveCount(0);
@@ -351,6 +352,10 @@ async function expectLoadedImages(images: Locator): Promise<void> {
   for (let index = 0; index < count; index += 1) {
     await expect.poll(async () => images.nth(index).evaluate(image => image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0)).toBe(true);
   }
+}
+
+async function captureEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
 }
 
 async function routeGeocode(page: Page, handler: (route: Route) => Promise<void>): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
@@ -255,7 +255,7 @@ test.describe('Trip Editor map geocode search', () => {
     await page.getByRole('button', { name: 'Preview Place' }).click();
     await expect(page.locator('img[alt="Search result preview: Preview Place"]')).toBeVisible();
     await expectLoadedImages(page.locator('[data-search-preview-marker]'));
-    await expect(page.locator('[data-search-preview-marker]')).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-black\/map\.png$/);
+    await expect(page.locator('[data-search-preview-marker]')).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-blue\/marker\.png$/);
     await captureEvidence(page, testInfo, 'map-search-preview-marker');
 
     await page.getByRole('searchbox', { name: 'Map search' }).fill('');

--- a/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
@@ -240,6 +240,36 @@ test.describe('Trip Editor map geocode search', () => {
     await expect(mapSearch.getByRole('button', { name: 'Result for athens acropolis' })).toBeVisible();
   });
 
+  test('map search contains long result lists without expanding the app page', async ({ page }, testInfo) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await signIn(page);
+    const state = await loadEditorState(page);
+    state.options.limits.nominatimSearchLimit = 36;
+    await routeEditorState(page, state);
+    await routeGeocode(page, async route => fulfillGeocode(route, manyResults(36), 'contained results'));
+
+    await page.goto(absoluteUrl(editorPath));
+    await expectMountedWorkspace(page);
+    const beforeSearchHeight = await pageHeight(page);
+    await runSearch(page, 'contained results');
+
+    const resultsPanel = page.locator('.trip-editor-map-search__results');
+    await expect(resultsPanel).toBeVisible();
+    await expect(resultsPanel.getByRole('button')).toHaveCount(36);
+    await expectContainedResultsPanel(resultsPanel);
+    expect(await pageHeight(page), 'Desktop search results must not expand the overall page height.').toBeLessThanOrEqual(beforeSearchHeight + 4);
+    await captureEvidence(page, testInfo, 'map-search-contained-results-dark-desktop');
+
+    await page.setViewportSize({ width: 520, height: 760 });
+    await page.reload();
+    await expectMountedWorkspace(page);
+    const beforeNarrowSearchHeight = await pageHeight(page);
+    await runSearch(page, 'contained results');
+    await expectContainedResultsPanel(resultsPanel);
+    expect(await pageHeight(page), 'Narrow search results should stay bounded by the internal results panel.').toBeLessThanOrEqual(beforeNarrowSearchHeight + 340);
+  });
+
   test('result preview marker appears, clears, and search-add opens the existing Add Place draft without saving', async ({ page }, testInfo) => {
     await signIn(page);
     let saveCalls = 0;
@@ -358,6 +388,27 @@ async function captureEvidence(page: Page, testInfo: TestInfo, name: string): Pr
   await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
 }
 
+async function expectContainedResultsPanel(resultsPanel: Locator): Promise<void> {
+  const metrics = await resultsPanel.evaluate(element => {
+    const styles = getComputedStyle(element);
+    return {
+      clientHeight: element.clientHeight,
+      maxHeight: styles.maxHeight,
+      overflowY: styles.overflowY,
+      scrollHeight: element.scrollHeight
+    };
+  });
+
+  expect(metrics.maxHeight, 'Search results should have a CSS max-height.').not.toBe('none');
+  expect(['auto', 'scroll']).toContain(metrics.overflowY);
+  expect(metrics.clientHeight, 'Search results panel should stay under the bounded max-height.').toBeLessThanOrEqual(parseFloat(metrics.maxHeight) + 2);
+  expect(metrics.scrollHeight, 'Long search results should scroll inside the panel.').toBeGreaterThan(metrics.clientHeight + 20);
+}
+
+async function pageHeight(page: Page): Promise<number> {
+  return await page.evaluate(() => document.scrollingElement?.scrollHeight ?? document.documentElement.scrollHeight);
+}
+
 async function routeGeocode(page: Page, handler: (route: Route) => Promise<void>): Promise<void> {
   await page.route(geocodePath, handler);
 }
@@ -387,6 +438,15 @@ function result(name: string): unknown {
     latitude: 37.9715,
     longitude: 23.7257
   };
+}
+
+function manyResults(count: number): unknown[] {
+  return Array.from({ length: count }, (_, index) => ({
+    ...result(`Contained Result ${String(index + 1).padStart(2, '0')}`),
+    id: `nominatim:contained-${index + 1}`,
+    latitude: 37.9 + index * 0.001,
+    longitude: 23.7 + index * 0.001
+  }));
 }
 
 function collectExternalProviderCalls(page: Page): () => string[] {

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -9,6 +9,11 @@ import {
 } from './tripEditorTestUtils';
 
 type MutableEditorState = Record<string, any>;
+type TripEditorContainmentMetrics = {
+  bodyHeight: number; documentHeight: number; footerTop: number | null; mapHeight: number;
+  sidebarClientHeight: number; sidebarScrollHeight: number; stableOverflow: Array<{ selector: string; overflow: number }>;
+  surfaceBodyOverflowY: string; viewportHeight: number; workspaceHeight: number;
+};
 
 const regionId = '00000000-0000-0000-0000-000000283101';
 const firstPlaceId = '00000000-0000-0000-0000-000000283201';
@@ -88,7 +93,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
 
     await page.locator('#trip-editor-place-form').getByLabel('Name').fill(`${firstPlaceName} saved`);
     await page.getByRole('button', { name: 'Save Place' }).click();
-    await expect(page.locator('.trip-editor-save-state').filter({ hasText: /Saved/i }).first()).toBeVisible();
+    await expect(page.locator('.trip-editor-save-state').filter({ hasText: /Place saved/i }).first()).toBeVisible();
     await expectSelectedPlace(page, firstPlaceId);
 
     await page.getByRole('button', { name: 'Cancel' }).click();
@@ -234,6 +239,37 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     expect(requests[0].notesHtml).not.toContain('/Public/ProxyImage');
   });
 
+  test('shows deterministic place save success and error feedback', async ({ page }) => {
+    const requests: Record<string, any>[] = [];
+    await signIn(page);
+    await loadWorkspaceWithMarkerFixture(page, requests);
+
+    await sidebarRow(page, firstPlaceId).getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.locator('#trip-editor-place-form').getByLabel('Address').fill('Successful save feedback address');
+    await page.getByRole('button', { name: 'Save Place' }).click();
+    await expect.poll(() => requests.length).toBe(1);
+    await expect(page.locator('.trip-editor-save-state').filter({ hasText: /Place saved/i }).first()).toBeVisible();
+    await expect(page.getByRole('alert')).toHaveCount(0);
+
+    await page.locator('#trip-editor-place-form').getByLabel('Address').fill('Failed save feedback address');
+    await failNextPlaceSave(page, 'Injected place save failure.');
+    await page.getByRole('button', { name: 'Save Place' }).click();
+    await expect(page.getByRole('alert')).toContainText('Injected place save failure.');
+    await expect(page.locator('.trip-editor-save-state').filter({ hasText: 'Save failed' }).first()).toBeVisible();
+  });
+
+  test('keeps docked place editing contained without expanding the page', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await signIn(page);
+    await loadWorkspaceWithMarkerFixture(page);
+    const before = await tripEditorContainmentMetrics(page);
+
+    await sidebarRow(page, firstPlaceId).getByRole('button', { name: 'Edit', exact: true }).click();
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(firstPlaceName)}`) })).toBeVisible();
+    await expectNonEmptyPlaceEditorRow(page);
+    await expectTripEditorContainment(page, before);
+  });
+
   test('keeps popup and attribution usable at a narrow viewport', async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 900 });
     await signIn(page);
@@ -377,6 +413,22 @@ function mapMarkerImages(page: Page): Locator {
   return page.locator('[data-place-marker-icon]');
 }
 
+async function failNextPlaceSave(page: Page, message: string): Promise<void> {
+  await page.route(editorApiMatcher, async route => {
+    const request = route.request();
+    if (request.method() === 'PUT' && request.url().includes(`/places/${firstPlaceId}`)) {
+      await route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ title: message, status: 400, errors: {} })
+      });
+      return;
+    }
+
+    await route.fallback();
+  }, { times: 1 });
+}
+
 function regionMarkerImages(page: Page): Locator {
   return page.locator('[data-region-marker-icon]');
 }
@@ -463,6 +515,47 @@ async function expectNoPageOverflow(page: Page): Promise<void> {
     );
   });
   expect(overflow, 'Popup and attribution should not create horizontal page overflow.').toBeLessThanOrEqual(1);
+}
+
+async function tripEditorContainmentMetrics(page: Page): Promise<TripEditorContainmentMetrics> {
+  return await page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth;
+    const sidebar = document.querySelector<HTMLElement>('.trip-editor-sidebar');
+    const workspace = document.querySelector<HTMLElement>('.trip-editor-workspace');
+    const map = document.querySelector<HTMLElement>('.trip-editor-map');
+    const surfaceBody = document.querySelector<HTMLElement>('.trip-editor-place-editor-row .trip-editor-surface__body');
+    const footer = document.querySelector<HTMLElement>('body footer, .footer');
+    const stableOverflow = ['#trip-editor-app', '.trip-editor-shell', '.trip-editor-workspace']
+      .map(selector => ({ selector, overflow: Math.max(0, (document.querySelector<HTMLElement>(selector)?.getBoundingClientRect().right ?? 0) - viewportWidth) }))
+      .filter(result => result.overflow > 2);
+
+    return {
+      bodyHeight: document.body?.scrollHeight ?? 0,
+      documentHeight: document.documentElement.scrollHeight,
+      footerTop: footer ? footer.getBoundingClientRect().top : null,
+      mapHeight: map?.getBoundingClientRect().height ?? 0,
+      sidebarClientHeight: sidebar?.clientHeight ?? 0,
+      sidebarScrollHeight: sidebar?.scrollHeight ?? 0,
+      stableOverflow,
+      surfaceBodyOverflowY: surfaceBody ? window.getComputedStyle(surfaceBody).overflowY : '',
+      viewportHeight: window.innerHeight,
+      workspaceHeight: workspace?.getBoundingClientRect().height ?? 0
+    };
+  });
+}
+
+async function expectTripEditorContainment(page: Page, before: TripEditorContainmentMetrics): Promise<void> {
+  const after = await tripEditorContainmentMetrics(page);
+  expect(after.stableOverflow, 'Stable Trip Editor containers should fit within the viewport.').toEqual([]);
+  expect(after.documentHeight - before.documentHeight, 'Opening place edit should not expand document height by many viewports.').toBeLessThanOrEqual(80);
+  expect(after.bodyHeight - before.bodyHeight, 'Opening place edit should not expand body height by many viewports.').toBeLessThanOrEqual(80);
+  expect(after.workspaceHeight, 'Trip Editor workspace should stay bounded by the viewport.').toBeLessThanOrEqual(after.viewportHeight + 1);
+  expect(after.mapHeight, 'Trip Editor map should remain usable after opening place edit.').toBeGreaterThan(300);
+  expect(after.sidebarScrollHeight, 'Place editor overflow should stay inside the sidebar/editor containers.').toBeGreaterThan(after.sidebarClientHeight);
+  expect(after.surfaceBodyOverflowY, 'Docked place editor body should scroll internally.').toBe('auto');
+  if (before.footerTop !== null && after.footerTop !== null) {
+    expect(after.footerTop - before.footerTop, 'Opening place edit should not push the footer down.').toBeLessThanOrEqual(80);
+  }
 }
 
 function readableColor(foreground: string, background: string): boolean {

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -13,8 +13,10 @@ type MutableEditorState = Record<string, any>;
 const regionId = '00000000-0000-0000-0000-000000283101';
 const firstPlaceId = '00000000-0000-0000-0000-000000283201';
 const secondPlaceId = '00000000-0000-0000-0000-000000283202';
+const fallbackPlaceId = '00000000-0000-0000-0000-000000283203';
 const firstPlaceName = 'PW marker parity place with a deliberately long sidebar name that must wrap without covering the Edit action';
 const secondPlaceName = 'PW marker parity second place';
+const fallbackPlaceName = 'PW marker parity fallback marker place';
 const externalImageUrl = 'https://images.example.test/pw-rich-note.png';
 const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
 const tinyPng = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=', 'base64');
@@ -28,6 +30,8 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expectLoadedImages(page.locator('[data-sidebar-place-icon]'));
     await expectLoadedImages(regionMarkerImages(page));
     await expect(regionMarkerImages(page).first()).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-red\/map\.png$/);
+    await expect(markerImage(page, fallbackPlaceId)).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-blue\/marker\.png$/);
+    await expect(sidebarRow(page, fallbackPlaceId).locator('[data-sidebar-place-icon]')).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-blue\/marker\.png$/);
     await captureEvidence(page, testInfo, 'region-marker-app-asset');
 
     await clickMarker(page, firstPlaceId);
@@ -297,9 +301,10 @@ function prepareMarkerState(state: MutableEditorState): void {
   state.regionOrder = [regionId];
   state.placesById = {
     [firstPlaceId]: placeFixture(state, firstPlaceId, firstPlaceName, 'camera', 'bg-blue', { latitude: 37.9838, longitude: 23.7275 }, true),
-    [secondPlaceId]: placeFixture(state, secondPlaceId, secondPlaceName, 'star', 'bg-red', { latitude: 38.2, longitude: 24.05 }, false)
+    [secondPlaceId]: placeFixture(state, secondPlaceId, secondPlaceName, 'star', 'bg-red', { latitude: 38.2, longitude: 24.05 }, false),
+    [fallbackPlaceId]: { ...placeFixture(state, fallbackPlaceId, fallbackPlaceName, '', '', { latitude: 38.1, longitude: 23.85 }, false), iconName: '', markerColor: '' }
   };
-  state.placeOrderByRegionId = { [regionId]: [firstPlaceId, secondPlaceId] };
+  state.placeOrderByRegionId = { [regionId]: [firstPlaceId, secondPlaceId, fallbackPlaceId] };
   state.areasById = {};
   state.areaOrderByRegionId = { [regionId]: [] };
   state.segmentsById = {};
@@ -312,8 +317,8 @@ function placeFixture(state: MutableEditorState, id: string, name: string, iconN
     tripId: state.tripId,
     regionId,
     name,
-    notesHtml: `<p>Marker popup rich note for ${name}</p><p><img src="${externalImageUrl}"></p>`,
-    address: 'Athens, Greece',
+    notesHtml: `<p>Marker popup rich note for ${name}. ${'Long popup note content. '.repeat(14)}</p><p><img src="${externalImageUrl}"></p>`,
+    address: id === firstPlaceId ? `Athens, Greece. ${'Long address content for popup body scrolling. '.repeat(12)}` : 'Athens, Greece',
     location,
     iconName: state.options.iconNames.includes(iconName) ? iconName : state.options.iconNames[0] ?? 'marker',
     markerColor: state.options.markerColorClasses.includes(markerColor) ? markerColor : state.options.markerColorClasses[0] ?? 'bg-blue',
@@ -403,25 +408,50 @@ async function expectLoadedImages(images: Locator): Promise<void> {
 }
 
 async function expectPopupSupportsScrolling(page: Page): Promise<void> {
-  const popupContent = page.locator('.trip-editor-place-popup__content');
+  const popupWrapper = page.locator('.trip-editor-place-popup__content');
+  const popupContent = page.locator('.trip-editor-place-popup__body');
+  const popupHeader = page.locator('.trip-editor-place-popup__header');
+  const popupFooter = page.locator('.trip-editor-place-popup__footer');
+  await expect(popupWrapper).toBeVisible();
   await expect(popupContent).toBeVisible();
+  await expect(popupHeader).toBeVisible();
+  await expect(popupFooter).toBeVisible();
   await expect.poll(async () => popupContent.evaluate(element => {
     const styles = window.getComputedStyle(element);
-    return styles.overflowY === 'auto' && styles.maxHeight !== 'none';
+    return styles.overflowY === 'auto' && styles.maxHeight !== 'none' && element.scrollHeight > element.clientHeight;
   })).toBe(true);
+  await popupWrapper.evaluate(element => {
+    element.scrollTop = 0;
+  });
+  await popupContent.evaluate(element => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect.poll(async () => popupWrapper.evaluate(element => element.scrollTop)).toBe(0);
+  await expect.poll(async () => popupContent.evaluate(element => element.scrollTop > 0)).toBe(true);
+  await expect(popupHeader).toBeVisible();
+  await expect(popupFooter).toBeVisible();
 }
 
 async function expectAttribution(page: Page): Promise<void> {
   const attribution = page.locator('.leaflet-control-attribution');
+  await expect(attribution).toHaveAttribute('aria-label', 'Map attribution');
+  await expect(attribution).toHaveAttribute('title', 'Map attribution');
   await expect(attribution).toContainText('Wayfarer');
   await expect(attribution).toContainText('Stef K');
   await expect(attribution).toContainText('Leaflet');
   await expect(attribution).toContainText('OpenStreetMap');
+  await expect(attribution.getByRole('link', { name: 'Wayfarer' })).toHaveAttribute('title', 'Powered by Wayfarer, made by Stef');
+  await expect(attribution.getByRole('link', { name: 'Stef K' })).toHaveAttribute('title', 'Check my blog');
   await expect(attribution.getByRole('link', { name: 'OpenStreetMap' })).toBeVisible();
-  await expect.poll(async () => attribution.evaluate(element => {
-    const styles = window.getComputedStyle(element);
-    return styles.color !== 'rgba(0, 0, 0, 0)' && styles.backgroundColor !== 'rgba(0, 0, 0, 0)';
-  })).toBe(true);
+  await expect.poll(async () => {
+    const colors = await attribution.evaluate(element => {
+      const styles = window.getComputedStyle(element);
+      const link = element.querySelector('a');
+      const linkStyles = link ? window.getComputedStyle(link) : null;
+      return { background: styles.backgroundColor, foreground: styles.color, link: linkStyles?.color ?? '' };
+    });
+    return readableColor(colors.foreground, colors.background) && readableColor(colors.link, colors.background);
+  }).toBe(true);
 }
 
 async function expectNoPageOverflow(page: Page): Promise<void> {
@@ -433,6 +463,35 @@ async function expectNoPageOverflow(page: Page): Promise<void> {
     );
   });
   expect(overflow, 'Popup and attribution should not create horizontal page overflow.').toBeLessThanOrEqual(1);
+}
+
+function readableColor(foreground: string, background: string): boolean {
+  const foregroundRgb = parseRgb(foreground);
+  const backgroundRgb = parseRgb(background);
+  if (!foregroundRgb || !backgroundRgb) {
+    return false;
+  }
+
+  const contrast = (relativeLuminance(foregroundRgb) + 0.05) / (relativeLuminance(backgroundRgb) + 0.05);
+  return Math.max(contrast, 1 / contrast) >= 2;
+}
+
+function parseRgb(value: string): [number, number, number] | null {
+  const rgbMatch = value.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (rgbMatch) {
+    return [Number(rgbMatch[1]), Number(rgbMatch[2]), Number(rgbMatch[3])];
+  }
+
+  const srgbMatch = value.match(/color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/);
+  return srgbMatch ? [Number(srgbMatch[1]) * 255, Number(srgbMatch[2]) * 255, Number(srgbMatch[3]) * 255] : null;
+}
+
+function relativeLuminance([red, green, blue]: [number, number, number]): number {
+  const [r, g, b] = [red, green, blue].map(channel => {
+    const value = channel / 255;
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
 async function clickMarker(page: Page, placeId: string): Promise<void> {
@@ -461,7 +520,7 @@ async function expectPlaceRowDoesNotOverlapEdit(page: Page, placeId: string): Pr
 }
 
 async function expectRegionAddActionsAttached(page: Page): Promise<void> {
-  const lastChildRow = sidebarRow(page, secondPlaceId);
+  const lastChildRow = sidebarRow(page, fallbackPlaceId);
   const addPlaceButton = regionCard(page).getByRole('button', { name: 'Add Place' });
   await expect(lastChildRow).toBeVisible();
   await expect(addPlaceButton).toBeVisible();

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -229,6 +229,20 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     expect(requests[0].notesHtml).toContain(externalImageUrl);
     expect(requests[0].notesHtml).not.toContain('/Public/ProxyImage');
   });
+
+  test('keeps popup and attribution usable at a narrow viewport', async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: 390, height: 900 });
+    await signIn(page);
+    await loadWorkspaceWithMarkerFixture(page);
+
+    await clickMarker(page, firstPlaceId);
+    await expectSelectedPlace(page, firstPlaceId);
+    await expect(page.locator('.leaflet-popup')).toContainText('PW marker parity region');
+    await expectPopupSupportsScrolling(page);
+    await expectAttribution(page);
+    await expectNoPageOverflow(page);
+    await captureEvidence(page, testInfo, 'narrow-popup-attribution-smoke');
+  });
 });
 
 async function loadWorkspaceWithMarkerFixture(page: Page, requests: Record<string, any>[] = []): Promise<MutableEditorState> {
@@ -408,6 +422,17 @@ async function expectAttribution(page: Page): Promise<void> {
     const styles = window.getComputedStyle(element);
     return styles.color !== 'rgba(0, 0, 0, 0)' && styles.backgroundColor !== 'rgba(0, 0, 0, 0)';
   })).toBe(true);
+}
+
+async function expectNoPageOverflow(page: Page): Promise<void> {
+  const overflow = await page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth;
+    return Math.max(
+      document.documentElement.scrollWidth - viewportWidth,
+      document.body ? document.body.scrollWidth - viewportWidth : 0
+    );
+  });
+  expect(overflow, 'Popup and attribution should not create horizontal page overflow.').toBeLessThanOrEqual(1);
 }
 
 async function clickMarker(page: Page, placeId: string): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -248,14 +248,21 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await page.locator('#trip-editor-place-form').getByLabel('Address').fill('Successful save feedback address');
     await page.getByRole('button', { name: 'Save Place' }).click();
     await expect.poll(() => requests.length).toBe(1);
-    await expect(page.locator('.trip-editor-save-state').filter({ hasText: /Place saved/i }).first()).toBeVisible();
+    const successFeedback = page.locator('.trip-editor-save-state').filter({ hasText: /Place saved/i }).first();
+    await expect(successFeedback).toBeVisible();
+    await expect(successFeedback).toHaveClass(/text-bg-success.*trip-editor-save-state--success/);
+    await expect(successFeedback).not.toHaveClass(/text-bg-info/);
     await expect(page.getByRole('alert')).toHaveCount(0);
 
     await page.locator('#trip-editor-place-form').getByLabel('Address').fill('Failed save feedback address');
     await failNextPlaceSave(page, 'Injected place save failure.');
     await page.getByRole('button', { name: 'Save Place' }).click();
-    await expect(page.getByRole('alert')).toContainText('Injected place save failure.');
-    await expect(page.locator('.trip-editor-save-state').filter({ hasText: 'Save failed' }).first()).toBeVisible();
+    const errorFeedback = page.getByRole('alert');
+    await expect(errorFeedback).toContainText('Injected place save failure.');
+    await expect(errorFeedback).toHaveClass(/trip-editor-form-error/);
+    const failedState = page.locator('.trip-editor-save-state').filter({ hasText: 'Save failed' }).first();
+    await expect(failedState).toBeVisible();
+    await expect(failedState).toHaveClass(/text-bg-danger.*trip-editor-save-state--danger/);
   });
 
   test('keeps docked place editing contained without expanding the page', async ({ page }) => {

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -26,6 +26,9 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
 
     await expectLoadedImages(mapMarkerImages(page));
     await expectLoadedImages(page.locator('[data-sidebar-place-icon]'));
+    await expectLoadedImages(regionMarkerImages(page));
+    await expect(regionMarkerImages(page).first()).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-red\/map\.png$/);
+    await captureEvidence(page, testInfo, 'region-marker-app-asset');
 
     await clickMarker(page, firstPlaceId);
     await expectSelectedPlace(page, firstPlaceId);
@@ -37,8 +40,19 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await expectRegionAddActionsAttached(page);
     await expectPlaceIconColumnAligned(page);
     await expect(page.locator('.leaflet-popup')).toContainText(firstPlaceName);
+    await expect(page.locator('.leaflet-popup')).toContainText('PW marker parity region');
+    await expect(page.locator('.leaflet-popup')).toContainText('Lat: 37.98380');
+    await expect(page.locator('.leaflet-popup')).toContainText('Lon: 23.72750');
+    await expect(page.locator('.leaflet-popup')).toContainText('Address: Athens, Greece');
+    await expect(page.locator('.leaflet-popup')).toContainText('Visits: 2 visits');
     await expect(page.locator('.leaflet-popup')).toContainText('Marker popup rich note');
+    await expectPopupSupportsScrolling(page);
+    await expectAttribution(page);
     await captureEvidence(page, testInfo, 'map-click-selects-sidebar-status');
+    await setTheme(page, 'dark');
+    await expectAttribution(page);
+    await captureEvidence(page, testInfo, 'dark-selected-marker-popup-attribution');
+    await setTheme(page, 'light');
 
     await sidebarRow(page, secondPlaceId).click();
     await expectSelectedPlace(page, secondPlaceId);
@@ -260,7 +274,7 @@ function prepareMarkerState(state: MutableEditorState): void {
       name: 'PW marker parity region',
       notesHtml: '',
       coverImage: null,
-      center: null,
+      center: { latitude: 37.95, longitude: 23.7 },
       displayOrder: 1,
       isShadow: false,
       capabilities: editableCapabilities()
@@ -344,6 +358,10 @@ function mapMarkerImages(page: Page): Locator {
   return page.locator('[data-place-marker-icon]');
 }
 
+function regionMarkerImages(page: Page): Locator {
+  return page.locator('[data-region-marker-icon]');
+}
+
 async function expectSelectedPlace(page: Page, placeId: string): Promise<void> {
   await expect(sidebarRow(page, placeId)).toHaveClass(/trip-editor-place-row--active/);
   await expect(markerImage(page, placeId).locator('xpath=ancestor::*[contains(@class, "trip-editor-map-marker")]')).toHaveClass(/trip-editor-map-marker--selected/);
@@ -370,6 +388,28 @@ async function expectLoadedImages(images: Locator): Promise<void> {
   }
 }
 
+async function expectPopupSupportsScrolling(page: Page): Promise<void> {
+  const popupContent = page.locator('.trip-editor-place-popup__content');
+  await expect(popupContent).toBeVisible();
+  await expect.poll(async () => popupContent.evaluate(element => {
+    const styles = window.getComputedStyle(element);
+    return styles.overflowY === 'auto' && styles.maxHeight !== 'none';
+  })).toBe(true);
+}
+
+async function expectAttribution(page: Page): Promise<void> {
+  const attribution = page.locator('.leaflet-control-attribution');
+  await expect(attribution).toContainText('Wayfarer');
+  await expect(attribution).toContainText('Stef K');
+  await expect(attribution).toContainText('Leaflet');
+  await expect(attribution).toContainText('OpenStreetMap');
+  await expect(attribution.getByRole('link', { name: 'OpenStreetMap' })).toBeVisible();
+  await expect.poll(async () => attribution.evaluate(element => {
+    const styles = window.getComputedStyle(element);
+    return styles.color !== 'rgba(0, 0, 0, 0)' && styles.backgroundColor !== 'rgba(0, 0, 0, 0)';
+  })).toBe(true);
+}
+
 async function clickMarker(page: Page, placeId: string): Promise<void> {
   await expect(markerImage(page, placeId)).toBeVisible();
   await markerImage(page, placeId).evaluate(element => {
@@ -379,6 +419,10 @@ async function clickMarker(page: Page, placeId: string): Promise<void> {
 
 async function captureEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {
   await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
+}
+
+async function setTheme(page: Page, theme: 'dark' | 'light'): Promise<void> {
+  await page.evaluate(value => document.documentElement.setAttribute('data-bs-theme', value), theme);
 }
 
 async function expectPlaceRowDoesNotOverlapEdit(page: Page, placeId: string): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page, type Route } from '@playwright/test';
+import { expect, test, type Locator, type Page, type Route } from '@playwright/test';
 import {
   absoluteUrl,
   editorApiPath,
@@ -43,6 +43,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await clickMap(page, { xRatio: 0.38, yRatio: 0.46 });
     await expect(mapWork).toContainText('Selected');
     await expect(page.getByTitle('Selected place location preview')).toHaveCount(1);
+    await expectLoadedImages(page.locator('[data-coordinate-preview-marker]'));
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
     expect(mutations(), 'Done has not been clicked and no mutation should have run.').toEqual([]);
 
@@ -296,6 +297,14 @@ async function expectDraftCoordinates(page: Page, values: { latitude: string; lo
   const form = page.locator('#trip-editor-place-form');
   await expect(form.getByLabel('Latitude')).toHaveValue(values.latitude);
   await expect(form.getByLabel('Longitude')).toHaveValue(values.longitude);
+}
+
+async function expectLoadedImages(images: Locator): Promise<void> {
+  const count = await images.count();
+  expect(count, 'Expected at least one image to validate.').toBeGreaterThan(0);
+  for (let index = 0; index < count; index += 1) {
+    await expect.poll(async () => images.nth(index).evaluate(image => image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0)).toBe(true);
+  }
 }
 
 function watchEditorMutations(page: Page): () => string[] {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -93,6 +93,8 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     });
     const before = await sidebarEditorState(page);
     expect(before.contextVisible, 'The active place editor should start visible before map-work.').toBe(true);
+    await expect(formNameField(page)).toHaveValue(editablePlaceName);
+    await expect(page.locator('#trip-editor-place-form').getByLabel('Latitude')).toHaveValue('10');
 
     await page.getByRole('button', { name: 'Pick on map' }).click();
     await expect(page.getByRole('region', { name: 'Map work' })).toContainText('Pick place location');
@@ -102,6 +104,12 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     expect(after.contextVisible, 'The active place editor context should remain visible while map-work is active.').toBe(true);
     expect(after.contextTop, 'The active place editor context should stay inside the sidebar viewport.').toBeGreaterThanOrEqual(after.sidebarTop - 1);
     expect(after.contextBottom, 'The active place editor context should stay inside the sidebar viewport.').toBeLessThanOrEqual(after.sidebarBottom + 1);
+    await expect(page.locator('#trip-editor-place-form')).toBeVisible();
+    await expect(formNameField(page)).toBeVisible();
+    await expect(formNameField(page)).toHaveValue(editablePlaceName);
+    await expect(page.locator('#trip-editor-place-form').getByLabel('Latitude')).toBeVisible();
+    await expect(page.locator('#trip-editor-place-form').getByLabel('Latitude')).toHaveValue('10');
+    await expect(page.getByRole('button', { name: 'Save Place' })).toBeDisabled();
   });
 
   test('edit-place Done applies the draft coordinate and moves the selected marker', async ({ page }) => {
@@ -170,7 +178,8 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await expect(page.locator('.leaflet-popup')).toHaveCount(0);
     await expect(mapWork).toContainText(`Edit Place - ${editablePlaceName}`);
     await expect(mapWork).not.toContainText(`Edit Place - ${secondPlaceName}`);
-    await expect(form).toHaveCount(0);
+    await expect(form).toBeVisible();
+    await expect(form.getByLabel('Name')).toHaveValue(editablePlaceName);
     await expect(mapWork).toContainText('Selected 11, 21');
     expect(mutations(), 'Marker click during pick mode must not call editor mutations.').toEqual([]);
 
@@ -305,6 +314,10 @@ function editableCapabilities(): Record<string, boolean> {
 async function openEditablePlace(page: Page): Promise<void> {
   await firstEditableRegion(page).getByText(editablePlaceName).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
   await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${editablePlaceName}`) })).toBeVisible();
+}
+
+function formNameField(page: Page): Locator {
+  return page.locator('#trip-editor-place-form').getByLabel('Name');
 }
 
 function firstEditableRegion(page: Page) {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -82,6 +82,34 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     expect(forbidden(), 'Canceling coordinate pick must not call geocode/search providers.').toEqual([]);
   });
 
+  test('edit-place Done applies the draft coordinate and moves the selected marker', async ({ page }) => {
+    await useMapWorkViewport(page);
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+    const mutations = watchEditorMutations(page);
+
+    await openEditablePlace(page);
+    await expectDraftCoordinates(page, { latitude: '10', longitude: '20' });
+    const originalAnchor = await markerAnchor(page.getByTitle(editablePlaceName));
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await clickMap(page, { xRatio: 0.58, yRatio: 0.44 });
+    const previewAnchor = await markerAnchor(page.getByTitle('Selected place location preview'));
+
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+    const form = page.locator('#trip-editor-place-form');
+    await expect(form.getByLabel('Latitude')).not.toHaveValue('10');
+    await expect(form.getByLabel('Longitude')).not.toHaveValue('20');
+    await expect(page.getByTitle('Selected place location preview')).toHaveCount(0);
+    await expect(page.locator(`.trip-editor-map-marker--selected[title="${editablePlaceName}"]`)).toBeVisible();
+
+    const selectedAnchor = await markerAnchor(page.getByTitle(editablePlaceName));
+    expect(Math.hypot(selectedAnchor.x - originalAnchor.x, selectedAnchor.y - originalAnchor.y), 'Selected marker should move away from the saved coordinate.').toBeGreaterThan(20);
+    expect(Math.abs(selectedAnchor.x - previewAnchor.x), 'Selected marker should move to the picked preview x-position.').toBeLessThanOrEqual(3);
+    expect(Math.abs(selectedAnchor.y - previewAnchor.y), 'Selected marker should move to the picked preview y-position.').toBeLessThanOrEqual(16);
+    expect(mutations(), 'Done must move only the client draft marker and must not persist.').toEqual([]);
+  });
+
   test('edit-place expanded enters map-work and returns to expanded surface', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithCoordinateFixture(page);
@@ -300,6 +328,12 @@ async function expectDraftCoordinates(page: Page, values: { latitude: string; lo
   const form = page.locator('#trip-editor-place-form');
   await expect(form.getByLabel('Latitude')).toHaveValue(values.latitude);
   await expect(form.getByLabel('Longitude')).toHaveValue(values.longitude);
+}
+
+async function markerAnchor(locator: Locator): Promise<{ x: number; y: number }> {
+  const box = await locator.boundingBox();
+  expect(box, 'Expected marker element to have a rendered box.').not.toBeNull();
+  return { x: box!.x + box!.width / 2, y: box!.y + box!.height };
 }
 
 async function expectLoadedImages(images: Locator): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -33,6 +33,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await expect(form.getByLabel('Latitude')).toHaveValue('');
     await expect(form.getByLabel('Longitude')).toHaveValue('');
 
+    await expectPickOnMapHelp(page);
     await page.getByRole('button', { name: 'Pick on map' }).click();
     const mapWork = page.getByRole('region', { name: 'Map work' });
     await expect(mapWork).toContainText('Pick place location');
@@ -44,6 +45,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await expect(mapWork).toContainText('Selected');
     await expect(page.getByTitle('Selected place location preview')).toHaveCount(1);
     await expectLoadedImages(page.locator('[data-coordinate-preview-marker]'));
+    await expect(page.locator('[data-coordinate-preview-marker]')).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-blue\/marker\.png$/);
     await captureEvidence(page, testInfo, 'pick-on-map-preview-marker');
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
     expect(mutations(), 'Done has not been clicked and no mutation should have run.').toEqual([]);
@@ -306,6 +308,14 @@ async function expectLoadedImages(images: Locator): Promise<void> {
   for (let index = 0; index < count; index += 1) {
     await expect.poll(async () => images.nth(index).evaluate(image => image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0)).toBe(true);
   }
+}
+
+async function expectPickOnMapHelp(page: Page): Promise<void> {
+  const pickButton = page.getByRole('button', { name: 'Pick on map' });
+  await expect(pickButton).toHaveAttribute('title', "Pick this place's latitude and longitude on the map");
+  const describedBy = await pickButton.getAttribute('aria-describedby');
+  expect(describedBy, 'Pick on map should expose an accessible help description.').toBeTruthy();
+  await expect(page.locator(`#${describedBy}`)).toContainText("Use the map to choose this place's latitude and longitude.");
 }
 
 async function captureEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page, type Route } from '@playwright/test';
+import { expect, test, type Locator, type Page, type Route, type TestInfo } from '@playwright/test';
 import {
   absoluteUrl,
   editorApiPath,
@@ -20,7 +20,7 @@ const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]
 const forbiddenPickRequest = /nominatim|geocode|geosearch|search-add|searchadd|\/search(?:[/?#]|$)/i;
 
 test.describe.serial('Trip Editor place coordinate map-work', () => {
-  test('add-place picks a temporary coordinate and Done updates only the draft', async ({ page }) => {
+  test('add-place picks a temporary coordinate and Done updates only the draft', async ({ page }, testInfo) => {
     await signIn(page);
     await loadWorkspaceWithCoordinateFixture(page);
     const mutations = watchEditorMutations(page);
@@ -44,6 +44,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await expect(mapWork).toContainText('Selected');
     await expect(page.getByTitle('Selected place location preview')).toHaveCount(1);
     await expectLoadedImages(page.locator('[data-coordinate-preview-marker]'));
+    await captureEvidence(page, testInfo, 'pick-on-map-preview-marker');
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
     expect(mutations(), 'Done has not been clicked and no mutation should have run.').toEqual([]);
 
@@ -305,6 +306,10 @@ async function expectLoadedImages(images: Locator): Promise<void> {
   for (let index = 0; index < count; index += 1) {
     await expect.poll(async () => images.nth(index).evaluate(image => image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0)).toBe(true);
   }
+}
+
+async function captureEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
 }
 
 function watchEditorMutations(page: Page): () => string[] {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -82,6 +82,28 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     expect(forbidden(), 'Canceling coordinate pick must not call geocode/search providers.').toEqual([]);
   });
 
+  test('Pick on map keeps the docked place editor stable in the sidebar', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+
+    await openEditablePlace(page);
+    await page.locator('.trip-editor-place-editor-row .trip-editor-surface--docked').evaluate(element => {
+      element.scrollIntoView({ block: 'center', inline: 'nearest' });
+    });
+    const before = await sidebarEditorState(page);
+    expect(before.contextVisible, 'The active place editor should start visible before map-work.').toBe(true);
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await expect(page.getByRole('region', { name: 'Map work' })).toContainText('Pick place location');
+    const after = await sidebarEditorState(page);
+
+    expect(Math.abs(after.scrollTop - before.scrollTop), 'Starting coordinate map-work should not move the sidebar enough to hide the active editor.').toBeLessThanOrEqual(96);
+    expect(after.contextVisible, 'The active place editor context should remain visible while map-work is active.').toBe(true);
+    expect(after.contextTop, 'The active place editor context should stay inside the sidebar viewport.').toBeGreaterThanOrEqual(after.sidebarTop - 1);
+    expect(after.contextBottom, 'The active place editor context should stay inside the sidebar viewport.').toBeLessThanOrEqual(after.sidebarBottom + 1);
+  });
+
   test('edit-place Done applies the draft coordinate and moves the selected marker', async ({ page }) => {
     await useMapWorkViewport(page);
     await signIn(page);
@@ -354,6 +376,30 @@ async function expectPickOnMapHelp(page: Page): Promise<void> {
 
 async function captureEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {
   await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
+}
+
+async function sidebarEditorState(page: Page): Promise<{
+  contextBottom: number;
+  contextTop: number;
+  contextVisible: boolean;
+  scrollTop: number;
+  sidebarBottom: number;
+  sidebarTop: number;
+}> {
+  return await page.evaluate(() => {
+    const sidebar = document.querySelector<HTMLElement>('.trip-editor-sidebar');
+    const context = document.querySelector<HTMLElement>('.trip-editor-place-editor-row .trip-editor-surface-context, .trip-editor-place-editor-row .trip-editor-surface--docked');
+    const sidebarBox = sidebar?.getBoundingClientRect();
+    const contextBox = context?.getBoundingClientRect();
+    return {
+      contextBottom: contextBox?.bottom ?? 0,
+      contextTop: contextBox?.top ?? 0,
+      contextVisible: Boolean(contextBox && sidebarBox && contextBox.bottom > sidebarBox.top && contextBox.top < sidebarBox.bottom),
+      scrollTop: sidebar?.scrollTop ?? 0,
+      sidebarBottom: sidebarBox?.bottom ?? 0,
+      sidebarTop: sidebarBox?.top ?? 0
+    };
+  });
 }
 
 function watchEditorMutations(page: Page): () => string[] {


### PR DESCRIPTION
## Summary

Fixes #288 Batch 2 marker, popup, and attribution presentation parity after Batch 1 / PR #289.

- renders region centers with explicit Wayfarer app marker assets instead of Leaflet circle markers;
- uses explicit app marker assets for pick-on-map and map-search preview markers;
- expands place popup content from existing editor state only: name, region, coordinates, address, visit summary, notes preview, and selection hint;
- makes popups scrollable for longer content and keeps attribution readable in light/dark themes;
- preserves Batch 1 selection, Clear Selection, dirty guard, and search-add workflow semantics.

## Design Translation Contract

### 1. Region marker rendering
- Legacy behavior preserved: region centers render as Wayfarer marker icons, specifically the red map marker from the legacy `mapManager.js` path.
- Current Vue behavior before this PR: region centers rendered as Leaflet circle markers.
- Vue-native translation: `regionMarkerIcon()` builds a Leaflet `divIcon` with the static app PNG `/icons/wayfarer-map-icons/dist/png/marker/bg-red/map.png` and a region-specific data attribute for tests.
- Must not change: region center meaning stays visible; no default Leaflet marker assets.
- Evidence: E2E image load assertion and `region-marker-app-asset.png`.

### 2. Selected marker visual refinement
- Legacy behavior preserved: selected feedback remains marker-focused and color-aware.
- Current Vue behavior before this PR: Batch 1 already moved away from the detached generic circle and uses a marker image drop-shadow.
- Vue-native translation: preserve Batch 1 selected marker class/flow; assertions prove selected marker state and dirty/clear behavior still work.
- Must not change: selected sidebar row, status sync, Clear Selection, dirty selection guard, and docked/expanded preservation.
- Evidence: marker parity tests plus `map-click-selects-sidebar-status.png`, `dark-selected-marker-popup-attribution.png`, and dirty/clear screenshots.

### 3. Pick-on-map preview marker
- Legacy behavior preserved: preview marker uses explicit Wayfarer PNG assets.
- Current Vue behavior before this PR: preview used bare `L.marker`, depending on Leaflet default image paths.
- Vue-native translation: `previewMarkerIcon('coordinate', ...)` renders an explicit app PNG marker with `data-coordinate-preview-marker`.
- Must not change: pick mode remains draft-only; persisted marker clicks are still consumed by coordinate pick mode.
- Evidence: coordinate map-work E2E image load assertion and `pick-on-map-preview-marker.png`.

### 4. Map search preview marker
- Legacy behavior preserved: search temp marker uses an explicit app PNG marker.
- Current Vue behavior before this PR: search preview used bare `L.marker`.
- Vue-native translation: `previewMarkerIcon('search', ...)` renders the app black map marker with `data-search-preview-marker`.
- Must not change: no map search/search-add workflow redesign; the existing result selection and Add Place draft semantics remain unchanged.
- Evidence: map-search E2E image load assertion and `map-search-preview-marker.png`.

### 5. Place popup content and usability
- Legacy behavior preserved: popup exposes useful existing state: name, region, coordinates, address, notes preview, and interaction hint.
- Current Vue behavior before this PR: popup showed only name, visit count, and notes.
- Vue-native translation: `placePopupRendering.ts` builds sanitized popup HTML from existing `EditorPlace` plus region lookup; notes continue through `placeNotesPreviewHtml()` and image proxy display behavior.
- Must not change: no DTO/API expansion; unavailable fields are omitted or deterministic fallback text is used.
- Evidence: marker parity E2E asserts field content and popup scroll CSS; narrow smoke screenshot `narrow-popup-attribution-smoke.png`.

### 6. Map attribution
- Legacy behavior preserved: app/Leaflet attribution is restored while provider/OpenStreetMap attribution remains present.
- Current Vue behavior before this PR: only configured tile attribution or OSM fallback was shown, with no app prefix styling.
- Vue-native translation: Leaflet prefix contains Wayfarer / Stef K / Leaflet, tile provider attribution is preserved and normalized to keep OpenStreetMap linked when the configured string is plain text.
- Must not change: provider/OpenStreetMap attribution is not replaced by app branding.
- Evidence: E2E DOM assertions for Wayfarer, Stef K, Leaflet, OpenStreetMap link/text and dark/light screenshots.

## Validation

- `npm run build` passed; existing Vite chunk-size warning remains.
- `dotnet build` passed; existing `Program.cs(200,20)` ASP0000 warning remains.
- `dotnet test --no-build` passed: 1535 passed.
- `npx playwright test --config=playwright.config.ts --list` passed: 88 tests listed.
- Focused affected Playwright specs passed: 22 passed.
- Full `npm run test:e2e:trip-editor` passed with ASP.NET `http://localhost:5012` and Vite `http://localhost:5173` running: 87 passed, 1 skipped.
- Published-output smoke passed from `dotnet publish Wayfarer.csproj -c Release -o .local/publish-marker-popup-batch2-app` output using `WAYFARER_E2E_BASE_URL=http://localhost:5014`: marker/popup parity smoke 1 passed.
- Development smoke passed: `Invoke-WebRequest http://localhost:5012` returned 200 and `Invoke-WebRequest http://localhost:5173/@vite/client` returned 200.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` passed with warnings only. Warning accepted for `tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts` because the added assertions remain one cohesive marker/popup/attribution parity spec. Existing warnings remain for large Trip Editor files.
- `git diff --check origin/main...HEAD` passed.
- Tracked artifact scan was clean for `.local`, `playwright-report`, `test-results`, `screenshots`, `traces`, `wwwroot/vite/trip-editor`, and `wwwroot/dist`.
- `rg "window\.confirm" ClientApps/trip-editor/src` returned no hits.
- `rg "\bconfirm\(" ClientApps/trip-editor/src` returned only shared confirm-dialog helper usage; no raw browser confirm usage.

## Screenshot / Manual Evidence Paths

Screenshots are generated locally under ignored `.local/playwright/test-output` and are not committed:

- `.local/playwright/test-output/tripEditorMarkerParity-Tri-17137-ynchronized-both-directions-chromium/screenshots/region-marker-app-asset.png`
- `.local/playwright/test-output/tripEditorMarkerParity-Tri-17137-ynchronized-both-directions-chromium/screenshots/map-click-selects-sidebar-status.png`
- `.local/playwright/test-output/tripEditorMarkerParity-Tri-17137-ynchronized-both-directions-chromium/screenshots/dark-selected-marker-popup-attribution.png`
- `.local/playwright/test-output/tripEditorMarkerParity-Tri-2ef24-usable-at-a-narrow-viewport-chromium/screenshots/narrow-popup-attribution-smoke.png`
- `.local/playwright/test-output/tripEditorPlaceCoordinateM-2a3ba-Done-updates-only-the-draft-chromium/screenshots/pick-on-map-preview-marker.png`
- `.local/playwright/test-output/tripEditorMapSearch-Trip-E-cefd0--Place-draft-without-saving-chromium/screenshots/map-search-preview-marker.png`

## Deferred / Out Of Scope

- Batch 3 icon selector redesign remains deferred.
- Rich-notes insertion-space after large images remains deferred.
- Broad map-search/Add Place workflow redesign remains deferred; this PR only fixes the search preview marker asset and related visual evidence.
- No backend/API DTO expansion, import/export/backfill, or legacy route/fallback changes are included.