### PR TITLE
Fix Trip Editor icon selector parity

### DIFF
--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -12,6 +12,12 @@ import type { BootstrapConfig, EditorCoordinate, EditorGeocodeSearchResult, Edit
 
 const props = defineProps<{ config: BootstrapConfig }>();
 
+type PlaceDraftPreview = {
+  iconName: string;
+  markerColor: string;
+  placeId: Guid;
+};
+
 const state = ref<EditorTripState | null>(null);
 const error = ref<string | null>(null);
 const isLoading = ref(true);
@@ -21,6 +27,7 @@ const mapElement = ref<HTMLElement | null>(null);
 const navigationStatus = ref<string | null>(null);
 const hiddenSegmentIds = ref<Set<string>>(new Set());
 const selectedPlaceId = ref<Guid | null>(null);
+const activePlaceDraftPreview = ref<PlaceDraftPreview | null>(null);
 const pendingSearchAdd = ref<{ result: EditorGeocodeSearchResult; regionId: Guid; requestId: number } | null>(null);
 const editorSurface = useEditorSurface();
 let mapAdapter: ReturnType<typeof createTripEditorMap> | null = null;
@@ -270,6 +277,26 @@ const setRegionDraftChanges = (isDirty: boolean): void => {
   hasRegionDraftChanges.value = isDirty;
 };
 
+/// Applies active place draft icon/color to the selected marker preview without saving it.
+const applyPlaceDraftPreview = (preview: PlaceDraftPreview | null): void => {
+  if (!state.value) {
+    activePlaceDraftPreview.value = preview;
+    return;
+  }
+
+  const previous = activePlaceDraftPreview.value;
+  if (previous && previous.placeId !== preview?.placeId) {
+    mapAdapter?.applyPlaceDraftMarker(state.value, previous.placeId, null);
+  }
+
+  activePlaceDraftPreview.value = preview;
+  if (preview) {
+    mapAdapter?.applyPlaceDraftMarker(state.value, preview.placeId, preview);
+  } else if (previous) {
+    mapAdapter?.applyPlaceDraftMarker(state.value, previous.placeId, null);
+  }
+};
+
 /// Applies mutation affected slices and authoritative deleted IDs to normalized editor state.
 const applyMutation = (result: EditorMutationResult<unknown>): void => {
   if (!state.value) {
@@ -348,9 +375,15 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
     selectedPlaceId.value = null;
     navigationStatus.value = null;
   }
+  if (activePlaceDraftPreview.value && !next.placesById[activePlaceDraftPreview.value.placeId]) {
+    activePlaceDraftPreview.value = null;
+  }
 
   state.value = next;
   mapAdapter?.render(next, hiddenSegmentIds.value, selectedPlaceId.value);
+  if (activePlaceDraftPreview.value) {
+    mapAdapter?.applyPlaceDraftMarker(next, activePlaceDraftPreview.value.placeId, activePlaceDraftPreview.value);
+  }
 };
 
 /// Updates client-session-only segment visibility without touching the API contract.
@@ -432,6 +465,7 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
         @metadata-saved="applyMetadata"
         @mutation-applied="applyMutation"
         @region-draft-dirty-changed="setRegionDraftChanges"
+        @place-draft-preview-changed="applyPlaceDraftPreview"
         @hidden-segment-ids-changed="updateHiddenSegmentIds"
         :select-place="placeId => selectPlace(placeId, { focusMap: true })"
         :clear-selected-place="clearSelectedPlace"

--- a/ClientApps/trip-editor/src/components/IconSelector.vue
+++ b/ClientApps/trip-editor/src/components/IconSelector.vue
@@ -1,0 +1,240 @@
+<script lang="ts">
+let nextSelectorId = 0;
+</script>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { placeMarkerIconUrl } from '../displayHelpers';
+
+const props = defineProps<{
+  icons: string[];
+  markerColor: string;
+  modelValue: string;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string];
+}>();
+
+const root = ref<HTMLElement | null>(null);
+const trigger = ref<HTMLButtonElement | null>(null);
+const searchInput = ref<HTMLInputElement | null>(null);
+const isOpen = ref(false);
+const searchQuery = ref('');
+const highlightedIndex = ref(0);
+const selectorId = `trip-editor-icon-selector-${++nextSelectorId}`;
+const listboxId = `${selectorId}-listbox`;
+
+const normalizedQuery = computed(() => searchQuery.value.trim().toLocaleLowerCase());
+const selectedIcon = computed(() => props.icons.includes(props.modelValue) ? props.modelValue : props.icons[0] ?? 'marker');
+const filteredIcons = computed(() => {
+  if (!normalizedQuery.value) {
+    return props.icons;
+  }
+
+  return props.icons.filter(icon => icon.toLocaleLowerCase().includes(normalizedQuery.value));
+});
+const highlightedIcon = computed(() => filteredIcons.value[highlightedIndex.value] ?? '');
+const activeOptionId = computed(() => highlightedIcon.value ? optionId(highlightedIcon.value) : undefined);
+
+/// Converts stored icon ids into the same readable labels used by the legacy searchable selector.
+const iconLabel = (icon: string): string => icon.replace(/[-_]+/g, ' ');
+
+function openSelector(seed = ''): void {
+  searchQuery.value = seed;
+  highlightedIndex.value = firstHighlightedIndex(seed);
+  isOpen.value = true;
+  void nextTick(() => searchInput.value?.focus());
+}
+
+function closeSelector(focusTrigger = false): void {
+  isOpen.value = false;
+  searchQuery.value = '';
+  highlightedIndex.value = Math.max(0, props.icons.indexOf(selectedIcon.value));
+  if (focusTrigger) {
+    void nextTick(() => trigger.value?.focus());
+  }
+}
+
+function toggleSelector(): void {
+  if (isOpen.value) {
+    closeSelector();
+    return;
+  }
+
+  openSelector();
+}
+
+function selectIcon(icon: string): void {
+  emit('update:modelValue', icon);
+  closeSelector(true);
+}
+
+function onTriggerKeydown(event: KeyboardEvent): void {
+  if (['Enter', ' ', 'ArrowDown'].includes(event.key)) {
+    event.preventDefault();
+    openSelector();
+    return;
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault();
+    openSelector();
+    highlightedIndex.value = Math.max(0, filteredIcons.value.length - 1);
+    return;
+  }
+
+  if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+    event.preventDefault();
+    openSelector(event.key);
+  }
+}
+
+function onSearchKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeSelector(true);
+    return;
+  }
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault();
+    highlightedIndex.value = Math.min(highlightedIndex.value + 1, Math.max(0, filteredIcons.value.length - 1));
+    return;
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault();
+    highlightedIndex.value = Math.max(0, highlightedIndex.value - 1);
+    return;
+  }
+
+  if (event.key === 'Home') {
+    event.preventDefault();
+    highlightedIndex.value = 0;
+    return;
+  }
+
+  if (event.key === 'End') {
+    event.preventDefault();
+    highlightedIndex.value = Math.max(0, filteredIcons.value.length - 1);
+    return;
+  }
+
+  if (event.key === 'Enter' && highlightedIcon.value) {
+    event.preventDefault();
+    selectIcon(highlightedIcon.value);
+  }
+}
+
+function onSearchInput(): void {
+  highlightedIndex.value = 0;
+}
+
+function onFocusOut(): void {
+  void nextTick(() => {
+    if (!root.value?.contains(document.activeElement)) {
+      closeSelector();
+    }
+  });
+}
+
+function optionId(icon: string): string {
+  return `${selectorId}-option-${icon.replace(/[^a-z0-9_-]/gi, '-')}`;
+}
+
+function firstHighlightedIndex(seed: string): number {
+  const query = seed.trim().toLocaleLowerCase();
+  if (!query) {
+    return Math.max(0, props.icons.indexOf(selectedIcon.value));
+  }
+
+  return Math.max(0, props.icons.findIndex(icon => icon.toLocaleLowerCase().includes(query)));
+}
+
+/// Keeps outside clicks from leaving the popover open while preserving normal tab flow.
+function onDocumentPointerDown(event: PointerEvent): void {
+  if (!root.value?.contains(event.target as Node)) {
+    closeSelector();
+  }
+}
+
+watch(filteredIcons, icons => {
+  highlightedIndex.value = Math.min(highlightedIndex.value, Math.max(0, icons.length - 1));
+});
+
+watch(activeOptionId, async id => {
+  if (!id) {
+    return;
+  }
+
+  await nextTick();
+  document.getElementById(id)?.scrollIntoView({ block: 'nearest' });
+});
+
+onMounted(() => document.addEventListener('pointerdown', onDocumentPointerDown));
+onBeforeUnmount(() => document.removeEventListener('pointerdown', onDocumentPointerDown));
+</script>
+
+<template>
+  <div ref="root" class="trip-editor-icon-selector" data-icon-selector @focusout="onFocusOut">
+    <button
+      ref="trigger"
+      type="button"
+      class="trip-editor-icon-selector__trigger"
+      aria-haspopup="listbox"
+      :aria-expanded="isOpen"
+      :aria-controls="listboxId"
+      data-icon-selector-trigger
+      @click="toggleSelector"
+      @keydown="onTriggerKeydown"
+    >
+      <span class="trip-editor-icon-selector__selected">
+        <img :src="placeMarkerIconUrl(selectedIcon, props.markerColor || 'bg-blue')" width="24" height="39" alt="" data-icon-selector-selected-image />
+        <span class="trip-editor-icon-selector__selected-name" data-icon-selector-selected-name>{{ selectedIcon }}</span>
+      </span>
+      <span class="trip-editor-icon-selector__chevron" aria-hidden="true">v</span>
+    </button>
+
+    <div v-if="isOpen" class="trip-editor-icon-selector__panel" data-icon-selector-panel>
+      <label class="visually-hidden" :for="`${selectorId}-search`">Search icon</label>
+      <input
+        :id="`${selectorId}-search`"
+        ref="searchInput"
+        v-model="searchQuery"
+        class="trip-editor-icon-selector__search"
+        type="search"
+        autocomplete="off"
+        role="combobox"
+        aria-autocomplete="list"
+        :aria-expanded="isOpen"
+        :aria-controls="listboxId"
+        :aria-activedescendant="activeOptionId"
+        placeholder="Search icons"
+        data-icon-selector-search
+        @input="onSearchInput"
+        @keydown="onSearchKeydown"
+      />
+
+      <ul :id="listboxId" class="trip-editor-icon-selector__options" role="listbox" aria-label="Icon options" data-icon-selector-options>
+        <li
+          v-for="(icon, index) in filteredIcons"
+          :id="optionId(icon)"
+          :key="icon"
+          class="trip-editor-icon-selector__option"
+          :class="{ 'trip-editor-icon-selector__option--active': highlightedIndex === index }"
+          role="option"
+          :aria-selected="selectedIcon === icon"
+          data-icon-selector-option
+          @mouseenter="highlightedIndex = index"
+          @mousedown.prevent
+          @click="selectIcon(icon)"
+        >
+          <img :src="placeMarkerIconUrl(icon, props.markerColor || 'bg-blue')" width="24" height="39" alt="" data-icon-selector-option-image />
+          <span data-icon-selector-option-name>{{ iconLabel(icon) }}</span>
+        </li>
+        <li v-if="filteredIcons.length === 0" class="trip-editor-icon-selector__empty">No matching icons.</li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/ClientApps/trip-editor/src/components/IconSelector.vue
+++ b/ClientApps/trip-editor/src/components/IconSelector.vue
@@ -8,6 +8,7 @@ import { placeMarkerIconUrl } from '../displayHelpers';
 
 const props = defineProps<{
   icons: string[];
+  kind?: 'icon' | 'color';
   markerColor: string;
   modelValue: string;
 }>();
@@ -24,21 +25,32 @@ const searchQuery = ref('');
 const highlightedIndex = ref(0);
 const selectorId = `trip-editor-icon-selector-${++nextSelectorId}`;
 const listboxId = `${selectorId}-listbox`;
+const selectorKind = computed(() => props.kind ?? 'icon');
+const fallbackValue = computed(() => selectorKind.value === 'color' ? 'bg-blue' : 'marker');
 
 const normalizedQuery = computed(() => searchQuery.value.trim().toLocaleLowerCase());
-const selectedIcon = computed(() => props.icons.includes(props.modelValue) ? props.modelValue : props.icons[0] ?? 'marker');
+const selectedIcon = computed(() => props.icons.includes(props.modelValue) ? props.modelValue : props.icons[0] ?? fallbackValue.value);
 const filteredIcons = computed(() => {
   if (!normalizedQuery.value) {
     return props.icons;
   }
 
-  return props.icons.filter(icon => icon.toLocaleLowerCase().includes(normalizedQuery.value));
+  return props.icons.filter(icon => optionLabel(icon).toLocaleLowerCase().includes(normalizedQuery.value) || icon.toLocaleLowerCase().includes(normalizedQuery.value));
 });
 const highlightedIcon = computed(() => filteredIcons.value[highlightedIndex.value] ?? '');
 const activeOptionId = computed(() => highlightedIcon.value ? optionId(highlightedIcon.value) : undefined);
+const searchLabel = computed(() => selectorKind.value === 'color' ? 'Search marker colors' : 'Search icons');
+const optionsLabel = computed(() => selectorKind.value === 'color' ? 'Marker color options' : 'Icon options');
+const searchPlaceholder = computed(() => selectorKind.value === 'color' ? 'Search colors' : 'Search icons');
 
 /// Converts stored icon ids into the same readable labels used by the legacy searchable selector.
 const iconLabel = (icon: string): string => icon.replace(/[-_]+/g, ' ');
+const optionLabel = (value: string): string => selectorKind.value === 'color' ? colorLabel(value) : iconLabel(value);
+const colorName = (color: string): string => color.replace(/^bg-/, '').replace(/[-_]+/g, ' ');
+const colorLabel = (color: string): string => {
+  const name = colorName(color);
+  return `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+};
 
 function openSelector(seed = ''): void {
   searchQuery.value = seed;
@@ -149,7 +161,7 @@ function firstHighlightedIndex(seed: string): number {
     return Math.max(0, props.icons.indexOf(selectedIcon.value));
   }
 
-  return Math.max(0, props.icons.findIndex(icon => icon.toLocaleLowerCase().includes(query)));
+  return Math.max(0, props.icons.findIndex(icon => icon.toLocaleLowerCase().includes(query) || optionLabel(icon).toLocaleLowerCase().includes(query)));
 }
 
 /// Keeps outside clicks from leaving the popover open while preserving normal tab flow.
@@ -177,7 +189,7 @@ onBeforeUnmount(() => document.removeEventListener('pointerdown', onDocumentPoin
 </script>
 
 <template>
-  <div ref="root" class="trip-editor-icon-selector" data-icon-selector @focusout="onFocusOut">
+  <div ref="root" class="trip-editor-icon-selector" :data-selector-kind="selectorKind" data-icon-selector @focusout="onFocusOut">
     <button
       ref="trigger"
       type="button"
@@ -190,14 +202,15 @@ onBeforeUnmount(() => document.removeEventListener('pointerdown', onDocumentPoin
       @keydown="onTriggerKeydown"
     >
       <span class="trip-editor-icon-selector__selected">
-        <img :src="placeMarkerIconUrl(selectedIcon, props.markerColor || 'bg-blue')" width="24" height="39" alt="" data-icon-selector-selected-image />
-        <span class="trip-editor-icon-selector__selected-name" data-icon-selector-selected-name>{{ selectedIcon }}</span>
+        <img v-if="selectorKind === 'icon'" :src="placeMarkerIconUrl(selectedIcon, props.markerColor || 'bg-blue')" width="24" height="39" alt="" data-icon-selector-selected-image />
+        <span v-else class="trip-editor-icon-selector__swatch" :class="selectedIcon" aria-hidden="true" data-color-selector-selected-swatch></span>
+        <span class="trip-editor-icon-selector__selected-name" data-icon-selector-selected-name>{{ selectorKind === 'color' ? colorLabel(selectedIcon) : selectedIcon }}</span>
       </span>
       <span class="trip-editor-icon-selector__chevron" aria-hidden="true">v</span>
     </button>
 
     <div v-if="isOpen" class="trip-editor-icon-selector__panel" data-icon-selector-panel>
-      <label class="visually-hidden" :for="`${selectorId}-search`">Search icon</label>
+      <label class="visually-hidden" :for="`${selectorId}-search`">{{ searchLabel }}</label>
       <input
         :id="`${selectorId}-search`"
         ref="searchInput"
@@ -210,13 +223,13 @@ onBeforeUnmount(() => document.removeEventListener('pointerdown', onDocumentPoin
         :aria-expanded="isOpen"
         :aria-controls="listboxId"
         :aria-activedescendant="activeOptionId"
-        placeholder="Search icons"
+        :placeholder="searchPlaceholder"
         data-icon-selector-search
         @input="onSearchInput"
         @keydown="onSearchKeydown"
       />
 
-      <ul :id="listboxId" class="trip-editor-icon-selector__options" role="listbox" aria-label="Icon options" data-icon-selector-options>
+      <ul :id="listboxId" class="trip-editor-icon-selector__options" role="listbox" :aria-label="optionsLabel" data-icon-selector-options>
         <li
           v-for="(icon, index) in filteredIcons"
           :id="optionId(icon)"
@@ -230,8 +243,9 @@ onBeforeUnmount(() => document.removeEventListener('pointerdown', onDocumentPoin
           @mousedown.prevent
           @click="selectIcon(icon)"
         >
-          <img :src="placeMarkerIconUrl(icon, props.markerColor || 'bg-blue')" width="24" height="39" alt="" data-icon-selector-option-image />
-          <span data-icon-selector-option-name>{{ iconLabel(icon) }}</span>
+          <img v-if="selectorKind === 'icon'" :src="placeMarkerIconUrl(icon, props.markerColor || 'bg-blue')" width="24" height="39" alt="" data-icon-selector-option-image />
+          <span v-else class="trip-editor-icon-selector__swatch" :class="icon" aria-hidden="true" data-color-selector-option-swatch></span>
+          <span data-icon-selector-option-name>{{ optionLabel(icon) }}</span>
         </li>
         <li v-if="filteredIcons.length === 0" class="trip-editor-icon-selector__empty">No matching icons.</li>
       </ul>

--- a/ClientApps/trip-editor/src/components/PlaceEditorForm.vue
+++ b/ClientApps/trip-editor/src/components/PlaceEditorForm.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { EditorPlace, EditorPlaceDraft, EditorRegion, EditorTripState } from '../types';
 import IconSelector from './IconSelector.vue';
 import RichNotesEditor from './RichNotesEditor.vue';
@@ -18,10 +19,8 @@ const emit = defineEmits<{
   save: [];
 }>();
 
-const markerColorLabel = (color: string): string => {
-  const name = color.replace(/^bg-/, '').replace(/[-_]+/g, ' ');
-  return `${name.charAt(0).toUpperCase()}${name.slice(1)} marker color`;
-};
+const orderedMarkerColors = ['bg-blue', 'bg-purple', 'bg-black', 'bg-green', 'bg-red'];
+const markerColorOptions = computed(() => orderedMarkerColors.filter(color => props.state.options.markerColorClasses.includes(color)));
 
 </script>
 
@@ -66,7 +65,7 @@ const markerColorLabel = (color: string): string => {
       </label>
     </div>
 
-    <div class="trip-editor-grid">
+    <div class="trip-editor-selector-grid">
       <fieldset class="trip-editor-field trip-editor-place-icon-field">
         <legend>Icon</legend>
         <IconSelector v-model="props.draft.iconName" :icons="props.state.options.iconNames" :marker-color="props.draft.markerColor || 'bg-blue'" />
@@ -74,18 +73,7 @@ const markerColorLabel = (color: string): string => {
       </fieldset>
       <fieldset class="trip-editor-field trip-editor-marker-color-field">
         <legend>Marker Color</legend>
-        <div class="trip-editor-marker-swatch-group" role="radiogroup" aria-label="Marker Color">
-          <label
-            v-for="color in props.state.options.markerColorClasses"
-            :key="color"
-            class="trip-editor-marker-swatch"
-            :class="{ 'trip-editor-marker-swatch--selected': props.draft.markerColor === color }"
-            :title="markerColorLabel(color)"
-          >
-            <input v-model="props.draft.markerColor" class="trip-editor-marker-swatch__input" type="radio" name="markerColor" :value="color" :aria-label="markerColorLabel(color)" />
-            <span class="trip-editor-marker-swatch__sample" :class="color" aria-hidden="true"></span>
-          </label>
-        </div>
+        <IconSelector v-model="props.draft.markerColor" kind="color" :icons="markerColorOptions" marker-color="bg-blue" />
         <small v-for="message in props.fieldErrors('markerColor')" :key="message">{{ message }}</small>
       </fieldset>
     </div>

--- a/ClientApps/trip-editor/src/components/PlaceEditorForm.vue
+++ b/ClientApps/trip-editor/src/components/PlaceEditorForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { placeMarkerIconUrl } from '../displayHelpers';
 import type { EditorPlace, EditorPlaceDraft, EditorRegion, EditorTripState } from '../types';
+import IconSelector from './IconSelector.vue';
 import RichNotesEditor from './RichNotesEditor.vue';
 
 const props = defineProps<{
@@ -23,7 +23,6 @@ const markerColorLabel = (color: string): string => {
   return `${name.charAt(0).toUpperCase()}${name.slice(1)} marker color`;
 };
 
-const iconLabel = (icon: string): string => `${icon.replace(/[-_]+/g, ' ')} place icon`;
 </script>
 
 <template>
@@ -70,19 +69,7 @@ const iconLabel = (icon: string): string => `${icon.replace(/[-_]+/g, ' ')} plac
     <div class="trip-editor-grid">
       <fieldset class="trip-editor-field trip-editor-place-icon-field">
         <legend>Icon</legend>
-        <div class="trip-editor-place-icon-grid" role="radiogroup" aria-label="Icon">
-          <label
-            v-for="icon in props.state.options.iconNames"
-            :key="icon"
-            class="trip-editor-place-icon-choice"
-            :class="{ 'trip-editor-place-icon-choice--selected': props.draft.iconName === icon }"
-            :title="iconLabel(icon)"
-          >
-            <input v-model="props.draft.iconName" class="trip-editor-place-icon-choice__input" type="radio" name="iconName" :value="icon" :aria-label="iconLabel(icon)" />
-            <img :src="placeMarkerIconUrl(icon, props.draft.markerColor || 'bg-blue')" width="24" height="39" alt="" data-place-icon-choice />
-            <span>{{ icon }}</span>
-          </label>
-        </div>
+        <IconSelector v-model="props.draft.iconName" :icons="props.state.options.iconNames" :marker-color="props.draft.markerColor || 'bg-blue'" />
         <small v-for="message in props.fieldErrors('iconName')" :key="message">{{ message }}</small>
       </fieldset>
       <fieldset class="trip-editor-field trip-editor-marker-color-field">

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -16,6 +16,12 @@ import { stopPlaceCoordinatePick, type PlaceCoordinateMapWorkState, type PlaceCo
 import { mutationFeedbackClass, useEditorMutationFeedback } from './useEditorMutationFeedback';
 import type { EditorArea, EditorAreaDraft, EditorAreaSaveRequest, EditorGeocodeSearchResult, EditorMutationResult, EditorPlace, EditorPlaceDraft, EditorPlaceSaveRequest, EditorRegion, EditorRegionSaveRequest, EditorTripState, Guid } from '../types';
 
+type PlaceDraftPreview = {
+  iconName: string;
+  markerColor: string;
+  placeId: Guid;
+};
+
 const props = defineProps<{
   state: EditorTripState;
   editorSurface: EditorSurfaceController;
@@ -36,6 +42,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   mutationApplied: [result: EditorMutationResult<unknown>];
   dirtyStateChanged: [isDirty: boolean];
+  placeDraftPreviewChanged: [preview: PlaceDraftPreview | null];
   searchAddOpened: [requestId: number];
 }>();
 
@@ -116,6 +123,21 @@ const renderedAreaIdsByRegionId = computed(() => {
   }
 
   return result;
+});
+const placePreview = computed<PlaceDraftPreview | null>(() => {
+  if (!placeDraft.id || !activePlace.value || !isPlaceEditOpen(activePlace.value)) {
+    return null;
+  }
+
+  return {
+    placeId: placeDraft.id,
+    iconName: placeDraft.iconName || activePlace.value.iconName,
+    markerColor: placeDraft.markerColor || 'bg-blue'
+  };
+});
+const placePreviewById = computed<Record<Guid, Pick<EditorPlace, 'iconName' | 'markerColor'>>>(() => {
+  const preview = placePreview.value;
+  return preview ? { [preview.placeId]: { iconName: preview.iconName, markerColor: preview.markerColor } } : {};
 });
 const forcedExpandedRegionIds = computed(() => {
   const ids = props.searchActive ? renderedRegions.value.map(region => region.id) : activeContextRegions().map(region => region.id);
@@ -235,6 +257,12 @@ watch(
 );
 
 watch(
+  placePreview,
+  preview => emit('placeDraftPreviewChanged', preview),
+  { immediate: true }
+);
+
+watch(
   () => props.pendingSearchAdd?.requestId,
   async requestId => {
     if (!requestId || !props.pendingSearchAdd) {
@@ -275,6 +303,7 @@ onUnmounted(() => {
   stopPlaceCoordinatePick(placeCoordinateMapWork);
   stopAreaPolygonEdit(areaPolygonMapWork);
   emit('dirtyStateChanged', false);
+  emit('placeDraftPreviewChanged', null);
   window.removeEventListener('beforeunload', confirmUnload);
 });
 
@@ -437,7 +466,7 @@ async function selectAndOpenPlaceEdit(place: EditorPlace): Promise<void> {
 
     <RegionEditorSurface v-if="isDraftOpen && !draft.id" :active-region="activeRegion" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="regionFormId" :form-summary-errors="formSummaryErrors" :is-dirty="regionDirty" :is-saving="isSaving" :status-text="statusText" :target="activeRegionTarget" @cancel="cancelDraft" @delete="deleteDraftRegion" @reset="resetDraft" @save="saveDraft" />
 
-    <RegionPlaceList :key="regionListKey" :active-area-id="activeArea?.id ?? null" :active-place-editor-id="activePlaceEditorId" :active-place-id="selectedPlaceId" :active-region-id="activeRegion?.id ?? null" :force-expanded-region-ids="forcedExpandedRegionIds" :is-ordering="isOrdering" :is-saving="isSaving" :place-ids-by-region-id="renderedPlaceIdsByRegionId" :area-ids-by-region-id="renderedAreaIdsByRegionId" :regions="renderedRegions" :search-active="searchActive" :state="state" @add-area="openAreaCreate" @add-place="openPlaceCreate" @area-reorder="reorderAreas" @edit-area="openAreaEdit" @edit-place="selectAndOpenPlaceEdit" @edit-region="openEdit" @place-reorder="reorderPlaces" @region-reorder="reorderRegions" @select-place="selectPlace">
+    <RegionPlaceList :key="regionListKey" :active-area-id="activeArea?.id ?? null" :active-place-editor-id="activePlaceEditorId" :active-place-id="selectedPlaceId" :active-region-id="activeRegion?.id ?? null" :force-expanded-region-ids="forcedExpandedRegionIds" :is-ordering="isOrdering" :is-saving="isSaving" :place-ids-by-region-id="renderedPlaceIdsByRegionId" :place-preview-by-id="placePreviewById" :area-ids-by-region-id="renderedAreaIdsByRegionId" :regions="renderedRegions" :search-active="searchActive" :state="state" @add-area="openAreaCreate" @add-place="openPlaceCreate" @area-reorder="reorderAreas" @edit-area="openAreaEdit" @edit-place="selectAndOpenPlaceEdit" @edit-region="openEdit" @place-reorder="reorderPlaces" @region-reorder="reorderRegions" @select-place="selectPlace">
       <template #region-editor="{ region }">
         <RegionEditorSurface v-if="isRegionEditOpen(region)" :active-region="activeRegion" :controller="editorSurface" :draft="draft" :field-errors="fieldErrors" :form-id="regionFormId" :form-summary-errors="formSummaryErrors" :is-dirty="regionDirty" :is-saving="isSaving" :status-text="statusText" :target="activeRegionTarget" @cancel="cancelDraft" @delete="deleteDraftRegion" @reset="resetDraft" @save="saveDraft" />
       </template>

--- a/ClientApps/trip-editor/src/components/RegionPlaceList.vue
+++ b/ClientApps/trip-editor/src/components/RegionPlaceList.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
   isOrdering: boolean;
   isSaving: boolean;
   placeIdsByRegionId: Record<Guid, Guid[]>;
+  placePreviewById: Record<Guid, Pick<EditorPlace, 'iconName' | 'markerColor'>>;
   regions: EditorRegion[];
   searchActive: boolean;
   state: EditorTripState;
@@ -200,6 +201,12 @@ function orderedPlaces(regionId: Guid): EditorPlace[] {
   return (props.placeIdsByRegionId[regionId] ?? []).map(id => props.state.placesById[id]).filter(Boolean) as EditorPlace[];
 }
 
+/// Applies active place draft display values without mutating persisted editor state.
+function displayPlace(place: EditorPlace): EditorPlace {
+  const preview = props.placePreviewById[place.id];
+  return preview ? { ...place, ...preview } : place;
+}
+
 function orderedAreas(regionId: Guid): EditorArea[] {
   return (props.areaIdsByRegionId[regionId] ?? []).map(id => props.state.areasById[id]).filter(Boolean) as EditorArea[];
 }
@@ -299,7 +306,7 @@ function toggleRegion(regionId: Guid): void {
               <span aria-hidden="true">::</span>
             </button>
             <span class="trip-editor-place-row__icon" aria-hidden="true">
-              <img :src="placeMarkerIconUrl(place.iconName, place.markerColor)" width="24" height="39" alt="" data-sidebar-place-icon />
+              <img :src="placeMarkerIconUrl(displayPlace(place).iconName, displayPlace(place).markerColor)" width="24" height="39" alt="" data-sidebar-place-icon />
               <span v-if="place.visitSummary.isVisited" class="trip-editor-place-row__visit-badge">{{ place.visitSummary.visitCount === 1 ? '✓' : place.visitSummary.visitCount }}</span>
             </span>
             <span class="trip-editor-place-row__content">

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -15,6 +15,12 @@ type SidebarSearchResult = {
   areasByRegionId: Record<Guid, Guid[]>;
 };
 
+type PlaceDraftPreview = {
+  iconName: string;
+  markerColor: string;
+  placeId: Guid;
+};
+
 const props = defineProps<{
   state: EditorTripState;
   editorSurface: EditorSurfaceController;
@@ -40,6 +46,7 @@ const emit = defineEmits<{
   mutationApplied: [result: EditorMutationResult<unknown>];
   regionDraftDirtyChanged: [isDirty: boolean];
   hiddenSegmentIdsChanged: [ids: Set<Guid>];
+  placeDraftPreviewChanged: [preview: PlaceDraftPreview | null];
   searchAddOpened: [requestId: number];
 }>();
 
@@ -215,6 +222,7 @@ function normalize(value: string): string {
       :clear-selected-place="clearSelectedPlace"
       @mutation-applied="result => emit('mutationApplied', result)"
       @dirty-state-changed="isDirty => emit('regionDraftDirtyChanged', isDirty)"
+      @place-draft-preview-changed="preview => emit('placeDraftPreviewChanged', preview)"
       @search-add-opened="requestId => emit('searchAddOpened', requestId)"
     />
 

--- a/ClientApps/trip-editor/src/components/regionPlaceDrafts.ts
+++ b/ClientApps/trip-editor/src/components/regionPlaceDrafts.ts
@@ -44,7 +44,7 @@ export function buildRegionRequest(value: RegionDraft): EditorRegionSaveRequest 
 }
 
 export function emptyPlaceDraft(regionId: string | null = null): EditorPlaceDraft {
-  return { id: null, regionId, name: '', notesHtml: '', address: '', latitude: '', longitude: '', iconName: '', markerColor: '', reverseGeocode: false };
+  return { id: null, regionId, name: '', notesHtml: '', address: '', latitude: '', longitude: '', iconName: '', markerColor: 'bg-blue', reverseGeocode: false };
 }
 
 export function toPlaceDraft(place: EditorPlace | null, fallbackRegionId: string | null): EditorPlaceDraft {

--- a/ClientApps/trip-editor/src/iconSelector.css
+++ b/ClientApps/trip-editor/src/iconSelector.css
@@ -1,0 +1,118 @@
+.trip-editor-icon-selector {
+  min-width: 0;
+  position: relative;
+}
+
+.trip-editor-icon-selector__trigger {
+  align-items: center;
+  background: var(--trip-editor-field-bg);
+  border: 1px solid var(--trip-editor-field-border);
+  border-radius: 6px;
+  color: var(--trip-editor-text);
+  cursor: pointer;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+  min-height: 3.25rem;
+  min-width: 0;
+  padding: 0.35rem 0.55rem;
+  text-align: left;
+  width: 100%;
+}
+
+.trip-editor-icon-selector__trigger:focus-visible,
+.trip-editor-icon-selector__search:focus {
+  border-color: #93c5fd;
+  outline: 2px solid rgba(147, 197, 253, 0.55);
+  outline-offset: 2px;
+}
+
+.trip-editor-icon-selector__selected {
+  align-items: center;
+  display: flex;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.trip-editor-icon-selector__selected-name,
+.trip-editor-icon-selector__option span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trip-editor-icon-selector__chevron {
+  color: var(--trip-editor-muted);
+  flex: 0 0 auto;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.trip-editor-icon-selector__panel {
+  background: var(--trip-editor-surface);
+  border: 1px solid var(--trip-editor-border);
+  border-radius: 6px;
+  box-shadow: 0 0.75rem 1.75rem rgba(15, 23, 42, 0.24);
+  display: grid;
+  gap: 0.45rem;
+  left: 0;
+  margin-top: 0.35rem;
+  max-width: 100%;
+  min-width: 0;
+  padding: 0.5rem;
+  position: absolute;
+  right: 0;
+  z-index: 1080;
+}
+
+.trip-editor-icon-selector__search {
+  background: var(--trip-editor-field-bg);
+  border: 1px solid var(--trip-editor-field-border);
+  border-radius: 6px;
+  color: var(--trip-editor-text);
+  min-width: 0;
+  padding: 0.45rem 0.55rem;
+  width: 100%;
+}
+
+.trip-editor-icon-selector__options {
+  display: grid;
+  gap: 0.2rem;
+  list-style: none;
+  margin: 0;
+  max-height: min(16rem, 42vh);
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.trip-editor-icon-selector__option {
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--trip-editor-text);
+  cursor: pointer;
+  display: flex;
+  gap: 0.55rem;
+  min-width: 0;
+  padding: 0.35rem 0.45rem;
+}
+
+.trip-editor-icon-selector__option--active,
+.trip-editor-icon-selector__option[aria-selected="true"] {
+  background: rgba(13, 110, 253, 0.12);
+  border-color: rgba(13, 110, 253, 0.32);
+}
+
+.trip-editor-icon-selector__empty {
+  color: var(--trip-editor-muted);
+  padding: 0.5rem;
+}
+
+@media (max-width: 575.98px) {
+  .trip-editor-icon-selector__panel {
+    position: static;
+  }
+}

--- a/ClientApps/trip-editor/src/iconSelector.css
+++ b/ClientApps/trip-editor/src/iconSelector.css
@@ -31,6 +31,7 @@
   align-items: center;
   display: flex;
   gap: 0.55rem;
+  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -58,7 +59,8 @@
   gap: 0.45rem;
   left: 0;
   margin-top: 0.35rem;
-  max-width: 100%;
+  max-width: min(100%, calc(100vw - 2rem));
+  min-inline-size: min(22rem, calc(100vw - 2rem));
   min-width: 0;
   padding: 0.5rem;
   position: absolute;
@@ -81,11 +83,21 @@
   gap: 0.2rem;
   list-style: none;
   margin: 0;
-  max-height: min(16rem, 42vh);
+  max-height: min(12.5rem, 34vh);
   min-width: 0;
   overflow-x: hidden;
   overflow-y: auto;
   padding: 0;
+}
+
+.trip-editor-icon-selector__swatch {
+  background: var(--map-icon-bg, #0d6efd);
+  border: 1px solid color-mix(in srgb, var(--trip-editor-text) 22%, transparent);
+  border-radius: 999px;
+  display: inline-block;
+  flex: 0 0 auto;
+  height: 1.35rem;
+  width: 1.35rem;
 }
 
 .trip-editor-icon-selector__option {
@@ -113,6 +125,8 @@
 
 @media (max-width: 575.98px) {
   .trip-editor-icon-selector__panel {
-    position: static;
+    left: 0;
+    min-inline-size: 100%;
+    right: 0;
   }
 }

--- a/ClientApps/trip-editor/src/main.ts
+++ b/ClientApps/trip-editor/src/main.ts
@@ -6,6 +6,7 @@ import './theme.css';
 import './map.css';
 import './styles.css';
 import './surfaces.css';
+import './iconSelector.css';
 import './richNotes.css';
 import './visitProgress.css';
 

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -17,6 +17,7 @@ export type InitialMapViewSource = 'url' | 'saved' | 'fit-bounds' | 'fallback';
 interface TripEditorMapAdapter {
   render: (state: EditorTripState, hiddenSegmentIds?: ReadonlySet<Guid>, selectedPlaceId?: Guid | null) => void;
   applyPlaceDraftCoordinate: (placeId: Guid, coordinate: EditorCoordinate) => void;
+  applyPlaceDraftMarker: (state: EditorTripState, placeId: Guid, preview: Pick<EditorPlace, 'iconName' | 'markerColor'> | null) => void;
   clearSearchPreview: () => void;
   selectPlace: (state: EditorTripState, placeId: Guid | null, options?: SelectPlaceOptions) => void;
   startCoordinatePick: (options: CoordinatePickOptions) => () => void;
@@ -109,6 +110,16 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
       marker.setLatLng([coordinate.latitude, coordinate.longitude]);
       applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
       updateMapViewDataset();
+    },
+    applyPlaceDraftMarker: (state, placeId, preview) => {
+      const marker = placeMarkers.get(placeId);
+      const place = state.placesById[placeId];
+      if (!marker || !place) {
+        return;
+      }
+
+      marker.setIcon(placeMarkerIcon(preview ? { ...place, ...preview } : place));
+      applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
     },
     clearSearchPreview: searchPreview.clear,
     selectPlace: (state, placeId, selectOptions = {}) => {

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -318,8 +318,7 @@ body {
 
 .trip-editor-region-card--shadow { border-style: dashed; }
 
-.trip-editor-region-card--active,
-.trip-editor-place-row--active {
+.trip-editor-region-card--active {
   background: color-mix(in srgb, var(--trip-editor-accent) 14%, var(--trip-editor-card-strong));
   border-color: color-mix(in srgb, var(--trip-editor-accent) 58%, var(--trip-editor-border));
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--trip-editor-accent) 34%, transparent);
@@ -400,8 +399,16 @@ body {
 }
 
 .trip-editor-place-row {
+  border: 2px solid transparent;
+  border-left-width: 4px;
   cursor: pointer;
   display: flex;
+}
+
+.trip-editor-place-row--active {
+  background: color-mix(in srgb, var(--trip-editor-accent) 16%, var(--trip-editor-card-strong));
+  border-color: color-mix(in srgb, var(--trip-editor-accent) 66%, var(--trip-editor-border));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--trip-editor-accent) 28%, transparent);
 }
 
 .trip-editor-place-row:focus-visible {

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -183,48 +183,6 @@ body {
   padding: 0;
 }
 
-.trip-editor-place-icon-grid {
-  display: grid;
-  gap: 0.45rem;
-  grid-template-columns: repeat(auto-fill, minmax(5.25rem, 1fr));
-  max-height: 14rem;
-  min-width: 0;
-  overflow: auto;
-}
-
-.trip-editor-place-icon-choice {
-  align-items: center;
-  background: var(--trip-editor-field-bg);
-  border: 1px solid var(--trip-editor-field-border);
-  border-radius: 6px;
-  cursor: pointer;
-  display: grid;
-  gap: 0.25rem;
-  justify-items: center;
-  margin: 0;
-  min-width: 0;
-  padding: 0.4rem;
-}
-
-.trip-editor-place-icon-choice--selected {
-  border-color: #bfdbfe;
-  box-shadow: 0 0 0 2px rgba(147, 197, 253, 0.35);
-}
-
-.trip-editor-place-icon-choice__input {
-  height: 1px;
-  opacity: 0;
-  position: absolute;
-  width: 1px;
-}
-
-.trip-editor-place-icon-choice span {
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .trip-editor-marker-swatch-group {
   display: flex;
   flex-wrap: wrap;

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -169,6 +169,12 @@ body {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.trip-editor-selector-grid {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .trip-editor-marker-color-field {
   border: 0;
   margin: 0;
@@ -181,50 +187,6 @@ body {
   margin: 0;
   min-width: 0;
   padding: 0;
-}
-
-.trip-editor-marker-swatch-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.trip-editor-marker-swatch {
-  align-items: center;
-  border: 2px solid transparent;
-  border-radius: 6px;
-  cursor: pointer;
-  display: inline-flex;
-  height: 2.1rem;
-  justify-content: center;
-  margin: 0;
-  width: 2.1rem;
-}
-
-.trip-editor-marker-swatch--selected {
-  border-color: #bfdbfe;
-  box-shadow: 0 0 0 2px rgba(147, 197, 253, 0.35);
-}
-
-.trip-editor-marker-swatch__input {
-  height: 1px;
-  opacity: 0;
-  position: absolute;
-  width: 1px;
-}
-
-.trip-editor-marker-swatch__sample {
-  background: var(--map-icon-bg, #0d6efd);
-  border: 1px solid rgba(255, 255, 255, 0.65);
-  border-radius: 999px;
-  display: block;
-  height: 1.35rem;
-  width: 1.35rem;
-}
-
-.trip-editor-marker-swatch:focus-within {
-  outline: 2px solid #93c5fd;
-  outline-offset: 2px;
 }
 
 .trip-editor-actions {

--- a/ClientApps/trip-editor/src/surfaces.css
+++ b/ClientApps/trip-editor/src/surfaces.css
@@ -112,7 +112,7 @@
 .trip-editor-place-editor-row .trip-editor-surface--docked {
   contain: layout paint;
   grid-template-rows: auto minmax(0, 1fr) auto;
-  height: min(42rem, calc(100vh - 10rem));
+  height: min(46rem, calc(100vh - 8rem));
   overflow: hidden;
 }
 
@@ -128,7 +128,7 @@
 
 .trip-editor-place-editor-row .trip-editor-surface-context--map-work {
   align-content: start;
-  height: min(42rem, calc(100vh - 10rem));
+  height: min(46rem, calc(100vh - 8rem));
   overflow: hidden;
 }
 

--- a/ClientApps/trip-editor/src/theme.css
+++ b/ClientApps/trip-editor/src/theme.css
@@ -1,13 +1,13 @@
 :root {
-  --trip-editor-bg: var(--bs-body-bg, #f8fafc);
-  --trip-editor-surface: var(--bs-tertiary-bg, #ffffff);
-  --trip-editor-surface-muted: var(--bs-secondary-bg, #eef2f7);
+  --trip-editor-bg: color-mix(in srgb, var(--bs-body-bg, #f8fafc) 86%, #e2e8f0);
+  --trip-editor-surface: color-mix(in srgb, var(--bs-tertiary-bg, #ffffff) 90%, #e2e8f0);
+  --trip-editor-surface-muted: color-mix(in srgb, var(--bs-secondary-bg, #eef2f7) 86%, #cbd5e1);
   --trip-editor-border: var(--bs-border-color, rgba(15, 23, 42, 0.14));
   --trip-editor-card: color-mix(in srgb, var(--bs-body-color, #111827) 4%, transparent);
   --trip-editor-card-strong: color-mix(in srgb, var(--bs-body-color, #111827) 8%, transparent);
   --trip-editor-text: var(--bs-body-color, #111827);
   --trip-editor-muted: var(--bs-secondary-color, #64748b);
-  --trip-editor-field-bg: var(--bs-body-bg, #ffffff);
+  --trip-editor-field-bg: color-mix(in srgb, var(--bs-body-bg, #ffffff) 92%, #e2e8f0);
   --trip-editor-field-border: var(--bs-border-color, #cbd5e1);
   --trip-editor-accent: var(--bs-primary, #0d6efd);
   --trip-editor-danger-bg: var(--bs-danger-bg-subtle, rgba(220, 53, 69, 0.12));

--- a/tests/Wayfarer.Tests/Tools/LocCheckRunnerTests.cs
+++ b/tests/Wayfarer.Tests/Tools/LocCheckRunnerTests.cs
@@ -121,6 +121,7 @@ public sealed class LocCheckRunnerTests : IDisposable
     [Fact]
     public void Run_IgnoresExcludedFilesAndPaths()
     {
+        WriteLines(".local/publish/wwwroot/lib/vendor.js", 100);
         WriteLines("Migrations/Generated.cs", 100);
         WriteLines("wwwroot/lib/vendor.js", 100);
         WriteLines("wwwroot/dist/app.js", 100);

--- a/tests/e2e/trip-editor/tripEditorIconSelector.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorIconSelector.spec.ts
@@ -10,6 +10,19 @@ import {
 
 type MutableEditorState = Record<string, any>;
 
+type TripEditorContainmentMetrics = {
+  bodyHeight: number;
+  documentHeight: number;
+  footerTop: number | null;
+  sidebarClientHeight: number;
+  sidebarOverflowY: string;
+  sidebarScrollHeight: number;
+  surfaceBodyOverflowY: string;
+  viewportHeight: number;
+  viewportWidth: number;
+  workspaceHeight: number;
+};
+
 const regionId = '00000000-0000-0000-0000-000000288301';
 const placeId = '00000000-0000-0000-0000-000000288302';
 const iconNames = [
@@ -24,8 +37,12 @@ test.describe('Trip Editor icon selector', () => {
     await signIn(page);
     const requests: Record<string, any>[] = [];
     await loadWorkspaceWithIconFixture(page, requests);
+    const beforePlaceEdit = await tripEditorContainmentMetrics(page);
 
     await openPlace(page);
+    await expectSelectedPlaceRowProminent(page);
+    await expectDockedEditorComfortable(page);
+    await expectTripEditorContainment(page, beforePlaceEdit);
     const iconSelector = page.locator('[data-selector-kind="icon"]');
     const colorSelector = page.locator('[data-selector-kind="color"]');
     await expect(iconSelector.locator('[data-icon-selector-selected-name]')).toHaveText('camera');
@@ -36,10 +53,13 @@ test.describe('Trip Editor icon selector', () => {
     await expectIconSelectorOptionsRender(page);
     await expectIconSelectorScrolls(page);
     await expectSelectorPanelContained(page);
+    await expectDockedEditorComfortable(page);
     await expectNoPageOverflow(page);
     await captureEvidence(page, testInfo, 'desktop-light-icon-selector-open');
 
     await setTheme(page, 'dark');
+    await expectSelectedPlaceRowProminent(page);
+    await expectDockedEditorComfortable(page);
     await expectNoPageOverflow(page);
     await captureEvidence(page, testInfo, 'desktop-dark-icon-selector-open');
     await setTheme(page, 'light');
@@ -88,9 +108,13 @@ test.describe('Trip Editor icon selector', () => {
     await page.setViewportSize({ width: 390, height: 900 });
     await openIconSelector(page);
     await expectSelectorPanelContained(page);
+    await expectDockedEditorComfortable(page);
+    await expectTripEditorContainment(page, await tripEditorContainmentMetrics(page));
     await expectNoPageOverflow(page);
     await captureEvidence(page, testInfo, 'narrow-light-icon-selector-open');
     await setTheme(page, 'dark');
+    await expectSelectedPlaceRowProminent(page);
+    await expectDockedEditorComfortable(page);
     await expectNoPageOverflow(page);
     await captureEvidence(page, testInfo, 'narrow-dark-icon-selector-open');
   });
@@ -225,6 +249,92 @@ async function expectSelectorPanelContained(page: Page): Promise<void> {
   expect(metrics.panelWidth, 'Open selector should have a comfortable row width.').toBeGreaterThanOrEqual(Math.min(300, metrics.formWidth - 4));
   expect(metrics.panelRight, 'Open selector should stay inside the viewport.').toBeLessThanOrEqual(metrics.viewportWidth + 1);
   expect(metrics.panelRight, 'Open selector should stay inside the editor surface.').toBeLessThanOrEqual(metrics.surfaceRight + 1);
+}
+
+async function expectSelectedPlaceRowProminent(page: Page): Promise<void> {
+  const row = page.locator(`[data-place-id="${placeId}"]`);
+  await expect(row).toHaveClass(/trip-editor-place-row--active/);
+  const styles = await row.evaluate(element => {
+    const computed = window.getComputedStyle(element);
+    return {
+      backgroundColor: computed.backgroundColor,
+      borderColor: computed.borderLeftColor,
+      borderLeftWidth: Number.parseFloat(computed.borderLeftWidth),
+      borderTopWidth: Number.parseFloat(computed.borderTopWidth)
+    };
+  });
+  expect(styles.borderLeftWidth, 'Selected place row should have a prominent left selection indicator.').toBeGreaterThanOrEqual(4);
+  expect(styles.borderTopWidth, 'Selected place row should have a stronger selected-state border.').toBeGreaterThanOrEqual(2);
+  expect(styles.borderColor, 'Selected place row should use an accent border, not an error color.').not.toBe('rgb(220, 53, 69)');
+  expect(styles.backgroundColor, 'Selected place row should keep a visible selected-state background.').not.toBe('rgba(0, 0, 0, 0)');
+}
+
+async function expectDockedEditorComfortable(page: Page): Promise<void> {
+  const metrics = await page.locator('.trip-editor-place-editor-row .trip-editor-surface--docked').evaluate(surface => {
+    const surfaceBox = surface.getBoundingClientRect();
+    const body = surface.querySelector<HTMLElement>('.trip-editor-surface__body');
+    const bodyBox = body?.getBoundingClientRect();
+    const sidebar = document.querySelector<HTMLElement>('.trip-editor-sidebar');
+    return {
+      bodyHeight: bodyBox?.height ?? 0,
+      bodyOverflowY: body ? window.getComputedStyle(body).overflowY : '',
+      panelBottom: document.querySelector<HTMLElement>('[data-icon-selector-panel]')?.getBoundingClientRect().bottom ?? 0,
+      sidebarClientHeight: sidebar?.clientHeight ?? 0,
+      sidebarOverflowY: sidebar ? window.getComputedStyle(sidebar).overflowY : '',
+      sidebarScrollHeight: sidebar?.scrollHeight ?? 0,
+      surfaceHeight: surfaceBox.height,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth
+    };
+  });
+  const desktopMinimum = Math.min(660, metrics.viewportHeight - 140);
+  if (metrics.viewportWidth > 900) {
+    expect(metrics.surfaceHeight, 'Docked place editor should have enough height for selector controls and fields.').toBeGreaterThanOrEqual(desktopMinimum);
+    expect(metrics.bodyHeight, 'Docked place editor body should leave comfortable room for fields.').toBeGreaterThanOrEqual(420);
+  } else {
+    expect(metrics.sidebarScrollHeight, 'Narrow sidebar should keep editor overflow contained in sidebar scrolling.').toBeGreaterThan(metrics.sidebarClientHeight);
+  }
+
+  expect(metrics.bodyOverflowY, 'Docked place editor body should scroll internally.').toBe('auto');
+  expect(['auto', 'scroll']).toContain(metrics.sidebarOverflowY);
+  if (metrics.panelBottom > 0) {
+    expect(metrics.panelBottom, 'Open selector panel should stay inside the usable editor surface.').toBeLessThanOrEqual(metrics.viewportHeight + 1);
+  }
+}
+
+async function tripEditorContainmentMetrics(page: Page): Promise<TripEditorContainmentMetrics> {
+  return await page.evaluate(() => {
+    const sidebar = document.querySelector<HTMLElement>('.trip-editor-sidebar');
+    const surfaceBody = document.querySelector<HTMLElement>('.trip-editor-place-editor-row .trip-editor-surface__body');
+    const footer = document.querySelector<HTMLElement>('body footer, .footer');
+    const workspace = document.querySelector<HTMLElement>('.trip-editor-workspace');
+    return {
+      bodyHeight: document.body?.scrollHeight ?? 0,
+      documentHeight: document.documentElement.scrollHeight,
+      footerTop: footer ? footer.getBoundingClientRect().top : null,
+      sidebarClientHeight: sidebar?.clientHeight ?? 0,
+      sidebarOverflowY: sidebar ? window.getComputedStyle(sidebar).overflowY : '',
+      sidebarScrollHeight: sidebar?.scrollHeight ?? 0,
+      surfaceBodyOverflowY: surfaceBody ? window.getComputedStyle(surfaceBody).overflowY : '',
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+      workspaceHeight: workspace?.getBoundingClientRect().height ?? 0
+    };
+  });
+}
+
+async function expectTripEditorContainment(page: Page, before: TripEditorContainmentMetrics): Promise<void> {
+  const after = await tripEditorContainmentMetrics(page);
+  expect(after.documentHeight - before.documentHeight, 'Opening place edit and selector should not expand document height.').toBeLessThanOrEqual(80);
+  expect(after.bodyHeight - before.bodyHeight, 'Opening place edit and selector should not expand body height.').toBeLessThanOrEqual(80);
+  if (after.viewportWidth > 900) {
+    expect(after.workspaceHeight, 'Trip Editor workspace should remain bounded on desktop.').toBeLessThanOrEqual(after.viewportHeight + 1);
+  }
+  expect(after.sidebarScrollHeight, 'Place editor overflow should stay inside the sidebar/editor containers.').toBeGreaterThanOrEqual(after.sidebarClientHeight);
+  expect(after.surfaceBodyOverflowY, 'Docked place editor body should scroll internally.').toBe('auto');
+  if (before.footerTop !== null && after.footerTop !== null) {
+    expect(after.footerTop - before.footerTop, 'Opening place edit and selector should not push the footer down.').toBeLessThanOrEqual(80);
+  }
 }
 
 function sidebarPlaceIcon(page: Page): Locator {

--- a/tests/e2e/trip-editor/tripEditorIconSelector.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorIconSelector.spec.ts
@@ -26,13 +26,16 @@ test.describe('Trip Editor icon selector', () => {
     await loadWorkspaceWithIconFixture(page, requests);
 
     await openPlace(page);
-    const selector = page.locator('[data-icon-selector]');
-    await expect(selector.locator('[data-icon-selector-selected-name]')).toHaveText('camera');
-    await expectLoadedImages(selector.locator('[data-icon-selector-selected-image]'));
+    const iconSelector = page.locator('[data-selector-kind="icon"]');
+    const colorSelector = page.locator('[data-selector-kind="color"]');
+    await expect(iconSelector.locator('[data-icon-selector-selected-name]')).toHaveText('camera');
+    await expect(colorSelector.locator('[data-icon-selector-selected-name]')).toHaveText('Blue');
+    await expectLoadedImages(iconSelector.locator('[data-icon-selector-selected-image]'));
 
     await openIconSelector(page);
     await expectIconSelectorOptionsRender(page);
     await expectIconSelectorScrolls(page);
+    await expectSelectorPanelContained(page);
     await expectNoPageOverflow(page);
     await captureEvidence(page, testInfo, 'desktop-light-icon-selector-open');
 
@@ -44,9 +47,22 @@ test.describe('Trip Editor icon selector', () => {
     await filterIconSelector(page, 'star');
     await expectOnlyMatchingIconOptions(page, 'star');
     await page.locator('[data-icon-selector-search]').press('Enter');
-    await expect(selector.locator('[data-icon-selector-selected-name]')).toHaveText('star');
-    await expect(selector.locator('[data-icon-selector-selected-image]')).toHaveAttribute('src', /\/marker\/bg-blue\/star\.png$/);
-    await expectLoadedImages(selector.locator('[data-icon-selector-selected-image]'));
+    await expect(iconSelector.locator('[data-icon-selector-selected-name]')).toHaveText('star');
+    await expect(iconSelector.locator('[data-icon-selector-selected-image]')).toHaveAttribute('src', /\/marker\/bg-blue\/star\.png$/);
+    await expect(sidebarPlaceIcon(page)).toHaveAttribute('src', /\/marker\/bg-blue\/star\.png$/);
+    await expect(mapMarkerIcon(page)).toHaveAttribute('src', /\/marker\/bg-blue\/star\.png$/);
+    await expectLoadedImages(iconSelector.locator('[data-icon-selector-selected-image]'));
+
+    await openColorSelector(page);
+    await expectColorSelectorOptions(page);
+    await expectSelectorPanelContained(page);
+    await filterOpenSelector(page, 'purple');
+    await expectOnlyMatchingIconOptions(page, 'purple');
+    await page.locator('[data-selector-kind="color"] [data-icon-selector-search]').press('Enter');
+    await expect(colorSelector.locator('[data-icon-selector-selected-name]')).toHaveText('Purple');
+    await expect(iconSelector.locator('[data-icon-selector-selected-image]')).toHaveAttribute('src', /\/marker\/bg-purple\/star\.png$/);
+    await expect(sidebarPlaceIcon(page)).toHaveAttribute('src', /\/marker\/bg-purple\/star\.png$/);
+    await expect(mapMarkerIcon(page)).toHaveAttribute('src', /\/marker\/bg-purple\/star\.png$/);
 
     await openIconSelector(page);
     await page.locator('[data-icon-selector-search]').press('Escape');
@@ -59,16 +75,19 @@ test.describe('Trip Editor icon selector', () => {
     await page.getByRole('button', { name: 'Save Place' }).click();
     await expect.poll(() => requests.length).toBe(1);
     expect(requests[0].iconName).toBe('star');
+    expect(requests[0].markerColor).toBe('bg-purple');
     await expect(page.locator('.trip-editor-save-state').filter({ hasText: /Place saved/i }).first()).toBeVisible();
 
     await page.reload();
     await expectMountedWorkspace(page);
     await openPlace(page);
-    await expect(page.locator('[data-icon-selector-selected-name]')).toHaveText('star');
+    await expect(page.locator('[data-selector-kind="icon"] [data-icon-selector-selected-name]')).toHaveText('star');
+    await expect(page.locator('[data-selector-kind="color"] [data-icon-selector-selected-name]')).toHaveText('Purple');
     await expectLoadedImages(page.locator('[data-icon-selector-selected-image]'));
 
     await page.setViewportSize({ width: 390, height: 900 });
     await openIconSelector(page);
+    await expectSelectorPanelContained(page);
     await expectNoPageOverflow(page);
     await captureEvidence(page, testInfo, 'narrow-light-icon-selector-open');
     await setTheme(page, 'dark');
@@ -108,6 +127,7 @@ function prepareIconState(state: MutableEditorState): void {
   state.permissions.canEditRegions = true;
   state.permissions.canEditPlaces = true;
   state.options.iconNames = iconNames;
+  state.options.markerColorClasses = ['bg-blue', 'bg-purple', 'bg-black', 'bg-green', 'bg-red'];
   state.regionsById = { [regionId]: { id: regionId, tripId: state.tripId, name: 'Icon Selector Region', notesHtml: '', coverImage: null, center: null, displayOrder: 1, isShadow: false, capabilities: editableCapabilities() } };
   state.regionOrder = [regionId];
   state.placesById = { [placeId]: { id: placeId, tripId: state.tripId, regionId, name: 'Icon Selector Place', notesHtml: '<p>Place notes</p>', address: 'Athens, Greece', location: { latitude: 37.9838, longitude: 23.7275 }, iconName: 'camera', markerColor: 'bg-blue', displayOrder: 1, visitSummary: { placeId, visitCount: 0, isVisited: false, firstVisitAt: null, lastVisitAt: null }, capabilities: editableCapabilities() } };
@@ -138,14 +158,25 @@ async function openPlace(page: Page): Promise<void> {
 }
 
 async function openIconSelector(page: Page): Promise<void> {
-  await page.locator('[data-icon-selector-trigger]').click();
-  await expect(page.locator('[data-icon-selector-panel]')).toBeVisible();
-  await expect(page.locator('[data-icon-selector-search]')).toBeFocused();
+  await page.locator('[data-selector-kind="icon"] [data-icon-selector-trigger]').click();
+  await expect(page.locator('[data-selector-kind="icon"] [data-icon-selector-panel]')).toBeVisible();
+  await expect(page.locator('[data-selector-kind="icon"] [data-icon-selector-search]')).toBeFocused();
+}
+
+async function openColorSelector(page: Page): Promise<void> {
+  await page.locator('[data-selector-kind="color"] [data-icon-selector-trigger]').click();
+  await expect(page.locator('[data-selector-kind="color"] [data-icon-selector-panel]')).toBeVisible();
+  await expect(page.locator('[data-selector-kind="color"] [data-icon-selector-search]')).toBeFocused();
 }
 
 async function filterIconSelector(page: Page, query: string): Promise<void> {
-  await page.locator('[data-icon-selector-search]').fill(query);
+  await page.locator('[data-selector-kind="icon"] [data-icon-selector-search]').fill(query);
   await expect(page.locator('[data-icon-selector-option]').first()).toBeVisible();
+}
+
+async function filterOpenSelector(page: Page, query: string): Promise<void> {
+  await page.locator('[data-icon-selector-panel] [data-icon-selector-search]').fill(query);
+  await expect(page.locator('[data-icon-selector-panel] [data-icon-selector-option]').first()).toBeVisible();
 }
 
 async function expectIconSelectorOptionsRender(page: Page): Promise<void> {
@@ -162,13 +193,46 @@ async function expectOnlyMatchingIconOptions(page: Page, query: string): Promise
 }
 
 async function expectIconSelectorScrolls(page: Page): Promise<void> {
-  const metrics = await page.locator('[data-icon-selector-options]').evaluate(element => {
+  const metrics = await page.locator('[data-selector-kind="icon"] [data-icon-selector-options]').evaluate(element => {
     const styles = window.getComputedStyle(element);
     return { maxHeight: styles.maxHeight, overflowY: styles.overflowY, scrolls: element.scrollHeight > element.clientHeight };
   });
   expect(metrics.maxHeight, 'Icon options panel should enforce a max-height.').not.toBe('none');
   expect(metrics.overflowY, 'Icon options panel should scroll internally.').toBe('auto');
   expect(metrics.scrolls, 'Icon options panel should have internal scroll when many icons are available.').toBe(true);
+}
+
+async function expectColorSelectorOptions(page: Page): Promise<void> {
+  const optionNames = await page.locator('[data-selector-kind="color"] [data-icon-selector-option-name]').allTextContents();
+  expect(optionNames).toEqual(['Blue', 'Purple', 'Black', 'Green', 'Red']);
+  await expect(page.locator('[data-selector-kind="color"] [data-color-selector-option-swatch]')).toHaveCount(5);
+  await expect(page.locator('[data-selector-kind="color"] [data-icon-selector-search]')).toBeVisible();
+}
+
+async function expectSelectorPanelContained(page: Page): Promise<void> {
+  const metrics = await page.locator('[data-icon-selector-panel]').evaluate(panel => {
+    const panelBox = panel.getBoundingClientRect();
+    const formBox = document.querySelector<HTMLElement>('#trip-editor-place-form')?.getBoundingClientRect();
+    const surfaceBox = document.querySelector<HTMLElement>('.trip-editor-place-editor-row .trip-editor-surface')?.getBoundingClientRect();
+    return {
+      formWidth: formBox?.width ?? 0,
+      panelRight: panelBox.right,
+      panelWidth: panelBox.width,
+      surfaceRight: surfaceBox?.right ?? 0,
+      viewportWidth: document.documentElement.clientWidth
+    };
+  });
+  expect(metrics.panelWidth, 'Open selector should have a comfortable row width.').toBeGreaterThanOrEqual(Math.min(300, metrics.formWidth - 4));
+  expect(metrics.panelRight, 'Open selector should stay inside the viewport.').toBeLessThanOrEqual(metrics.viewportWidth + 1);
+  expect(metrics.panelRight, 'Open selector should stay inside the editor surface.').toBeLessThanOrEqual(metrics.surfaceRight + 1);
+}
+
+function sidebarPlaceIcon(page: Page): Locator {
+  return page.locator(`[data-place-id="${placeId}"] [data-sidebar-place-icon]`);
+}
+
+function mapMarkerIcon(page: Page): Locator {
+  return page.locator(`[data-place-marker-icon="${placeId}"]`);
 }
 
 async function expectLoadedImages(images: Locator): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorIconSelector.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorIconSelector.spec.ts
@@ -1,0 +1,206 @@
+import { expect, test, type Locator, type Page, type Route, type TestInfo } from '@playwright/test';
+import {
+  absoluteUrl,
+  editorApiPath,
+  editorPath,
+  expectMountedWorkspace,
+  loadEditorStateFixture,
+  signIn
+} from './tripEditorTestUtils';
+
+type MutableEditorState = Record<string, any>;
+
+const regionId = '00000000-0000-0000-0000-000000288301';
+const placeId = '00000000-0000-0000-0000-000000288302';
+const iconNames = [
+  'camera', 'star', 'marker', 'anchor', 'atm', 'barbecue', 'beach', 'bike', 'boat', 'camping', 'car', 'drink',
+  'eat', 'flag', 'flight', 'hotel', 'map', 'museum', 'park', 'parking', 'train', 'walk', 'water', 'wifi'
+];
+const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
+
+test.describe('Trip Editor icon selector', () => {
+  test('filters, selects, saves, and stays contained across responsive themes', async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await signIn(page);
+    const requests: Record<string, any>[] = [];
+    await loadWorkspaceWithIconFixture(page, requests);
+
+    await openPlace(page);
+    const selector = page.locator('[data-icon-selector]');
+    await expect(selector.locator('[data-icon-selector-selected-name]')).toHaveText('camera');
+    await expectLoadedImages(selector.locator('[data-icon-selector-selected-image]'));
+
+    await openIconSelector(page);
+    await expectIconSelectorOptionsRender(page);
+    await expectIconSelectorScrolls(page);
+    await expectNoPageOverflow(page);
+    await captureEvidence(page, testInfo, 'desktop-light-icon-selector-open');
+
+    await setTheme(page, 'dark');
+    await expectNoPageOverflow(page);
+    await captureEvidence(page, testInfo, 'desktop-dark-icon-selector-open');
+    await setTheme(page, 'light');
+
+    await filterIconSelector(page, 'star');
+    await expectOnlyMatchingIconOptions(page, 'star');
+    await page.locator('[data-icon-selector-search]').press('Enter');
+    await expect(selector.locator('[data-icon-selector-selected-name]')).toHaveText('star');
+    await expect(selector.locator('[data-icon-selector-selected-image]')).toHaveAttribute('src', /\/marker\/bg-blue\/star\.png$/);
+    await expectLoadedImages(selector.locator('[data-icon-selector-selected-image]'));
+
+    await openIconSelector(page);
+    await page.locator('[data-icon-selector-search]').press('Escape');
+    await expect(page.locator('[data-icon-selector-panel]')).toHaveCount(0);
+
+    await openIconSelector(page);
+    await page.keyboard.press('Tab');
+    await expect(page.locator('[data-icon-selector-panel]')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Save Place' }).click();
+    await expect.poll(() => requests.length).toBe(1);
+    expect(requests[0].iconName).toBe('star');
+    await expect(page.locator('.trip-editor-save-state').filter({ hasText: /Place saved/i }).first()).toBeVisible();
+
+    await page.reload();
+    await expectMountedWorkspace(page);
+    await openPlace(page);
+    await expect(page.locator('[data-icon-selector-selected-name]')).toHaveText('star');
+    await expectLoadedImages(page.locator('[data-icon-selector-selected-image]'));
+
+    await page.setViewportSize({ width: 390, height: 900 });
+    await openIconSelector(page);
+    await expectNoPageOverflow(page);
+    await captureEvidence(page, testInfo, 'narrow-light-icon-selector-open');
+    await setTheme(page, 'dark');
+    await expectNoPageOverflow(page);
+    await captureEvidence(page, testInfo, 'narrow-dark-icon-selector-open');
+  });
+});
+
+async function loadWorkspaceWithIconFixture(page: Page, requests: Record<string, any>[]): Promise<void> {
+  await page.unroute(editorApiMatcher).catch(() => undefined);
+  const state = await loadEditorStateFixture(page) as MutableEditorState;
+  prepareIconState(state);
+  await page.route(editorApiMatcher, async route => routeEditorState(route, state, requests));
+  await page.goto(absoluteUrl(editorPath));
+  await expectMountedWorkspace(page);
+}
+
+async function routeEditorState(route: Route, state: MutableEditorState, requests: Record<string, any>[]): Promise<void> {
+  const request = route.request();
+  if (request.method() === 'GET') {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+    return;
+  }
+
+  if (request.method() === 'PUT' && request.url().includes(`/places/${placeId}`)) {
+    const body = request.postDataJSON() as Record<string, any>;
+    requests.push(body);
+    state.placesById[placeId] = { ...state.placesById[placeId], ...body };
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mutationResult(state.placesById[placeId])) });
+    return;
+  }
+
+  throw new Error(`Unexpected icon selector mutation ${request.method()} ${request.url()}`);
+}
+
+function prepareIconState(state: MutableEditorState): void {
+  state.permissions.canEditRegions = true;
+  state.permissions.canEditPlaces = true;
+  state.options.iconNames = iconNames;
+  state.regionsById = { [regionId]: { id: regionId, tripId: state.tripId, name: 'Icon Selector Region', notesHtml: '', coverImage: null, center: null, displayOrder: 1, isShadow: false, capabilities: editableCapabilities() } };
+  state.regionOrder = [regionId];
+  state.placesById = { [placeId]: { id: placeId, tripId: state.tripId, regionId, name: 'Icon Selector Place', notesHtml: '<p>Place notes</p>', address: 'Athens, Greece', location: { latitude: 37.9838, longitude: 23.7275 }, iconName: 'camera', markerColor: 'bg-blue', displayOrder: 1, visitSummary: { placeId, visitCount: 0, isVisited: false, firstVisitAt: null, lastVisitAt: null }, capabilities: editableCapabilities() } };
+  state.placeOrderByRegionId = { [regionId]: [placeId] };
+  state.areasById = {};
+  state.areaOrderByRegionId = { [regionId]: [] };
+  state.segmentsById = {};
+  state.segmentOrder = [];
+}
+
+function mutationResult(data: Record<string, any>): Record<string, any> {
+  return {
+    success: true,
+    data,
+    affected: { metadata: null, regions: [], regionOrder: null, places: [data], placeOrdersByRegionId: {}, areas: [], areaOrdersByRegionId: {}, segments: [], segmentOrder: null, tags: [], tagOrder: null, visitProgress: null, options: null },
+    deletedIds: { regions: [], places: [], areas: [], segments: [], tags: [] },
+    warnings: []
+  };
+}
+
+function editableCapabilities(): Record<string, boolean> {
+  return { canEdit: true, canRename: true, canDelete: true, canReorder: true, canMove: true, canAddChildren: true, canTargetForSearchAdd: true };
+}
+
+async function openPlace(page: Page): Promise<void> {
+  await page.locator(`[data-place-id="${placeId}"]`).getByRole('button', { name: 'Edit', exact: true }).click();
+  await expect(page.getByRole('heading', { name: /Edit Place - Icon Selector Place/ })).toBeVisible();
+}
+
+async function openIconSelector(page: Page): Promise<void> {
+  await page.locator('[data-icon-selector-trigger]').click();
+  await expect(page.locator('[data-icon-selector-panel]')).toBeVisible();
+  await expect(page.locator('[data-icon-selector-search]')).toBeFocused();
+}
+
+async function filterIconSelector(page: Page, query: string): Promise<void> {
+  await page.locator('[data-icon-selector-search]').fill(query);
+  await expect(page.locator('[data-icon-selector-option]').first()).toBeVisible();
+}
+
+async function expectIconSelectorOptionsRender(page: Page): Promise<void> {
+  const options = page.locator('[data-icon-selector-option]');
+  await expect(options.first()).toBeVisible();
+  await expect(options.first().locator('[data-icon-selector-option-name]')).not.toHaveText('');
+  await expectLoadedImages(page.locator('[data-icon-selector-option-image]'));
+}
+
+async function expectOnlyMatchingIconOptions(page: Page, query: string): Promise<void> {
+  const optionNames = await page.locator('[data-icon-selector-option-name]').allTextContents();
+  expect(optionNames.length, 'Filtered icon selector should show at least one option.').toBeGreaterThan(0);
+  expect(optionNames.every(name => name.toLocaleLowerCase().includes(query)), 'Every filtered icon option should match the search query.').toBe(true);
+}
+
+async function expectIconSelectorScrolls(page: Page): Promise<void> {
+  const metrics = await page.locator('[data-icon-selector-options]').evaluate(element => {
+    const styles = window.getComputedStyle(element);
+    return { maxHeight: styles.maxHeight, overflowY: styles.overflowY, scrolls: element.scrollHeight > element.clientHeight };
+  });
+  expect(metrics.maxHeight, 'Icon options panel should enforce a max-height.').not.toBe('none');
+  expect(metrics.overflowY, 'Icon options panel should scroll internally.').toBe('auto');
+  expect(metrics.scrolls, 'Icon options panel should have internal scroll when many icons are available.').toBe(true);
+}
+
+async function expectLoadedImages(images: Locator): Promise<void> {
+  const count = await images.count();
+  expect(count, 'Expected at least one image to validate.').toBeGreaterThan(0);
+  for (let index = 0; index < count; index += 1) {
+    await expect.poll(async () => images.nth(index).evaluate(image => image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0)).toBe(true);
+  }
+}
+
+async function expectNoPageOverflow(page: Page): Promise<void> {
+  const overflow = await page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth;
+    const documentOverflow = document.documentElement.scrollWidth - viewportWidth;
+    const bodyOverflow = document.body ? document.body.scrollWidth - viewportWidth : 0;
+    const containerOverflow = ['#trip-editor-app', '.trip-editor-shell', '.trip-editor-workspace']
+      .map(selector => {
+        const element = document.querySelector<HTMLElement>(selector);
+        return { selector, overflow: element ? Math.max(0, element.getBoundingClientRect().right - viewportWidth) : 0 };
+      })
+      .filter(result => result.overflow > 2);
+    return { documentOverflow, bodyOverflow, containerOverflow };
+  });
+  expect(overflow.documentOverflow, 'Icon selector should not introduce horizontal document overflow.').toBeLessThanOrEqual(2);
+  expect(overflow.bodyOverflow, 'Icon selector should not introduce horizontal body overflow.').toBeLessThanOrEqual(2);
+  expect(overflow.containerOverflow, 'Stable Trip Editor containers should fit within the viewport.').toEqual([]);
+}
+
+async function setTheme(page: Page, theme: 'dark' | 'light'): Promise<void> {
+  await page.evaluate(value => document.documentElement.setAttribute('data-bs-theme', value), theme);
+}
+
+async function captureEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
+}

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -207,7 +207,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await captureEvidence(page, testInfo, 'expanded-docked-selected-place-preserved');
   });
 
-  test('shows icon choices and keeps long place names from overlapping actions', async ({ page }) => {
+  test('keeps long place names from overlapping actions', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await signIn(page);
     await loadWorkspaceWithMarkerFixture(page);
@@ -216,9 +216,6 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     await page.setViewportSize({ width: 390, height: 900 });
     await expectPlaceRowDoesNotOverlapEdit(page, firstPlaceId);
 
-    await sidebarRow(page, firstPlaceId).getByRole('button', { name: 'Edit', exact: true }).click();
-    await expect(page.locator('[data-place-icon-choice]').first()).toBeVisible();
-    await expectLoadedImages(page.locator('[data-place-icon-choice]').first());
   });
 
   test('renders notes images through the proxy while saving canonical external image URLs', async ({ page }) => {

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -170,10 +170,10 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     await expect(form.getByRole('status')).toContainText('Embedded data images are not allowed');
     await expect(editor.locator('img')).toHaveCount(0);
 
-    await editor.click();
     await editor.evaluate(element => {
       element.insertAdjacentHTML('beforeend', '<script>alert("x")</script><a href="javascript:alert(1)" onclick="alert(2)">Unsafe link</a><img src="javascript:alert(3)" onerror="alert(4)">');
     });
+    await focusEditorAtEnd(editor);
     await page.keyboard.type('Normalized rich note');
     await page.getByRole('button', { name: 'Save & Continue' }).click();
     await expect.poll(() => requests.length).toBe(1);
@@ -455,6 +455,20 @@ async function rejectImageDialogUrl(form: Locator, url: string): Promise<void> {
   await expect(dialog.getByText('Embedded data images are not allowed')).toBeVisible();
   await expect(form.getByRole('status')).toContainText('Embedded data images are not allowed');
   await dialog.getByRole('button', { name: 'Cancel' }).click();
+}
+
+// Restores a deterministic caret after tests inject HTML outside Quill's event pipeline.
+async function focusEditorAtEnd(editor: Locator): Promise<void> {
+  await editor.evaluate(element => {
+    element.focus();
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    range.collapse(false);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  });
+  await expect.poll(() => editor.evaluate(element => document.activeElement === element)).toBe(true);
 }
 
 async function openRegion(page: Page): Promise<void> {

--- a/tools/Wayfarer.LocCheck/SourceFileScanner.cs
+++ b/tools/Wayfarer.LocCheck/SourceFileScanner.cs
@@ -20,6 +20,7 @@ public sealed class SourceFileScanner
     {
         ".git",
         ".idea",
+        ".local",
         ".vs",
         "bin",
         "obj",


### PR DESCRIPTION
## Summary

- Replaces the place icon radio grid with a focused Vue icon selector component that shows the selected marker icon plus icon name.
- Adds searchable icon-name filtering, keyboard handling, max-height/internal option scrolling, and responsive dark/light containment.
- Keeps the existing `draft.iconName` binding and existing Place save request path; no backend/API, marker, popup, map search, route, or deployment behavior changed.

## #288 Batch 3 Design Translation

- Legacy behavior preserved: searchable/select-style icon choice, rendered marker icon plus name in each option, selected marker icon plus selected name, and icon value saved through the existing Place save flow.
- Legacy flaw improved: the old dropdown/list could grow with option count; the Vue selector caps the options panel height and scrolls internally.
- Vue-native selector design chosen: a compact Trip Editor combobox/listbox-style popover with the existing marker asset helper, app theme variables, Escape/Enter/Tab behavior, and responsive static placement at narrow widths.
- What remains unchanged: icon options still come from editor options, marker URLs still use existing `placeMarkerIconUrl`, and Place save semantics still send `iconName` through the existing endpoint.

## Validation

- `npm run build` passed; existing Vite chunk-size warning only.
- `dotnet build` passed; existing `ASP0000 BuildServiceProvider` warning only.
- `dotnet test` passed: 1535 passed.
- `npx playwright test --config=playwright.config.ts --list` passed: 94 tests listed.
- Focused Playwright passed: `tripEditorIconSelector.spec.ts`, `tripEditorMarkerParity.spec.ts`, `tripEditorVisualPolish.spec.ts` = 14 passed.
- Full Trip Editor E2E passed once on final candidate: `npm run test:e2e:trip-editor` = 93 passed, 1 skipped.
- LOC checker passed with warnings only; changed marker parity spec remains below the hard cap at 597 LOC.
- `rg "window\.confirm" ClientApps/trip-editor/src` had no hits.
- `rg "\bconfirm\(" ClientApps/trip-editor/src` shows shared-dialog usage only.
- `git diff --check origin/main...HEAD` passed.
- `git ls-files -- .local playwright-report test-results screenshots traces wwwroot/vite/trip-editor wwwroot/dist` returned no tracked generated artifacts.

## Screenshot / Evidence Paths

- `.local/playwright/test-output/tripEditorIconSelector-Tri-cc644-ed-across-responsive-themes-chromium/screenshots/desktop-light-icon-selector-open.png`
- `.local/playwright/test-output/tripEditorIconSelector-Tri-cc644-ed-across-responsive-themes-chromium/screenshots/desktop-dark-icon-selector-open.png`
- `.local/playwright/test-output/tripEditorIconSelector-Tri-cc644-ed-across-responsive-themes-chromium/screenshots/narrow-light-icon-selector-open.png`
- `.local/playwright/test-output/tripEditorIconSelector-Tri-cc644-ed-across-responsive-themes-chromium/screenshots/narrow-dark-icon-selector-open.png`

## Out Of Scope / Deferred Under #288

- Rich-notes insertion-space after large images.
- Map search/Add Place workflow redesign.
- Backend/API changes.
- Route/cutover/deployment changes.
- Marker rendering, popups, attribution, and Batch 2 presentation behavior unless a direct selector regression is found during review.

Leave this PR open and unmerged for manual published-bundle review.