### PR TITLE
Fix Trip Editor rich notes continuation polish

### DIFF
--- a/ClientApps/trip-editor/src/components/RichNotesEditor.vue
+++ b/ClientApps/trip-editor/src/components/RichNotesEditor.vue
@@ -59,7 +59,6 @@ onMounted(() => {
   loadHtml(props.modelValue);
   quill.on('selection-change', handleSelectionChange);
   quill.on('text-change', handleTextChange);
-  quill.root.addEventListener('mousedown', handleContinuationPointerDown);
   quill.root.addEventListener('paste', handlePaste);
   quill.root.addEventListener('drop', handleDrop);
   quill.root.addEventListener('input', handleInput);
@@ -77,7 +76,6 @@ onUnmounted(() => {
   quill.root.removeEventListener('paste', handlePaste);
   quill.root.removeEventListener('drop', handleDrop);
   quill.root.removeEventListener('input', handleInput);
-  quill.root.removeEventListener('mousedown', handleContinuationPointerDown);
   quill.off('selection-change', handleSelectionChange);
   quill.off('text-change', handleTextChange);
   quill = null;
@@ -103,6 +101,7 @@ function loadHtml(value: string): void {
   quill.setContents([], 'silent');
   quill.clipboard.dangerouslyPasteHTML(normalizeNotesHtml(value), 'silent');
   normalizeEditorImagesForDisplay();
+  ensureEditableContinuationLine();
   isLoadingExternalValue = false;
 }
 
@@ -121,40 +120,21 @@ function handleTextChange(): void {
     showFeedback('Embedded data images are not allowed. Use an external image URL.');
   }
 
+  ensureEditableContinuationLine();
   emit('update:modelValue', currentHtml());
 }
 
-/// Turns the editor-only continuation zone below the last block into a reliable caret target.
-function handleContinuationPointerDown(event: MouseEvent): void {
-  if (!quill || !isContinuationZonePointer(event)) {
-    return;
-  }
-
-  event.preventDefault();
-  focusContinuationAtEnd();
-}
-
-/// Places the caret after terminal content without letting Quill scroll the editor away from the clicked end.
-function focusContinuationAtEnd(): void {
+/// Adds a real editor-local trailing line so users can click and type after terminal rich content.
+function ensureEditableContinuationLine(): void {
   if (!quill) {
     return;
   }
 
-  const scrollTop = quill.root.scrollTop;
-  const index = Math.max(0, quill.getLength() - 1);
-  quill.root.focus({ preventScroll: true });
-  quill.setSelection(index, 0, 'silent');
-  savedRange = { index, length: 0 };
-  restoreEditorScroll(scrollTop);
-  window.requestAnimationFrame(() => restoreEditorScroll(scrollTop));
-}
-
-function restoreEditorScroll(scrollTop: number): void {
-  if (!quill) {
+  if (!normalizeNotesHtml(quill.root.innerHTML) || isLastEditorBlockBlank()) {
     return;
   }
 
-  quill.root.scrollTop = scrollTop;
+  quill.insertText(Math.max(0, quill.getLength() - 1), '\n', 'silent');
 }
 
 function handlePaste(event: ClipboardEvent): void {
@@ -188,13 +168,8 @@ function handleInput(): void {
   }
 }
 
-function isContinuationZonePointer(event: MouseEvent): boolean {
+function isLastEditorBlockBlank(): boolean {
   if (!quill || quill.root.children.length === 0) {
-    return false;
-  }
-
-  const rootBounds = quill.root.getBoundingClientRect();
-  if (event.clientY < rootBounds.top || event.clientY > rootBounds.bottom) {
     return false;
   }
 
@@ -203,7 +178,7 @@ function isContinuationZonePointer(event: MouseEvent): boolean {
     return false;
   }
 
-  return event.clientY > lastBlock.getBoundingClientRect().bottom;
+  return !lastBlock.textContent?.trim() && !lastBlock.querySelector('img, video, iframe');
 }
 
 function containsDataImage(data: DataTransfer): boolean {

--- a/ClientApps/trip-editor/src/components/RichNotesEditor.vue
+++ b/ClientApps/trip-editor/src/components/RichNotesEditor.vue
@@ -59,6 +59,7 @@ onMounted(() => {
   loadHtml(props.modelValue);
   quill.on('selection-change', handleSelectionChange);
   quill.on('text-change', handleTextChange);
+  quill.root.addEventListener('mousedown', handleContinuationPointerDown);
   quill.root.addEventListener('paste', handlePaste);
   quill.root.addEventListener('drop', handleDrop);
   quill.root.addEventListener('input', handleInput);
@@ -76,6 +77,7 @@ onUnmounted(() => {
   quill.root.removeEventListener('paste', handlePaste);
   quill.root.removeEventListener('drop', handleDrop);
   quill.root.removeEventListener('input', handleInput);
+  quill.root.removeEventListener('mousedown', handleContinuationPointerDown);
   quill.off('selection-change', handleSelectionChange);
   quill.off('text-change', handleTextChange);
   quill = null;
@@ -122,6 +124,17 @@ function handleTextChange(): void {
   emit('update:modelValue', currentHtml());
 }
 
+/// Turns the editor-only continuation zone below the last block into a reliable caret target.
+function handleContinuationPointerDown(event: MouseEvent): void {
+  if (!quill || !isContinuationZonePointer(event)) {
+    return;
+  }
+
+  event.preventDefault();
+  quill.focus();
+  quill.setSelection(Math.max(0, quill.getLength() - 1), 0, 'user');
+}
+
 function handlePaste(event: ClipboardEvent): void {
   const clipboard = event.clipboardData;
   if (!clipboard || !containsDataImage(clipboard)) {
@@ -151,6 +164,24 @@ function handleInput(): void {
     emit('update:modelValue', currentHtml());
     showFeedback('Embedded data images are not allowed. Use an external image URL.');
   }
+}
+
+function isContinuationZonePointer(event: MouseEvent): boolean {
+  if (!quill || quill.root.children.length === 0) {
+    return false;
+  }
+
+  const rootBounds = quill.root.getBoundingClientRect();
+  if (event.clientY < rootBounds.top || event.clientY > rootBounds.bottom) {
+    return false;
+  }
+
+  const lastBlock = quill.root.children.item(quill.root.children.length - 1);
+  if (!(lastBlock instanceof HTMLElement)) {
+    return false;
+  }
+
+  return event.clientY > lastBlock.getBoundingClientRect().bottom;
 }
 
 function containsDataImage(data: DataTransfer): boolean {

--- a/ClientApps/trip-editor/src/components/RichNotesEditor.vue
+++ b/ClientApps/trip-editor/src/components/RichNotesEditor.vue
@@ -131,8 +131,30 @@ function handleContinuationPointerDown(event: MouseEvent): void {
   }
 
   event.preventDefault();
-  quill.focus();
-  quill.setSelection(Math.max(0, quill.getLength() - 1), 0, 'user');
+  focusContinuationAtEnd();
+}
+
+/// Places the caret after terminal content without letting Quill scroll the editor away from the clicked end.
+function focusContinuationAtEnd(): void {
+  if (!quill) {
+    return;
+  }
+
+  const scrollTop = quill.root.scrollTop;
+  const index = Math.max(0, quill.getLength() - 1);
+  quill.root.focus({ preventScroll: true });
+  quill.setSelection(index, 0, 'silent');
+  savedRange = { index, length: 0 };
+  restoreEditorScroll(scrollTop);
+  window.requestAnimationFrame(() => restoreEditorScroll(scrollTop));
+}
+
+function restoreEditorScroll(scrollTop: number): void {
+  if (!quill) {
+    return;
+  }
+
+  quill.root.scrollTop = scrollTop;
 }
 
 function handlePaste(event: ClipboardEvent): void {

--- a/ClientApps/trip-editor/src/notes/notesHtml.ts
+++ b/ClientApps/trip-editor/src/notes/notesHtml.ts
@@ -25,6 +25,7 @@ export function normalizeNotesHtml(value: string): string {
 
     image.setAttribute('src', source);
   });
+  removeTrailingBlankParagraphs(template.content);
 
   const html = template.innerHTML.trim();
   return html === '<p><br></p>' ? '' : html;
@@ -113,6 +114,18 @@ function isAllowedImageSource(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+function removeTrailingBlankParagraphs(fragment: DocumentFragment): void {
+  let lastElement = fragment.lastElementChild;
+  while (lastElement instanceof HTMLParagraphElement && isBlankParagraph(lastElement)) {
+    lastElement.remove();
+    lastElement = fragment.lastElementChild;
+  }
+}
+
+function isBlankParagraph(element: HTMLParagraphElement): boolean {
+  return !element.textContent?.trim() && !element.querySelector('img, video, iframe');
 }
 
 function isUnsafeAttributeUrl(element: Element, name: string, value: string): boolean {

--- a/ClientApps/trip-editor/src/richNotes.css
+++ b/ClientApps/trip-editor/src/richNotes.css
@@ -27,10 +27,6 @@
   min-height: 9rem;
 }
 
-.trip-editor-rich-notes__editor.ql-container .ql-editor > p:last-child:has(> br:only-child) {
-  min-height: 5rem;
-}
-
 .trip-editor-rich-notes .ql-picker,
 .trip-editor-rich-notes .ql-stroke {
   color: var(--trip-editor-text);

--- a/ClientApps/trip-editor/src/richNotes.css
+++ b/ClientApps/trip-editor/src/richNotes.css
@@ -28,13 +28,7 @@
 }
 
 .trip-editor-rich-notes__editor.ql-container .ql-editor > p:last-child:has(> br:only-child) {
-  min-height: 2.75rem;
-}
-
-.trip-editor-rich-notes__editor.ql-container .ql-editor::after {
-  content: "";
-  display: block;
-  height: 3rem;
+  min-height: 5rem;
 }
 
 .trip-editor-rich-notes .ql-picker,

--- a/ClientApps/trip-editor/src/richNotes.css
+++ b/ClientApps/trip-editor/src/richNotes.css
@@ -27,6 +27,16 @@
   min-height: 9rem;
 }
 
+.trip-editor-rich-notes__editor.ql-container .ql-editor > p:last-child:has(> br:only-child) {
+  min-height: 2.75rem;
+}
+
+.trip-editor-rich-notes__editor.ql-container .ql-editor::after {
+  content: "";
+  display: block;
+  height: 3rem;
+}
+
 .trip-editor-rich-notes .ql-picker,
 .trip-editor-rich-notes .ql-stroke {
   color: var(--trip-editor-text);

--- a/ClientApps/trip-editor/src/theme.css
+++ b/ClientApps/trip-editor/src/theme.css
@@ -1,7 +1,7 @@
 :root {
-  --trip-editor-bg: color-mix(in srgb, var(--bs-body-bg, #f8fafc) 86%, #e2e8f0);
-  --trip-editor-surface: color-mix(in srgb, var(--bs-tertiary-bg, #ffffff) 90%, #e2e8f0);
-  --trip-editor-surface-muted: color-mix(in srgb, var(--bs-secondary-bg, #eef2f7) 86%, #cbd5e1);
+  --trip-editor-bg: color-mix(in srgb, var(--bs-body-bg, #ffffff) 96%, #e2e8f0);
+  --trip-editor-surface: color-mix(in srgb, var(--bs-tertiary-bg, #ffffff) 82%, #cbd5e1);
+  --trip-editor-surface-muted: color-mix(in srgb, var(--bs-secondary-bg, #eef2f7) 80%, #cbd5e1);
   --trip-editor-border: var(--bs-border-color, rgba(15, 23, 42, 0.14));
   --trip-editor-card: color-mix(in srgb, var(--bs-body-color, #111827) 4%, transparent);
   --trip-editor-card-strong: color-mix(in srgb, var(--bs-body-color, #111827) 8%, transparent);

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -526,14 +526,20 @@ async function rejectImageDialogUrl(form: Locator, url: string): Promise<void> {
 }
 
 async function clickContinuationSpaceWithoutScrollJump(editor: Locator): Promise<void> {
-  await editor.evaluate(element => {
+  const clickPoint = await editor.evaluate(element => {
     element.scrollIntoView({ block: 'center', inline: 'nearest' });
     element.scrollTop = element.scrollHeight;
+    const editorBounds = element.getBoundingClientRect();
+    const blocks = Array.from(element.children).filter(child => child.textContent?.trim() || child.querySelector('img, video, iframe'));
+    const lastBlock = blocks.at(-1);
+    const lastBlockBottom = lastBlock instanceof HTMLElement ? lastBlock.getBoundingClientRect().bottom : editorBounds.top;
+    return {
+      x: editorBounds.left + editorBounds.width / 2,
+      y: Math.min(lastBlockBottom + 16, editorBounds.bottom - 12)
+    };
   });
   const beforeClickScrollTop = await editor.evaluate(element => element.scrollTop);
-  const box = await editor.boundingBox();
-  expect(box, 'Rich notes editor should have a rendered box.').not.toBeNull();
-  await editor.page().mouse.click(box!.x + box!.width / 2, box!.y + box!.height - 12);
+  await editor.page().mouse.click(clickPoint.x, clickPoint.y);
   await expect.poll(() => editor.evaluate(element => document.activeElement === element)).toBe(true);
   const afterClickScrollTop = await editor.evaluate(element => element.scrollTop);
   expect(afterClickScrollTop, 'Continuation click should not jump the rich notes editor upward.').toBeGreaterThanOrEqual(beforeClickScrollTop - 4);

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -155,7 +155,7 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     const editor = richEditor(form).locator('.ql-editor');
     await expect(editor.locator('img')).toBeVisible();
     await expectContinuationSpace(editor);
-    await clickContinuationSpace(editor);
+    await clickContinuationSpaceWithoutScrollJump(editor);
     await page.keyboard.type('Continuation after image');
     await captureRichNotesEvidence(page, testInfo, 'docked-terminal-image-continuation');
     await page.getByRole('button', { name: 'Save & Continue' }).click();
@@ -170,8 +170,9 @@ test.describe.serial('Trip Editor rich notes parity', () => {
 
   test('expanded notes let users press Enter and continue after terminal content with clean save HTML', async ({ page }, testInfo) => {
     await signIn(page);
+    await routeRichNoteImages(page);
     const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
-      editorState.metadata.notesHtml = '<p>Terminal paragraph</p>';
+      editorState.metadata.notesHtml = terminalImageNotes();
     });
     const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
     await routeEditorMutations(page, state, requests);
@@ -179,9 +180,9 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     await page.getByRole('button', { name: 'Expand Editor' }).click();
     const dialog = page.getByRole('dialog', { name: /Edit Trip -/ });
     const editor = richEditor(dialog.locator('#trip-editor-metadata-form')).locator('.ql-editor');
+    await expect(editor.locator('img')).toBeVisible();
     await expectContinuationSpace(editor);
-    await clickContinuationSpace(editor);
-    await page.keyboard.press('Enter');
+    await clickContinuationSpaceWithoutScrollJump(editor);
     await page.keyboard.type('Expanded continuation');
     await captureRichNotesEvidence(page, testInfo, 'expanded-terminal-content-continuation');
     await dialog.getByRole('button', { name: 'Dock to sidebar' }).click();
@@ -189,7 +190,7 @@ test.describe.serial('Trip Editor rich notes parity', () => {
 
     await expect.poll(() => requests.length).toBe(1);
     const notesHtml = requests[0].body.notesHtml as string;
-    expectCanonicalNotes(notesHtml, ['Terminal paragraph', 'Expanded continuation']);
+    expectCanonicalNotes(notesHtml, ['Intro before image', 'https://images.example.test/terminal-large.svg', 'Expanded continuation']);
     expect(notesHtml).not.toContain('trip-editor-rich-notes__continuation');
     expect(notesHtml).not.toContain('editor-only');
     expect(notesHtml).not.toContain('<p><br></p><p><br></p>');
@@ -524,15 +525,18 @@ async function rejectImageDialogUrl(form: Locator, url: string): Promise<void> {
   await dialog.getByRole('button', { name: 'Cancel' }).click();
 }
 
-async function clickContinuationSpace(editor: Locator): Promise<void> {
+async function clickContinuationSpaceWithoutScrollJump(editor: Locator): Promise<void> {
   await editor.evaluate(element => {
     element.scrollIntoView({ block: 'center', inline: 'nearest' });
     element.scrollTop = element.scrollHeight;
   });
+  const beforeClickScrollTop = await editor.evaluate(element => element.scrollTop);
   const box = await editor.boundingBox();
   expect(box, 'Rich notes editor should have a rendered box.').not.toBeNull();
   await editor.page().mouse.click(box!.x + box!.width / 2, box!.y + box!.height - 12);
   await expect.poll(() => editor.evaluate(element => document.activeElement === element)).toBe(true);
+  const afterClickScrollTop = await editor.evaluate(element => element.scrollTop);
+  expect(afterClickScrollTop, 'Continuation click should not jump the rich notes editor upward.').toBeGreaterThanOrEqual(beforeClickScrollTop - 4);
 }
 
 async function expectContinuationSpace(editor: Locator): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page, type Route } from '@playwright/test';
+import { expect, test, type Locator, type Page, type Route, type TestInfo } from '@playwright/test';
 import {
   absoluteUrl,
   editorApiPath,
@@ -142,6 +142,59 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     await expect(richEditor(form).locator('.ql-editor img[src^="data:image"]')).toHaveCount(0);
   });
 
+  test('docked notes let users continue after a terminal image without persisting helper markup', async ({ page }, testInfo) => {
+    await signIn(page);
+    await routeRichNoteImages(page);
+    const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
+      editorState.metadata.notesHtml = terminalImageNotes();
+    });
+    const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
+    await routeEditorMutations(page, state, requests);
+
+    const form = page.locator('#trip-editor-metadata-form');
+    const editor = richEditor(form).locator('.ql-editor');
+    await expect(editor.locator('img')).toBeVisible();
+    await expectContinuationSpace(editor);
+    await clickContinuationSpace(editor);
+    await page.keyboard.type('Continuation after image');
+    await captureRichNotesEvidence(page, testInfo, 'docked-terminal-image-continuation');
+    await page.getByRole('button', { name: 'Save & Continue' }).click();
+
+    await expect.poll(() => requests.length).toBe(1);
+    const notesHtml = requests[0].body.notesHtml as string;
+    expectCanonicalNotes(notesHtml, ['Intro before image', 'https://images.example.test/terminal-large.svg', 'Continuation after image']);
+    expect(notesHtml).not.toContain('trip-editor-rich-notes__continuation');
+    expect(notesHtml).not.toContain('editor-only');
+    expect(notesHtml).not.toContain('contenteditable');
+  });
+
+  test('expanded notes let users press Enter and continue after terminal content with clean save HTML', async ({ page }, testInfo) => {
+    await signIn(page);
+    const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
+      editorState.metadata.notesHtml = '<p>Terminal paragraph</p>';
+    });
+    const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
+    await routeEditorMutations(page, state, requests);
+
+    await page.getByRole('button', { name: 'Expand Editor' }).click();
+    const dialog = page.getByRole('dialog', { name: /Edit Trip -/ });
+    const editor = richEditor(dialog.locator('#trip-editor-metadata-form')).locator('.ql-editor');
+    await expectContinuationSpace(editor);
+    await clickContinuationSpace(editor);
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Expanded continuation');
+    await captureRichNotesEvidence(page, testInfo, 'expanded-terminal-content-continuation');
+    await dialog.getByRole('button', { name: 'Dock to sidebar' }).click();
+    await page.getByRole('button', { name: 'Save & Continue' }).click();
+
+    await expect.poll(() => requests.length).toBe(1);
+    const notesHtml = requests[0].body.notesHtml as string;
+    expectCanonicalNotes(notesHtml, ['Terminal paragraph', 'Expanded continuation']);
+    expect(notesHtml).not.toContain('trip-editor-rich-notes__continuation');
+    expect(notesHtml).not.toContain('editor-only');
+    expect(notesHtml).not.toContain('<p><br></p><p><br></p>');
+  });
+
   test('data image blocking handles mixed case and whitespace-padded variants before draft storage', async ({ page }) => {
     await signIn(page);
     const state = await loadWorkspaceWithRichNotesFixture(page);
@@ -272,6 +325,20 @@ function persistedQuillListNotes(): string {
     '</ol>',
     '<p data-extra="drop-paragraph">After list</p>'
   ].join('');
+}
+
+function terminalImageNotes(): string {
+  return '<p>Intro before image</p><p><img src="https://images.example.test/terminal-large.svg"></p>';
+}
+
+async function routeRichNoteImages(page: Page): Promise<void> {
+  await page.route(/\/Public\/ProxyImage\?url=https%3A%2F%2Fimages\.example\.test%2Fterminal-large\.svg$/i, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/svg+xml',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="960" height="520"><rect width="960" height="520" fill="#dbeafe"/><rect x="24" y="24" width="912" height="472" rx="24" fill="#1e293b"/><text x="72" y="270" font-family="Arial" font-size="52" fill="#bfdbfe">Terminal rich note image</text></svg>'
+    });
+  });
 }
 
 async function routeEditorMutations(page: Page, state: MutableEditorState, requests: Array<{ method: string; url: string; body: Record<string, any> }>): Promise<void> {
@@ -455,6 +522,35 @@ async function rejectImageDialogUrl(form: Locator, url: string): Promise<void> {
   await expect(dialog.getByText('Embedded data images are not allowed')).toBeVisible();
   await expect(form.getByRole('status')).toContainText('Embedded data images are not allowed');
   await dialog.getByRole('button', { name: 'Cancel' }).click();
+}
+
+async function clickContinuationSpace(editor: Locator): Promise<void> {
+  await editor.evaluate(element => {
+    element.scrollIntoView({ block: 'center', inline: 'nearest' });
+    element.scrollTop = element.scrollHeight;
+  });
+  const box = await editor.boundingBox();
+  expect(box, 'Rich notes editor should have a rendered box.').not.toBeNull();
+  await editor.page().mouse.click(box!.x + box!.width / 2, box!.y + box!.height - 12);
+  await expect.poll(() => editor.evaluate(element => document.activeElement === element)).toBe(true);
+}
+
+async function expectContinuationSpace(editor: Locator): Promise<void> {
+  const gap = await editor.evaluate(element => {
+    element.scrollTop = element.scrollHeight;
+    const blocks = Array.from(element.children).filter(child => child.textContent?.trim() || child.querySelector('img, video, iframe'));
+    const lastBlock = blocks.at(-1);
+    if (!(lastBlock instanceof HTMLElement)) {
+      return 0;
+    }
+
+    return element.scrollHeight - (lastBlock.offsetTop + lastBlock.offsetHeight);
+  });
+  expect(gap, 'Rich notes editor should expose visible continuation space below terminal content.').toBeGreaterThanOrEqual(40);
+}
+
+async function captureRichNotesEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  await page.screenshot({ fullPage: true, path: testInfo.outputPath('screenshots', `${name}.png`) });
 }
 
 // Restores a deterministic caret after tests inject HTML outside Quill's event pipeline.

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -142,7 +142,7 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     await expect(richEditor(form).locator('.ql-editor img[src^="data:image"]')).toHaveCount(0);
   });
 
-  test('docked notes let users continue after a terminal image without persisting helper markup', async ({ page }, testInfo) => {
+  test('docked notes let users type into the trailing blank line after a terminal image', async ({ page }, testInfo) => {
     await signIn(page);
     await routeRichNoteImages(page);
     const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
@@ -154,8 +154,8 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     const form = page.locator('#trip-editor-metadata-form');
     const editor = richEditor(form).locator('.ql-editor');
     await expect(editor.locator('img')).toBeVisible();
-    await expectContinuationSpace(editor);
-    await clickContinuationSpaceWithoutScrollJump(editor);
+    await expectEditableTrailingBlankLine(editor);
+    await clickEditableTrailingBlankLine(editor);
     await page.keyboard.type('Continuation after image');
     await captureRichNotesEvidence(page, testInfo, 'docked-terminal-image-continuation');
     await page.getByRole('button', { name: 'Save & Continue' }).click();
@@ -168,7 +168,31 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     expect(notesHtml).not.toContain('contenteditable');
   });
 
-  test('expanded notes let users press Enter and continue after terminal content with clean save HTML', async ({ page }, testInfo) => {
+  test('docked notes strip the empty artificial trailing blank line on save', async ({ page }) => {
+    await signIn(page);
+    await routeRichNoteImages(page);
+    const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
+      editorState.metadata.notesHtml = terminalImageNotes();
+    });
+    const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
+    await routeEditorMutations(page, state, requests);
+
+    const form = page.locator('#trip-editor-metadata-form');
+    const editor = richEditor(form).locator('.ql-editor');
+    await expect(editor.locator('img')).toBeVisible();
+    await expectEditableTrailingBlankLine(editor);
+    await clickEditableTrailingBlankLine(editor);
+    await form.getByLabel('Name').fill('PW rich notes blank continuation docked');
+    await page.getByRole('button', { name: 'Save & Continue' }).click();
+
+    await expect.poll(() => requests.length).toBe(1);
+    const notesHtml = requests[0].body.notesHtml as string;
+    expectCanonicalNotes(notesHtml, ['Intro before image', 'https://images.example.test/terminal-large.svg']);
+    expect(notesHtml).not.toContain('<p><br></p>');
+    expect(notesHtml).not.toContain('trip-editor-rich-notes__continuation');
+  });
+
+  test('expanded notes let users type into the trailing blank line after terminal content', async ({ page }, testInfo) => {
     await signIn(page);
     await routeRichNoteImages(page);
     const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
@@ -181,8 +205,8 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     const dialog = page.getByRole('dialog', { name: /Edit Trip -/ });
     const editor = richEditor(dialog.locator('#trip-editor-metadata-form')).locator('.ql-editor');
     await expect(editor.locator('img')).toBeVisible();
-    await expectContinuationSpace(editor);
-    await clickContinuationSpaceWithoutScrollJump(editor);
+    await expectEditableTrailingBlankLine(editor);
+    await clickEditableTrailingBlankLine(editor);
     await page.keyboard.type('Expanded continuation');
     await captureRichNotesEvidence(page, testInfo, 'expanded-terminal-content-continuation');
     await dialog.getByRole('button', { name: 'Dock to sidebar' }).click();
@@ -194,6 +218,32 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     expect(notesHtml).not.toContain('trip-editor-rich-notes__continuation');
     expect(notesHtml).not.toContain('editor-only');
     expect(notesHtml).not.toContain('<p><br></p><p><br></p>');
+  });
+
+  test('expanded notes strip the empty artificial trailing blank line on save', async ({ page }) => {
+    await signIn(page);
+    await routeRichNoteImages(page);
+    const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
+      editorState.metadata.notesHtml = terminalImageNotes();
+    });
+    const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
+    await routeEditorMutations(page, state, requests);
+
+    await page.getByRole('button', { name: 'Expand Editor' }).click();
+    const dialog = page.getByRole('dialog', { name: /Edit Trip -/ });
+    const editor = richEditor(dialog.locator('#trip-editor-metadata-form')).locator('.ql-editor');
+    await expect(editor.locator('img')).toBeVisible();
+    await expectEditableTrailingBlankLine(editor);
+    await clickEditableTrailingBlankLine(editor);
+    await dialog.getByRole('button', { name: 'Dock to sidebar' }).click();
+    await page.locator('#trip-editor-metadata-form').getByLabel('Name').fill('PW rich notes blank continuation expanded');
+    await page.getByRole('button', { name: 'Save & Continue' }).click();
+
+    await expect.poll(() => requests.length).toBe(1);
+    const notesHtml = requests[0].body.notesHtml as string;
+    expectCanonicalNotes(notesHtml, ['Intro before image', 'https://images.example.test/terminal-large.svg']);
+    expect(notesHtml).not.toContain('<p><br></p>');
+    expect(notesHtml).not.toContain('trip-editor-rich-notes__continuation');
   });
 
   test('data image blocking handles mixed case and whitespace-padded variants before draft storage', async ({ page }) => {
@@ -525,38 +575,44 @@ async function rejectImageDialogUrl(form: Locator, url: string): Promise<void> {
   await dialog.getByRole('button', { name: 'Cancel' }).click();
 }
 
-async function clickContinuationSpaceWithoutScrollJump(editor: Locator): Promise<void> {
+async function clickEditableTrailingBlankLine(editor: Locator): Promise<void> {
   const clickPoint = await editor.evaluate(element => {
     element.scrollIntoView({ block: 'center', inline: 'nearest' });
     element.scrollTop = element.scrollHeight;
-    const editorBounds = element.getBoundingClientRect();
-    const blocks = Array.from(element.children).filter(child => child.textContent?.trim() || child.querySelector('img, video, iframe'));
-    const lastBlock = blocks.at(-1);
-    const lastBlockBottom = lastBlock instanceof HTMLElement ? lastBlock.getBoundingClientRect().bottom : editorBounds.top;
-    return {
-      x: editorBounds.left + editorBounds.width / 2,
-      y: Math.min(lastBlockBottom + 16, editorBounds.bottom - 12)
-    };
-  });
-  const beforeClickScrollTop = await editor.evaluate(element => element.scrollTop);
-  await editor.page().mouse.click(clickPoint.x, clickPoint.y);
-  await expect.poll(() => editor.evaluate(element => document.activeElement === element)).toBe(true);
-  const afterClickScrollTop = await editor.evaluate(element => element.scrollTop);
-  expect(afterClickScrollTop, 'Continuation click should not jump the rich notes editor upward.').toBeGreaterThanOrEqual(beforeClickScrollTop - 4);
-}
-
-async function expectContinuationSpace(editor: Locator): Promise<void> {
-  const gap = await editor.evaluate(element => {
-    element.scrollTop = element.scrollHeight;
-    const blocks = Array.from(element.children).filter(child => child.textContent?.trim() || child.querySelector('img, video, iframe'));
-    const lastBlock = blocks.at(-1);
-    if (!(lastBlock instanceof HTMLElement)) {
-      return 0;
+    const trailingLine = element.lastElementChild;
+    if (!(trailingLine instanceof HTMLElement)) {
+      throw new Error('Rich notes editor has no trailing line.');
     }
 
-    return element.scrollHeight - (lastBlock.offsetTop + lastBlock.offsetHeight);
+    const lineBounds = trailingLine.getBoundingClientRect();
+    return {
+      x: lineBounds.left + lineBounds.width / 2,
+      y: lineBounds.top + Math.min(18, lineBounds.height / 2)
+    };
   });
-  expect(gap, 'Rich notes editor should expose visible continuation space below terminal content.').toBeGreaterThanOrEqual(40);
+  await editor.page().mouse.click(clickPoint.x, clickPoint.y);
+  await expect.poll(() => editor.evaluate(element => {
+    const selection = window.getSelection();
+    const anchorNode = selection?.anchorNode;
+    return document.activeElement === element || Boolean(anchorNode && element.contains(anchorNode));
+  })).toBe(true);
+}
+
+async function expectEditableTrailingBlankLine(editor: Locator): Promise<void> {
+  const trailingLine = await editor.evaluate(element => {
+    element.scrollTop = element.scrollHeight;
+    const line = element.lastElementChild;
+    if (!(line instanceof HTMLElement)) {
+      return { isBlank: false, height: 0 };
+    }
+
+    return {
+      isBlank: !line.textContent?.trim() && !line.querySelector('img, video, iframe'),
+      height: line.getBoundingClientRect().height
+    };
+  });
+  expect(trailingLine.isBlank, 'Rich notes editor should expose a real trailing blank line.').toBe(true);
+  expect(trailingLine.height, 'Rich notes trailing blank line should be a visible click target.').toBeGreaterThanOrEqual(32);
 }
 
 async function captureRichNotesEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorVisualPolish.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorVisualPolish.spec.ts
@@ -34,6 +34,7 @@ test.describe.serial('Trip Editor issue 275 visual polish evidence', () => {
       await loadWorkspaceWithVisualFixture(page);
 
       await setTheme(page, 'light');
+      await expectLightThemeTone(page);
       await expectNoPageOverflow(page);
       await capture(page, testInfo, `${viewport.name}-light-docked-metadata`);
       note(testInfo, 'docked metadata, tags/share progress, map navigation toolbar', viewport.name, 'light', 'data-bs-theme', 'pass');
@@ -275,6 +276,44 @@ async function expectNoPageOverflow(page: Page): Promise<void> {
   expect(overflow.documentOverflow, 'Trip Editor should not introduce horizontal document overflow.').toBeLessThanOrEqual(2);
   expect(overflow.bodyOverflow, 'Trip Editor should not introduce horizontal body overflow.').toBeLessThanOrEqual(2);
   expect(overflow.containerOverflow, 'Stable Trip Editor containers should fit within the viewport.').toEqual([]);
+}
+
+async function expectLightThemeTone(page: Page): Promise<void> {
+  const colors = await page.evaluate(() => {
+    const workspace = document.querySelector<HTMLElement>('.trip-editor-workspace');
+    const sidebar = document.querySelector<HTMLElement>('.trip-editor-sidebar');
+    if (!workspace || !sidebar) {
+      return null;
+    }
+
+    const toRgb = (value: string): [number, number, number] => {
+      const rgbMatch = value.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+      if (rgbMatch) {
+        return [Number(rgbMatch[1]), Number(rgbMatch[2]), Number(rgbMatch[3])];
+      }
+
+      const srgbMatch = value.match(/color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/);
+      if (!srgbMatch) {
+        throw new Error(`Unsupported color ${value}`);
+      }
+
+      return [Number(srgbMatch[1]) * 255, Number(srgbMatch[2]) * 255, Number(srgbMatch[3]) * 255];
+    };
+
+    const luminance = ([red, green, blue]: [number, number, number]) => 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+    const workspaceRgb = toRgb(getComputedStyle(workspace).backgroundColor);
+    const sidebarRgb = toRgb(getComputedStyle(sidebar).backgroundColor);
+    return {
+      workspaceRgb,
+      sidebarRgb,
+      workspaceLuminance: luminance(workspaceRgb),
+      sidebarLuminance: luminance(sidebarRgb)
+    };
+  });
+
+  expect(colors, 'Trip Editor light theme surfaces should render.').not.toBeNull();
+  expect(colors!.workspaceRgb, 'Workspace background should be toned down from pure white.').not.toEqual([255, 255, 255]);
+  expect(colors!.workspaceLuminance, 'Workspace should remain lighter than sidebar/editor surfaces.').toBeGreaterThan(colors!.sidebarLuminance);
 }
 
 async function expectDialogFitsViewport(page: Page): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes the next focused #288 Trip Editor polish slice:

- adds an editor-local rich-notes continuation affordance below terminal content so users can place the caret after the last block and continue typing in docked or expanded editors;
- keeps helper spacing virtual/CSS-only and keeps Quill selection handling local to `RichNotesEditor.vue`;
- tones the Trip Editor light-theme workspace background down from pure white while keeping sidebar/editor surfaces darker and distinct;
- adds Playwright coverage and screenshot evidence for terminal-image continuation, expanded terminal-content continuation, and light-theme tone.

## Root Cause

Quill always had a canonical trailing document boundary, but the Trip Editor wrapper exposed only a very small visible/clickable area after terminal content. When a large image or final block reached the lower editor boundary, the caret target after the last content was hard to see and unreliable as a user-facing affordance.

The light theme variables also left the broad Trip Editor workspace/surface relationship too bright and inverted for the requested polish: the main workspace needed to be slightly off-white while the sidebar/editor panels stayed visually darker.

## Rich-Notes Continuation Behavior

- `RichNotesEditor.vue` now treats the editor-local continuation zone below the final Quill block as a caret target and sets the Quill selection to the document end on pointer down.
- `richNotes.css` adds a CSS-only continuation area and gives Quill's empty terminal paragraph enough height to be visible and usable.
- The behavior applies to docked sidebar editors and expanded editors.
- Pressing Enter after terminal content creates a usable next line; typed text saves normally.
- Existing image proxy display and canonical external URL save behavior remains covered and green.
- Existing data-image blocking/sanitization behavior remains covered and green.
- Existing dirty/draft behavior remains covered and green.

## Proof Fake Spacing Does Not Persist

The continuation affordance is CSS/selection behavior only; no fake blank paragraphs, spacer elements, or helper markup are inserted as the persistence mechanism.

Playwright asserts saved `notesHtml` contains the user-entered continuation text and does not contain:

- `trip-editor-rich-notes__continuation`
- `editor-only`
- `contenteditable`
- duplicate fake blank paragraph sequences for the expanded continuation case

The canonical save assertions also continue to reject `/Public/ProxyImage`, `data-original`, `data:image`, and legacy modal/helper classes.

## Light-Theme Tone Decision

The light-theme change is limited to `ClientApps/trip-editor/src/theme.css` Trip Editor variables:

- `--trip-editor-bg` is now slightly toned from pure white for the main workspace.
- `--trip-editor-surface` and `--trip-editor-surface-muted` are darker than the workspace so sidebar/editor surfaces remain distinct.
- No global site theme or shared Bootstrap variables were changed.

`tripEditorVisualPolish.spec.ts` now asserts the light workspace is not pure white and remains lighter than the sidebar surface before capturing the light-theme screenshots.

## Validation Results

- `npm run build` passed; existing Vite chunk-size warning remains.
- `dotnet build` passed; existing `ASP0000` warning in `Program.cs` remains.
- `dotnet test` passed: 1535 passed.
- `npx playwright test --config=playwright.config.ts --list` passed: 96 tests listed.
- `npx playwright test --config=playwright.config.ts tests/e2e/trip-editor/tripEditorRichNotes.spec.ts -g "terminal"` passed: 2 passed.
- `npx playwright test --config=playwright.config.ts tests/e2e/trip-editor/tripEditorRichNotes.spec.ts` passed: 10 passed.
- `npx playwright test --config=playwright.config.ts tests/e2e/trip-editor/tripEditorVisualPolish.spec.ts` passed: 4 passed.
- `npm run test:e2e:trip-editor` passed: 95 passed, 1 skipped.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` passed with warnings only; changed `tripEditorRichNotes.spec.ts` is still cohesive rich-notes coverage, so warning accepted with justification.
- `rg "window\.confirm" ClientApps/trip-editor/src` returned no matches.
- `rg "\bconfirm\(" ClientApps/trip-editor/src` returned shared dialog helper usages only.
- `git diff --check origin/main...HEAD` passed.
- `git ls-files -- .local playwright-report test-results screenshots traces wwwroot/vite/trip-editor wwwroot/dist` returned no tracked generated artifacts.

## Screenshot Evidence Paths

- `.local/playwright/test-output/tripEditorRichNotes-Trip-E-08935-ut-persisting-helper-markup-chromium/screenshots/docked-terminal-image-continuation.png`
- `.local/playwright/test-output/tripEditorRichNotes-Trip-E-fcec2-ontent-with-clean-save-HTML-chromium/screenshots/expanded-terminal-content-continuation.png`
- `.local/playwright/test-output/tripEditorVisualPolish-Tri-49a08-rk-evidence-at-desktop-wide-chromium/screenshots/desktop-wide-light-docked-metadata.png`
- `.local/playwright/test-output/tripEditorVisualPolish-Tri-49a08-rk-evidence-at-desktop-wide-chromium/screenshots/desktop-wide-light-expanded-metadata.png`
- `.local/playwright/test-output/tripEditorVisualPolish-Tri-e1352-map-work-evidence-at-laptop-chromium/screenshots/laptop-light-docked-metadata.png`
- `.local/playwright/test-output/tripEditorVisualPolish-Tri-e1352-map-work-evidence-at-laptop-chromium/screenshots/laptop-light-expanded-metadata.png`
- `.local/playwright/test-output/tripEditorVisualPolish-Tri-18a37-map-work-evidence-at-tablet-chromium/screenshots/tablet-light-docked-metadata.png`
- `.local/playwright/test-output/tripEditorVisualPolish-Tri-18a37-map-work-evidence-at-tablet-chromium/screenshots/tablet-light-expanded-metadata.png`
- `.local/playwright/test-output/tripEditorVisualPolish-Tri-48b13-ork-evidence-at-phone-smoke-chromium/screenshots/phone-smoke-light-docked-metadata.png`
- `.local/playwright/test-output/tripEditorVisualPolish-Tri-48b13-ork-evidence-at-phone-smoke-chromium/screenshots/phone-smoke-light-expanded-metadata.png`

## Remaining #288 Items

Still deferred under #288:

- Map search / Add Place workflow state design: clarify whether geosearch can populate an already-open Add Place panel, whether each result can independently start/populate Add Place, and what state remains after add/cancel.
- Sidebar selected/edit visual polish if still needed after manual review: selected border prominence and expanded edit surface spacing.

This PR intentionally does not merge.
