### PR TITLE
Document Trip Editor E2E claim scope

### DIFF
--- a/docs/22-Testing.md
+++ b/docs/22-Testing.md
@@ -44,6 +44,41 @@ npx playwright install
 
 - If browser verification cannot run, report the exact reason, such as missing `WAYFARER_E2E_*` settings, ASP.NET not running, Vite not running, or missing Playwright browser binaries. Do not describe skipped browser checks as passed.
 
+Trip Editor Test Credibility Matrix
+- This matrix is the durable #297 claim-honesty artifact for Trip Editor tests.
+- Labels:
+  - `contract`: proves the final user-visible outcome for the covered behavior.
+  - `backend-rule`: proves server mutation, authorization, validation, persistence, or read mapping.
+  - `integration`: drives the UI against a real endpoint path and asserts a user-visible outcome.
+  - `mocked-only`: uses fixture state or `page.route(...).fulfill(...)` for the relevant behavior; it proves frontend behavior only.
+  - `proxy`: proves selector, button, request, or presence behavior without proving persistence.
+  - `missing`: no meaningful automated proof exists yet.
+  - `out of scope`: not part of Trip Editor E2E unless an editor entry point directly depends on it.
+- A Playwright test that uses `page.route(...).fulfill(...)` for a mutation response is not E2E CRUD proof.
+- Mocked mutation tests may prove frontend rendering, request shape, loading/error state, visual behavior, map adapter behavior, or response handling only.
+- CRUD release proof requires backend-rule coverage plus real endpoint UI coverage, reload/API reread, or an explicit pairing that names both sides.
+
+| Workflow | Current automated proof | Classification | Current claim boundary | Remaining #297 batch work |
+|---|---|---:|---|---|
+| Trip metadata save, public trip, share progress | Backend metadata/share-progress tests plus `tripEditorRemainingParity.spec.ts` real PATCH success. | backend-rule + proxy | Proves endpoint success and UI feedback, not reload/API reread persistence. | Add real reload/API reread if release proof needs persisted URLs/toggles. |
+| Region create/edit/delete/reorder | Backend region mutation tests; browser coverage is partial. | backend-rule | Proves server rules. Browser create/delete/reorder outcome is not yet release proof. | Batch 2 real endpoint UI flow if region CRUD is release-critical. |
+| Place create/edit/delete/reorder/move/Unassigned Places | Backend place mutation tests; `tripEditorPlaceReassignment.spec.ts`, `tripEditorIconSelector.spec.ts`, and marker feedback specs use mocked mutation responses. | backend-rule + mocked-only | Mocked tests prove request shape, affected-slice rendering, icon/feedback UI, and visual behavior only. | Batch 2 real endpoint place move/reorder/create coverage with reload/API reread. |
+| Place geosearch add | Backend geocode proxy tests; `tripEditorMapSearch.spec.ts` mocks geocode and opens drafts. | backend-rule + proxy | Proves proxy/search UI states, target selector behavior, pending marker, and draft handoff; it does not prove saved search-add persistence. | Batch 4 real Save Place from search-add draft with reload/API reread. |
+| Place coordinate pick | Backend coordinate mutation tests; `tripEditorPlaceCoordinateMapWork.spec.ts` uses fixture state and a mocked save response. | backend-rule + mocked-only | Proves map-work draft behavior, request body, and no geocode side effects only. | Batch 2 real coordinate save/reload if coordinate persistence is release-critical. |
+| Area create/edit/delete/reorder/polygon map work | Backend area mutation tests; `tripEditorAreaEditing.spec.ts` mocks create/update/order responses. | backend-rule + mocked-only | Proves polygon draft behavior, request shape, interior-ring request preservation, and mocked order response handling. | Batch 2 real area create/save/reorder/delete coverage with reload/API reread. |
+| Segment create/edit/delete/reorder/route map work | Backend segment mutation tests; `tripEditorSegmentEditing.spec.ts` mocks route-save and order responses. | backend-rule + mocked-only | Proves route draft behavior, request shape, and mocked order response handling. | Batch 2 real segment create/route-save/reorder/delete coverage with reload/API reread. |
+| Visit progress/history | Backend read-state tests; Playwright visit specs use synthetic read models. | backend-rule + mocked-only | Proves mapper/read shape and component rendering, not a real UI fixture against seeded visit data. | Optional real read-only UI smoke if a release candidate finds a regression. |
+| Rich notes text/images/alignment/sanitize/save | Rich notes Playwright specs use mocked editor mutation routes; backend notes coverage is partial through owner mutation tests. | mocked-only + partial backend-rule | Proves client canonicalization, sanitizer request shape, proxy image rendering, and editor UX only. | Batch 5 backend sanitizer/persistence plus one real UI save/reload. |
+| Sidebar search/filter | `tripEditorSidebarSearch.spec.ts` and remaining parity coverage drive the real app without backend search requests. | contract | Proves frontend filter behavior and no search-provider calls. | No Batch 2 CRUD work. Keep frontend-only claim. |
+| Map utilities: fit, recenter, focus, zoom display, measure, copy link | Utility smoke uses real UI; geometry variant tests may use synthetic read models. | contract + mocked-only | Utility behavior is credible frontend contract coverage; synthetic geometry variants prove map adapter behavior only. | Add no backend work unless a real geometry fixture gap appears. |
+| Published production bundle loading | Dev-served editor smoke exists; published-output Production smoke is absent. | missing | Current Playwright runs prove development ASP.NET + Vite mounting only. | Batch 6 published-output Production bundle smoke. |
+| Light/dark/narrow layout | Layout and visual polish specs mix real app and fixture-backed states. | contract + mocked-only | Proves browser-visible layout/visual regressions; mocked data-dependent visuals are not CRUD proof. | No broad rewrite; keep labels honest. |
+| Auth/ownership/error behavior | Backend auth/missing/cross-trip coverage exists; browser-visible error and stale mutation UX is partial. | backend-rule + missing | Server rules are covered more strongly than UI stale/failure feedback. | Batch 3 failed-save, stale entity, delete-failure feedback coverage. |
+| Dirty/cancel/delete/error-feedback flows | Shared discard/delete confirmations and some feedback paths are covered, often fixture-backed. | contract + mocked-only + missing | Proves confirmation and frontend feedback states, not real delete persistence. | Batch 3 and Batch 2 real delete visual-removal pairing where needed. |
+| Save & Exit and route/navigation-away behavior | Metadata navigation and dirty guards have partial UI coverage. | proxy + mocked-only | Proves navigation/feedback behavior only where named; not broad CRUD persistence. | Clarify scope before adding real coverage. |
+| Development Vite server smoke | Standard Trip Editor Playwright run mounts the dev-served shell. | contract | Proves local ASP.NET + Vite dev integration only. | Keep separate from production bundle claims. |
+| Import/export/backfill/public viewer/mobile/API | Not Trip Editor E2E unless the editor entry point depends on the behavior. | out of scope | Do not report these as Trip Editor release proof. | Track in separate issue/suite if needed. |
+
 Coverage
 - Install tools and generate HTML: `dotnet tool restore` then `.\tools\coverage-report.ps1`
 - Reports land in `coverage-report/index.html` (cobertura XML in `tests/Wayfarer.Tests/TestResults/coverage/coverage.cobertura.xml`).

--- a/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorAreaEditing.spec.ts
@@ -65,12 +65,13 @@ test.describe.serial('Trip Editor area editing', () => {
     expect(mutations(), 'Area map-work Done must not call create/update/geometry endpoints.').toEqual([]);
   });
 
-  test('new area starts without a temporary polygon and Save after Done persists it', async ({ page }) => {
+  test('new area starts without a temporary polygon and Save after Done sends a mocked create request', async ({ page }) => {
     await useMapWorkViewport(page);
     await signIn(page);
     const state = await loadWorkspaceWithAreaFixture(page);
     const regionId = normalRegion(state).id;
     const savedRequests: Array<Record<string, any>> = [];
+    // Mocked area mutations prove request shape and affected-slice UI handling, not real area CRUD persistence.
     await page.route(editorApiMatcher, async route => {
       if (route.request().method() === 'GET') {
         await route.fallback();
@@ -102,12 +103,13 @@ test.describe.serial('Trip Editor area editing', () => {
     expect(savedRequests[0].geometry.coordinates[0]).toHaveLength(4);
   });
 
-  test('existing polygon map-work preserves interior rings on Done and Save', async ({ page }) => {
+  test('existing polygon map-work preserves interior rings in the mocked update request', async ({ page }) => {
     await signIn(page);
     const savedRequests: Array<Record<string, any>> = [];
     const state = await loadWorkspaceWithAreaFixture(page, fixture => {
       fixture.areasById[areaId].geometry = polygonWithHole();
     });
+    // Mocked area mutations prove request shape and affected-slice UI handling, not real area CRUD persistence.
     await page.route(editorApiMatcher, async route => {
       if (route.request().method() === 'GET') {
         await route.fallback();
@@ -161,11 +163,12 @@ test.describe.serial('Trip Editor area editing', () => {
     }
   });
 
-  test('reorders areas within one normal region and persists after reload', async ({ page }) => {
+  test('reorders areas within one normal region and applies the mocked order response after reload', async ({ page }) => {
     await signIn(page);
     const state = await loadWorkspaceWithAreaFixture(page);
     const regionId = normalRegion(state).id;
     await page.unroute(editorApiMatcher);
+    // This fulfilled order response proves frontend reorder handling only; pair with backend/real endpoint tests for CRUD proof.
     await page.route(editorApiMatcher, async route => {
       if (route.request().method() === 'GET') {
         await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });

--- a/tests/e2e/trip-editor/tripEditorIconSelector.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorIconSelector.spec.ts
@@ -32,7 +32,7 @@ const iconNames = [
 const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
 
 test.describe('Trip Editor icon selector', () => {
-  test('filters, selects, saves, and stays contained across responsive themes', async ({ page }, testInfo) => {
+  test('filters, selects, sends a mocked place save, and stays contained across responsive themes', async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await signIn(page);
     const requests: Record<string, any>[] = [];
@@ -137,6 +137,7 @@ async function routeEditorState(route: Route, state: MutableEditorState, request
   }
 
   if (request.method() === 'PUT' && request.url().includes(`/places/${placeId}`)) {
+    // This fulfilled response proves selector request shape and UI handling, not persisted icon/color CRUD.
     const body = request.postDataJSON() as Record<string, any>;
     requests.push(body);
     state.placesById[placeId] = { ...state.placesById[placeId], ...body };

--- a/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapSearch.spec.ts
@@ -351,7 +351,7 @@ test.describe('Trip Editor map geocode search', () => {
     await expect(page.getByRole('button', { name: 'Add as place' })).toBeEnabled();
   });
 
-  test('geosearch Add as place defaults back to Unassigned Places after one normal-region add', async ({ page }) => {
+  test('geosearch Add as place defaults back to Unassigned Places after one normal-region draft handoff', async ({ page }) => {
     await signIn(page);
     const baseState = withTwoEligibleRegions(await loadEditorState(page));
     const unassignedId = unassignedPlacesRegionId(baseState);
@@ -465,6 +465,7 @@ async function routeGeocode(page: Page, handler: (route: Route) => Promise<void>
 
 async function fulfillGeocode(route: Route, results: unknown[], query?: string): Promise<void> {
   const echoedQuery = query ?? new URL(route.request().url()).searchParams.get('q') ?? '';
+  // Mocked geocode responses prove proxy/search UI behavior; saved place CRUD needs a real create-place pairing.
   await route.fulfill({
     status: 200,
     contentType: 'application/json',

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -218,7 +218,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
 
   });
 
-  test('renders notes images through the proxy while saving canonical external image URLs', async ({ page }) => {
+  test('renders notes images through the proxy while sending canonical external image URLs', async ({ page }) => {
     const requests: Record<string, any>[] = [];
     await signIn(page);
     await loadWorkspaceWithMarkerFixture(page, requests);
@@ -236,7 +236,7 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
     expect(requests[0].notesHtml).not.toContain('/Public/ProxyImage');
   });
 
-  test('shows deterministic place save success and error feedback', async ({ page }) => {
+  test('shows deterministic mocked place save success and error feedback', async ({ page }) => {
     const requests: Record<string, any>[] = [];
     await signIn(page);
     await loadWorkspaceWithMarkerFixture(page, requests);
@@ -310,6 +310,7 @@ async function routeEditorState(route: Route, state: MutableEditorState, request
   }
 
   if (request.method() === 'PUT' && request.url().includes(`/places/${firstPlaceId}`)) {
+    // Mocked place mutations cover frontend request shape and feedback states, not real endpoint persistence.
     const body = request.postDataJSON() as Record<string, any>;
     requests.push(body);
     state.placesById[firstPlaceId] = { ...state.placesById[firstPlaceId], ...body };

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -238,7 +238,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await expect(page.locator('#trip-editor-place-form').getByLabel('Name')).toHaveValue('Unsaved switch name');
   });
 
-  test('Save after Done sends the picked coordinate through the existing place endpoint', async ({ page }) => {
+  test('Save after Done sends the picked coordinate to a mocked existing place endpoint', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithCoordinateFixture(page);
     const forbidden = watchForbiddenPickRequests(page);
@@ -256,6 +256,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
 
       const body = request.postDataJSON() as Record<string, any>;
       savedRequests.push(body);
+      // Fulfilled here to prove picked-coordinate request shape and UI save handling only.
       await route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/tests/e2e/trip-editor/tripEditorPlaceReassignment.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceReassignment.spec.ts
@@ -8,7 +8,7 @@ import {
 } from './tripEditorTestUtils';
 
 test.describe('Trip Editor place reassignment', () => {
-  test('place Region selector saves moves into and out of Unassigned Places', async ({ page }) => {
+  test('place Region selector sends mocked moves into and out of Unassigned Places', async ({ page }) => {
     await signIn(page);
     const baseState = await loadEditorState(page);
     const fixture = withMovablePlace(baseState);
@@ -78,6 +78,7 @@ function withMovablePlace(state: any): { state: any; normalRegionId: string; pla
 
 async function routeEditorStateWithPlaceMove(page: Page, state: any, requests: Array<Record<string, any>>, placeId: string): Promise<void> {
   const matcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
+  // Mocked mutation responses prove request shape and frontend affected-slice handling only, not endpoint CRUD persistence.
   await page.route(matcher, async route => {
     const request = route.request();
     if (request.method() === 'GET') {

--- a/tests/e2e/trip-editor/tripEditorRemainingParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRemainingParity.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, type Locator, type Page } from '@playwright/test';
 import { absoluteUrl, editorApiPath, editorPath, expectMountedWorkspace, signIn } from './tripEditorTestUtils';
 
 test.describe.serial('Trip Editor remaining parity verification', () => {
-  test('public trip and share-progress saves use editor endpoints successfully', async ({ page }) => {
+  test('public trip and share-progress saves return success from editor endpoints', async ({ page }) => {
     await signIn(page);
     await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -44,7 +44,7 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     await expect(page.getByText('Notes HTML')).toHaveCount(0);
   });
 
-  test('metadata and child owner saves send canonical rich notes through existing mutation endpoints', async ({ page }) => {
+  test('metadata and child owner saves send canonical rich notes through mocked mutation routes', async ({ page }) => {
     await signIn(page);
     const state = await loadWorkspaceWithRichNotesFixture(page);
     const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
@@ -80,7 +80,7 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     expectCanonicalNotes(requests[1].body.notesHtml, ['Region rich note']);
   });
 
-  test('metadata save sanitizes unedited persisted notes when another field changes', async ({ page }) => {
+  test('metadata mocked save sanitizes unedited persisted notes when another field changes', async ({ page }) => {
     await signIn(page);
     const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
       editorState.metadata.notesHtml = unsafePersistedMetadataNotes();
@@ -117,7 +117,7 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     expect(notesHtml).not.toContain('not a url');
   });
 
-  test('bullet and ordered lists keep Quill list metadata through reload and save normalization', async ({ page }) => {
+  test('bullet and ordered lists keep Quill list metadata through fixture load and mocked save normalization', async ({ page }) => {
     await signIn(page);
     const state = await loadWorkspaceWithRichNotesFixture(page, editorState => {
       editorState.metadata.notesHtml = persistedQuillListNotes();
@@ -405,6 +405,7 @@ async function routeRichNoteImages(page: Page): Promise<void> {
 
 async function routeEditorMutations(page: Page, state: MutableEditorState, requests: Array<{ method: string; url: string; body: Record<string, any> }>): Promise<void> {
   await page.unroute(editorApiMatcher);
+  // Mocked mutation routes keep rich-editor behavior deterministic; pair with backend/real endpoint coverage for CRUD proof.
   await page.route(editorApiMatcher, async route => routeEditorState(route, state, requests));
 }
 

--- a/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
@@ -34,11 +34,12 @@ test.describe.serial('Trip Editor segment editing', () => {
     await expect(page.locator('#trip-editor-segment-form')).toHaveCount(1);
   });
 
-  test('route map-work from docked and expanded writes draft only until Save', async ({ page }) => {
+  test('route map-work from docked and expanded sends a mocked route save only after Save', async ({ page }) => {
     await signIn(page);
     const state = await loadWorkspaceWithSegmentFixture(page);
     const savedRequests: Array<Record<string, any>> = [];
     await page.unroute(editorApiMatcher);
+    // Mocked segment mutations prove request shape and route UI handling, not real segment CRUD persistence.
     await page.route(editorApiMatcher, async route => {
       if (route.request().method() === 'GET') {
         await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
@@ -134,10 +135,11 @@ test.describe.serial('Trip Editor segment editing', () => {
     await expect.poll(routeCount).toBeGreaterThan(0);
   });
 
-  test('reorders segments and persists order after reload', async ({ page }) => {
+  test('reorders segments and applies the mocked order response after reload', async ({ page }) => {
     await signIn(page);
     const state = await loadWorkspaceWithSegmentFixture(page);
     await page.unroute(editorApiMatcher);
+    // This fulfilled order response proves frontend reorder handling only; pair with backend/real endpoint tests for CRUD proof.
     await page.route(editorApiMatcher, async route => {
       if (route.request().method() === 'GET') {
         await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });


### PR DESCRIPTION
## Summary

Implements #297 Batch 1 only: Trip Editor test-claim honesty.

- Adds the Trip Editor test credibility matrix and testing policy to `docs/22-Testing.md`.
- Documents that mocked Playwright mutation responses are not E2E CRUD proof.
- Relabels misleading Trip Editor Playwright test names/comments so mocked/proxy specs are described as frontend rendering, request-shape, affected-slice handling, visual, map-adapter, or proxy behavior.
- Does not add real endpoint CRUD coverage and does not change product behavior.

## Remaining #297 Work

Batch 2+ remains pending:

- real endpoint CRUD coverage;
- stale/error UX and failed-save preservation;
- search-add persistence after #295;
- rich-notes persistence/sanitizer contract;
- Development vs published production asset smoke.

## Validation

- `npx playwright test --config=playwright.config.ts --list`: passed, 106 tests listed.
- LOC check: passed with warnings only for existing large Trip Editor/spec files touched by label/comment edits.
- `git diff --check origin/main...HEAD`: passed.
- tracked/generated artifact scan: clean.
- `npm run build`: skipped because no frontend source changed.
- `dotnet build`: skipped because no .NET source/tooling changed.
