### PR TITLE
Add Trip Editor rich-notes persistence contracts

### DIFF
--- a/Models/Dtos/Editor/EditorAreaRequestParser.cs
+++ b/Models/Dtos/Editor/EditorAreaRequestParser.cs
@@ -11,10 +11,6 @@ internal static class EditorAreaRequestParser
 {
     private static readonly string[] SaveServerOwnedFields = { "id", "tripId", "displayOrder", "capabilities" };
     private static readonly Regex FillHexRegex = new("^#[0-9a-fA-F]{6}$", RegexOptions.Compiled);
-    private static readonly Regex DataImageSourceRegex = new(
-        @"<img\b[^>]*?\bsrc\s*=\s*[""']?\s*data:image/",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
     /// <summary>
     /// Attempts to parse a complete-draft area create request.
     /// </summary>
@@ -46,7 +42,7 @@ internal static class EditorAreaRequestParser
 
         update = new EditorAreaSaveRequest(
             string.IsNullOrWhiteSpace(name) ? "Area" : name!.Trim(),
-            notesHtml,
+            EditorRichNotesRequestHtml.NormalizeForPersistence(notesHtml),
             string.IsNullOrWhiteSpace(fillHex) ? "#ff6600" : fillHex!.Trim().ToLowerInvariant(),
             geometry!);
         return true;
@@ -78,7 +74,7 @@ internal static class EditorAreaRequestParser
             return false;
         }
 
-        update = new EditorAreaSaveRequest(name!.Trim(), notesHtml, fillHex!.Trim().ToLowerInvariant(), geometry!);
+        update = new EditorAreaSaveRequest(name!.Trim(), EditorRichNotesRequestHtml.NormalizeForPersistence(notesHtml), fillHex!.Trim().ToLowerInvariant(), geometry!);
         return true;
     }
 
@@ -350,7 +346,7 @@ internal static class EditorAreaRequestParser
 
     private static void ValidateNotes(string? notesHtml, Dictionary<string, string[]> errors)
     {
-        if (!string.IsNullOrEmpty(notesHtml) && DataImageSourceRegex.IsMatch(notesHtml))
+        if (EditorRichNotesRequestHtml.ContainsDataImageSource(notesHtml))
         {
             errors["notesHtml"] = new[] { "Notes cannot contain data image sources." };
         }

--- a/Models/Dtos/Editor/EditorPlaceRequestParser.cs
+++ b/Models/Dtos/Editor/EditorPlaceRequestParser.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.RegularExpressions;
 
 namespace Wayfarer.Models.Dtos.Editor;
 
@@ -16,10 +15,6 @@ internal static class EditorPlaceRequestParser
         "visitSummary",
         "capabilities"
     };
-
-    private static readonly Regex DataImageSourceRegex = new(
-        @"<img\b[^>]*?\bsrc\s*=\s*[""']?\s*data:image/",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
     /// Attempts to parse a complete-draft place create request.
@@ -51,7 +46,7 @@ internal static class EditorPlaceRequestParser
 
         update = new EditorPlaceCreateRequest(
             fields.Name!,
-            fields.NotesHtml,
+            EditorRichNotesRequestHtml.NormalizeForPersistence(fields.NotesHtml),
             fields.Address,
             fields.Location,
             fields.IconName!,
@@ -90,7 +85,7 @@ internal static class EditorPlaceRequestParser
         update = new EditorPlaceUpdateRequest(
             regionId!.Value,
             fields.Name!,
-            fields.NotesHtml,
+            EditorRichNotesRequestHtml.NormalizeForPersistence(fields.NotesHtml),
             fields.Address,
             fields.Location,
             fields.IconName!,
@@ -337,7 +332,7 @@ internal static class EditorPlaceRequestParser
     }
 
     private static bool ContainsDataImageSource(string? notesHtml) =>
-        !string.IsNullOrEmpty(notesHtml) && DataImageSourceRegex.IsMatch(notesHtml);
+        EditorRichNotesRequestHtml.ContainsDataImageSource(notesHtml);
 
     private sealed record PlaceSaveFields(
         string? Name,

--- a/Models/Dtos/Editor/EditorRegionRequestParser.cs
+++ b/Models/Dtos/Editor/EditorRegionRequestParser.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.RegularExpressions;
 
 namespace Wayfarer.Models.Dtos.Editor;
 
@@ -19,10 +18,6 @@ internal static class EditorRegionRequestParser
         "isShadow",
         "capabilities"
     };
-
-    private static readonly Regex DataImageSourceRegex = new(
-        @"<img\b[^>]*?\bsrc\s*=\s*[""']?\s*data:image/",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
     /// Attempts to parse a complete-draft region save request.
@@ -57,7 +52,7 @@ internal static class EditorRegionRequestParser
             return false;
         }
 
-        update = new EditorRegionSaveRequest(name!, notesHtml, coverImage, center);
+        update = new EditorRegionSaveRequest(name!, EditorRichNotesRequestHtml.NormalizeForPersistence(notesHtml), coverImage, center);
         return true;
     }
 
@@ -276,7 +271,7 @@ internal static class EditorRegionRequestParser
 
     private static void ValidateNotesHtml(string? notesHtml, Dictionary<string, string[]> errors)
     {
-        if (!string.IsNullOrEmpty(notesHtml) && DataImageSourceRegex.IsMatch(notesHtml))
+        if (EditorRichNotesRequestHtml.ContainsDataImageSource(notesHtml))
         {
             errors["notesHtml"] = new[] { "Notes images must use external image URLs, not data:image sources." };
         }

--- a/Models/Dtos/Editor/EditorRichNotesRequestHtml.cs
+++ b/Models/Dtos/Editor/EditorRichNotesRequestHtml.cs
@@ -30,9 +30,19 @@ internal static class EditorRichNotesRequestHtml
         "base", "button", "embed", "form", "iframe", "input", "link", "meta", "object", "option", "script", "select", "style", "textarea"
     };
 
-    private static readonly HashSet<string> AllowedClasses = new(StringComparer.Ordinal)
+    private static readonly HashSet<string> AllowedAlignmentClasses = new(StringComparer.Ordinal)
     {
-        "ql-align-center", "ql-align-right", "ql-font-monospace", "ql-font-serif"
+        "ql-align-center", "ql-align-right"
+    };
+
+    private static readonly HashSet<string> AllowedFontClasses = new(StringComparer.Ordinal)
+    {
+        "ql-font-monospace", "ql-font-serif"
+    };
+
+    private static readonly HashSet<string> QuillBlockTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "blockquote", "h1", "h2", "h3", "h4", "h5", "h6", "li", "p"
     };
 
     private static readonly HashSet<string> AllowedListKinds = new(StringComparer.Ordinal)
@@ -139,7 +149,7 @@ internal static class EditorRichNotesRequestHtml
 
     private static bool NormalizeClassAttribute(IElement element)
     {
-        var allowed = element.ClassList.Where(className => AllowedClasses.Contains(className)).ToArray();
+        var allowed = element.ClassList.Where(className => IsAllowedClass(element, className)).ToArray();
         if (allowed.Length == 0)
         {
             return false;
@@ -148,6 +158,10 @@ internal static class EditorRichNotesRequestHtml
         element.SetAttribute("class", string.Join(" ", allowed));
         return true;
     }
+
+    private static bool IsAllowedClass(IElement element, string className) =>
+        (string.Equals(element.TagName, "span", StringComparison.OrdinalIgnoreCase) && AllowedFontClasses.Contains(className))
+        || (QuillBlockTags.Contains(element.TagName) && AllowedAlignmentClasses.Contains(className));
 
     private static void NormalizeImage(IElement element)
     {

--- a/Models/Dtos/Editor/EditorRichNotesRequestHtml.cs
+++ b/Models/Dtos/Editor/EditorRichNotesRequestHtml.cs
@@ -1,0 +1,216 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace Wayfarer.Models.Dtos.Editor;
+
+/// <summary>
+/// Normalizes Trip Editor rich-notes request HTML before editor mutations persist it.
+/// </summary>
+internal static class EditorRichNotesRequestHtml
+{
+    private static readonly Regex DataImageSourceRegex = new(
+        @"<img\b[^>]*?\bsrc\s*=\s*[""']?\s*data:image/",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex ImageSourceRegex = new(
+        @"(?<prefix><img\b[^>]*?\bsrc\s*=\s*[""'])(?<url>[^""']+)(?<suffix>[""'])",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly HtmlParser Parser = new();
+    private static readonly HashSet<string> AllowedTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "a", "blockquote", "br", "em", "h1", "h2", "h3", "h4", "h5", "h6", "img", "li", "ol", "p", "span", "strong", "u", "ul"
+    };
+
+    private static readonly HashSet<string> RemovedTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "base", "button", "embed", "form", "iframe", "input", "link", "meta", "object", "option", "script", "select", "style", "textarea"
+    };
+
+    private static readonly HashSet<string> AllowedClasses = new(StringComparer.Ordinal)
+    {
+        "ql-align-center", "ql-align-right", "ql-font-monospace", "ql-font-serif"
+    };
+
+    private static readonly HashSet<string> AllowedListKinds = new(StringComparer.Ordinal)
+    {
+        "bullet", "ordered"
+    };
+
+    /// <summary>
+    /// Returns true when request HTML contains a direct embedded data image source.
+    /// </summary>
+    public static bool ContainsDataImageSource(string? notesHtml) =>
+        !string.IsNullOrEmpty(notesHtml) && DataImageSourceRegex.IsMatch(notesHtml);
+
+    /// <summary>
+    /// Canonicalizes and sanitizes rich-notes HTML accepted by Trip Editor mutation requests.
+    /// </summary>
+    public static string? NormalizeForPersistence(string? notesHtml)
+    {
+        if (string.IsNullOrWhiteSpace(notesHtml))
+        {
+            return string.Empty;
+        }
+
+        var canonicalImages = ImageSourceRegex.Replace(notesHtml.Trim(), match =>
+        {
+            var source = CanonicalImageSource(match.Groups["url"].Value);
+            return $"{match.Groups["prefix"].Value}{WebUtility.HtmlEncode(source)}{match.Groups["suffix"].Value}";
+        });
+
+        var document = Parser.ParseDocument(canonicalImages);
+        var body = document.Body;
+        if (body == null)
+        {
+            return string.Empty;
+        }
+
+        foreach (var element in body.QuerySelectorAll("span.ql-ui").ToArray())
+        {
+            element.Remove();
+        }
+
+        foreach (var element in body.QuerySelectorAll("*").Reverse().ToArray())
+        {
+            NormalizeElement(element);
+        }
+
+        RemoveTrailingBlankParagraphs(body);
+        var html = body.InnerHtml.Trim();
+        return string.Equals(html, "<p><br></p>", StringComparison.OrdinalIgnoreCase)
+            ? string.Empty
+            : html;
+    }
+
+    private static void NormalizeElement(IElement element)
+    {
+        if (RemovedTags.Contains(element.TagName))
+        {
+            element.Remove();
+            return;
+        }
+
+        if (!AllowedTags.Contains(element.TagName))
+        {
+            element.Replace(element.ChildNodes.ToArray());
+            return;
+        }
+
+        foreach (var attribute in element.Attributes.ToArray())
+        {
+            if (!IsAllowedAttribute(element, attribute))
+            {
+                element.RemoveAttribute(attribute.Name);
+            }
+        }
+
+        if (string.Equals(element.TagName, "img", StringComparison.OrdinalIgnoreCase))
+        {
+            NormalizeImage(element);
+        }
+    }
+
+    private static bool IsAllowedAttribute(IElement element, IAttr attribute)
+    {
+        var name = attribute.Name.ToLowerInvariant();
+        if (name == "class")
+        {
+            return NormalizeClassAttribute(element);
+        }
+
+        if (name == "href" && string.Equals(element.TagName, "a", StringComparison.OrdinalIgnoreCase))
+        {
+            return IsAllowedLink(attribute.Value);
+        }
+
+        if (name == "src" && string.Equals(element.TagName, "img", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return name == "data-list"
+            && string.Equals(element.TagName, "li", StringComparison.OrdinalIgnoreCase)
+            && AllowedListKinds.Contains(attribute.Value);
+    }
+
+    private static bool NormalizeClassAttribute(IElement element)
+    {
+        var allowed = element.ClassList.Where(className => AllowedClasses.Contains(className)).ToArray();
+        if (allowed.Length == 0)
+        {
+            return false;
+        }
+
+        element.SetAttribute("class", string.Join(" ", allowed));
+        return true;
+    }
+
+    private static void NormalizeImage(IElement element)
+    {
+        var source = CanonicalImageSource(element.GetAttribute("src") ?? string.Empty);
+        if (!IsAllowedAbsoluteHttpUrl(source))
+        {
+            element.Remove();
+            return;
+        }
+
+        element.SetAttribute("src", source);
+    }
+
+    private static bool IsAllowedLink(string value)
+    {
+        var compact = CompactUrlScheme(value);
+        return !compact.StartsWith("javascript:", StringComparison.Ordinal)
+            && !compact.StartsWith("data:", StringComparison.Ordinal)
+            && !compact.StartsWith("vbscript:", StringComparison.Ordinal);
+    }
+
+    private static bool IsAllowedAbsoluteHttpUrl(string value) =>
+        Uri.TryCreate(StripUrlBoundaryControls(value), UriKind.Absolute, out var uri)
+        && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+
+    private static void RemoveTrailingBlankParagraphs(IElement body)
+    {
+        while (body.LastElementChild != null
+            && string.Equals(body.LastElementChild.TagName, "p", StringComparison.OrdinalIgnoreCase)
+            && IsBlankParagraph(body.LastElementChild))
+        {
+            body.LastElementChild.Remove();
+        }
+    }
+
+    private static bool IsBlankParagraph(IElement element)
+    {
+        var text = (element.TextContent ?? string.Empty).Replace('\u00a0', ' ');
+        return string.IsNullOrWhiteSpace(text)
+            && element.QuerySelector("img") == null
+            && element.QuerySelector("video") == null
+            && element.QuerySelector("iframe") == null;
+    }
+
+    private static string CanonicalImageSource(string value)
+    {
+        var trimmed = StripUrlBoundaryControls(WebUtility.HtmlDecode(value));
+        if (!Uri.TryCreate(trimmed, UriKind.RelativeOrAbsolute, out var uri)
+            || !string.Equals(uri.IsAbsoluteUri ? uri.AbsolutePath : uri.OriginalString.Split('?')[0], "/Public/ProxyImage", StringComparison.OrdinalIgnoreCase))
+        {
+            return trimmed;
+        }
+
+        var query = uri.IsAbsoluteUri ? uri.Query : new Uri(new Uri("https://wayfarer.local"), uri).Query;
+        var values = QueryHelpers.ParseQuery(query);
+        return values.TryGetValue("url", out var target) && target.Count > 0
+            ? StripUrlBoundaryControls(target[0] ?? trimmed)
+            : trimmed;
+    }
+
+    private static string StripUrlBoundaryControls(string value) =>
+        Regex.Replace(value, @"^[\u0000-\u0020\u007f-\u009f]+|[\u0000-\u0020\u007f-\u009f]+$", string.Empty);
+
+    private static string CompactUrlScheme(string value) =>
+        Regex.Replace(StripUrlBoundaryControls(value)[..Math.Min(64, StripUrlBoundaryControls(value).Length)], @"[\u0000-\u0020\u007f-\u009f]+", string.Empty).ToLowerInvariant();
+}

--- a/Models/Dtos/Editor/EditorSegmentRequestParser.cs
+++ b/Models/Dtos/Editor/EditorSegmentRequestParser.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using NetTopologySuite.Geometries;
 using Wayfarer.Services;
 
@@ -11,10 +10,6 @@ namespace Wayfarer.Models.Dtos.Editor;
 internal static class EditorSegmentRequestParser
 {
     private static readonly string[] ServerOwnedFields = { "id", "tripId", "displayOrder", "capabilities" };
-    private static readonly Regex DataImageSourceRegex = new(
-        @"<img\b[^>]*?\bsrc\s*=\s*[""']?\s*data:image/",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
     /// <summary>
     /// Attempts to parse a complete-draft segment save request.
     /// </summary>
@@ -49,7 +44,7 @@ internal static class EditorSegmentRequestParser
             CanonicalMode(mode),
             distance,
             duration,
-            notesHtml,
+            EditorRichNotesRequestHtml.NormalizeForPersistence(notesHtml),
             route);
         return true;
     }
@@ -288,7 +283,7 @@ internal static class EditorSegmentRequestParser
 
     private static void ValidateNotes(string? notesHtml, Dictionary<string, string[]> errors)
     {
-        if (!string.IsNullOrEmpty(notesHtml) && DataImageSourceRegex.IsMatch(notesHtml))
+        if (EditorRichNotesRequestHtml.ContainsDataImageSource(notesHtml))
         {
             errors["notesHtml"] = new[] { "Notes cannot contain data image sources." };
         }

--- a/Models/Dtos/Editor/EditorTripMetadataUpdateRequestParser.cs
+++ b/Models/Dtos/Editor/EditorTripMetadataUpdateRequestParser.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.RegularExpressions;
 
 namespace Wayfarer.Models.Dtos.Editor;
 
@@ -15,10 +14,6 @@ internal static class EditorTripMetadataUpdateRequestParser
         "progressPublicUrl",
         "updatedAt"
     };
-
-    private static readonly Regex DataImageSourceRegex = new(
-        @"<img\b[^>]*?\bsrc\s*=\s*[""']?\s*data:image/",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
     /// Attempts to parse an editor metadata update request and returns field-keyed validation errors.
@@ -55,7 +50,7 @@ internal static class EditorTripMetadataUpdateRequestParser
             return false;
         }
 
-        update = new EditorTripMetadataUpdateRequest(name!, notesHtml, isPublic!.Value, coverImage, center, zoom);
+        update = new EditorTripMetadataUpdateRequest(name!, EditorRichNotesRequestHtml.NormalizeForPersistence(notesHtml), isPublic!.Value, coverImage, center, zoom);
         return true;
     }
 
@@ -267,7 +262,7 @@ internal static class EditorTripMetadataUpdateRequestParser
 
     private static void ValidateNotesHtml(string? notesHtml, Dictionary<string, string[]> errors)
     {
-        if (!string.IsNullOrEmpty(notesHtml) && DataImageSourceRegex.IsMatch(notesHtml))
+        if (EditorRichNotesRequestHtml.ContainsDataImageSource(notesHtml))
         {
             errors["notesHtml"] = new[] { "Notes images must use external image URLs, not data:image sources." };
         }

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
@@ -78,6 +78,29 @@ public sealed class TripEditorMetadataControllerTests : TestBase
         Assert.Equal(string.Empty, db.Trips.Single(t => t.Id == trip.Id).Notes);
     }
 
+    [Fact]
+    public async Task PatchMetadataNormalizesRichNotesBeforePersisting()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+        const string expectedNotes = "<p class=\"ql-align-center\">Centered</p><p><img src=\"https://cdn.example.test/proxied.jpg\"></p>";
+
+        var result = await PatchMetadata(controller, trip.Id, ValidMetadataJson(notesHtml: """
+        "<p class=\"ql-align-center\" onclick=\"alert(1)\">Centered</p><p><img src=\"/Public/ProxyImage?url=https%3A%2F%2Fcdn.example.test%2Fproxied.jpg\" onerror=\"alert(2)\"></p><p><br></p>"
+        """), CancellationToken.None);
+
+        var envelope = AssertMutation(result);
+        var stored = db.Trips.Single(t => t.Id == trip.Id);
+        Assert.Equal(expectedNotes, envelope.Data.NotesHtml);
+        Assert.Equal(expectedNotes, stored.Notes);
+        Assert.DoesNotContain("/Public/ProxyImage", stored.Notes);
+        Assert.DoesNotContain("onclick", stored.Notes);
+        Assert.DoesNotContain("onerror", stored.Notes);
+        Assert.DoesNotContain("<p><br></p>", stored.Notes);
+    }
+
     [Theory]
     [InlineData("null")]
     [InlineData("""{ "rawUrl": null }""")]

--- a/tests/Wayfarer.Tests/Models/EditorRichNotesRequestHtmlTests.cs
+++ b/tests/Wayfarer.Tests/Models/EditorRichNotesRequestHtmlTests.cs
@@ -19,6 +19,7 @@ public sealed class EditorRichNotesRequestHtmlTests
             "<p class=\"ql-align-left\">Left</p>",
             "<p class=\"ql-align-center\">Center</p>",
             "<p class=\"ql-align-right\">Right</p>",
+            "<p><span class=\"ql-font-serif\">Serif</span></p>",
             "<p><a href=\"https://example.test/page\" onclick=\"alert(1)\">Link</a></p>",
             "<p><img src=\"https://cdn.example.test/image.jpg\" onerror=\"alert(1)\"></p>");
 
@@ -32,12 +33,25 @@ public sealed class EditorRichNotesRequestHtmlTests
         Assert.Contains("<p>Left</p>", result);
         Assert.Contains("<p class=\"ql-align-center\">Center</p>", result);
         Assert.Contains("<p class=\"ql-align-right\">Right</p>", result);
+        Assert.Contains("<span class=\"ql-font-serif\">Serif</span>", result);
         Assert.Contains("href=\"https://example.test/page\"", result);
         Assert.Contains("src=\"https://cdn.example.test/image.jpg\"", result);
         Assert.DoesNotContain("ql-align-left", result);
         Assert.DoesNotContain("ql-ui", result);
         Assert.DoesNotContain("onclick", result);
         Assert.DoesNotContain("onerror", result);
+    }
+
+    [Fact]
+    public void NormalizeForPersistence_StripsQuillClassesFromUnsupportedElements()
+    {
+        var result = EditorRichNotesRequestHtml.NormalizeForPersistence(
+            "<p><span class=\"ql-align-right\">Inline alignment</span></p><p class=\"ql-font-serif\">Block font</p>");
+
+        Assert.Contains("<span>Inline alignment</span>", result);
+        Assert.Contains("<p>Block font</p>", result);
+        Assert.DoesNotContain("ql-align-right", result);
+        Assert.DoesNotContain("ql-font-serif", result);
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Models/EditorRichNotesRequestHtmlTests.cs
+++ b/tests/Wayfarer.Tests/Models/EditorRichNotesRequestHtmlTests.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using Wayfarer.Models.Dtos.Editor;
+using Xunit;
+
+namespace Wayfarer.Tests.Models;
+
+/// <summary>
+/// Contract tests for Trip Editor rich-notes request HTML before persistence.
+/// </summary>
+public sealed class EditorRichNotesRequestHtmlTests
+{
+    [Fact]
+    public void NormalizeForPersistence_PreservesAllowedFormattingListsAlignmentLinksAndImages()
+    {
+        var input = string.Concat(
+            "<p><strong>Bold</strong> <em>Italic</em> <u>Underline</u></p>",
+            "<ol><li data-list=\"bullet\"><span class=\"ql-ui\" contenteditable=\"false\"></span>Bullet</li>",
+            "<li data-list=\"ordered\">Ordered</li></ol>",
+            "<p class=\"ql-align-left\">Left</p>",
+            "<p class=\"ql-align-center\">Center</p>",
+            "<p class=\"ql-align-right\">Right</p>",
+            "<p><a href=\"https://example.test/page\" onclick=\"alert(1)\">Link</a></p>",
+            "<p><img src=\"https://cdn.example.test/image.jpg\" onerror=\"alert(1)\"></p>");
+
+        var result = EditorRichNotesRequestHtml.NormalizeForPersistence(input);
+
+        Assert.Contains("<strong>Bold</strong>", result);
+        Assert.Contains("<em>Italic</em>", result);
+        Assert.Contains("<u>Underline</u>", result);
+        Assert.Contains("data-list=\"bullet\"", result);
+        Assert.Contains("data-list=\"ordered\"", result);
+        Assert.Contains("<p>Left</p>", result);
+        Assert.Contains("<p class=\"ql-align-center\">Center</p>", result);
+        Assert.Contains("<p class=\"ql-align-right\">Right</p>", result);
+        Assert.Contains("href=\"https://example.test/page\"", result);
+        Assert.Contains("src=\"https://cdn.example.test/image.jpg\"", result);
+        Assert.DoesNotContain("ql-align-left", result);
+        Assert.DoesNotContain("ql-ui", result);
+        Assert.DoesNotContain("onclick", result);
+        Assert.DoesNotContain("onerror", result);
+    }
+
+    [Fact]
+    public void NormalizeForPersistence_UnwrapsProxyImageUrlsBeforeSave()
+    {
+        var result = EditorRichNotesRequestHtml.NormalizeForPersistence(
+            "<p><img src=\"/Public/ProxyImage?url=https%3A%2F%2Fcdn.example.test%2Fproxied.jpg\"></p>");
+
+        Assert.Contains("src=\"https://cdn.example.test/proxied.jpg\"", result);
+        Assert.DoesNotContain("/Public/ProxyImage", result);
+    }
+
+    [Fact]
+    public void NormalizeForPersistence_StripsDataImagesUnsafeUrlsAndScripts()
+    {
+        var input = string.Concat(
+            "<script>alert(1)</script>",
+            "<p onclick=\"alert(2)\">Safe text</p>",
+            "<p><a href=\"javascript:alert(3)\">Unsafe link</a></p>",
+            "<p><img src=\"data:image/png;base64,abc\"></p>",
+            "<p><img src=\"vbscript:msgbox(1)\"></p>");
+
+        var result = EditorRichNotesRequestHtml.NormalizeForPersistence(input);
+
+        Assert.Contains("Safe text", result);
+        Assert.Contains("Unsafe link", result);
+        Assert.DoesNotContain("<script", result);
+        Assert.DoesNotContain("onclick", result);
+        Assert.DoesNotContain("javascript:", result);
+        Assert.DoesNotContain("data:image", result);
+        Assert.DoesNotContain("<img", result);
+        Assert.DoesNotContain("vbscript:", result);
+    }
+
+    [Theory]
+    [InlineData("<p><br></p>", "")]
+    [InlineData("<p>Real content</p><p><br></p><p> </p>", "<p>Real content</p>")]
+    [InlineData("<p><img src=\"https://cdn.example.test/image.jpg\"></p><p><br></p>", "<p><img src=\"https://cdn.example.test/image.jpg\"></p>")]
+    public void NormalizeForPersistence_RemovesOnlyTrailingHelperBlankParagraphs(string input, string expected)
+    {
+        var result = EditorRichNotesRequestHtml.NormalizeForPersistence(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ContainsDataImageSource_DetectsDirectDataImageBeforeNormalization()
+    {
+        Assert.True(EditorRichNotesRequestHtml.ContainsDataImageSource("<p><img src=\" DATA:image/png;base64,abc\"></p>"));
+        Assert.False(EditorRichNotesRequestHtml.ContainsDataImageSource("<p><img src=\"https://cdn.example.test/image.jpg\"></p>"));
+    }
+
+    [Fact]
+    public void SaveRequestParsersNormalizeRichNotesBeforeMutationServicesPersist()
+    {
+        const string notesHtml = "<p class=\"ql-align-right\" onclick=\"alert(1)\">Right</p><p><img src=\"/Public/ProxyImage?url=https%3A%2F%2Fcdn.example.test%2Fimage.jpg\"></p><p><br></p>";
+        const string expectedNotesHtml = "<p class=\"ql-align-right\">Right</p><p><img src=\"https://cdn.example.test/image.jpg\"></p>";
+
+        Assert.True(EditorTripMetadataUpdateRequestParser.TryParse(Json($$"""
+        {
+          "name": "Trip",
+          "notesHtml": "{{JsonEncodedText(notesHtml)}}",
+          "isPublic": false,
+          "coverImage": null,
+          "center": null,
+          "zoom": null
+        }
+        """), out var metadata, out _));
+        Assert.Equal(expectedNotesHtml, metadata.NotesHtml);
+
+        Assert.True(EditorRegionRequestParser.TryParseSave(Json($$"""
+        {
+          "name": "Region",
+          "notesHtml": "{{JsonEncodedText(notesHtml)}}",
+          "coverImage": null,
+          "center": null
+        }
+        """), out var region, out _));
+        Assert.Equal(expectedNotesHtml, region.NotesHtml);
+
+        Assert.True(EditorPlaceRequestParser.TryParseCreate(Json($$"""
+        {
+          "name": "Place",
+          "notesHtml": "{{JsonEncodedText(notesHtml)}}",
+          "address": null,
+          "location": null,
+          "iconName": "marker",
+          "markerColor": "bg-blue",
+          "reverseGeocode": false
+        }
+        """), new HashSet<string> { "marker" }, new HashSet<string> { "bg-blue" }, out var place, out _));
+        Assert.Equal(expectedNotesHtml, place.NotesHtml);
+
+        Assert.True(EditorAreaRequestParser.TryParseCreate(Json($$"""
+        {
+          "name": "Area",
+          "notesHtml": "{{JsonEncodedText(notesHtml)}}",
+          "fillHex": "#ff6600",
+          "geometry": { "type": "Polygon", "coordinates": [[[23,37],[24,37],[24,38],[23,37]]] }
+        }
+        """), out var area, out _));
+        Assert.Equal(expectedNotesHtml, area.NotesHtml);
+
+        Assert.True(EditorSegmentRequestParser.TryParseSave(Json($$"""
+        {
+          "fromPlaceId": null,
+          "toPlaceId": null,
+          "mode": "walk",
+          "estimatedDistanceKm": null,
+          "estimatedDurationMinutes": null,
+          "notesHtml": "{{JsonEncodedText(notesHtml)}}",
+          "route": null
+        }
+        """), out var segment, out _));
+        Assert.Equal(expectedNotesHtml, segment.NotesHtml);
+    }
+
+    private static JsonElement Json(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    private static string JsonEncodedText(string value) => System.Text.Json.JsonEncodedText.Encode(value).ToString();
+}

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -61,7 +61,7 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     await page.keyboard.press('Enter');
     await metadataEditor.locator('button.ql-align[value="right"]').click();
     await page.keyboard.type('Right aligned note');
-    await routeImageUrl(page, 'https://example.com/photo.jpg');
+    await routeRichNoteImages(page, 'https://example.com/photo.jpg');
     await insertImageUrl(metadataForm, 'https://example.com/photo.jpg');
     await page.getByRole('button', { name: 'Save & Continue' }).click();
     await expect.poll(() => requests.length).toBe(1);
@@ -145,7 +145,7 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     await loadWorkspaceWithRichNotesFixture(page);
 
     const form = page.locator('#trip-editor-metadata-form');
-    await routeImageUrl(page, 'https://images.example.test/rich-note.png');
+    await routeRichNoteImages(page, 'https://images.example.test/rich-note.png');
     await insertImageUrl(form, 'https://images.example.test/rich-note.png');
     const image = richEditor(form).locator('.ql-editor img');
     await expect(image).toHaveAttribute('src', /\/Public\/ProxyImage\?url=https%3A%2F%2Fimages\.example\.test%2Frich-note\.png$/);
@@ -395,25 +395,10 @@ function terminalImageNotes(): string {
   return '<p>Intro before image</p><p><img src="https://images.example.test/terminal-large.svg"></p>';
 }
 
-async function routeRichNoteImages(page: Page): Promise<void> {
-  await page.route(/\/Public\/ProxyImage\?url=https%3A%2F%2Fimages\.example\.test%2Fterminal-large\.svg$/i, async route => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'image/svg+xml',
-      body: '<svg xmlns="http://www.w3.org/2000/svg" width="960" height="520"><rect width="960" height="520" fill="#dbeafe"/><rect x="24" y="24" width="912" height="472" rx="24" fill="#1e293b"/><text x="72" y="270" font-family="Arial" font-size="52" fill="#bfdbfe">Terminal rich note image</text></svg>'
-    });
-  });
-}
-
-async function routeImageUrl(page: Page, url: string): Promise<void> {
-  const escaped = encodeURIComponent(url).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  await page.route(new RegExp(`/Public/ProxyImage\\?url=${escaped}$`, 'i'), async route => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'image/svg+xml',
-      body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="#dbeafe"/></svg>'
-    });
-  });
+async function routeRichNoteImages(page: Page, ...urls: string[]): Promise<void> {
+  for (const url of ['https://images.example.test/terminal-large.svg', ...urls]) {
+    await page.route(new RegExp(`/Public/ProxyImage\\?url=${encodeURIComponent(url).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i'), route => route.fulfill({ status: 200, contentType: 'image/svg+xml', body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="#dbeafe"/></svg>' }));
+  }
 }
 
 async function routeEditorMutations(page: Page, state: MutableEditorState, requests: Array<{ method: string; url: string; body: Record<string, any> }>): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotes.spec.ts
@@ -61,6 +61,7 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     await page.keyboard.press('Enter');
     await metadataEditor.locator('button.ql-align[value="right"]').click();
     await page.keyboard.type('Right aligned note');
+    await routeImageUrl(page, 'https://example.com/photo.jpg');
     await insertImageUrl(metadataForm, 'https://example.com/photo.jpg');
     await page.getByRole('button', { name: 'Save & Continue' }).click();
     await expect.poll(() => requests.length).toBe(1);
@@ -144,6 +145,7 @@ test.describe.serial('Trip Editor rich notes parity', () => {
     await loadWorkspaceWithRichNotesFixture(page);
 
     const form = page.locator('#trip-editor-metadata-form');
+    await routeImageUrl(page, 'https://images.example.test/rich-note.png');
     await insertImageUrl(form, 'https://images.example.test/rich-note.png');
     const image = richEditor(form).locator('.ql-editor img');
     await expect(image).toHaveAttribute('src', /\/Public\/ProxyImage\?url=https%3A%2F%2Fimages\.example\.test%2Frich-note\.png$/);
@@ -399,6 +401,17 @@ async function routeRichNoteImages(page: Page): Promise<void> {
       status: 200,
       contentType: 'image/svg+xml',
       body: '<svg xmlns="http://www.w3.org/2000/svg" width="960" height="520"><rect width="960" height="520" fill="#dbeafe"/><rect x="24" y="24" width="912" height="472" rx="24" fill="#1e293b"/><text x="72" y="270" font-family="Arial" font-size="52" fill="#bfdbfe">Terminal rich note image</text></svg>'
+    });
+  });
+}
+
+async function routeImageUrl(page: Page, url: string): Promise<void> {
+  const escaped = encodeURIComponent(url).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  await page.route(new RegExp(`/Public/ProxyImage\\?url=${escaped}$`, 'i'), async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/svg+xml',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="#dbeafe"/></svg>'
     });
   });
 }

--- a/tests/e2e/trip-editor/tripEditorRichNotesPersistence.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotesPersistence.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import {
+  absoluteUrl,
+  editorApiPath,
+  editorPath,
+  expectMountedWorkspace,
+  loadEditorStateFixture,
+  signIn,
+  uniqueName
+} from './tripEditorTestUtils';
+
+type EditorState = Record<string, any>;
+
+test.describe.serial('Trip Editor rich notes real persistence contract', () => {
+  test('metadata rich notes save through the real endpoint and reload as canonical HTML', async ({ page }) => {
+    await signIn(page);
+    await page.goto(absoluteUrl(editorPath));
+    await expectMountedWorkspace(page);
+    const originalState = await loadEditorStateFixture(page) as EditorState;
+    const originalMetadata = { ...originalState.metadata };
+    const imageUrl = 'https://images.example.test/rich-notes-persistence.png';
+    const runText = uniqueName('PW rich notes persisted');
+    await routeProxyImage(page, imageUrl);
+
+    try {
+      const form = page.locator('#trip-editor-metadata-form');
+      const editor = richEditor(form).locator('.ql-editor');
+      await editor.click();
+      await page.keyboard.press('Control+A');
+      await page.keyboard.press('Backspace');
+      await page.keyboard.type(runText);
+      await page.keyboard.press('Enter');
+      await richEditor(form).locator('button.ql-align[value="center"]').click();
+      await page.keyboard.type('Centered persisted note');
+      await insertImageUrl(form, imageUrl);
+
+      await page.getByRole('button', { name: 'Save & Continue' }).click();
+      await expectSaved(page);
+
+      await expectState(page, state => {
+        const notes = state.metadata.notesHtml as string;
+        expect(notes).toContain(runText);
+        expect(notes).toContain('<p class="ql-align-center">Centered persisted note');
+        expect(notes).toContain(`src="${imageUrl}"`);
+        expect(notes).not.toContain('/Public/ProxyImage');
+        expect(notes).not.toContain('<p><br></p>');
+      });
+
+      await page.reload();
+      await expectMountedWorkspace(page);
+      const reloadedForm = page.locator('#trip-editor-metadata-form');
+      const reloadedEditor = richEditor(reloadedForm).locator('.ql-editor');
+      await expect(reloadedEditor).toContainText(runText);
+      await expect(reloadedEditor.locator('p.ql-align-center')).toContainText('Centered persisted note');
+      await expect(reloadedEditor.locator('img')).toHaveAttribute('src', /\/Public\/ProxyImage\?url=https%3A%2F%2Fimages\.example\.test%2Frich-notes-persistence\.png$/);
+    } finally {
+      if (!page.isClosed()) {
+        await restoreMetadata(page, originalMetadata);
+      }
+    }
+  });
+});
+
+async function routeProxyImage(page: Page, url: string): Promise<void> {
+  const escaped = encodeURIComponent(url).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  await page.route(new RegExp(`/Public/ProxyImage\\?url=${escaped}$`, 'i'), async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/svg+xml',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="#dbeafe"/><text x="24" y="96" font-family="Arial" font-size="24" fill="#1e293b">Rich notes persistence</text></svg>'
+    });
+  });
+}
+
+function richEditor(form: Locator): Locator {
+  return form.locator('.trip-editor-rich-notes');
+}
+
+async function insertImageUrl(form: Locator, url: string): Promise<void> {
+  await richEditor(form).locator('.ql-image').click();
+  const dialog = form.page().getByRole('dialog', { name: 'Insert image URL' });
+  await expect(dialog).toBeVisible();
+  await dialog.getByLabel('Image URL').fill(url);
+  await dialog.getByRole('button', { name: 'Insert Image' }).click();
+  await expect(dialog).toHaveCount(0);
+}
+
+async function expectSaved(page: Page): Promise<void> {
+  await expect(page.locator('.trip-editor-save-state').filter({ hasText: /saved/i }).first()).toBeVisible();
+}
+
+async function expectState(page: Page, assertion: (state: EditorState) => void): Promise<void> {
+  assertion(await loadEditorStateFixture(page) as EditorState);
+}
+
+async function restoreMetadata(page: Page, metadata: Record<string, any>): Promise<void> {
+  const token = await page.locator('#trip-editor-antiforgery input[name="__RequestVerificationToken"]').inputValue().catch(() => '');
+  if (!token) {
+    return;
+  }
+
+  const response = await page.request.patch(absoluteUrl(`${editorApiPath}/metadata`), {
+    data: {
+      name: metadata.name,
+      notesHtml: metadata.notesHtml,
+      isPublic: metadata.isPublic,
+      coverImage: metadata.coverImage,
+      center: metadata.center,
+      zoom: metadata.zoom
+    },
+    headers: { RequestVerificationToken: token }
+  });
+  expect(response.ok(), `metadata cleanup PATCH returned ${response.status()}: ${await response.text()}`).toBeTruthy();
+}

--- a/tests/e2e/trip-editor/tripEditorRichNotesPersistence.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRichNotesPersistence.spec.ts
@@ -33,8 +33,13 @@ test.describe.serial('Trip Editor rich notes real persistence contract', () => {
       await richEditor(form).locator('button.ql-align[value="center"]').click();
       await page.keyboard.type('Centered persisted note');
       await insertImageUrl(form, imageUrl);
+      await expect(editor).toContainText(runText);
+      await expect(editor.locator('p.ql-align-center')).toContainText('Centered persisted note');
 
+      const saveResponse = page.waitForResponse(response =>
+        response.url().endsWith(`${editorApiPath}/metadata`) && response.request().method() === 'PATCH');
       await page.getByRole('button', { name: 'Save & Continue' }).click();
+      expect((await saveResponse).ok()).toBeTruthy();
       await expectSaved(page);
 
       await expectState(page, state => {
@@ -51,7 +56,7 @@ test.describe.serial('Trip Editor rich notes real persistence contract', () => {
       const reloadedForm = page.locator('#trip-editor-metadata-form');
       const reloadedEditor = richEditor(reloadedForm).locator('.ql-editor');
       await expect(reloadedEditor).toContainText(runText);
-      await expect(reloadedEditor.locator('p.ql-align-center')).toContainText('Centered persisted note');
+      await expect(reloadedEditor.locator('p.ql-align-center').filter({ hasText: 'Centered persisted note' })).toBeVisible();
       await expect(reloadedEditor.locator('img')).toHaveAttribute('src', /\/Public\/ProxyImage\?url=https%3A%2F%2Fimages\.example\.test%2Frich-notes-persistence\.png$/);
     } finally {
       if (!page.isClosed()) {


### PR DESCRIPTION
## Summary

Implements #297 Batch 5 only: Trip Editor request-boundary rich-notes normalization and persistence coverage.

- Adds `EditorRichNotesRequestHtml` as a Trip Editor request-boundary helper, not a broad app sanitizer.
- Wires metadata, region, place, area, and segment editor request parsers through the helper before persistence.
- Backend tests cover canonical HTML behavior for formatting, lists, links, alignment, images, proxy URL unwrapping, data-image handling, unsafe attribute stripping, and trailing helper paragraph removal.
- Adds controller-level metadata persistence proof through parser/service/database.
- Adds one real Playwright metadata rich-notes persistence spec that saves through the actual PATCH endpoint and verifies API reread/reload behavior.

## Claim Boundary

Existing rich-notes Playwright specs remain mocked/fixture-backed and validate editor UX, client canonicalization, request shape, image-dialog behavior, and draft behavior only. They are not backend persistence proof.

The real persistence proof in this PR is limited to the new metadata rich-notes persistence spec plus backend request-boundary tests for the shared parser path.

## Out Of Scope

- Batch 6 Development/published production asset smoke.
- Legacy/public/mobile HTML sanitization redesign.
- Broad app-wide sanitizer replacement.

## Validation

- Focused helper tests passed.
- Focused helper + metadata persistence tests passed.
- Focused rich-notes Playwright specs passed.
- Playwright list passed with 117 tests listed.
- `dotnet build` passed.
- `dotnet test` passed, 1547 tests.
- LOC check passed under hard cap; warnings only.
- `git diff --check origin/main...HEAD` passed.
- tracked artifact scan: clean.
