### PR TITLE
Fix reset-password CLI scope

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -34,7 +34,7 @@ var builder = WebApplication.CreateBuilder(args);
 #region CLI Command Handling
 
 // Handling the "reset-password" command from the CLI
-if (args.Length > 0 && args[0] == "reset-password") await HandlePasswordResetCommand(args);
+if (args.Length > 0 && args[0] == "reset-password") { await HandlePasswordResetCommand(args); return; }
 
 #endregion CLI Command Handling
 
@@ -187,7 +187,7 @@ static async Task HandlePasswordResetCommand(string[] args)
     var username = args[1];
     var newPassword = args[2];
 
-    // Rebuild services to handle the password reset
+    // Build a minimal command host so UserManager is resolved from a normal DI scope.
     var builder = WebApplication.CreateBuilder(args);
     builder.Services.AddDbContext<ApplicationDbContext>(options =>
         options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection"),
@@ -197,11 +197,10 @@ static async Task HandlePasswordResetCommand(string[] args)
         .AddEntityFrameworkStores<ApplicationDbContext>()
         .AddDefaultTokenProviders();
 
-    var services = builder.Services.BuildServiceProvider();
+    await using var app = builder.Build();
+    using var scope = app.Services.CreateScope();
+    var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
 
-    var userManager = services.GetRequiredService<UserManager<ApplicationUser>>();
-
-    builder.Services.AddHttpContextAccessor();
     var user = await userManager.FindByNameAsync(username);
     if (user == null)
     {


### PR DESCRIPTION
## Summary
- Fixes #306.
- Stops the `reset-password` CLI command after the password reset instead of continuing into web startup.
- Replaces `builder.Services.BuildServiceProvider()` in the CLI path with a minimal command host and scoped `UserManager<ApplicationUser>` resolution.
- Keeps the existing CLI success/failure feedback messages.

## Validation
- `dotnet build`: passed, 0 warnings / 0 errors; ASP0000 is gone.
- `dotnet run -- reset-password`: printed usage and exited without starting the web app.
- `dotnet run -- reset-password user2 User2!`: reset succeeded and printed the success message.
- Manual login check with `user2` / `User2!`: passed.
- `dotnet test`: passed, 1547/1547.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600`: passed with existing warnings only.
- `git diff --check`: passed, normal CRLF working-copy warning only.
- Tracked artifact scan: clean.

## Notes
No normal web startup service registration was changed; the patch is scoped to the admin CLI reset-password path.
