### PR TITLE
Fix Trip Editor public progress URL

### DIFF
--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -9,7 +9,6 @@ using Wayfarer.Models;
 using Wayfarer.Models.Dtos.Editor;
 using Wayfarer.Services;
 using Wayfarer.Util;
-using PublicTripViewerController = Wayfarer.Areas.Public.Controllers.TripViewerController;
 
 namespace Wayfarer.Areas.Api.Controllers;
 
@@ -22,6 +21,8 @@ namespace Wayfarer.Areas.Api.Controllers;
 [Route("api/trips/{tripId:guid}/editor")]
 public sealed partial class TripEditorController : ControllerBase
 {
+    private const string PublicTripViewRouteName = "PublicTripView";
+
     private readonly ApplicationDbContext _dbContext;
     private readonly IWebHostEnvironment _environment;
     private readonly IIconColorProvider _iconColorProvider;
@@ -375,7 +376,7 @@ public sealed partial class TripEditorController : ControllerBase
 
         return Url.RouteUrl(new UrlRouteContext
         {
-            RouteName = PublicTripViewerController.PublicTripViewRouteName,
+            RouteName = PublicTripViewRouteName,
             Values = values,
             Protocol = Request.Scheme
         });

--- a/Areas/Api/Controllers/TripEditorController.cs
+++ b/Areas/Api/Controllers/TripEditorController.cs
@@ -3,11 +3,13 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.EntityFrameworkCore;
 using Wayfarer.Models;
 using Wayfarer.Models.Dtos.Editor;
 using Wayfarer.Services;
 using Wayfarer.Util;
+using PublicTripViewerController = Wayfarer.Areas.Public.Controllers.TripViewerController;
 
 namespace Wayfarer.Areas.Api.Controllers;
 
@@ -362,11 +364,25 @@ public sealed partial class TripEditorController : ControllerBase
             new EditorLimitsDto(6, 1));
     }
 
-    private string? GeneratePublicTripUrl(Guid tripId) =>
-        Url.Action("View", "TripViewer", new { area = "Public", id = tripId }, Request.Scheme);
+    /// <summary>
+    /// Generates absolute public trip links through the named attribute route to avoid conventional area fallback URLs.
+    /// </summary>
+    private string? GeneratePublicTripUrl(Guid tripId, int? progress = null)
+    {
+        object values = progress.HasValue
+            ? new { id = tripId, progress = progress.Value }
+            : new { id = tripId };
+
+        return Url.RouteUrl(new UrlRouteContext
+        {
+            RouteName = PublicTripViewerController.PublicTripViewRouteName,
+            Values = values,
+            Protocol = Request.Scheme
+        });
+    }
 
     private string? GenerateProgressPublicTripUrl(Guid tripId) =>
-        Url.Action("View", "TripViewer", new { area = "Public", id = tripId, progress = 1 }, Request.Scheme);
+        GeneratePublicTripUrl(tripId, progress: 1);
 
     private IActionResult? RequireEditorUser(out string? userId)
     {

--- a/Areas/Public/Controllers/TripViewerController.cs
+++ b/Areas/Public/Controllers/TripViewerController.cs
@@ -16,11 +16,6 @@ namespace Wayfarer.Areas.Public.Controllers;
 public class TripViewerController : BaseController
 {
     /// <summary>
-    /// Canonical named route for absolute public trip links generated outside the public controller.
-    /// </summary>
-    public const string PublicTripViewRouteName = "PublicTripView";
-
-    /// <summary>
     /// Thread-safe dictionary for rate limiting anonymous requests by IP address.
     /// Uses atomic operations via <see cref="RateLimitHelper"/> to prevent race conditions.
     /// Exposed internally for periodic background cleanup by <see cref="Wayfarer.Jobs.RateLimitCleanupJob"/>.
@@ -224,7 +219,7 @@ public class TripViewerController : BaseController
 
     // GET: /Public/Trips/{id}?embed=true
     [HttpGet]
-    [Route("/Public/Trips/{id}", Name = PublicTripViewRouteName, Order = 2)]
+    [Route("/Public/Trips/{id}", Name = "PublicTripView", Order = 2)]
     public async Task<IActionResult> View(Guid id, bool embed = false)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);

--- a/Areas/Public/Controllers/TripViewerController.cs
+++ b/Areas/Public/Controllers/TripViewerController.cs
@@ -16,6 +16,11 @@ namespace Wayfarer.Areas.Public.Controllers;
 public class TripViewerController : BaseController
 {
     /// <summary>
+    /// Canonical named route for absolute public trip links generated outside the public controller.
+    /// </summary>
+    public const string PublicTripViewRouteName = "PublicTripView";
+
+    /// <summary>
     /// Thread-safe dictionary for rate limiting anonymous requests by IP address.
     /// Uses atomic operations via <see cref="RateLimitHelper"/> to prevent race conditions.
     /// Exposed internally for periodic background cleanup by <see cref="Wayfarer.Jobs.RateLimitCleanupJob"/>.
@@ -217,9 +222,9 @@ public class TripViewerController : BaseController
         return RedirectToRoute("PublicTripsIndex", new { tags = slug, view, sort, page });
     }
 
-    // GET: /Public/Trips/View/{id}?embed=true
+    // GET: /Public/Trips/{id}?embed=true
     [HttpGet]
-    [Route("/Public/Trips/{id}", Order = 2)]
+    [Route("/Public/Trips/{id}", Name = PublicTripViewRouteName, Order = 2)]
     public async Task<IActionResult> View(Guid id, bool embed = false)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -23,6 +23,8 @@ namespace Wayfarer.Tests.Controllers;
 /// </summary>
 public sealed class TripEditorControllerTests : TestBase
 {
+    private const string PublicTripViewRouteName = "PublicTripView";
+
     [Fact]
     public async Task GetEditorStateWithoutUserReturnsUnauthorized()
     {
@@ -162,7 +164,7 @@ public sealed class TripEditorControllerTests : TestBase
             .Single(method => method.Name == nameof(PublicTripViewerController.View))
             .GetCustomAttributes(typeof(RouteAttribute), inherit: false)
             .Cast<RouteAttribute>()
-            .Single(attribute => attribute.Name == PublicTripViewerController.PublicTripViewRouteName);
+            .Single(attribute => attribute.Name == PublicTripViewRouteName);
 
         Assert.Equal("/Public/Trips/{id}", route.Template);
     }
@@ -322,7 +324,7 @@ public sealed class TripEditorControllerTests : TestBase
             {
                 var id = context.Values?.GetType().GetProperty("id")?.GetValue(context.Values);
                 var progress = context.Values?.GetType().GetProperty("progress")?.GetValue(context.Values);
-                Assert.Equal(PublicTripViewerController.PublicTripViewRouteName, context.RouteName);
+                Assert.Equal(PublicTripViewRouteName, context.RouteName);
                 Assert.Equal("https", context.Protocol);
                 return progress == null
                     ? $"https://example.test/Public/Trips/{id}"

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -12,6 +13,7 @@ using Wayfarer.Models.Dtos.Editor;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
+using PublicTripViewerController = Wayfarer.Areas.Public.Controllers.TripViewerController;
 using Xunit;
 
 namespace Wayfarer.Tests.Controllers;
@@ -153,6 +155,19 @@ public sealed class TripEditorControllerTests : TestBase
     }
 
     [Fact]
+    public void PublicTripViewRouteUsesCanonicalPublicTripsTemplate()
+    {
+        var route = typeof(PublicTripViewerController)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+            .Single(method => method.Name == nameof(PublicTripViewerController.View))
+            .GetCustomAttributes(typeof(RouteAttribute), inherit: false)
+            .Cast<RouteAttribute>()
+            .Single(attribute => attribute.Name == PublicTripViewerController.PublicTripViewRouteName);
+
+        Assert.Equal("/Public/Trips/{id}", route.Template);
+    }
+
+    [Fact]
     public async Task GetEditorStateMapsCoordinatesAndGeoJsonWithExpectedShapes()
     {
         using var db = CreateDbContext();
@@ -265,9 +280,13 @@ public sealed class TripEditorControllerTests : TestBase
 
     private static void ConfigureControllerWithUserRole(ControllerBase controller, string userId, string role = "User")
     {
+        var httpContext = BuildHttpContextWithUser(userId, role);
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("example.test");
+
         controller.ControllerContext = new ControllerContext
         {
-            HttpContext = BuildHttpContextWithUser(userId, role)
+            HttpContext = httpContext
         };
     }
 
@@ -297,12 +316,14 @@ public sealed class TripEditorControllerTests : TestBase
             new TripEditorSegmentMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
-        var url = new Mock<IUrlHelper>();
-        url.Setup(u => u.Action(It.IsAny<UrlActionContext>()))
-            .Returns((UrlActionContext context) =>
+        var url = new Mock<IUrlHelper>(MockBehavior.Strict);
+        url.Setup(u => u.RouteUrl(It.IsAny<UrlRouteContext>()))
+            .Returns((UrlRouteContext context) =>
             {
                 var id = context.Values?.GetType().GetProperty("id")?.GetValue(context.Values);
                 var progress = context.Values?.GetType().GetProperty("progress")?.GetValue(context.Values);
+                Assert.Equal(PublicTripViewerController.PublicTripViewRouteName, context.RouteName);
+                Assert.Equal("https", context.Protocol);
                 return progress == null
                     ? $"https://example.test/Public/Trips/{id}"
                     : $"https://example.test/Public/Trips/{id}?progress={progress}";

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
@@ -12,7 +12,6 @@ using Wayfarer.Models.Dtos.Editor;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
-using PublicTripViewerController = Wayfarer.Areas.Public.Controllers.TripViewerController;
 using Xunit;
 
 namespace Wayfarer.Tests.Controllers;
@@ -22,6 +21,8 @@ namespace Wayfarer.Tests.Controllers;
 /// </summary>
 public sealed class TripEditorMetadataControllerTests : TestBase
 {
+    private const string PublicTripViewRouteName = "PublicTripView";
+
     [Fact]
     public async Task PatchMetadataForOwnerUpdatesMetadataAndReturnsMetadataOnlyEnvelope()
     {
@@ -246,7 +247,7 @@ public sealed class TripEditorMetadataControllerTests : TestBase
             {
                 var id = context.Values?.GetType().GetProperty("id")?.GetValue(context.Values);
                 var progress = context.Values?.GetType().GetProperty("progress")?.GetValue(context.Values);
-                Assert.Equal(PublicTripViewerController.PublicTripViewRouteName, context.RouteName);
+                Assert.Equal(PublicTripViewRouteName, context.RouteName);
                 Assert.Equal("https", context.Protocol);
                 return progress == null
                     ? $"https://example.test/Public/Trips/{id}"

--- a/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorMetadataControllerTests.cs
@@ -12,6 +12,7 @@ using Wayfarer.Models.Dtos.Editor;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
+using PublicTripViewerController = Wayfarer.Areas.Public.Controllers.TripViewerController;
 using Xunit;
 
 namespace Wayfarer.Tests.Controllers;
@@ -210,9 +211,13 @@ public sealed class TripEditorMetadataControllerTests : TestBase
 
     private static void ConfigureControllerWithUserRole(ControllerBase controller, string userId, string role = "User")
     {
+        var httpContext = BuildHttpContextWithUser(userId, role);
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("example.test");
+
         controller.ControllerContext = new ControllerContext
         {
-            HttpContext = BuildHttpContextWithUser(userId, role)
+            HttpContext = httpContext
         };
     }
 
@@ -235,12 +240,14 @@ public sealed class TripEditorMetadataControllerTests : TestBase
             new TripEditorSegmentMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
-        var url = new Mock<IUrlHelper>();
-        url.Setup(u => u.Action(It.IsAny<UrlActionContext>()))
-            .Returns((UrlActionContext context) =>
+        var url = new Mock<IUrlHelper>(MockBehavior.Strict);
+        url.Setup(u => u.RouteUrl(It.IsAny<UrlRouteContext>()))
+            .Returns((UrlRouteContext context) =>
             {
                 var id = context.Values?.GetType().GetProperty("id")?.GetValue(context.Values);
                 var progress = context.Values?.GetType().GetProperty("progress")?.GetValue(context.Values);
+                Assert.Equal(PublicTripViewerController.PublicTripViewRouteName, context.RouteName);
+                Assert.Equal("https", context.Protocol);
                 return progress == null
                     ? $"https://example.test/Public/Trips/{id}"
                     : $"https://example.test/Public/Trips/{id}?progress={progress}";

--- a/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
@@ -12,7 +12,6 @@ using Wayfarer.Models.Dtos.Editor;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
-using PublicTripViewerController = Wayfarer.Areas.Public.Controllers.TripViewerController;
 using Xunit;
 
 namespace Wayfarer.Tests.Controllers;
@@ -22,6 +21,8 @@ namespace Wayfarer.Tests.Controllers;
 /// </summary>
 public sealed class TripEditorTagsShareProgressControllerTests : TestBase
 {
+    private const string PublicTripViewRouteName = "PublicTripView";
+
     [Fact]
     public async Task PutTagsReplacesCompleteSetAndReturnsAffectedTags()
     {
@@ -240,7 +241,7 @@ public sealed class TripEditorTagsShareProgressControllerTests : TestBase
             {
                 var id = context.Values?.GetType().GetProperty("id")?.GetValue(context.Values);
                 var progress = context.Values?.GetType().GetProperty("progress")?.GetValue(context.Values);
-                Assert.Equal(PublicTripViewerController.PublicTripViewRouteName, context.RouteName);
+                Assert.Equal(PublicTripViewRouteName, context.RouteName);
                 Assert.Equal("https", context.Protocol);
                 return progress == null
                     ? $"https://example.test/Public/Trips/{id}"

--- a/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorTagsShareProgressControllerTests.cs
@@ -12,6 +12,7 @@ using Wayfarer.Models.Dtos.Editor;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
+using PublicTripViewerController = Wayfarer.Areas.Public.Controllers.TripViewerController;
 using Xunit;
 
 namespace Wayfarer.Tests.Controllers;
@@ -233,12 +234,14 @@ public sealed class TripEditorTagsShareProgressControllerTests : TestBase
             new TripEditorSegmentMutationService(db),
             Mock.Of<ILogger<TripEditorController>>());
 
-        var url = new Mock<IUrlHelper>();
-        url.Setup(u => u.Action(It.IsAny<UrlActionContext>()))
-            .Returns((UrlActionContext context) =>
+        var url = new Mock<IUrlHelper>(MockBehavior.Strict);
+        url.Setup(u => u.RouteUrl(It.IsAny<UrlRouteContext>()))
+            .Returns((UrlRouteContext context) =>
             {
                 var id = context.Values?.GetType().GetProperty("id")?.GetValue(context.Values);
                 var progress = context.Values?.GetType().GetProperty("progress")?.GetValue(context.Values);
+                Assert.Equal(PublicTripViewerController.PublicTripViewRouteName, context.RouteName);
+                Assert.Equal("https", context.Protocol);
                 return progress == null
                     ? $"https://example.test/Public/Trips/{id}"
                     : $"https://example.test/Public/Trips/{id}?progress={progress}";
@@ -263,9 +266,13 @@ public sealed class TripEditorTagsShareProgressControllerTests : TestBase
 
     private static void ConfigureControllerWithUserRole(ControllerBase controller, string userId, string role = "User")
     {
+        var httpContext = BuildHttpContextWithUser(userId, role);
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("example.test");
+
         controller.ControllerContext = new ControllerContext
         {
-            HttpContext = BuildHttpContextWithUser(userId, role)
+            HttpContext = httpContext
         };
     }
 


### PR DESCRIPTION
## Summary
Fixes #308.

Root cause: Trip Editor metadata URL generation used `Url.Action("View", "TripViewer", new { area = "Public", ... })`. Because the public trip view endpoint is an attribute route, MVC could fall back to the conventional public-area route and generate `/Public/TripViewer/View/{tripId}` instead of the canonical `/Public/Trips/{tripId}` route.

Before:
- public URL could generate `https://example.test/Public/TripViewer/View/{tripId}`
- progress URL generated `https://example.test/Public/TripViewer/View/{tripId}?progress=1`

After:
- public URL generates `https://example.test/Public/Trips/{tripId}`
- progress URL generates `https://example.test/Public/Trips/{tripId}?progress=1`

Implementation notes:
- Named the existing public trip view attribute route as `PublicTripView`.
- Updated Trip Editor read-state/metadata generation to use `Url.RouteUrl(...)` against that named route.
- Strengthened controller tests so the previous `Url.Action(...)` path is no longer masked by a permissive URL-helper mock.

## Validation
- `dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --filter "FullyQualifiedName~TripEditorControllerTests|FullyQualifiedName~TripEditorTagsShareProgressControllerTests|FullyQualifiedName~TripEditorMetadataControllerTests"` - passed, 46 tests
- `dotnet build` - passed, 0 warnings/errors
- `dotnet test` - passed, 1548 tests
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` - passed with existing warning-threshold files; no hard failures
- `git diff --check origin/main...HEAD` - passed
- `git ls-files -- .local playwright-report test-results screenshots traces wwwroot/vite/trip-editor wwwroot/dist` - no tracked artifacts reported

Manual deployed validation is still required after this PR is deployed, because the fix has been validated locally through backend route-generation tests and not against the deployed environment that originally produced the 404.