### PR TITLE
Polish Trip Editor visit progress modal

### DIFF
--- a/ClientApps/trip-editor/src/components/VisitProgressSurface.vue
+++ b/ClientApps/trip-editor/src/components/VisitProgressSurface.vue
@@ -17,6 +17,9 @@ type VisitPlaceRow = {
 type VisitRegionGroup = {
   regionId: Guid;
   regionName: string;
+  visitedCount: number;
+  totalCount: number;
+  percentVisited: number;
   rows: VisitPlaceRow[];
 };
 
@@ -42,14 +45,21 @@ const regionGroups = computed<VisitRegionGroup[]>(() => {
 
   for (const regionId of props.state.regionOrder) {
     const placeIds = props.state.placeOrderByRegionId[regionId] ?? [];
-    const rows = placeIds
+    const allRows = placeIds
       .map(placeId => visitPlaceRow(regionId, placeId, orderedHistory))
-      .filter(row => row && filterMatches(row.summary)) as VisitPlaceRow[];
+      .filter(row => row) as VisitPlaceRow[];
+    const rows = allRows.filter(row => filterMatches(row.summary));
 
     if (rows.length > 0) {
+      const visitedCount = allRows.filter(row => row.summary.isVisited).length;
+      const totalCount = allRows.length;
+
       groups.push({
         regionId,
         regionName: regionName(regionId),
+        visitedCount,
+        totalCount,
+        percentVisited: percentVisited(visitedCount, totalCount),
         rows
       });
     }
@@ -118,6 +128,10 @@ function filterMatches(summary: EditorPlaceVisitSummary): boolean {
 
 function regionName(regionId: Guid): string {
   return props.state.regionsById[regionId]?.name || 'Unknown region';
+}
+
+function percentVisited(visitedCount: number, totalCount: number): number {
+  return totalCount > 0 ? Math.round((visitedCount / totalCount) * 100) : 0;
 }
 
 function historyRegionName(row: EditorVisitHistoryRow, fallbackRegionId: Guid): string {
@@ -198,30 +212,43 @@ async function manageVisit(event: MouseEvent, visitId: Guid): Promise<void> {
 
         <div class="trip-editor-expanded__body trip-editor-visit-progress__body">
           <section class="trip-editor-visit-progress__summary" aria-label="Trip visit progress summary">
-            <div class="trip-editor-panel__line">
-              <span>Visit progress</span>
-              <strong>{{ state.visitProgress.percentVisited }}%</strong>
+            <div class="trip-editor-visit-progress__summary-heading">
+              <div>
+                <span>Visit progress</span>
+                <strong>Your overall trip progress</strong>
+              </div>
+              <strong class="trip-editor-visit-progress__percent">{{ state.visitProgress.percentVisited }}%</strong>
             </div>
-            <div class="trip-editor-progress" aria-hidden="true">
+            <div
+              class="trip-editor-progress trip-editor-visit-progress__bar"
+              role="progressbar"
+              aria-label="Overall visit progress"
+              :aria-valuenow="state.visitProgress.percentVisited"
+              aria-valuemin="0"
+              aria-valuemax="100"
+            >
               <span :style="{ width: `${state.visitProgress.percentVisited}%` }"></span>
             </div>
-            <p>{{ state.visitProgress.visitedPlaces }} / {{ state.visitProgress.totalPlaces }} places visited</p>
+            <p class="trip-editor-visit-progress__summary-count">
+              <span class="trip-editor-visit-status trip-editor-visit-status--visited" aria-hidden="true">&check;</span>
+              {{ state.visitProgress.visitedPlaces }} / {{ state.visitProgress.totalPlaces }} places visited
+            </p>
             <p v-if="totalPlaces > 0 && !hasVisits">No visit history yet.</p>
           </section>
 
           <fieldset class="trip-editor-visit-progress__filters" aria-label="Visit filters">
             <legend>Filter places</legend>
-            <label>
+            <label class="trip-editor-visit-filter-option">
               <input v-model="filter" type="radio" name="trip-editor-visit-filter" value="all" />
               <span>All</span>
             </label>
-            <label>
+            <label class="trip-editor-visit-filter-option">
               <input v-model="filter" type="radio" name="trip-editor-visit-filter" value="visited" />
-              <span>Visited</span>
+              <span><span class="trip-editor-visit-status trip-editor-visit-status--visited" aria-hidden="true">&check;</span>Visited</span>
             </label>
-            <label>
+            <label class="trip-editor-visit-filter-option">
               <input v-model="filter" type="radio" name="trip-editor-visit-filter" value="not-visited" />
-              <span>Not visited</span>
+              <span><span class="trip-editor-visit-status trip-editor-visit-status--pending" aria-hidden="true"></span>Not visited</span>
             </label>
           </fieldset>
 
@@ -229,14 +256,38 @@ async function manageVisit(event: MouseEvent, visitId: Guid): Promise<void> {
 
           <div v-else class="trip-editor-visit-region-list">
             <section v-for="group in regionGroups" :key="group.regionId" class="trip-editor-visit-region" :aria-label="group.regionName">
-              <h3>{{ group.regionName }}</h3>
+              <header class="trip-editor-visit-region__header">
+                <h3>{{ group.regionName }}</h3>
+                <span>{{ group.visitedCount }} / {{ group.totalCount }} visited</span>
+              </header>
+              <div
+                v-if="group.totalCount > 0"
+                class="trip-editor-progress trip-editor-visit-region__bar"
+                role="progressbar"
+                :aria-label="`${group.regionName} visit progress`"
+                :aria-valuenow="group.percentVisited"
+                aria-valuemin="0"
+                aria-valuemax="100"
+              >
+                <span :style="{ width: `${group.percentVisited}%` }"></span>
+              </div>
               <article v-for="row in group.rows" :key="row.placeId" class="trip-editor-visit-place-row" :data-visit-place-id="row.placeId">
                 <header>
-                  <div>
-                    <h4>{{ row.placeName }}</h4>
-                    <small>{{ row.summary.isVisited ? 'Visited' : 'Not visited' }}</small>
+                  <div class="trip-editor-visit-place-row__title">
+                    <span
+                      class="trip-editor-visit-status"
+                      :class="row.summary.isVisited ? 'trip-editor-visit-status--visited' : 'trip-editor-visit-status--pending'"
+                      :aria-label="row.summary.isVisited ? 'Visited' : 'Not visited'"
+                      role="img"
+                    >
+                      <span v-if="row.summary.isVisited" aria-hidden="true">&check;</span>
+                    </span>
+                    <div>
+                      <h4>{{ row.placeName }}</h4>
+                      <small>{{ row.summary.isVisited ? 'Visited' : 'Not visited' }}</small>
+                    </div>
                   </div>
-                  <strong>{{ row.summary.visitCount }} visit{{ row.summary.visitCount === 1 ? '' : 's' }}</strong>
+                  <strong class="trip-editor-visit-count-pill">{{ row.summary.visitCount }} visit{{ row.summary.visitCount === 1 ? '' : 's' }}</strong>
                 </header>
                 <dl class="trip-editor-visit-place-row__summary">
                   <div>
@@ -252,7 +303,7 @@ async function manageVisit(event: MouseEvent, visitId: Guid): Promise<void> {
                 <div v-if="row.summary.isVisited" class="trip-editor-visit-history">
                   <p v-if="row.historyRows.length === 0" class="trip-editor-empty-state">No visit history rows available for this place.</p>
                   <div v-for="history in row.historyRows" :key="history.visitId" class="trip-editor-visit-history-row" :data-visit-id="history.visitId">
-                    <div>
+                    <div class="trip-editor-visit-history-row__title">
                       <strong>{{ row.placeName }}</strong>
                       <span>{{ historyRegionName(history, row.regionId) }}</span>
                     </div>

--- a/ClientApps/trip-editor/src/visitProgress.css
+++ b/ClientApps/trip-editor/src/visitProgress.css
@@ -11,8 +11,7 @@
 .trip-editor-visit-progress__summary,
 .trip-editor-visit-progress__filters,
 .trip-editor-visit-region,
-.trip-editor-visit-place-row,
-.trip-editor-visit-history-row {
+.trip-editor-visit-place-row {
   border: 1px solid var(--trip-editor-border);
   border-radius: 6px;
 }
@@ -24,34 +23,134 @@
   padding: 0.75rem;
 }
 
+.trip-editor-visit-progress__summary {
+  background: color-mix(in srgb, var(--trip-editor-accent) 8%, var(--trip-editor-card));
+  display: grid;
+  gap: 0.65rem;
+}
+
+.trip-editor-visit-progress__summary-heading {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.trip-editor-visit-progress__summary-heading > div:first-child {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.trip-editor-visit-progress__summary-heading span,
+.trip-editor-visit-progress__filters legend,
+.trip-editor-visit-place-row dt,
+.trip-editor-visit-history-row dt {
+  color: var(--trip-editor-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.trip-editor-visit-progress__summary-heading strong {
+  overflow-wrap: anywhere;
+}
+
+.trip-editor-visit-progress__percent,
+.trip-editor-visit-count-pill {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  font-weight: 700;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.trip-editor-visit-progress__percent {
+  background: var(--bs-primary-bg-subtle);
+  border: 1px solid var(--bs-primary-border-subtle);
+  color: var(--bs-primary-text-emphasis);
+  font-size: 1rem;
+  min-width: 3.4rem;
+  padding: 0.3rem 0.65rem;
+}
+
+.trip-editor-visit-progress__bar,
+.trip-editor-visit-region__bar {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--trip-editor-border) 70%, transparent);
+  margin: 0;
+}
+
+.trip-editor-visit-progress__bar {
+  height: 0.75rem;
+}
+
+.trip-editor-visit-region__bar {
+  height: 0.45rem;
+}
+
 .trip-editor-visit-progress__summary p {
   color: var(--trip-editor-muted);
-  margin: 0.35rem 0 0;
+  margin: 0;
+}
+
+.trip-editor-visit-progress__summary-count {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.4rem;
 }
 
 .trip-editor-visit-progress__filters {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.5rem;
   margin: 0;
 }
 
 .trip-editor-visit-progress__filters legend {
-  color: var(--trip-editor-muted);
   float: none;
-  font-size: 0.8rem;
-  font-weight: 700;
   margin: 0;
-  text-transform: uppercase;
   width: auto;
 }
 
-.trip-editor-visit-progress__filters label {
+.trip-editor-visit-filter-option {
   align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  margin: 0;
+}
+
+.trip-editor-visit-filter-option input {
+  height: 1px;
+  margin: 0;
+  opacity: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.trip-editor-visit-filter-option > span {
+  align-items: center;
+  background: var(--trip-editor-field-bg);
+  border: 1px solid var(--trip-editor-field-border);
+  border-radius: 999px;
+  color: var(--trip-editor-text);
   display: inline-flex;
   gap: 0.35rem;
-  margin: 0;
+  min-height: 2rem;
+  padding: 0.35rem 0.7rem;
+}
+
+.trip-editor-visit-filter-option input:checked + span {
+  background: color-mix(in srgb, var(--trip-editor-accent) 18%, var(--trip-editor-card-strong));
+  border-color: color-mix(in srgb, var(--trip-editor-accent) 62%, var(--trip-editor-field-border));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--trip-editor-accent) 25%, transparent);
+}
+
+.trip-editor-visit-filter-option input:focus-visible + span {
+  outline: 2px solid #93c5fd;
+  outline-offset: 2px;
 }
 
 .trip-editor-visit-region-list {
@@ -64,6 +163,14 @@
   gap: 0.65rem;
 }
 
+.trip-editor-visit-region__header {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  min-width: 0;
+}
+
 .trip-editor-visit-region h3,
 .trip-editor-visit-place-row h4 {
   margin: 0;
@@ -71,6 +178,12 @@
 
 .trip-editor-visit-region h3 {
   font-size: 1rem;
+}
+
+.trip-editor-visit-region__header span {
+  color: var(--trip-editor-muted);
+  flex: 0 0 auto;
+  font-size: 0.85rem;
 }
 
 .trip-editor-visit-place-row {
@@ -90,9 +203,56 @@
   min-width: 0;
 }
 
+.trip-editor-visit-place-row__title {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.trip-editor-visit-place-row__title > div,
+.trip-editor-visit-history-row__title {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
 .trip-editor-visit-place-row header small,
 .trip-editor-visit-history-row span {
   color: var(--trip-editor-muted);
+}
+
+.trip-editor-visit-status {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  font-weight: 800;
+  height: 1.15rem;
+  justify-content: center;
+  line-height: 1;
+  margin-top: 0.1rem;
+  width: 1.15rem;
+}
+
+.trip-editor-visit-status--visited {
+  background: var(--bs-success-bg-subtle);
+  border: 1px solid var(--bs-success-border-subtle);
+  color: var(--bs-success-text-emphasis);
+}
+
+.trip-editor-visit-status--pending {
+  background: var(--trip-editor-surface-muted);
+  border: 1px solid var(--trip-editor-field-border);
+}
+
+.trip-editor-visit-count-pill {
+  background: var(--bs-success-bg-subtle);
+  border: 1px solid var(--bs-success-border-subtle);
+  color: var(--bs-success-text-emphasis);
+  font-size: 0.8rem;
+  padding: 0.2rem 0.55rem;
 }
 
 .trip-editor-visit-place-row__summary,
@@ -110,10 +270,7 @@
 
 .trip-editor-visit-place-row dt,
 .trip-editor-visit-history-row dt {
-  color: var(--trip-editor-muted);
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
+  margin-bottom: 0.05rem;
 }
 
 .trip-editor-visit-place-row dd,
@@ -128,14 +285,8 @@
 }
 
 .trip-editor-visit-history-row {
-  background: var(--trip-editor-surface);
+  border-top: 1px solid var(--trip-editor-border);
   padding: 0.6rem;
-}
-
-.trip-editor-visit-history-row > div:first-child {
-  display: grid;
-  gap: 0.15rem;
-  min-width: 0;
 }
 
 .trip-editor-visit-history-row dl {
@@ -157,5 +308,19 @@
 
   .trip-editor-visit-history-row dl {
     min-width: 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .trip-editor-visit-progress__summary-heading,
+  .trip-editor-visit-region__header,
+  .trip-editor-visit-place-row header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .trip-editor-visit-progress__percent,
+  .trip-editor-visit-count-pill {
+    width: fit-content;
   }
 }

--- a/tests/e2e/trip-editor/tripEditorVisitProgress.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorVisitProgress.spec.ts
@@ -29,11 +29,21 @@ test.describe.serial('Trip Editor visit progress and history', () => {
     await openVisits(page);
     const dialog = visitDialog(page);
     await expect(dialog).toContainText('2 / 3 places visited');
+    await expect(dialog.getByText('67%')).toBeVisible();
+    await expect(dialog.getByRole('progressbar', { name: 'Overall visit progress' })).toHaveAttribute('aria-valuenow', '67');
+    await expect(dialog.locator('.trip-editor-visit-filter-option')).toHaveCount(3);
     await expect(visitPlaceRow(page, visitedPlaceId)).toContainText('PW visited place');
     await expect(visitPlaceRow(page, notVisitedPlaceId)).toContainText('PW not visited place');
     await expect(visitPlaceRow(page, missingHistoryPlaceId)).toContainText('PW missing history place');
+    await expect(dialog.getByRole('region', { name: 'PW visit region one' })).toContainText('2 / 2 visited');
+    await expect(dialog.getByRole('progressbar', { name: 'PW visit region one visit progress' })).toHaveAttribute('aria-valuenow', '100');
+    await expect(dialog.getByRole('region', { name: 'PW visit region two' })).toContainText('0 / 1 visited');
+    await expect(dialog.getByRole('progressbar', { name: 'PW visit region two visit progress' })).toHaveAttribute('aria-valuenow', '0');
+    await expect(visitPlaceRow(page, visitedPlaceId).getByRole('img', { name: 'Visited' })).toBeVisible();
+    await expect(visitPlaceRow(page, notVisitedPlaceId).getByRole('img', { name: 'Not visited' })).toBeVisible();
 
     await dialog.getByRole('radio', { name: 'Visited', exact: true }).check();
+    await expect(dialog.getByRole('radio', { name: 'Visited', exact: true })).toBeChecked();
     await expect(visitPlaceRow(page, visitedPlaceId)).toBeVisible();
     await expect(visitPlaceRow(page, missingHistoryPlaceId)).toBeVisible();
     await expect(visitPlaceRow(page, notVisitedPlaceId)).toHaveCount(0);
@@ -56,6 +66,7 @@ test.describe.serial('Trip Editor visit progress and history', () => {
     const row = visitPlaceRow(page, visitedPlaceId);
     await expect(row).toContainText('Visited');
     await expect(row).toContainText('3 visits');
+    await expect(row.locator('.trip-editor-visit-count-pill')).toHaveText('3 visits');
     await expect(row).toContainText('First visit');
     await expect(row).toContainText('2026-01-01 08:00 UTC');
     await expect(row).toContainText('Last visit');
@@ -68,6 +79,7 @@ test.describe.serial('Trip Editor visit progress and history', () => {
     await expect(row.locator(`[data-visit-id="${newerVisitId}"]`)).toContainText('2026-01-03 08:00 UTC');
     await expect(row.locator(`[data-visit-id="${newerVisitId}"]`)).toContainText('Open');
     await expect(row.locator(`[data-visit-id="${newerVisitId}"]`)).toContainText('Duration unavailable');
+    await expect(row.locator(`[data-visit-id="${newerVisitId}"]`).getByRole('link', { name: 'Manage visit' })).toHaveAttribute('href', `/User/Visit/Edit/${newerVisitId}`);
     await expect(row.locator(`[data-visit-id="${olderVisitId}"]`)).toContainText('45 min');
   });
 
@@ -152,6 +164,21 @@ test.describe.serial('Trip Editor visit progress and history', () => {
     await loadWorkspaceWithVisitFixture(page, prepareMixedVisitState);
     await openVisits(page);
     await expect(visitPlaceRow(page, missingHistoryPlaceId)).toContainText('No visit history rows available for this place.');
+  });
+
+  test('keeps the visit progress modal contained at desktop and narrow widths', async ({ page }) => {
+    for (const viewport of [
+      { width: 1280, height: 900 },
+      { width: 390, height: 900 }
+    ]) {
+      await page.setViewportSize(viewport);
+      await signIn(page);
+      await loadWorkspaceWithVisitFixture(page, prepareMixedVisitState);
+      await openVisits(page);
+      await expectDialogFitsViewport(page);
+      await expectNoPageOverflow(page);
+      await visitDialog(page).getByRole('button', { name: 'Close' }).click();
+    }
   });
 });
 
@@ -296,6 +323,30 @@ function visitDialog(page: Page) {
 
 function visitPlaceRow(page: Page, placeId: string) {
   return page.locator(`[data-visit-place-id="${placeId}"]`);
+}
+
+async function expectNoPageOverflow(page: Page): Promise<void> {
+  const overflow = await page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth;
+    const documentOverflow = document.documentElement.scrollWidth - viewportWidth;
+    const bodyOverflow = document.body ? document.body.scrollWidth - viewportWidth : 0;
+
+    return { documentOverflow, bodyOverflow };
+  });
+
+  expect(overflow.documentOverflow, 'Visit progress modal should not introduce horizontal document overflow.').toBeLessThanOrEqual(2);
+  expect(overflow.bodyOverflow, 'Visit progress modal should not introduce horizontal body overflow.').toBeLessThanOrEqual(2);
+}
+
+async function expectDialogFitsViewport(page: Page): Promise<void> {
+  const dialog = page.locator('.trip-editor-expanded__dialog:visible').first();
+  const [box, viewport] = await Promise.all([dialog.boundingBox(), page.viewportSize()]);
+  expect(box, 'Visit progress dialog should have a rendered box.').not.toBeNull();
+  expect(viewport, 'Viewport should be available for dialog fit check.').not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(-1);
+  expect(box!.y).toBeGreaterThanOrEqual(-1);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
 }
 
 async function clickMap(page: Page, position: { xRatio: number; yRatio: number }): Promise<void> {


### PR DESCRIPTION
## Summary

Closes #309.

## Design changes summary

- Polishes the Trip Editor `Visit progress and history` modal with a stronger overall progress summary, percent badge, intentional progress bars, segmented filter controls, status affordances, compact visit-count pills, per-region progress counts, and denser visit detail rows.
- Keeps the styling scoped to the existing Vue Trip Editor visit-progress surface and focused `visitProgress.css` file.

## Preserved from the Vue editor

- Preserves the expanded modal shell, header, backdrop, scroll containment, `Read-only visits` context, current filtering state, and existing editor DTO/state model.
- Preserves owner/editor data richness: first visit, last visit, full visit history rows, and the `Manage visit` action.
- Preserves the shared dirty/map-work guard before navigating to manage a visit.

## Translated from public/legacy progress UI

- Uses the public viewer progress modal as a visual reference only, translating the hierarchy and affordances into Vue-native markup and Trip Editor CSS.
- Adds a percent badge, stronger progress bar treatment, segmented filter buttons, visited/not-visited status indicators, region visited/total counts, per-region progress bars, and compact visit-count pills.

## Behavior preserved

- Filter options still work for all, visited, and not visited places.
- Close button still works.
- `Manage visit` links still use `/User/Visit/Edit/{visitId}` and guarded navigation still appends the current editor `returnUrl`.
- No backend/API/DTO changes were added; the current editor state was enough.
- Desktop and narrow modal/page overflow checks are covered in focused Playwright.

## Validation run

- `npm run build` passed; Vite reported the existing large chunk warning.
- Initial focused Playwright attempt failed because `http://localhost:5012` was not running.
- Second focused Playwright attempt reached the editor but timed out during first login navigation while the app was warming up.
- After starting ASP.NET on `http://localhost:5012` and Vite on `http://localhost:5173`, rerun passed: `npx playwright test --config=playwright.config.ts tests/e2e/trip-editor/tripEditorVisitProgress.spec.ts` -> 10 passed.
- `npx playwright test --config=playwright.config.ts tests/e2e/trip-editor/tripEditorVisualPolish.spec.ts` -> 4 passed.
- `npx playwright test --config=playwright.config.ts --list` -> 118 tests listed.
- `dotnet build` passed.
- `dotnet test` passed: 1548 passed.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` passed with existing over-400 LOC warnings only; no touched file crossed the warning threshold.
- `git diff --check origin/main...HEAD` passed.
- `git ls-files -- .local playwright-report test-results screenshots traces wwwroot/vite/trip-editor wwwroot/dist` returned no tracked artifacts.

## Manual-validation notes/screenshots

- Existing visual-polish Playwright screenshot evidence was generated by `tripEditorVisualPolish.spec.ts` for desktop-wide, laptop, tablet, and phone-smoke visit-progress states under the local Playwright output directory. No screenshots or Playwright artifacts are committed.