### PR TITLE
Fix PDF cover export image proxy handling

### DIFF
--- a/Services/TripExportCoverSnapshotBuilder.cs
+++ b/Services/TripExportCoverSnapshotBuilder.cs
@@ -1,0 +1,44 @@
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Builds PDF cover snapshot data URIs through the shared image proxy pipeline.
+/// </summary>
+internal static class TripExportCoverSnapshotBuilder
+{
+    /// <summary>
+    /// Fetches the cover image through the proxy service and returns a complete data URI.
+    /// </summary>
+    public static async Task<string?> BuildDataUriAsync(
+        IImageProxyService imageProxyService,
+        string? coverImageUrl,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(coverImageUrl))
+        {
+            return null;
+        }
+
+        try
+        {
+            var result = await imageProxyService.GetOrFetchAsync(
+                new ImageProxyRequest(coverImageUrl),
+                allowOriginFetch: true,
+                cancellationToken);
+
+            if (!result.HasBytes)
+            {
+                return null;
+            }
+
+            return $"data:{result.ContentType};base64,{Convert.ToBase64String(result.Bytes!)}";
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/Services/TripExportService.cs
+++ b/Services/TripExportService.cs
@@ -10,6 +10,7 @@ using Microsoft.Playwright;
 using NetTopologySuite.Geometries;
 using Wayfarer.Models;
 using Wayfarer.Models.ViewModels;
+using Wayfarer.Services;
 using static Wayfarer.Parsers.KmlMappings;
 
 namespace Wayfarer.Parsers
@@ -29,6 +30,7 @@ namespace Wayfarer.Parsers
         readonly ILogger<TripExportService> _logger;
         readonly IConfiguration _configuration;
         readonly SseService _sseService;
+        readonly IImageProxyService _imageProxyService;
         readonly string _chromeCachePath;
         private static readonly CultureInfo CI = CultureInfo.InvariantCulture;
 
@@ -40,7 +42,8 @@ namespace Wayfarer.Parsers
             IRazorViewRenderer razor,
             ILogger<TripExportService> logger,
             IConfiguration configuration,
-            SseService sseService)
+            SseService sseService,
+            IImageProxyService imageProxyService)
         {
             _db = dbContext;
             _snap = mapSnapshot;
@@ -50,6 +53,7 @@ namespace Wayfarer.Parsers
             _logger = logger;
             _configuration = configuration;
             _sseService = sseService;
+            _imageProxyService = imageProxyService;
 
             // Get Chrome cache directory from configuration (defaults to ChromeCache if not specified)
             _chromeCachePath = configuration["CacheSettings:ChromeCacheDirectory"] ?? "ChromeCache";
@@ -354,20 +358,13 @@ namespace Wayfarer.Parsers
 
             /* 3 ── snapshots dictionary --------------------------------------- */
             var snap = new Dictionary<string, byte[]>();
+            string? coverDataUri = null;
 
             // cover photo (download once)
             if (!string.IsNullOrWhiteSpace(trip.CoverImageUrl))
             {
                 await ReportProgress("📷 Downloading cover photo...");
-                try
-                {
-                    using var http = new HttpClient();
-                    snap["cover"] = await http.GetByteArrayAsync(trip.CoverImageUrl, cancellationToken);
-                }
-                catch
-                {
-                    /* ignore – cover simply omitted on failure */
-                }
+                coverDataUri = await TripExportCoverSnapshotBuilder.BuildDataUriAsync(_imageProxyService, trip.CoverImageUrl, cancellationToken);
             }
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -461,6 +458,7 @@ namespace Wayfarer.Parsers
 
             // convert snapshots dictionary to data-URI strings
             var snapUris = snap.ToDictionary(kvp => kvp.Key, kvp => ToDataUri(kvp.Value));
+            if (coverDataUri is not null) snapUris["cover"] = coverDataUri;
 
             // build view-model
             var vm = new TripPrintViewModel

--- a/tests/Wayfarer.Tests/Services/TripExportCoverSnapshotBuilderTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripExportCoverSnapshotBuilderTests.cs
@@ -1,0 +1,113 @@
+using Moq;
+using Wayfarer.Services;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>
+/// Tests PDF cover snapshot conversion without invoking full Playwright PDF generation.
+/// </summary>
+public class TripExportCoverSnapshotBuilderTests
+{
+    [Fact]
+    public async Task BuildDataUriAsync_UsesProxyBytesAndContentType()
+    {
+        // Arrange
+        var coverBytes = new byte[] { 1, 2, 3 };
+        var imageProxy = new Mock<IImageProxyService>();
+        imageProxy
+            .Setup(s => s.GetOrFetchAsync(
+                It.Is<ImageProxyRequest>(r => r.Url == "https://example.com/cover.jpg"),
+                true,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ImageProxyResult(
+                ImageProxyResultStatus.Fetched,
+                "cover-key",
+                coverBytes,
+                "image/jpeg"));
+
+        // Act
+        var dataUri = await TripExportCoverSnapshotBuilder.BuildDataUriAsync(
+            imageProxy.Object,
+            "https://example.com/cover.jpg");
+
+        // Assert
+        Assert.Equal("data:image/jpeg;base64,AQID", dataUri);
+    }
+
+    [Theory]
+    [InlineData(ImageProxyResultStatus.BadRequest, null, null)]
+    [InlineData(ImageProxyResultStatus.NotFound, null, null)]
+    [InlineData(ImageProxyResultStatus.TooLarge, null, null)]
+    [InlineData(ImageProxyResultStatus.Failed, null, null)]
+    [InlineData(ImageProxyResultStatus.Fetched, new byte[0], "image/jpeg")]
+    [InlineData(ImageProxyResultStatus.Fetched, new byte[] { 1 }, null)]
+    public async Task BuildDataUriAsync_OmitsCover_WhenProxyHasNoUsableBytes(
+        ImageProxyResultStatus status,
+        byte[]? bytes,
+        string? contentType)
+    {
+        // Arrange
+        var imageProxy = new Mock<IImageProxyService>();
+        imageProxy
+            .Setup(s => s.GetOrFetchAsync(
+                It.IsAny<ImageProxyRequest>(),
+                true,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ImageProxyResult(status, "cover-key", bytes, contentType));
+
+        // Act
+        var dataUri = await TripExportCoverSnapshotBuilder.BuildDataUriAsync(
+            imageProxy.Object,
+            "https://example.com/cover.jpg");
+
+        // Assert
+        Assert.Null(dataUri);
+    }
+
+    [Fact]
+    public async Task BuildDataUriAsync_OmitsCover_WhenProxyThrows()
+    {
+        // Arrange
+        var imageProxy = new Mock<IImageProxyService>();
+        imageProxy
+            .Setup(s => s.GetOrFetchAsync(
+                It.IsAny<ImageProxyRequest>(),
+                true,
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Origin fetch failed"));
+
+        // Act
+        var dataUri = await TripExportCoverSnapshotBuilder.BuildDataUriAsync(
+            imageProxy.Object,
+            "https://example.com/cover.jpg");
+
+        // Assert
+        Assert.Null(dataUri);
+    }
+
+    [Fact]
+    public async Task BuildDataUriAsync_PreservesNonPngContentType()
+    {
+        // Arrange
+        var imageProxy = new Mock<IImageProxyService>();
+        imageProxy
+            .Setup(s => s.GetOrFetchAsync(
+                It.IsAny<ImageProxyRequest>(),
+                true,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ImageProxyResult(
+                ImageProxyResultStatus.Fetched,
+                "cover-key",
+                new byte[] { 4, 5, 6 },
+                "image/webp"));
+
+        // Act
+        var dataUri = await TripExportCoverSnapshotBuilder.BuildDataUriAsync(
+            imageProxy.Object,
+            "https://example.com/cover.webp");
+
+        // Assert
+        Assert.Equal("data:image/webp;base64,BAUG", dataUri);
+    }
+}

--- a/tests/Wayfarer.Tests/Services/TripExportCoverSnapshotBuilderTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripExportCoverSnapshotBuilderTests.cs
@@ -35,6 +35,57 @@ public class TripExportCoverSnapshotBuilderTests
         Assert.Equal("data:image/jpeg;base64,AQID", dataUri);
     }
 
+    [Fact]
+    public async Task BuildDataUriAsync_ForwardsCancellationTokenToProxy()
+    {
+        // Arrange
+        using var cancellation = new CancellationTokenSource();
+        var forwardedToken = CancellationToken.None;
+        var imageProxy = new Mock<IImageProxyService>();
+        imageProxy
+            .Setup(s => s.GetOrFetchAsync(
+                It.Is<ImageProxyRequest>(r => r.Url == "https://example.com/cover.jpg"),
+                true,
+                It.IsAny<CancellationToken>()))
+            .Callback<ImageProxyRequest, bool, CancellationToken>((_, _, ct) => forwardedToken = ct)
+            .ReturnsAsync(new ImageProxyResult(
+                ImageProxyResultStatus.Fetched,
+                "cover-key",
+                new byte[] { 1 },
+                "image/jpeg"));
+
+        // Act
+        await TripExportCoverSnapshotBuilder.BuildDataUriAsync(
+            imageProxy.Object,
+            "https://example.com/cover.jpg",
+            cancellation.Token);
+
+        // Assert
+        Assert.Equal(cancellation.Token, forwardedToken);
+    }
+
+    [Fact]
+    public async Task BuildDataUriAsync_RethrowsProxyCancellation()
+    {
+        // Arrange
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+        var imageProxy = new Mock<IImageProxyService>();
+        imageProxy
+            .Setup(s => s.GetOrFetchAsync(
+                It.IsAny<ImageProxyRequest>(),
+                true,
+                It.Is<CancellationToken>(ct => ct == cancellation.Token)))
+            .Returns(Task.FromCanceled<ImageProxyResult>(cancellation.Token));
+
+        // Act and assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            TripExportCoverSnapshotBuilder.BuildDataUriAsync(
+                imageProxy.Object,
+                "https://example.com/cover.jpg",
+                cancellation.Token));
+    }
+
     [Theory]
     [InlineData(ImageProxyResultStatus.BadRequest, null, null)]
     [InlineData(ImageProxyResultStatus.NotFound, null, null)]

--- a/tests/Wayfarer.Tests/Services/TripExportServiceTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripExportServiceTests.cs
@@ -14,14 +14,14 @@ namespace Wayfarer.Tests.Services;
 
 /// <summary>
 /// Tests for <see cref="TripExportService"/> covering KML export operations.
-/// Note: PDF generation tests are skipped due to complex external dependencies (Playwright, HttpContext).
+/// Note: Full PDF generation tests are skipped due to complex external dependencies (Playwright, HttpContext).
 /// </summary>
 public class TripExportServiceTests : TestBase
 {
     /// <summary>
-    /// Creates a TripExportService with minimal mocked dependencies for KML-only testing.
+    /// Creates a TripExportService with minimal mocked dependencies for scoped export testing.
     /// </summary>
-    private TripExportService CreateService(ApplicationDbContext db)
+    private TripExportService CreateService(ApplicationDbContext db, IImageProxyService? imageProxyService = null)
     {
         var mockConfig = new Mock<IConfiguration>();
         mockConfig.Setup(c => c["CacheSettings:ChromeCacheDirectory"]).Returns("TestCache");
@@ -34,7 +34,7 @@ public class TripExportServiceTests : TestBase
             null!, // IRazorViewRenderer - not needed for KML
             NullLogger<TripExportService>.Instance,
             mockConfig.Object,
-            null!  // SseService - not needed for KML
+            null!, imageProxyService ?? Mock.Of<IImageProxyService>()
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes #319.
- Routes PDF cover snapshot generation through `IImageProxyService` instead of raw `HttpClient` downloads.
- Builds cover data URIs with the proxy result content type while keeping map snapshots PNG-backed.
- Leaves KML export behavior and `CoverImageUrl` metadata unchanged.

## Validation

- `dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --filter "FullyQualifiedName~TripExportCoverSnapshotBuilderTests|FullyQualifiedName~TripExportServiceTests"` - 29 passed.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` - passed; only existing unrelated warning-threshold files reported.
- Full `dotnet test` - 1585 passed per implementation validation.

## Notes

- The final read-only review found no blocking or non-blocking findings and marked this ready to open PR.