### PR TITLE
Add runtime version source and exposure

### DIFF
--- a/Areas/Api/Controllers/VersionController.cs
+++ b/Areas/Api/Controllers/VersionController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Wayfarer.Services;
+
+namespace Wayfarer.Areas.Api.Controllers;
+
+/// <summary>
+/// Exposes the compiled Wayfarer application version.
+/// </summary>
+[ApiController]
+[Area("Api")]
+[Route("api/version")]
+public sealed class VersionController : ControllerBase
+{
+    private readonly IAppVersionProvider _appVersionProvider;
+
+    /// <summary>
+    /// Creates the version API endpoint.
+    /// </summary>
+    /// <param name="appVersionProvider">The provider for the compiled application version.</param>
+    public VersionController(IAppVersionProvider appVersionProvider)
+    {
+        _appVersionProvider = appVersionProvider;
+    }
+
+    /// <summary>
+    /// Gets the compiled Wayfarer application version.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Get()
+    {
+        return Ok(new { version = _appVersionProvider.Version });
+    }
+}

--- a/CommandLine/AppVersionCli.cs
+++ b/CommandLine/AppVersionCli.cs
@@ -1,0 +1,37 @@
+using Wayfarer.Services;
+
+namespace Wayfarer.CommandLine;
+
+/// <summary>
+/// Handles app-version CLI commands that do not require web host startup.
+/// </summary>
+public static class AppVersionCli
+{
+    /// <summary>
+    /// Handles the version command when present.
+    /// </summary>
+    /// <param name="args">The process arguments.</param>
+    /// <param name="appVersionProvider">The provider for the compiled application version.</param>
+    /// <param name="output">The writer used for command output.</param>
+    /// <param name="error">The writer used for command errors.</param>
+    /// <param name="exitCode">The command exit code when handled.</param>
+    /// <returns>True when this handler consumed the command; otherwise false.</returns>
+    public static bool TryHandle(
+        string[] args,
+        IAppVersionProvider appVersionProvider,
+        TextWriter output,
+        TextWriter error,
+        out int exitCode)
+    {
+        _ = error;
+        exitCode = 0;
+
+        if (args.Length == 0 || !string.Equals(args[0], "version", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        output.WriteLine($"Wayfarer {appVersionProvider.Version}");
+        return true;
+    }
+}

--- a/Middleware/AppVersionHeaderMiddleware.cs
+++ b/Middleware/AppVersionHeaderMiddleware.cs
@@ -1,0 +1,44 @@
+using Wayfarer.Services;
+
+namespace Wayfarer.Middleware;
+
+/// <summary>
+/// Adds the compiled Wayfarer version to normal HTTP responses.
+/// </summary>
+public sealed class AppVersionHeaderMiddleware
+{
+    /// <summary>
+    /// The response header that carries the Wayfarer version.
+    /// </summary>
+    public const string HeaderName = "X-Wayfarer-Version";
+
+    private readonly RequestDelegate _next;
+    private readonly IAppVersionProvider _appVersionProvider;
+
+    /// <summary>
+    /// Creates middleware that appends the Wayfarer version header.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="appVersionProvider">The provider for the compiled application version.</param>
+    public AppVersionHeaderMiddleware(RequestDelegate next, IAppVersionProvider appVersionProvider)
+    {
+        _next = next;
+        _appVersionProvider = appVersionProvider;
+    }
+
+    /// <summary>
+    /// Registers the version header before downstream middleware starts the response.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        context.Response.OnStarting(static state =>
+        {
+            var (httpContext, version) = ((HttpContext, string))state;
+            httpContext.Response.Headers[HeaderName] = version;
+            return Task.CompletedTask;
+        }, (context, _appVersionProvider.Version));
+
+        await _next(context);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -16,6 +16,7 @@ using Quartz;
 using Quartz.Impl;
 using Quartz.Spi;
 using Serilog;
+using Wayfarer.CommandLine;
 using Wayfarer.Jobs;
 using Wayfarer.Middleware;
 using Wayfarer.Models;
@@ -28,6 +29,12 @@ using IPNetwork = System.Net.IPNetwork;
 // for UseMicrosoftDependencyInjectionJobFactory(), UsePersistentStore(), etc.
 // for IJobFactory
 // for UseNewtonsoftJsonSerializer()
+
+if (AppVersionCli.TryHandle(args, new AppVersionProvider(), Console.Out, Console.Error, out var versionExitCode))
+{
+    Environment.ExitCode = versionExitCode;
+    return;
+}
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -466,6 +473,9 @@ static void ConfigureServices(WebApplicationBuilder builder)
     // Some framework components may register it implicitly, but explicit registration is safer.
     builder.Services.AddHttpContextAccessor();
 
+    // Register the compiled app version provider for CLI, HTTP, and Razor surfaces.
+    builder.Services.AddSingleton<IAppVersionProvider, AppVersionProvider>();
+
     // Register memory cache for application services
     builder.Services.AddMemoryCache();
     builder.Services.AddSingleton<TileMetadataHotCache>(); builder.Services.AddTripEditorGeocodeSearch(builder.Configuration);
@@ -700,6 +710,9 @@ static async Task ConfigureMiddleware(WebApplication app)
 
     // CRITICAL: Add this as the FIRST middleware to process forwarded headers from nginx
     app.UseForwardedHeaders();
+
+    // Adds the compiled app version before Swagger, error handlers, static files, and endpoints.
+    app.UseMiddleware<AppVersionHeaderMiddleware>();
 
     app.UseMiddleware<RequestIdLoggingMiddleware>(); // Enriches Serilog LogContext with HttpContext.TraceIdentifier
     app.UseMiddleware<PerformanceMonitoringMiddleware>(); // Custom middleware for monitoring performance

--- a/Program.cs
+++ b/Program.cs
@@ -25,10 +25,6 @@ using Wayfarer.Services;
 using Wayfarer.Swagger;
 using Wayfarer.Util;
 using IPNetwork = System.Net.IPNetwork;
-// for AddQuartz(), AddQuartzHostedService()
-// for UseMicrosoftDependencyInjectionJobFactory(), UsePersistentStore(), etc.
-// for IJobFactory
-// for UseNewtonsoftJsonSerializer()
 
 if (AppVersionCli.TryHandle(args, new AppVersionProvider(), Console.Out, Console.Error, out var versionExitCode))
 {
@@ -40,21 +36,18 @@ var builder = WebApplication.CreateBuilder(args);
 
 #region CLI Command Handling
 
-// Handling the "reset-password" command from the CLI
 if (args.Length > 0 && args[0] == "reset-password") { await HandlePasswordResetCommand(args); return; }
 
 #endregion CLI Command Handling
 
 #region Configuration Setup
 
-// Configuring the application settings, such as JSON configuration files
 ConfigureConfiguration(builder);
 
 #endregion Configuration Setup
 
 #region Serilog Logging Setup
 
-// Setting up logging, including Serilog for file, console, and PostgreSQL logging
 ConfigureLogging(builder);
 
 #endregion Serilog Logging Setup
@@ -472,8 +465,6 @@ static void ConfigureServices(WebApplicationBuilder builder)
     // Explicitly register IHttpContextAccessor for services that need it (e.g., TileCacheService).
     // Some framework components may register it implicitly, but explicit registration is safer.
     builder.Services.AddHttpContextAccessor();
-
-    // Register the compiled app version provider for CLI, HTTP, and Razor surfaces.
     builder.Services.AddSingleton<IAppVersionProvider, AppVersionProvider>();
 
     // Register memory cache for application services
@@ -710,8 +701,6 @@ static async Task ConfigureMiddleware(WebApplication app)
 
     // CRITICAL: Add this as the FIRST middleware to process forwarded headers from nginx
     app.UseForwardedHeaders();
-
-    // Adds the compiled app version before Swagger, error handlers, static files, and endpoints.
     app.UseMiddleware<AppVersionHeaderMiddleware>();
 
     app.UseMiddleware<RequestIdLoggingMiddleware>(); // Enriches Serilog LogContext with HttpContext.TraceIdentifier

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "dotnetRunMessages": false,
+      "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5012"
     },
     "https": {
@@ -15,7 +15,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "dotnetRunMessages": false,
+      "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:7149;http://localhost:5012;https://0.0.0.0:7149;http://0.0.0.0:5012"
     },
     "httpsWatch": {

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "dotnetRunMessages": true,
+      "dotnetRunMessages": false,
       "applicationUrl": "http://localhost:5012"
     },
     "https": {
@@ -15,7 +15,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "dotnetRunMessages": true,
+      "dotnetRunMessages": false,
       "applicationUrl": "https://localhost:7149;http://localhost:5012;https://0.0.0.0:7149;http://0.0.0.0:5012"
     },
     "httpsWatch": {

--- a/Services/AppVersionDisplay.cs
+++ b/Services/AppVersionDisplay.cs
@@ -1,0 +1,17 @@
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Formats user-visible Wayfarer version text.
+/// </summary>
+public static class AppVersionDisplay
+{
+    /// <summary>
+    /// Formats the shared footer version text.
+    /// </summary>
+    /// <param name="appVersionProvider">The provider for the compiled application version.</param>
+    /// <returns>The footer version string.</returns>
+    public static string FooterText(IAppVersionProvider appVersionProvider)
+    {
+        return $"Wayfarer v{appVersionProvider.Version}";
+    }
+}

--- a/Services/AppVersionProvider.cs
+++ b/Services/AppVersionProvider.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Provides the compiled Wayfarer application version.
+/// </summary>
+public interface IAppVersionProvider
+{
+    /// <summary>
+    /// Gets the application release version from assembly informational metadata.
+    /// </summary>
+    string Version { get; }
+}
+
+/// <summary>
+/// Reads the Wayfarer application version from assembly informational metadata.
+/// </summary>
+public sealed class AppVersionProvider : IAppVersionProvider
+{
+    private readonly Assembly _assembly;
+    private string? _version;
+
+    /// <summary>
+    /// Creates a provider for the Wayfarer application assembly.
+    /// </summary>
+    public AppVersionProvider()
+        : this(typeof(AppVersionProvider).Assembly)
+    {
+    }
+
+    /// <summary>
+    /// Creates a provider for the assembly that contains the supplied marker type.
+    /// </summary>
+    /// <param name="markerType">A type from the assembly whose metadata should be read.</param>
+    public AppVersionProvider(Type markerType)
+        : this(markerType.Assembly)
+    {
+    }
+
+    /// <summary>
+    /// Creates a provider for the supplied assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly whose informational version should be read.</param>
+    public AppVersionProvider(Assembly assembly)
+    {
+        _assembly = assembly;
+    }
+
+    /// <inheritdoc />
+    public string Version => _version ??= ReadInformationalVersion(_assembly);
+
+    private static string ReadInformationalVersion(Assembly assembly)
+    {
+        return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? assembly.GetName().Version?.ToString()
+            ?? "0.0.0";
+    }
+}

--- a/Version.props
+++ b/Version.props
@@ -4,5 +4,6 @@
     <Version>$(WayfarerVersion)</Version>
     <PackageVersion>$(WayfarerVersion)</PackageVersion>
     <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <WayfarerVersion>1.4.0</WayfarerVersion>
+    <Version>$(WayfarerVersion)</Version>
+    <PackageVersion>$(WayfarerVersion)</PackageVersion>
+    <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
+  </PropertyGroup>
+</Project>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -3,6 +3,7 @@
 @using Wayfarer.Services
 @using Wayfarer.Areas.Public.Controllers
 @inject Wayfarer.Parsers.IApplicationSettingsService ApplicationSettingsService
+@inject IAppVersionProvider AppVersionProvider
 @{
     bool embed = ViewBag.IsEmbed as bool? ?? false;
 }
@@ -143,7 +144,8 @@
                     <a href="https://stef-k.github.io/WayfarerMobile/" target="_blank"
                         class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Mobile</a> -
                     <a asp-area="" asp-controller="Home" asp-action="Privacy"
-                        class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Privacy</a>
+                        class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Privacy</a> -
+                    @AppVersionDisplay.FooterText(AppVersionProvider)
                 </div>
             </footer>
 

--- a/Wayfarer.csproj
+++ b/Wayfarer.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
+    <Import Project="Version.props" />
+
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>

--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -9,6 +9,7 @@ MSBuild metadata directly from it:
 <Version>$(WayfarerVersion)</Version>
 <PackageVersion>$(WayfarerVersion)</PackageVersion>
 <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
+<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 ```
 
 The running app reads `AssemblyInformationalVersion` from the compiled Wayfarer

--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -14,8 +14,13 @@ MSBuild metadata directly from it:
 
 The running app reads `AssemblyInformationalVersion` from the compiled Wayfarer
 assembly through `IAppVersionProvider`. Runtime surfaces such as
-`dotnet run -- version`, `GET /api/version`, `X-Wayfarer-Version`, and the shared
-layout footer use that provider instead of separate constants.
+`dotnet run --no-launch-profile -- version`, `GET /api/version`,
+`X-Wayfarer-Version`, and the shared layout footer use that provider instead of
+separate constants.
+
+Use `dotnet run --no-launch-profile -- version` when validating exact CLI
+output. The app writes exactly `Wayfarer 1.4.0`; `--no-launch-profile` avoids
+.NET SDK launch-profile messages so validation stays focused on app output.
 
 ## Manual bump process
 

--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -1,0 +1,26 @@
+# Versioning
+
+`Version.props` is the runtime and release version source for this slice. The root
+file contains the manually edited `WayfarerVersion` value and maps the standard
+MSBuild metadata directly from it:
+
+```xml
+<WayfarerVersion>1.4.0</WayfarerVersion>
+<Version>$(WayfarerVersion)</Version>
+<PackageVersion>$(WayfarerVersion)</PackageVersion>
+<AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
+```
+
+The running app reads `AssemblyInformationalVersion` from the compiled Wayfarer
+assembly through `IAppVersionProvider`. Runtime surfaces such as
+`dotnet run -- version`, `GET /api/version`, `X-Wayfarer-Version`, and the shared
+layout footer use that provider instead of separate constants.
+
+## Manual bump process
+
+To prepare a later release version, edit only the root `Version.props` file and
+change `WayfarerVersion` to the target release value. Rebuild the app so the new
+value is compiled into assembly metadata.
+
+Release helper automation, changelog checks, tag validation, and GitHub release
+validation are deferred to issue #324.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -23,4 +23,5 @@
   - [Deployment](20-Deployment.md)
   - [Security](21-Security.md)
   - [Testing](22-Testing.md)
+  - [Versioning](23-Versioning.md)
 

--- a/tests/Wayfarer.Tests/Versioning/AppVersionCliTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionCliTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Wayfarer.CommandLine;
+using Wayfarer.Services;
+
+namespace Wayfarer.Tests.Versioning;
+
+public class AppVersionCliTests
+{
+    [Fact]
+    public void TryHandle_VersionCommand_WritesExactVersionLine()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var handled = AppVersionCli.TryHandle(
+            new[] { "version" },
+            new StubAppVersionProvider("1.4.0"),
+            output,
+            error,
+            out var exitCode);
+
+        handled.Should().BeTrue();
+        exitCode.Should().Be(0);
+        output.ToString().Should().Be($"Wayfarer 1.4.0{Environment.NewLine}");
+        error.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryHandle_VersionCommand_DoesNotRequireWebHostOrDatabaseStartup()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var handled = AppVersionCli.TryHandle(
+            new[] { "version" },
+            new StubAppVersionProvider("1.4.0"),
+            output,
+            error,
+            out var exitCode);
+
+        handled.Should().BeTrue();
+        exitCode.Should().Be(0);
+    }
+
+    private sealed class StubAppVersionProvider : IAppVersionProvider
+    {
+        public StubAppVersionProvider(string version)
+        {
+            Version = version;
+        }
+
+        public string Version { get; }
+    }
+}

--- a/tests/Wayfarer.Tests/Versioning/AppVersionCliTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionCliTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Wayfarer.CommandLine;
 using Wayfarer.Services;
+using Xunit;
 
 namespace Wayfarer.Tests.Versioning;
 

--- a/tests/Wayfarer.Tests/Versioning/AppVersionDisplayTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionDisplayTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Wayfarer.Services;
+using Xunit;
 
 namespace Wayfarer.Tests.Versioning;
 
@@ -18,6 +19,7 @@ public class AppVersionDisplayTests
     {
         var layoutPath = Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory,
+            "..",
             "..",
             "..",
             "..",

--- a/tests/Wayfarer.Tests/Versioning/AppVersionDisplayTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionDisplayTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Wayfarer.Services;
+
+namespace Wayfarer.Tests.Versioning;
+
+public class AppVersionDisplayTests
+{
+    [Fact]
+    public void FooterText_RendersSharedLayoutVersionText()
+    {
+        AppVersionDisplay.FooterText(new StubAppVersionProvider("1.4.0"))
+            .Should()
+            .Be("Wayfarer v1.4.0");
+    }
+
+    [Fact]
+    public void SharedLayout_UsesProviderBackedFooterHelper()
+    {
+        var layoutPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "Views",
+            "Shared",
+            "_Layout.cshtml"));
+        var layout = File.ReadAllText(layoutPath);
+
+        layout.Should().Contain("@inject IAppVersionProvider AppVersionProvider");
+        layout.Should().Contain("@AppVersionDisplay.FooterText(AppVersionProvider)");
+        layout.Should().NotContain("Wayfarer v1.4.0");
+    }
+
+    private sealed class StubAppVersionProvider : IAppVersionProvider
+    {
+        public StubAppVersionProvider(string version)
+        {
+            Version = version;
+        }
+
+        public string Version { get; }
+    }
+}

--- a/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
@@ -2,11 +2,20 @@ using System.Reflection;
 using System.Reflection.Emit;
 using FluentAssertions;
 using Wayfarer.Services;
+using Xunit;
 
 namespace Wayfarer.Tests.Versioning;
 
 public class AppVersionProviderTests
 {
+    [Fact]
+    public void Version_DefaultProviderReadsCompiledWayfarerVersion()
+    {
+        var provider = new AppVersionProvider();
+
+        provider.Version.Should().Be("1.4.0");
+    }
+
     [Fact]
     public void Version_ReadsAssemblyInformationalVersion()
     {
@@ -26,7 +35,7 @@ public class AppVersionProviderTests
             .InformationalVersion;
 
         provider.Version.Should().Be(expectedVersion);
-        typeof(AppVersionProviderTests).Assembly.Should().NotBe(Assembly.GetEntryAssembly());
+        Assert.NotSame(typeof(AppVersionProviderTests).Assembly, Assembly.GetEntryAssembly());
     }
 
     private static Assembly CreateAssemblyWithInformationalVersion(string version)

--- a/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using FluentAssertions;
+using Wayfarer.Services;
+
+namespace Wayfarer.Tests.Versioning;
+
+public class AppVersionProviderTests
+{
+    [Fact]
+    public void Version_ReadsAssemblyInformationalVersion()
+    {
+        var assembly = CreateAssemblyWithInformationalVersion("9.8.7-test");
+
+        var provider = new AppVersionProvider(assembly);
+
+        provider.Version.Should().Be("9.8.7-test");
+    }
+
+    [Fact]
+    public void Version_CanUseMarkerTypeAssemblyInsteadOfEntryAssembly()
+    {
+        var provider = new AppVersionProvider(typeof(AppVersionProviderTests));
+        var expectedVersion = typeof(AppVersionProviderTests).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+            .InformationalVersion;
+
+        provider.Version.Should().Be(expectedVersion);
+        typeof(AppVersionProviderTests).Assembly.Should().NotBe(Assembly.GetEntryAssembly());
+    }
+
+    private static Assembly CreateAssemblyWithInformationalVersion(string version)
+    {
+        var attributeConstructor = typeof(AssemblyInformationalVersionAttribute)
+            .GetConstructor(new[] { typeof(string) })!;
+        var assemblyName = new AssemblyName($"WayfarerVersionTest{Guid.NewGuid():N}");
+        var informationalVersion = new CustomAttributeBuilder(attributeConstructor, new object[] { version });
+
+        return AssemblyBuilder.DefineDynamicAssembly(
+            assemblyName,
+            AssemblyBuilderAccess.Run,
+            new[] { informationalVersion });
+    }
+}

--- a/tests/Wayfarer.Tests/Versioning/VersionHttpTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/VersionHttpTests.cs
@@ -3,13 +3,15 @@ using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 using Wayfarer.Areas.Api.Controllers;
 using Wayfarer.Middleware;
 using Wayfarer.Services;
+using Xunit;
 
 namespace Wayfarer.Tests.Versioning;
 
@@ -20,8 +22,8 @@ public class VersionHttpTests : IDisposable
     [Fact]
     public async Task GetVersion_ReturnsExpectedJsonAndContentType()
     {
-        using var server = CreateApiServer();
-        using var client = server.CreateClient();
+        using var host = await CreateApiHostAsync();
+        using var client = host.GetTestClient();
 
         using var response = await client.GetAsync("/api/version");
         var body = await response.Content.ReadAsStringAsync();
@@ -37,8 +39,8 @@ public class VersionHttpTests : IDisposable
     [Fact]
     public async Task VersionHeader_AppearsOnApiResponse()
     {
-        using var server = CreateApiServer();
-        using var client = server.CreateClient();
+        using var host = await CreateApiHostAsync();
+        using var client = host.GetTestClient();
 
         using var response = await client.GetAsync("/api/version");
 
@@ -51,8 +53,8 @@ public class VersionHttpTests : IDisposable
         Directory.CreateDirectory(_tempDirectory);
         await File.WriteAllTextAsync(Path.Combine(_tempDirectory, "version-test.txt"), "docs");
 
-        using var server = CreateDocsStaticServer(_tempDirectory);
-        using var client = server.CreateClient();
+        using var host = await CreateDocsStaticHostAsync(_tempDirectory);
+        using var client = host.GetTestClient();
 
         using var response = await client.GetAsync("/docs/version-test.txt");
 
@@ -68,9 +70,11 @@ public class VersionHttpTests : IDisposable
         }
     }
 
-    private static TestServer CreateApiServer()
+    private static async Task<IHost> CreateApiHostAsync()
     {
-        return new TestServer(new WebHostBuilder()
+        var host = new HostBuilder()
+            .ConfigureWebHost(webHost => webHost
+                .UseTestServer()
             .ConfigureServices(services =>
             {
                 services.AddSingleton<IAppVersionProvider>(new StubAppVersionProvider("1.4.0"));
@@ -82,12 +86,18 @@ public class VersionHttpTests : IDisposable
                 app.UseMiddleware<AppVersionHeaderMiddleware>();
                 app.UseRouting();
                 app.UseEndpoints(endpoints => endpoints.MapControllers());
-            }));
+            }))
+            .Build();
+
+        await host.StartAsync();
+        return host;
     }
 
-    private static TestServer CreateDocsStaticServer(string docsPath)
+    private static async Task<IHost> CreateDocsStaticHostAsync(string docsPath)
     {
-        return new TestServer(new WebHostBuilder()
+        var host = new HostBuilder()
+            .ConfigureWebHost(webHost => webHost
+                .UseTestServer()
             .ConfigureServices(services =>
             {
                 services.AddSingleton<IAppVersionProvider>(new StubAppVersionProvider("1.4.0"));
@@ -101,7 +111,11 @@ public class VersionHttpTests : IDisposable
                     RequestPath = "/docs",
                     ContentTypeProvider = new FileExtensionContentTypeProvider()
                 });
-            }));
+            }))
+            .Build();
+
+        await host.StartAsync();
+        return host;
     }
 
     private sealed class StubAppVersionProvider : IAppVersionProvider

--- a/tests/Wayfarer.Tests/Versioning/VersionHttpTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/VersionHttpTests.cs
@@ -1,0 +1,116 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Wayfarer.Areas.Api.Controllers;
+using Wayfarer.Middleware;
+using Wayfarer.Services;
+
+namespace Wayfarer.Tests.Versioning;
+
+public class VersionHttpTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), $"wayfarer-version-tests-{Guid.NewGuid():N}");
+
+    [Fact]
+    public async Task GetVersion_ReturnsExpectedJsonAndContentType()
+    {
+        using var server = CreateApiServer();
+        using var client = server.CreateClient();
+
+        using var response = await client.GetAsync("/api/version");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+        using var document = JsonDocument.Parse(body);
+        var property = document.RootElement.EnumerateObject().Should().ContainSingle().Subject;
+        property.Name.Should().Be("version");
+        property.Value.GetString().Should().Be("1.4.0");
+    }
+
+    [Fact]
+    public async Task VersionHeader_AppearsOnApiResponse()
+    {
+        using var server = CreateApiServer();
+        using var client = server.CreateClient();
+
+        using var response = await client.GetAsync("/api/version");
+
+        response.Headers.GetValues(AppVersionHeaderMiddleware.HeaderName).Should().ContainSingle("1.4.0");
+    }
+
+    [Fact]
+    public async Task VersionHeader_AppearsOnDocsStaticResponse()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        await File.WriteAllTextAsync(Path.Combine(_tempDirectory, "version-test.txt"), "docs");
+
+        using var server = CreateDocsStaticServer(_tempDirectory);
+        using var client = server.CreateClient();
+
+        using var response = await client.GetAsync("/docs/version-test.txt");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.GetValues(AppVersionHeaderMiddleware.HeaderName).Should().ContainSingle("1.4.0");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    private static TestServer CreateApiServer()
+    {
+        return new TestServer(new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IAppVersionProvider>(new StubAppVersionProvider("1.4.0"));
+                services.AddControllers()
+                    .AddApplicationPart(typeof(VersionController).Assembly);
+            })
+            .Configure(app =>
+            {
+                app.UseMiddleware<AppVersionHeaderMiddleware>();
+                app.UseRouting();
+                app.UseEndpoints(endpoints => endpoints.MapControllers());
+            }));
+    }
+
+    private static TestServer CreateDocsStaticServer(string docsPath)
+    {
+        return new TestServer(new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IAppVersionProvider>(new StubAppVersionProvider("1.4.0"));
+            })
+            .Configure(app =>
+            {
+                app.UseMiddleware<AppVersionHeaderMiddleware>();
+                app.UseStaticFiles(new StaticFileOptions
+                {
+                    FileProvider = new PhysicalFileProvider(docsPath),
+                    RequestPath = "/docs",
+                    ContentTypeProvider = new FileExtensionContentTypeProvider()
+                });
+            }));
+    }
+
+    private sealed class StubAppVersionProvider : IAppVersionProvider
+    {
+        public StubAppVersionProvider(string version)
+        {
+            Version = version;
+        }
+
+        public string Version { get; }
+    }
+}

--- a/tests/Wayfarer.Tests/Wayfarer.Tests.csproj
+++ b/tests/Wayfarer.Tests/Wayfarer.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- Fixes #322.
- Adds `Version.props` as the runtime version source with `WayfarerVersion` set to `1.4.0`.
- Exposes the compiled version through `dotnet run --no-launch-profile -- version`, `GET /api/version`, `X-Wayfarer-Version`, and the shared layout footer.
- Keeps release-helper automation, changelog checks, tag validation, and GitHub release validation deferred to #324.

## Validation

- `dotnet build` - passed, 0 warnings/errors.
- `dotnet test --filter Versioning` - passed, 10 tests.
- `dotnet run --no-launch-profile -- version` - output exactly `Wayfarer 1.4.0`.
- `dotnet test` - passed, 1595 tests.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` - passed; warnings are existing Trip Editor/legacy LOC warnings, not files changed by #322.
- `git diff --check origin/main...HEAD` - passed.

## Notes

- Final read-only review passed against `origin/main...HEAD`; local `main` was stale and was not used as the review base.