### PR TITLE
Add release version helper automation

### DIFF
--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -22,11 +22,19 @@ Use `dotnet run --no-launch-profile -- version` when validating exact CLI
 output. The app writes exactly `Wayfarer 1.4.0`; `--no-launch-profile` avoids
 .NET SDK launch-profile messages so validation stays focused on app output.
 
-## Manual bump process
+## Release helper
 
-To prepare a later release version, edit only the root `Version.props` file and
-change `WayfarerVersion` to the target release value. Rebuild the app so the new
-value is compiled into assembly metadata.
+Use the repo-local helper to prepare and validate release metadata:
 
-Release helper automation, changelog checks, tag validation, and GitHub release
-validation are deferred to issue #324.
+```powershell
+python tools/release/version.py prepare <next-version>
+python tools/release/version.py check
+python tools/release/version.py check --require-tag
+python tools/release/version.py check --require-github-release
+```
+
+`prepare <next-version>` updates only `WayfarerVersion` in `Version.props` and
+adds the required changelog skeleton for the target release. The default `check`
+command validates only offline repo files; tag and GitHub release checks run
+only when their explicit flags are supplied. The helper validates release state
+but does not create, edit, publish, or delete GitHub releases.

--- a/tools/release/tests/test_version.py
+++ b/tools/release/tests/test_version.py
@@ -1,0 +1,328 @@
+"""Unit tests for the Wayfarer release version helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "version.py"
+SPEC = importlib.util.spec_from_file_location("release_version", MODULE_PATH)
+version = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["release_version"] = version
+SPEC.loader.exec_module(version)
+
+
+def write_repo(tmp_path: Path, release_version: str = "1.4.0") -> None:
+    """Create the minimal release metadata files used by the helper."""
+
+    (tmp_path / "Version.props").write_text(
+        "\n".join(
+            [
+                "<Project>",
+                "  <PropertyGroup>",
+                f"    <WayfarerVersion>{release_version}</WayfarerVersion>",
+                "    <Version>$(WayfarerVersion)</Version>",
+                "    <PackageVersion>$(WayfarerVersion)</PackageVersion>",
+                "    <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>",
+                "  </PropertyGroup>",
+                "</Project>",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "CHANGELOG.md").write_text(
+        "\n".join(
+            [
+                "# CHANGELOG",
+                "",
+                f"## [{release_version}] - 2026-05-20",
+                "",
+                "### Changed",
+                "- Existing release note.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def use_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the release helper at a temporary repo root."""
+
+    monkeypatch.setattr(version, "REPO_ROOT", tmp_path)
+
+
+def test_prepare_success_updates_version_and_inserts_skeleton(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """prepare updates only WayfarerVersion and adds the exact changelog skeleton."""
+
+    write_repo(tmp_path)
+    use_repo(monkeypatch, tmp_path)
+
+    version.prepare("1.4.1")
+
+    version_props = (tmp_path / "Version.props").read_text(encoding="utf-8")
+    assert "<WayfarerVersion>1.4.1</WayfarerVersion>" in version_props
+    assert "<Version>$(WayfarerVersion)</Version>" in version_props
+    assert "<PackageVersion>$(WayfarerVersion)</PackageVersion>" in version_props
+    assert (
+        "<AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>"
+        in version_props
+    )
+
+    changelog = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert changelog.startswith(
+        "# CHANGELOG\n\n"
+        "## [1.4.1] - "
+        f"{version.date.today().isoformat()}\n\n"
+        "### Changed\n"
+        "- TODO: Add release notes before publishing.\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_version",
+    ["v1.4.1", "1.4", "1.4.1-beta.1", "1.4.1+build.1", "-1.4.1", "1.x.1"],
+)
+def test_invalid_version_format_rejection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, invalid_version: str
+) -> None:
+    """prepare rejects anything outside strict SemVer core syntax."""
+
+    write_repo(tmp_path)
+    use_repo(monkeypatch, tmp_path)
+
+    with pytest.raises(version.ValidationError):
+        version.prepare(invalid_version)
+
+
+@pytest.mark.parametrize("target_version", ["1.4.0", "1.3.9"])
+def test_lower_or_repeated_version_rejection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target_version: str
+) -> None:
+    """prepare rejects target versions that are not greater numerically."""
+
+    write_repo(tmp_path)
+    use_repo(monkeypatch, tmp_path)
+
+    with pytest.raises(version.ValidationError):
+        version.prepare(target_version)
+    assert "<WayfarerVersion>1.4.0</WayfarerVersion>" in (
+        tmp_path / "Version.props"
+    ).read_text(encoding="utf-8")
+
+
+def test_changelog_skeleton_insertion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """prepare inserts the skeleton immediately after the changelog title."""
+
+    write_repo(tmp_path)
+    use_repo(monkeypatch, tmp_path)
+
+    version.prepare("1.4.2")
+
+    lines = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "# CHANGELOG"
+    assert lines[1] == ""
+    assert lines[2] == f"## [1.4.2] - {version.date.today().isoformat()}"
+    assert lines[3] == ""
+    assert lines[4] == "### Changed"
+    assert lines[5] == "- TODO: Add release notes before publishing."
+
+
+def test_existing_changelog_section_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """prepare fails without rewriting when the target section already exists."""
+
+    write_repo(tmp_path)
+    original_version_props = (tmp_path / "Version.props").read_text(encoding="utf-8")
+    original_changelog = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    use_repo(monkeypatch, tmp_path)
+
+    with pytest.raises(version.ValidationError):
+        version.prepare("1.4.0")
+
+    assert (tmp_path / "Version.props").read_text(encoding="utf-8") == original_version_props
+    assert (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8") == original_changelog
+
+
+def test_malformed_changelog_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """prepare fails when CHANGELOG.md does not start with the required title."""
+
+    write_repo(tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text("# Changes\n", encoding="utf-8")
+    use_repo(monkeypatch, tmp_path)
+
+    with pytest.raises(version.ValidationError):
+        version.prepare("1.4.1")
+
+
+def test_missing_changelog_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """prepare fails when CHANGELOG.md is absent."""
+
+    write_repo(tmp_path)
+    (tmp_path / "CHANGELOG.md").unlink()
+    use_repo(monkeypatch, tmp_path)
+
+    with pytest.raises(version.ValidationError):
+        version.prepare("1.4.1")
+
+
+def test_offline_check_detects_changelog_version_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """default check fails when the top changelog version drifts from Version.props."""
+
+    write_repo(tmp_path, release_version="1.4.0")
+    changelog = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text(
+        changelog.replace("## [1.4.0]", "## [1.4.1]"),
+        encoding="utf-8",
+    )
+    use_repo(monkeypatch, tmp_path)
+
+    with pytest.raises(version.ValidationError):
+        version.check(require_tag=False, require_github_release=False)
+
+
+def test_derived_msbuild_property_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """default check fails when derived MSBuild properties stop using WayfarerVersion."""
+
+    write_repo(tmp_path)
+    version_props = (tmp_path / "Version.props").read_text(encoding="utf-8")
+    (tmp_path / "Version.props").write_text(
+        version_props.replace(
+            "<Version>$(WayfarerVersion)</Version>",
+            "<Version>1.4.0</Version>",
+        ),
+        encoding="utf-8",
+    )
+    use_repo(monkeypatch, tmp_path)
+
+    with pytest.raises(version.ValidationError):
+        version.check(require_tag=False, require_github_release=False)
+
+
+def test_explicit_local_tag_validation_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """check --require-tag accepts an exact local tag match."""
+
+    write_repo(tmp_path)
+    use_repo(monkeypatch, tmp_path)
+
+    def fake_run(command, **kwargs):
+        assert command == ["git", "tag", "--list", "v1.4.0"]
+        return subprocess.CompletedProcess(command, 0, stdout="v1.4.0\n", stderr="")
+
+    monkeypatch.setattr(version.subprocess, "run", fake_run)
+
+    version.check(require_tag=True, require_github_release=False)
+
+
+def test_explicit_local_tag_validation_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """check --require-tag rejects a missing local tag."""
+
+    write_repo(tmp_path)
+    use_repo(monkeypatch, tmp_path)
+
+    def fake_run(command, **kwargs):
+        assert command == ["git", "tag", "--list", "v1.4.0"]
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(version.subprocess, "run", fake_run)
+
+    with pytest.raises(version.ValidationError):
+        version.check(require_tag=True, require_github_release=False)
+
+
+def test_mocked_github_release_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """check --require-github-release accepts exact release metadata."""
+
+    write_repo(tmp_path)
+    use_repo(monkeypatch, tmp_path)
+
+    def fake_run(command, **kwargs):
+        assert command == [
+            "gh",
+            "release",
+            "view",
+            "v1.4.0",
+            "--json",
+            "tagName,name,isDraft,isPrerelease",
+        ]
+        payload = (
+            '{"tagName":"v1.4.0","name":"v1.4.0",'
+            '"isDraft":false,"isPrerelease":false}'
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=payload, stderr="")
+
+    monkeypatch.setattr(version.subprocess, "run", fake_run)
+
+    version.check(require_tag=False, require_github_release=True)
+
+
+def test_mocked_github_release_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """check --require-github-release rejects draft or mismatched releases."""
+
+    write_repo(tmp_path)
+    use_repo(monkeypatch, tmp_path)
+
+    def fake_run(command, **kwargs):
+        payload = (
+            '{"tagName":"v1.4.0","name":"v1.4.0",'
+            '"isDraft":true,"isPrerelease":false}'
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=payload, stderr="")
+
+    monkeypatch.setattr(version.subprocess, "run", fake_run)
+
+    with pytest.raises(version.ValidationError):
+        version.check(require_tag=False, require_github_release=True)
+
+
+def test_default_check_does_not_call_gh_or_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """default check validates only offline files and never calls subprocess."""
+
+    write_repo(tmp_path)
+    use_repo(monkeypatch, tmp_path)
+
+    def fail_run(command, **kwargs):
+        raise AssertionError(f"default check called subprocess: {command}")
+
+    monkeypatch.setattr(version.subprocess, "run", fail_run)
+
+    version.check(require_tag=False, require_github_release=False)
+
+
+def test_usage_error_exit_code() -> None:
+    """invalid command-line arguments use argparse's required usage exit code."""
+
+    with pytest.raises(SystemExit) as exc_info:
+        version.main(["prepare"])
+
+    assert exc_info.value.code == 2

--- a/tools/release/version.py
+++ b/tools/release/version.py
@@ -1,0 +1,330 @@
+"""Prepare and validate Wayfarer release version metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERSION_PROPS = "Version.props"
+CHANGELOG = "CHANGELOG.md"
+WAYFARER_VERSION = "WayfarerVersion"
+DERIVED_PROPERTIES = (
+    "Version",
+    "PackageVersion",
+    "AssemblyInformationalVersion",
+)
+DERIVED_VALUE = "$(WayfarerVersion)"
+SEMVER_CORE_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+CHANGELOG_HEADING_PATTERN = re.compile(
+    r"^## \[(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\] - \d{4}-\d{2}-\d{2}$"
+)
+
+
+class ValidationError(Exception):
+    """Raised when release metadata does not satisfy the command contract."""
+
+
+@dataclass(frozen=True)
+class TextFile:
+    """A UTF-8 text file and its detected newline style."""
+
+    path: Path
+    text: str
+    newline: str
+
+
+@dataclass(frozen=True)
+class VersionState:
+    """Validated release metadata read from Version.props."""
+
+    file: TextFile
+    version: str
+
+
+@dataclass(frozen=True)
+class ChangelogState:
+    """Validated changelog text and its top release heading."""
+
+    file: TextFile
+    top_heading: str
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the release helper command line interface."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "prepare":
+            prepare(args.version)
+        elif args.command == "check":
+            check(args.require_tag, args.require_github_release)
+        else:
+            parser.error("unknown command")
+    except ValidationError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command parser with the required subcommands."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare_parser = subparsers.add_parser("prepare")
+    prepare_parser.add_argument("version")
+
+    check_parser = subparsers.add_parser("check")
+    check_parser.add_argument("--require-tag", action="store_true")
+    check_parser.add_argument("--require-github-release", action="store_true")
+    return parser
+
+
+def prepare(target_version: str) -> None:
+    """Prepare Version.props and CHANGELOG.md for the target release."""
+
+    target_tuple = parse_semver(target_version)
+    version_state = read_version_state()
+    current_tuple = parse_semver(version_state.version)
+    if target_tuple <= current_tuple:
+        raise ValidationError(
+            f"{target_version} must be greater than current version {version_state.version}"
+        )
+
+    changelog_state = read_changelog_state()
+    ensure_changelog_section_missing(changelog_state.file.text, target_version)
+
+    updated_version_props = replace_wayfarer_version(
+        version_state.file.text, target_version
+    )
+    updated_changelog = insert_changelog_skeleton(
+        changelog_state.file.text,
+        changelog_state.file.newline,
+        target_version,
+        date.today().isoformat(),
+    )
+
+    write_text(version_state.file.path, updated_version_props, version_state.file.newline)
+    write_text(changelog_state.file.path, updated_changelog, changelog_state.file.newline)
+    print(f"Prepared Wayfarer {target_version}")
+
+
+def check(require_tag: bool, require_github_release: bool) -> None:
+    """Validate the current release metadata and optional external release state."""
+
+    version_state = read_version_state()
+    changelog_state = read_changelog_state()
+    changelog_version = parse_top_changelog_version(changelog_state.top_heading)
+    if changelog_version != version_state.version:
+        raise ValidationError(
+            "top changelog release version "
+            f"{changelog_version} does not match {version_state.version}"
+        )
+
+    expected_tag = f"v{version_state.version}"
+    if require_tag:
+        validate_local_tag(expected_tag)
+    if require_github_release:
+        validate_github_release(expected_tag)
+    print(f"Wayfarer release metadata is valid for {expected_tag}")
+
+
+def read_version_state() -> VersionState:
+    """Read and validate root Version.props release metadata."""
+
+    text_file = read_text(REPO_ROOT / VERSION_PROPS)
+    values = find_msbuild_values(text_file.text, WAYFARER_VERSION)
+    if len(values) != 1:
+        raise ValidationError("Version.props must contain exactly one WayfarerVersion")
+
+    version = values[0]
+    parse_semver(version)
+    for property_name in DERIVED_PROPERTIES:
+        property_values = find_msbuild_values(text_file.text, property_name)
+        if not property_values:
+            raise ValidationError(f"Version.props is missing {property_name}")
+        if len(property_values) != 1 or property_values[0] != DERIVED_VALUE:
+            raise ValidationError(
+                f"Version.props {property_name} must be exactly {DERIVED_VALUE}"
+            )
+    return VersionState(text_file, version)
+
+
+def read_changelog_state() -> ChangelogState:
+    """Read CHANGELOG.md and validate the top release heading."""
+
+    text_file = read_text(REPO_ROOT / CHANGELOG)
+    if not text_file.text.startswith("# CHANGELOG"):
+        raise ValidationError("CHANGELOG.md must start with # CHANGELOG")
+
+    top_heading = find_top_changelog_heading(text_file.text)
+    if not CHANGELOG_HEADING_PATTERN.match(top_heading):
+        raise ValidationError(
+            "top changelog release heading must match ## [X.Y.Z] - YYYY-MM-DD"
+        )
+    return ChangelogState(text_file, top_heading)
+
+
+def read_text(path: Path) -> TextFile:
+    """Read a UTF-8 text file and preserve its dominant newline style."""
+
+    if not path.exists():
+        raise ValidationError(f"{path.name} is missing")
+    text = path.read_text(encoding="utf-8")
+    newline = "\r\n" if "\r\n" in text else "\n"
+    return TextFile(path, text, newline)
+
+
+def write_text(path: Path, text: str, newline: str) -> None:
+    """Write UTF-8 text while preserving the detected newline style."""
+
+    normalized = text.replace("\r\n", "\n").replace("\n", newline)
+    path.write_text(normalized, encoding="utf-8", newline="")
+
+
+def parse_semver(version: str) -> tuple[int, int, int]:
+    """Parse strict SemVer core syntax into a numeric tuple."""
+
+    match = SEMVER_CORE_PATTERN.match(version)
+    if not match:
+        raise ValidationError(f"{version} is not a strict SemVer core version")
+    return tuple(int(part) for part in match.groups())
+
+
+def find_msbuild_values(text: str, property_name: str) -> list[str]:
+    """Find simple MSBuild property element values by name."""
+
+    pattern = re.compile(
+        rf"<{re.escape(property_name)}>(.*?)</{re.escape(property_name)}>",
+        re.DOTALL,
+    )
+    return [match.group(1) for match in pattern.finditer(text)]
+
+
+def replace_wayfarer_version(text: str, target_version: str) -> str:
+    """Replace only the single WayfarerVersion element value."""
+
+    pattern = re.compile(r"(<WayfarerVersion>)(.*?)(</WayfarerVersion>)", re.DOTALL)
+    updated, count = pattern.subn(rf"\g<1>{target_version}\g<3>", text)
+    if count != 1:
+        raise ValidationError("Version.props must contain exactly one WayfarerVersion")
+    return updated
+
+
+def find_top_changelog_heading(text: str) -> str:
+    """Return the first release heading after the changelog title."""
+
+    for line in text.splitlines():
+        if line.startswith("## "):
+            return line
+    raise ValidationError("CHANGELOG.md is missing a release heading")
+
+
+def parse_top_changelog_version(heading: str) -> str:
+    """Extract the release version from an already validated heading."""
+
+    match = CHANGELOG_HEADING_PATTERN.match(heading)
+    if not match:
+        raise ValidationError(
+            "top changelog release heading must match ## [X.Y.Z] - YYYY-MM-DD"
+        )
+    return ".".join(match.groups())
+
+
+def ensure_changelog_section_missing(text: str, target_version: str) -> None:
+    """Fail when the changelog already has a section for the target release."""
+
+    section_pattern = re.compile(
+        rf"^## \[{re.escape(target_version)}\] - \d{{4}}-\d{{2}}-\d{{2}}$",
+        re.MULTILINE,
+    )
+    if section_pattern.search(text):
+        raise ValidationError(f"CHANGELOG.md already contains {target_version}")
+
+
+def insert_changelog_skeleton(
+    text: str, newline: str, target_version: str, release_date: str
+) -> str:
+    """Insert the required release skeleton immediately after the changelog title."""
+
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].rstrip("\r\n") != "# CHANGELOG":
+        raise ValidationError("CHANGELOG.md must start with # CHANGELOG")
+
+    skeleton = (
+        f"{newline}## [{target_version}] - {release_date}{newline}"
+        f"{newline}### Changed{newline}"
+        f"- TODO: Add release notes before publishing.{newline}"
+    )
+    return "".join([lines[0], skeleton, *lines[1:]])
+
+
+def validate_local_tag(expected_tag: str) -> None:
+    """Require the exact local Git tag for the current release version."""
+
+    result = run_command(["git", "tag", "--list", expected_tag])
+    tags = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if tags != [expected_tag]:
+        raise ValidationError(f"local Git tag {expected_tag} is missing")
+
+
+def validate_github_release(expected_tag: str) -> None:
+    """Require an exact non-draft, non-prerelease GitHub release."""
+
+    result = run_command(
+        [
+            "gh",
+            "release",
+            "view",
+            expected_tag,
+            "--json",
+            "tagName,name,isDraft,isPrerelease",
+        ]
+    )
+    try:
+        release = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValidationError("gh release view returned invalid JSON") from exc
+
+    expected = {
+        "tagName": expected_tag,
+        "name": expected_tag,
+        "isDraft": False,
+        "isPrerelease": False,
+    }
+    for key, expected_value in expected.items():
+        if release.get(key) != expected_value:
+            raise ValidationError(f"GitHub release {key} must be {expected_value!r}")
+
+
+def run_command(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Run a validation command without mutating release state."""
+
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        suffix = f": {detail}" if detail else ""
+        raise ValidationError(f"{' '.join(command)} failed{suffix}")
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Fixes #324.
- Adds `tools/release/version.py` for deterministic release version preparation and validation.
- Adds pytest coverage for prepare/check, local tag validation, and mocked GitHub release validation.
- Documents the release helper commands in `docs/23-Versioning.md`.

## Validation

- `python -m pytest tools/release/tests` - 21 passed.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` - passed; only existing out-of-scope LOC warnings.
- `git diff --check origin/main...HEAD` - passed.

Note: `python tools/release/version.py check` currently exits 1 on the live repo because it correctly detects release metadata drift: `Version.props` is `1.4.0` while the top `CHANGELOG.md` entry is `1.3.2`.

## Scope Notes

- No runtime version provider, CLI version command, HTTP header, `/api/version`, footer display, release publishing, or GitHub release mutation was added.