### PR TITLE
Fix footer version placement and dynamic year

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -136,7 +136,7 @@
 
             <footer data-bs-theme="light">
                 <div class="container">
-                    &copy; 2025 - Wayfarer by <a href="https://stefk.me"
+                    &copy; @DateTime.UtcNow.Year - @AppVersionDisplay.FooterText(AppVersionProvider) by <a href="https://stefk.me"
                         class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
                         target="_blank" title="Hi, I am Stef check out my blog!">Stef</a> -
                     <a href="/docs/" target="_blank"
@@ -144,8 +144,7 @@
                     <a href="https://stef-k.github.io/WayfarerMobile/" target="_blank"
                         class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Mobile</a> -
                     <a asp-area="" asp-controller="Home" asp-action="Privacy"
-                        class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Privacy</a> -
-                    @AppVersionDisplay.FooterText(AppVersionProvider)
+                        class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Privacy</a>
                 </div>
             </footer>
 

--- a/tests/Wayfarer.Tests/Versioning/AppVersionDisplayTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionDisplayTests.cs
@@ -31,6 +31,9 @@ public class AppVersionDisplayTests
 
         layout.Should().Contain("@inject IAppVersionProvider AppVersionProvider");
         layout.Should().Contain("@AppVersionDisplay.FooterText(AppVersionProvider)");
+        layout.Should().Contain("&copy; @DateTime.UtcNow.Year - @AppVersionDisplay.FooterText(AppVersionProvider) by");
+        layout.Should().NotContain("&copy; 2025");
+        layout.Should().NotContain("Privacy</a> -");
         layout.Should().NotContain("Wayfarer v1.4.0");
     }
 


### PR DESCRIPTION
## Summary

- Moves the footer version next to the copyright year, so the footer reads `© <year> - Wayfarer v1.4.0 by Stef - Docs - Mobile - Privacy`.
- Uses `DateTime.UtcNow.Year` instead of a hardcoded year.
- Tightens the focused layout/version display test.

## Validation

- `dotnet test --filter FullyQualifiedName~Versioning` - passed, 26 tests.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` - passed; only existing unrelated LOC warnings.
- `git diff --check` - passed; Git reported only line-ending normalization warnings.
- `dotnet test` - hit the existing intermittent `TripViewerControllerTests.ProxyImage_ReturnsBadRequest_WhenStreamExceedsConfiguredLimit` semaphore failure; immediate focused rerun of that test passed.