### PR TITLE
Prepare v1.4.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [1.4.1] - 2026-05-21
+
+### Changed
+- Moved the shared footer version next to the copyright year and made the year use UTC so deployed pages show the current year without duplicating `Wayfarer` at the end of the footer (#330)
+
 ## [1.4.0] - 2026-05-21
 
 ### Added

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <WayfarerVersion>1.4.0</WayfarerVersion>
+    <WayfarerVersion>1.4.1</WayfarerVersion>
     <Version>$(WayfarerVersion)</Version>
     <PackageVersion>$(WayfarerVersion)</PackageVersion>
     <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>

--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -5,7 +5,7 @@ file contains the manually edited `WayfarerVersion` value and maps the standard
 MSBuild metadata directly from it:
 
 ```xml
-<WayfarerVersion>1.4.0</WayfarerVersion>
+<WayfarerVersion>1.4.1</WayfarerVersion>
 <Version>$(WayfarerVersion)</Version>
 <PackageVersion>$(WayfarerVersion)</PackageVersion>
 <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
@@ -19,7 +19,7 @@ assembly through `IAppVersionProvider`. Runtime surfaces such as
 separate constants.
 
 Use `dotnet run --no-launch-profile -- version` when validating exact CLI
-output. The app writes exactly `Wayfarer 1.4.0`; `--no-launch-profile` avoids
+output. The app writes exactly `Wayfarer 1.4.1`; `--no-launch-profile` avoids
 .NET SDK launch-profile messages so validation stays focused on app output.
 
 ## Release helper

--- a/tests/Wayfarer.Tests/Versioning/AppVersionCliTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionCliTests.cs
@@ -47,7 +47,7 @@ public class AppVersionCliTests
 
         var handled = AppVersionCli.TryHandle(
             new[] { command },
-            new StubAppVersionProvider("1.4.0"),
+            new StubAppVersionProvider("1.4.1"),
             output,
             error,
             out var exitCode);
@@ -66,14 +66,14 @@ public class AppVersionCliTests
 
         var handled = AppVersionCli.TryHandle(
             new[] { "version" },
-            new StubAppVersionProvider("1.4.0"),
+            new StubAppVersionProvider("1.4.1"),
             output,
             error,
             out var exitCode);
 
         handled.Should().BeTrue();
         exitCode.Should().Be(0);
-        output.ToString().Should().Be($"Wayfarer 1.4.0{Environment.NewLine}");
+        output.ToString().Should().Be($"Wayfarer 1.4.1{Environment.NewLine}");
         error.ToString().Should().BeEmpty();
     }
 
@@ -87,7 +87,7 @@ public class AppVersionCliTests
 
         var handled = AppVersionCli.TryHandle(
             new[] { "version", option },
-            new StubAppVersionProvider("1.4.0"),
+            new StubAppVersionProvider("1.4.1"),
             output,
             error,
             out var exitCode);
@@ -108,7 +108,7 @@ public class AppVersionCliTests
 
         var handled = AppVersionCli.TryHandle(
             new[] { "reset-password", option },
-            new StubAppVersionProvider("1.4.0"),
+            new StubAppVersionProvider("1.4.1"),
             output,
             error,
             out var exitCode);
@@ -135,7 +135,7 @@ public class AppVersionCliTests
 
         var handled = AppVersionCli.TryHandle(
             args,
-            new StubAppVersionProvider("1.4.0"),
+            new StubAppVersionProvider("1.4.1"),
             output,
             error,
             out var exitCode);
@@ -152,7 +152,7 @@ public class AppVersionCliTests
 
         var handled = AppVersionCli.TryHandle(
             new[] { "unknown" },
-            new StubAppVersionProvider("1.4.0"),
+            new StubAppVersionProvider("1.4.1"),
             output,
             error,
             out var exitCode);
@@ -171,7 +171,7 @@ public class AppVersionCliTests
 
         var handled = AppVersionCli.TryHandle(
             new[] { "reset-password", "user", "pass" },
-            new StubAppVersionProvider("1.4.0"),
+            new StubAppVersionProvider("1.4.1"),
             output,
             error,
             out var exitCode);

--- a/tests/Wayfarer.Tests/Versioning/AppVersionDisplayTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionDisplayTests.cs
@@ -9,9 +9,9 @@ public class AppVersionDisplayTests
     [Fact]
     public void FooterText_RendersSharedLayoutVersionText()
     {
-        AppVersionDisplay.FooterText(new StubAppVersionProvider("1.4.0"))
+        AppVersionDisplay.FooterText(new StubAppVersionProvider("1.4.1"))
             .Should()
-            .Be("Wayfarer v1.4.0");
+            .Be("Wayfarer v1.4.1");
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class AppVersionDisplayTests
         layout.Should().Contain("&copy; @DateTime.UtcNow.Year - @AppVersionDisplay.FooterText(AppVersionProvider) by");
         layout.Should().NotContain("&copy; 2025");
         layout.Should().NotContain("Privacy</a> -");
-        layout.Should().NotContain("Wayfarer v1.4.0");
+        layout.Should().NotContain("Wayfarer v1.4.1");
     }
 
     private sealed class StubAppVersionProvider : IAppVersionProvider

--- a/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
@@ -13,7 +13,7 @@ public class AppVersionProviderTests
     {
         var provider = new AppVersionProvider();
 
-        provider.Version.Should().Be("1.4.0");
+        provider.Version.Should().Be("1.4.1");
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Versioning/VersionHttpTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/VersionHttpTests.cs
@@ -33,7 +33,7 @@ public class VersionHttpTests : IDisposable
         using var document = JsonDocument.Parse(body);
         var property = document.RootElement.EnumerateObject().Should().ContainSingle().Subject;
         property.Name.Should().Be("version");
-        property.Value.GetString().Should().Be("1.4.0");
+        property.Value.GetString().Should().Be("1.4.1");
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class VersionHttpTests : IDisposable
 
         using var response = await client.GetAsync("/api/version");
 
-        response.Headers.GetValues(AppVersionHeaderMiddleware.HeaderName).Should().ContainSingle("1.4.0");
+        response.Headers.GetValues(AppVersionHeaderMiddleware.HeaderName).Should().ContainSingle("1.4.1");
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class VersionHttpTests : IDisposable
         using var response = await client.GetAsync("/docs/version-test.txt");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.Headers.GetValues(AppVersionHeaderMiddleware.HeaderName).Should().ContainSingle("1.4.0");
+        response.Headers.GetValues(AppVersionHeaderMiddleware.HeaderName).Should().ContainSingle("1.4.1");
     }
 
     public void Dispose()
@@ -77,7 +77,7 @@ public class VersionHttpTests : IDisposable
                 .UseTestServer()
             .ConfigureServices(services =>
             {
-                services.AddSingleton<IAppVersionProvider>(new StubAppVersionProvider("1.4.0"));
+                services.AddSingleton<IAppVersionProvider>(new StubAppVersionProvider("1.4.1"));
                 services.AddControllers()
                     .AddApplicationPart(typeof(VersionController).Assembly);
             })
@@ -100,7 +100,7 @@ public class VersionHttpTests : IDisposable
                 .UseTestServer()
             .ConfigureServices(services =>
             {
-                services.AddSingleton<IAppVersionProvider>(new StubAppVersionProvider("1.4.0"));
+                services.AddSingleton<IAppVersionProvider>(new StubAppVersionProvider("1.4.1"));
             })
             .Configure(app =>
             {


### PR DESCRIPTION
## Summary

- Prepares the `v1.4.1` patch release.
- Bumps `WayfarerVersion` from `1.4.0` to `1.4.1`.
- Adds the changelog note for the shared footer year/version placement fix from #330.

## Validation

- `python tools/release/version.py check` - passed, metadata valid for `v1.4.1`.
- `dotnet test --filter FullyQualifiedName~Versioning` - passed, 26 tests.
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600` - passed; only existing out-of-scope LOC warnings.
- `git diff --check` - passed; Git reported only line-ending normalization warnings.

## Notes

- Local full `dotnet test` before this release branch hit the existing intermittent `TripViewerControllerTests.ProxyImage_ReturnsBadRequest_WhenStreamExceedsConfiguredLimit` semaphore failure; immediate focused rerun passed. CI will run the full suite for this PR.