### PR TITLE
test(image-proxy): isolate static coordination tests

### DIFF
--- a/tests/Wayfarer.Tests/Controllers/PublicTripImagesTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/PublicTripImagesTests.cs
@@ -16,6 +16,7 @@ namespace Wayfarer.Tests.Controllers;
 /// <summary>
 /// Tests for direct-serve public trip image endpoints (CoverImage and MapSnapshot).
 /// </summary>
+[Collection(ImageProxyStaticStateTestCollection.Name)]
 public class PublicTripImagesTests : TestBase
 {
     [Fact]

--- a/tests/Wayfarer.Tests/Controllers/TripViewerControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripViewerControllerTests.cs
@@ -22,6 +22,7 @@ namespace Wayfarer.Tests.Controllers;
 /// <summary>
 /// Public trip viewer behaviors: index search/pagination, view gating, preview, thumbnail proxy.
 /// </summary>
+[Collection(ImageProxyStaticStateTestCollection.Name)]
 public class TripViewerControllerTests : TestBase
 {
     [Fact]

--- a/tests/Wayfarer.Tests/Infrastructure/ImageProxyStaticStateTestCollection.cs
+++ b/tests/Wayfarer.Tests/Infrastructure/ImageProxyStaticStateTestCollection.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace Wayfarer.Tests.Infrastructure;
+
+/// <summary>
+/// Serializes tests that share <see cref="Wayfarer.Services.ImageProxyService"/> static coordination state.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ImageProxyStaticStateTestCollection
+{
+    /// <summary>Stable collection name for tests using the real image proxy service.</summary>
+    public const string Name = "Image proxy static state";
+}

--- a/tests/Wayfarer.Tests/Services/ImageProxyServiceTests.cs
+++ b/tests/Wayfarer.Tests/Services/ImageProxyServiceTests.cs
@@ -14,11 +14,38 @@ namespace Wayfarer.Tests.Services;
 /// Tests for <see cref="ImageProxyService"/>: SSRF check, fetch+cache pipeline,
 /// upstream failures, already-cached entries, and oversized images.
 /// </summary>
+[Collection(ImageProxyStaticStateTestCollection.Name)]
 public partial class ImageProxyServiceTests : TestBase
 {
     public ImageProxyServiceTests()
     {
         ImageProxyService.ResetStaticStateForTesting();
+    }
+
+    /// <summary>Guards the non-parallel boundary required by shared image proxy static state.</summary>
+    [Fact]
+    public void StaticStateUsers_ShareTheNonParallelImageProxyCollection()
+    {
+        var staticStateUsers = new[]
+        {
+            typeof(ImageProxyServiceTests),
+            typeof(Wayfarer.Tests.Controllers.TripViewerControllerTests),
+            typeof(Wayfarer.Tests.Controllers.PublicTripImagesTests)
+        };
+
+        Assert.All(staticStateUsers, type =>
+        {
+            var attribute = Assert.Single(
+                type.CustomAttributes,
+                attribute => attribute.AttributeType == typeof(CollectionAttribute));
+            Assert.Equal(ImageProxyStaticStateTestCollection.Name, attribute.ConstructorArguments.Single().Value);
+        });
+
+        var definition = typeof(ImageProxyStaticStateTestCollection)
+            .GetCustomAttributes(typeof(CollectionDefinitionAttribute), inherit: false)
+            .Cast<CollectionDefinitionAttribute>()
+            .Single();
+        Assert.True(definition.DisableParallelization);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- serialize only tests sharing ImageProxyService static coordination state
- prevent test reset from refilling an in-use origin-work semaphore
- preserve global test parallelism and production behavior

Closes #343

## Validation
- ImageProxyServiceTests and TripViewerControllerTests: 10 repeated passes
- full dotnet test: passed with expected PostgreSQL prerequisite skips
- dotnet build
- LOC check
- git diff --check