### PR TITLE
fix(layout): normalize shared footer behavior

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -35,8 +35,11 @@
         <link rel="stylesheet" href="~/icons/wayfarer-map-icons/dist/wayfarer-map-icons.css"
             asp-append-version="true" />
         @Html.FrontendGlobalStyles()
-        @* The standard shell owns header/content/footer geometry and footer link states. *@
-        <link rel="stylesheet" href="~/css/shared-layout.css" asp-append-version="true" />
+        @if (!embed)
+        {
+            @* The standard shell owns header/content/footer geometry and footer link states. *@
+            <link rel="stylesheet" href="~/css/shared-layout.css" asp-append-version="true" />
+        }
         <link rel="stylesheet" href="~/Wayfarer.styles.css" asp-append-version="true" />
         @if (ViewData["LoadLeaflet"] as bool? == true)
         {

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -35,6 +35,8 @@
         <link rel="stylesheet" href="~/icons/wayfarer-map-icons/dist/wayfarer-map-icons.css"
             asp-append-version="true" />
         @Html.FrontendGlobalStyles()
+        @* The standard shell owns header/content/footer geometry and footer link states. *@
+        <link rel="stylesheet" href="~/css/shared-layout.css" asp-append-version="true" />
         <link rel="stylesheet" href="~/Wayfarer.styles.css" asp-append-version="true" />
         @if (ViewData["LoadLeaflet"] as bool? == true)
         {
@@ -54,7 +56,7 @@
         @RenderSection("Styles", required: false)
     </head>
 
-    <body data-bs-theme="light" class="@(embed ? "embed-mode" : "")">
+    <body data-bs-theme="light" class="site-shell @(embed ? "embed-mode" : "")">
         @if (!embed)
         {
             <header>
@@ -93,7 +95,7 @@
                 </nav>
             </header>
         }
-        <div class="@(ViewData["BodyClass"] as string ?? "container")">
+        <div class="site-content @(ViewData["BodyClass"] as string ?? "container")">
             @if (TempData["AlertMessage"] != null)
             {
                 <div class="alert alert-@TempData["AlertType"] alert-dismissible fade show" role="alert">
@@ -134,17 +136,17 @@
                 <i class="bi bi-arrow-up"></i>
             </button>
 
-            <footer data-bs-theme="light">
+            <footer class="site-footer" data-bs-theme="light">
                 <div class="container">
                     &copy; @DateTime.UtcNow.Year - @AppVersionDisplay.FooterText(AppVersionProvider) by <a href="https://stefk.me"
-                        class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
+                        class="site-footer__link link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover"
                         target="_blank" title="Hi, I am Stef check out my blog!">Stef</a> -
                     <a href="/docs/" target="_blank"
-                        class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Docs</a> -
+                        class="site-footer__link link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Docs</a> -
                     <a href="https://stef-k.github.io/WayfarerMobile/" target="_blank"
-                        class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Mobile</a> -
+                        class="site-footer__link link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Mobile</a> -
                     <a asp-area="" asp-controller="Home" asp-action="Privacy"
-                        class="link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Privacy</a>
+                        class="site-footer__link link-offset-2 link-offset-3-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover">Privacy</a>
                 </div>
             </footer>
 

--- a/Views/Shared/_Layout.cshtml.css
+++ b/Views/Shared/_Layout.cshtml.css
@@ -38,11 +38,3 @@ button.accept-policy {
   font-size: 1rem;
   line-height: inherit;
 }
-
-.footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  white-space: nowrap;
-  line-height: 60px;
-}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "test:trip-import-client": "node --test tests/client/tripImportClient.test.mjs",
     "test:e2e:trip-editor": "playwright test --config=playwright.config.ts",
+    "test:e2e:shared-layout": "playwright test --config=playwright.shared-layout.config.ts",
     "smoke:trip-editor:assets": "node tools/trip-editor-asset-smoke.mjs --mode=all",
     "smoke:trip-editor:assets:dev": "node tools/trip-editor-asset-smoke.mjs --mode=development",
     "smoke:trip-editor:assets:published": "node tools/trip-editor-asset-smoke.mjs --mode=published"

--- a/playwright.shared-layout.config.ts
+++ b/playwright.shared-layout.config.ts
@@ -14,5 +14,13 @@ export default defineConfig({
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure'
   },
+  webServer: {
+    command: 'powershell -NoProfile -ExecutionPolicy Bypass -File .\\tools\\start-shared-layout-e2e-host.ps1',
+    url: `${baseURL}/Home/Privacy`,
+    ignoreHTTPSErrors: true,
+    reuseExistingServer: false,
+    timeout: 180_000
+  },
+  globalTeardown: './tests/e2e/shared-layout/sharedLayoutGlobalTeardown.ts',
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }]
 });

--- a/playwright.shared-layout.config.ts
+++ b/playwright.shared-layout.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.WAYFARER_E2E_BASE_URL ?? 'https://localhost:7150';
+
+export default defineConfig({
+  testDir: './tests/e2e/shared-layout',
+  outputDir: '.local/playwright/shared-layout-output',
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: '.local/playwright/shared-layout-report' }]],
+  use: {
+    baseURL,
+    ignoreHTTPSErrors: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure'
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }]
+});

--- a/playwright.shared-layout.config.ts
+++ b/playwright.shared-layout.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const baseURL = process.env.WAYFARER_E2E_BASE_URL ?? 'https://localhost:7150';
+const baseURL = 'https://localhost:7150';
 
 export default defineConfig({
   testDir: './tests/e2e/shared-layout',
@@ -16,7 +16,7 @@ export default defineConfig({
   },
   webServer: {
     command: 'powershell -NoProfile -ExecutionPolicy Bypass -File .\\tools\\start-shared-layout-e2e-host.ps1',
-    url: `${baseURL}/Home/Privacy`,
+    url: 'https://localhost:7150/Home/Privacy',
     ignoreHTTPSErrors: true,
     reuseExistingServer: false,
     timeout: 180_000

--- a/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
+++ b/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { loadSharedLayoutConfig } from './sharedLayoutConfig';
+
+const config = loadSharedLayoutConfig();
+const footerLinks = '.site-footer__link';
+
+test.describe('shared standard-layout footer', () => {
+  for (const [name, viewport] of Object.entries({ desktop: { width: 1440, height: 900 }, tablet: { width: 768, height: 1024 }, mobile: { width: 375, height: 667 } })) {
+    test(`keeps the short public page contained at ${name}`, async ({ page }) => {
+      await page.setViewportSize(viewport);
+      await page.goto('/Home/Privacy');
+      await expectStandardFooter(page);
+      await expect(page.locator(footerLinks)).toHaveCount(4);
+      await expectMatchingColors(page, 'light');
+    });
+  }
+
+  for (const theme of ['light', 'dark'] as const) {
+    test(`matches footer link colors across ${theme} theme interaction states`, async ({ page }) => {
+      await page.addInitScript(value => localStorage.setItem('theme', value), theme);
+      await page.goto('/Home/Privacy');
+      await expect(page.locator('body')).toHaveAttribute('data-bs-theme', theme);
+      await expectMatchingColors(page, theme);
+      await expectMatchingInteractionColors(page, 'hover');
+      await expectMatchingInteractionColors(page, 'focus');
+    });
+  }
+
+  test('scrolls normal long content without the footer overlaying it', async ({ page }) => {
+    await page.goto('/Home/Privacy');
+    await page.locator('.site-content main').evaluate(main => {
+      const probe = document.createElement('div');
+      probe.textContent = 'Shared layout scroll probe';
+      probe.style.height = '220vh';
+      main.append(probe);
+    });
+    const documentHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+    expect(documentHeight).toBeGreaterThan(await page.evaluate(() => innerHeight));
+    await page.evaluate(() => scrollTo(0, document.documentElement.scrollHeight));
+    await expect(page.locator('.site-footer')).toBeInViewport();
+    const footerDocumentBottom = await page.locator('.site-footer').evaluate(element => element.getBoundingClientRect().bottom + scrollY);
+    expect(footerDocumentBottom).toBeCloseTo(documentHeight, 0);
+  });
+
+  test('keeps the authenticated trip shell compact without restoring the viewer footer calculation', async ({ page }) => {
+    await signIn(page);
+    await page.goto('/User/Trip');
+    await expectStandardFooter(page);
+    expect((await page.locator('.site-footer').boundingBox())!.height).toBeLessThan(100);
+
+    const viewerLink = page.locator('a[href^="/User/Trip/View/"]').first();
+    await expect(viewerLink).toBeVisible();
+    await viewerLink.click();
+    await expect(page.locator('#trip-view')).toBeVisible();
+    await expect(page.locator('.site-footer')).toBeVisible();
+    const viewerBox = await page.locator('#trip-view').boundingBox();
+    const viewerFooterBox = await page.locator('.site-footer').boundingBox();
+    expect(viewerBox!.y + viewerBox!.height).toBeCloseTo(viewerFooterBox!.y, 0);
+  });
+});
+
+async function signIn(page: Page): Promise<void> {
+  await page.goto('/Identity/Account/Login?ReturnUrl=%2FUser%2FTrip');
+  await page.getByLabel('Username').fill(config.username);
+  await page.getByLabel('Password').fill(config.password);
+  await Promise.all([
+    page.waitForURL(url => !url.pathname.includes('/Identity/Account/Login')),
+    page.getByRole('button', { name: 'Log in' }).click()
+  ]);
+}
+
+async function expectStandardFooter(page: Page): Promise<void> {
+  const footer = page.locator('.site-footer');
+  await expect(footer).toBeVisible();
+  expect(await footer.evaluate(element => getComputedStyle(element).position)).not.toBe('fixed');
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(await page.evaluate(() => innerWidth));
+  const footerBox = await footer.boundingBox();
+  expect(footerBox!.y + footerBox!.height).toBeGreaterThanOrEqual((await page.evaluate(() => innerHeight)) - 1);
+}
+
+async function expectMatchingColors(page: Page, theme: string): Promise<void> {
+  const colors = await page.locator(footerLinks).evaluateAll(links => links.map(link => getComputedStyle(link).color));
+  expect(colors, `${theme} default footer colors`).toEqual([colors[0], colors[0], colors[0], colors[0]]);
+}
+
+async function expectMatchingInteractionColors(page: Page, interaction: 'hover' | 'focus'): Promise<void> {
+  const colors: string[] = [];
+  for (const link of await page.locator(footerLinks).all()) {
+    if (interaction === 'hover') await link.hover();
+    else await focusWithKeyboard(page, link);
+    colors.push(await link.evaluate(element => getComputedStyle(element).color));
+  }
+  expect(colors, `${interaction} footer colors`).toEqual([colors[0], colors[0], colors[0], colors[0]]);
+}
+
+async function focusWithKeyboard(page: Page, link: Locator): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt++) {
+    if (await link.evaluate(element => document.activeElement === element)) return;
+    await page.keyboard.press('Tab');
+  }
+  throw new Error('Footer link was not reachable by keyboard navigation.');
+}

--- a/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
+++ b/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
@@ -104,8 +104,14 @@ async function expectShortStandardFooter(page: Page): Promise<void> {
 async function expectCompactFooter(page: Page): Promise<void> {
   const footer = page.locator('.site-footer');
   await expect(footer).toBeVisible();
-  expect((await footer.boundingBox())!.height).toBeLessThan(100);
-  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(await page.evaluate(() => innerWidth));
+  expect(await footer.evaluate(element => getComputedStyle(element).position)).not.toBe('fixed');
+  const geometry = await footer.evaluate(element => {
+    const bounds = element.getBoundingClientRect();
+    return { height: bounds.height, left: bounds.left, right: bounds.right, viewportWidth: innerWidth };
+  });
+  expect(geometry.height).toBeLessThan(100);
+  expect(geometry.left).toBeGreaterThanOrEqual(0);
+  expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth);
 }
 
 async function expectLegacyViewerContained(page: Page): Promise<void> {

--- a/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
+++ b/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
@@ -1,15 +1,19 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
 import { loadSharedLayoutConfig } from './sharedLayoutConfig';
 
-const config = loadSharedLayoutConfig();
 const footerLinks = '.site-footer__link';
+const viewports = {
+  desktop: { width: 1440, height: 900 },
+  tablet: { width: 768, height: 1024 },
+  mobile: { width: 375, height: 667 }
+};
 
 test.describe('shared standard-layout footer', () => {
-  for (const [name, viewport] of Object.entries({ desktop: { width: 1440, height: 900 }, tablet: { width: 768, height: 1024 }, mobile: { width: 375, height: 667 } })) {
+  for (const [name, viewport] of Object.entries(viewports)) {
     test(`keeps the short public page contained at ${name}`, async ({ page }) => {
       await page.setViewportSize(viewport);
       await page.goto('/Home/Privacy');
-      await expectStandardFooter(page);
+      await expectShortStandardFooter(page);
       await expect(page.locator(footerLinks)).toHaveCount(4);
       await expectMatchingColors(page, 'light');
     });
@@ -42,24 +46,38 @@ test.describe('shared standard-layout footer', () => {
     expect(footerDocumentBottom).toBeCloseTo(documentHeight, 0);
   });
 
-  test('keeps the authenticated trip shell compact without restoring the viewer footer calculation', async ({ page }) => {
-    await signIn(page);
-    await page.goto('/User/Trip');
-    await expectStandardFooter(page);
-    expect((await page.locator('.site-footer').boundingBox())!.height).toBeLessThan(100);
+  for (const [name, viewport] of Object.entries(viewports)) {
+    test(`keeps the authenticated trip shell and legacy viewer contained at ${name}`, async ({ page }) => {
+      await page.setViewportSize(viewport);
+      await signIn(page);
+      await page.goto('/User/Trip');
+      await expectCompactFooter(page);
 
-    const viewerLink = page.locator('a[href^="/User/Trip/View/"]').first();
-    await expect(viewerLink).toBeVisible();
-    await viewerLink.click();
+      const viewerLink = page.locator('a[href^="/User/Trip/View/"]').first();
+      await expect(viewerLink).toBeVisible();
+      const viewerHref = await viewerLink.getAttribute('href');
+      expect(viewerHref, 'The authenticated trip index should expose a real legacy viewer route.').toBeTruthy();
+
+      await page.goto(viewerHref!);
+      await expectLegacyViewerContained(page);
+    });
+  }
+
+  test('keeps the discovered public viewer embed free of the standard footer stylesheet', async ({ page }) => {
+    await page.goto('/Public/Trips');
+    const publicViewerHref = await page.locator('a[href^="/Public/Trips/"]').evaluateAll(links =>
+      links.map(link => link.getAttribute('href')).find(href => /^\/Public\/Trips\/[0-9a-f-]+$/i.test(href ?? '')));
+    expect(publicViewerHref, 'The public index should provide a real public viewer route.').toBeTruthy();
+
+    await page.goto(`${publicViewerHref}?embed=true`);
     await expect(page.locator('#trip-view')).toBeVisible();
-    await expect(page.locator('.site-footer')).toBeVisible();
-    const viewerBox = await page.locator('#trip-view').boundingBox();
-    const viewerFooterBox = await page.locator('.site-footer').boundingBox();
-    expect(viewerBox!.y + viewerBox!.height).toBeCloseTo(viewerFooterBox!.y, 0);
+    await expect(page.locator('.site-footer')).toHaveCount(0);
+    await expect(page.locator('link[href*="/css/shared-layout.css"]')).toHaveCount(0);
   });
 });
 
 async function signIn(page: Page): Promise<void> {
+  const config = loadSharedLayoutConfig();
   await page.goto('/Identity/Account/Login?ReturnUrl=%2FUser%2FTrip');
   await page.getByLabel('Username').fill(config.username);
   await page.getByLabel('Password').fill(config.password);
@@ -69,13 +87,34 @@ async function signIn(page: Page): Promise<void> {
   ]);
 }
 
-async function expectStandardFooter(page: Page): Promise<void> {
+async function expectShortStandardFooter(page: Page): Promise<void> {
   const footer = page.locator('.site-footer');
   await expect(footer).toBeVisible();
   expect(await footer.evaluate(element => getComputedStyle(element).position)).not.toBe('fixed');
   expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(await page.evaluate(() => innerWidth));
-  const footerBox = await footer.boundingBox();
-  expect(footerBox!.y + footerBox!.height).toBeGreaterThanOrEqual((await page.evaluate(() => innerHeight)) - 1);
+  const geometry = await footer.evaluate(element => ({
+    documentHeight: document.documentElement.scrollHeight,
+    footerBottom: element.getBoundingClientRect().bottom,
+    viewportHeight: innerHeight
+  }));
+  expect(Math.abs(geometry.documentHeight - geometry.viewportHeight), 'The privacy page must remain a short document.').toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.footerBottom - geometry.viewportHeight), 'The short-page footer must meet the viewport bottom.').toBeLessThanOrEqual(1);
+}
+
+async function expectCompactFooter(page: Page): Promise<void> {
+  const footer = page.locator('.site-footer');
+  await expect(footer).toBeVisible();
+  expect((await footer.boundingBox())!.height).toBeLessThan(100);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(await page.evaluate(() => innerWidth));
+}
+
+async function expectLegacyViewerContained(page: Page): Promise<void> {
+  await expect(page.locator('#trip-view')).toBeVisible();
+  await expectCompactFooter(page);
+  const viewerBox = await page.locator('#trip-view').boundingBox();
+  const footerBox = await page.locator('.site-footer').boundingBox();
+  expect(viewerBox!.y + viewerBox!.height).toBeCloseTo(footerBox!.y, 0);
+  expect(await page.evaluate(() => document.documentElement.scrollHeight)).toBeLessThanOrEqual(await page.evaluate(() => innerHeight) + 1);
 }
 
 async function expectMatchingColors(page: Page, theme: string): Promise<void> {

--- a/tests/e2e/shared-layout/sharedLayoutConfig.ts
+++ b/tests/e2e/shared-layout/sharedLayoutConfig.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type SharedLayoutE2EConfig = {
+  username: string;
+  password: string;
+};
+
+const configKeys = ['WAYFARER_E2E_USERNAME', 'WAYFARER_E2E_PASSWORD'] as const;
+type ConfigKey = (typeof configKeys)[number];
+
+// Reads the same ignored local runbook used by Trip Editor coverage without exposing credentials.
+export function loadSharedLayoutConfig(): SharedLayoutE2EConfig {
+  const localConfig = readLocalManualVerification();
+  const values = Object.fromEntries(configKeys.map(key => [key, process.env[key] || localConfig[key] || ''])) as Record<ConfigKey, string>;
+  const missing = configKeys.filter(key => !values[key].trim());
+  if (missing.length > 0) {
+    throw new Error(`Missing shared-layout E2E configuration: ${missing.join(', ')}. Set WAYFARER_E2E_* or use .local/manual-verification.md.`);
+  }
+
+  return { username: values.WAYFARER_E2E_USERNAME.trim(), password: values.WAYFARER_E2E_PASSWORD };
+}
+
+function readLocalManualVerification(): Partial<Record<ConfigKey, string>> {
+  const filePath = path.resolve(process.cwd(), '.local', 'manual-verification.md');
+  if (!fs.existsSync(filePath)) return {};
+
+  const result: Partial<Record<ConfigKey, string>> = {};
+  for (const line of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+    const envMatch = line.match(/^\s*(?:\$env:)?(WAYFARER_E2E_[A-Z_]+)\s*=\s*['"`]?([^'"`\r\n]+)['"`]?\s*$/);
+    if (envMatch && configKeys.includes(envMatch[1] as ConfigKey)) result[envMatch[1] as ConfigKey] = envMatch[2].trim();
+    const labelMatch = line.match(/^\s*(Username|Password):\s*(.+?)\s*$/i);
+    if (!labelMatch) continue;
+    const value = labelMatch[2].trim().replace(/`/g, '');
+    if (/^Username$/i.test(labelMatch[1])) result.WAYFARER_E2E_USERNAME = value;
+    if (/^Password$/i.test(labelMatch[1])) result.WAYFARER_E2E_PASSWORD = value;
+  }
+  return result;
+}

--- a/tests/e2e/shared-layout/sharedLayoutConfig.ts
+++ b/tests/e2e/shared-layout/sharedLayoutConfig.ts
@@ -9,7 +9,7 @@ type SharedLayoutE2EConfig = {
 const configKeys = ['WAYFARER_E2E_USERNAME', 'WAYFARER_E2E_PASSWORD'] as const;
 type ConfigKey = (typeof configKeys)[number];
 
-// Reads the same ignored local runbook used by Trip Editor coverage without exposing credentials.
+// Reads ignored local credentials only for the authenticated checks and never prints them.
 export function loadSharedLayoutConfig(): SharedLayoutE2EConfig {
   const localConfig = readLocalManualVerification();
   const values = Object.fromEntries(configKeys.map(key => [key, process.env[key] || localConfig[key] || ''])) as Record<ConfigKey, string>;

--- a/tests/e2e/shared-layout/sharedLayoutGlobalTeardown.ts
+++ b/tests/e2e/shared-layout/sharedLayoutGlobalTeardown.ts
@@ -1,0 +1,18 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const pidFile = path.join(process.env.TEMP ?? process.env.TMP ?? '.', 'wayfarer-shared-layout-e2e-host.pid');
+
+/** Stops only the isolated host process recorded by the shared-layout launcher. */
+export default async function sharedLayoutGlobalTeardown(): Promise<void> {
+  if (!fs.existsSync(pidFile)) return;
+
+  const processId = Number(fs.readFileSync(pidFile, 'utf8').trim());
+  if (Number.isInteger(processId) && processId > 0) {
+    const command = `$processId = ${processId}; if (Get-NetTCPConnection -State Listen -LocalPort 7150 -ErrorAction SilentlyContinue | Where-Object OwningProcess -eq $processId) { Stop-Process -Id $processId -Force }`;
+    execFileSync('powershell', ['-NoProfile', '-Command', command], { stdio: 'inherit' });
+  }
+
+  fs.rmSync(pidFile, { force: true });
+}

--- a/tools/start-shared-layout-e2e-host.ps1
+++ b/tools/start-shared-layout-e2e-host.ps1
@@ -1,0 +1,39 @@
+<#!
+.SYNOPSIS
+Builds a disposable copy outside the repository and foregrounds its isolated HTTPS host for Playwright.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$port = 7150
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "wayfarer-shared-layout-e2e-$PID"
+$sourceRoot = Join-Path $tempRoot 'source'
+$hostOutput = Join-Path $tempRoot 'host'
+$pidFile = Join-Path ([System.IO.Path]::GetTempPath()) 'wayfarer-shared-layout-e2e-host.pid'
+
+if (Get-NetTCPConnection -State Listen -LocalPort $port -ErrorAction SilentlyContinue) {
+    throw "Shared-layout E2E requires exclusive use of HTTPS port $port."
+}
+
+New-Item -ItemType Directory -Path $sourceRoot -Force | Out-Null
+& robocopy $repoRoot $sourceRoot /E /XD .git bin obj .local node_modules /NFL /NDL /NJH /NJS /NC /NS
+if ($LASTEXITCODE -gt 1) {
+    throw "Unable to prepare the isolated shared-layout E2E source copy (robocopy exit code $LASTEXITCODE)."
+}
+
+# Build artifacts and SDK intermediates stay in the disposable TEMP copy, never under the repository.
+& dotnet build (Join-Path $sourceRoot 'Wayfarer.csproj') --configuration Debug --output $hostOutput --nologo
+if ($LASTEXITCODE -ne 0) {
+    throw 'Unable to build the isolated shared-layout E2E host.'
+}
+
+$env:ASPNETCORE_ENVIRONMENT = 'Development'
+$hostProcess = Start-Process -FilePath dotnet -ArgumentList @((Join-Path $hostOutput 'Wayfarer.dll'), '--urls', "https://127.0.0.1:$port") -WorkingDirectory $sourceRoot -WindowStyle Hidden -PassThru
+$hostProcess.Id | Set-Content -LiteralPath $pidFile -NoNewline
+
+# Wait in the foreground; global teardown verifies this exact listener is stopped after the suite.
+$hostProcess.WaitForExit()
+Remove-Item -LiteralPath $pidFile -Force -ErrorAction SilentlyContinue
+exit $hostProcess.ExitCode

--- a/wwwroot/css/shared-layout.css
+++ b/wwwroot/css/shared-layout.css
@@ -32,21 +32,25 @@ body {
     align-items: center;
     border-top: 1px solid rgba(33, 37, 41, 0.10);
     display: flex;
+    font-size: 0.875rem;
     justify-content: center;
-    min-height: 3.5rem;
-    padding: 0.75rem 0;
+    line-height: 1.25;
+    min-height: 0;
+    padding: 0.5rem 0;
     text-align: center;
 }
 
-.site-footer__link {
+/* Override the legacy Razor-isolated anchor rule for every footer link state. */
+.site-footer .site-footer__link,
+.site-footer .site-footer__link:visited {
     color: #0077cc;
 }
 
-.site-footer__link:hover {
+.site-footer .site-footer__link:hover {
     color: #005fa3;
 }
 
-.site-footer__link:focus-visible {
+.site-footer .site-footer__link:focus-visible {
     color: #005fa3;
     outline: 2px solid currentColor;
     outline-offset: 2px;
@@ -57,12 +61,17 @@ body {
     color: #c9d1d9;
 }
 
-[data-bs-theme="dark"] .site-footer__link {
+.site-shell[data-bs-theme="dark"] .site-footer .site-footer__link,
+.site-shell[data-bs-theme="dark"] .site-footer .site-footer__link:visited,
+.site-footer[data-bs-theme="dark"] .site-footer__link,
+.site-footer[data-bs-theme="dark"] .site-footer__link:visited {
     color: #6ea8fe;
 }
 
-[data-bs-theme="dark"] .site-footer__link:hover,
-[data-bs-theme="dark"] .site-footer__link:focus-visible {
+.site-shell[data-bs-theme="dark"] .site-footer .site-footer__link:hover,
+.site-shell[data-bs-theme="dark"] .site-footer .site-footer__link:focus-visible,
+.site-footer[data-bs-theme="dark"] .site-footer__link:hover,
+.site-footer[data-bs-theme="dark"] .site-footer__link:focus-visible {
     color: #9ec5fe;
 }
 
@@ -74,8 +83,7 @@ body {
 
 @media (max-width: 575.98px) {
     .site-footer {
-        min-height: 3rem;
-        padding: 0.625rem 0;
+        padding: 0.5rem 0.75rem;
     }
 
     .site-footer .container {

--- a/wwwroot/css/shared-layout.css
+++ b/wwwroot/css/shared-layout.css
@@ -1,0 +1,84 @@
+/* Standard-layout shell and footer contract; embed pages retain their dedicated viewport rules. */
+html,
+body {
+    min-height: 100%;
+}
+
+.site-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    min-height: 100dvh;
+}
+
+.site-shell > header,
+.site-footer {
+    flex: 0 0 auto;
+}
+
+.site-content {
+    display: flex;
+    flex: 1 0 auto;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.site-content > main {
+    flex: 1 0 auto;
+    min-height: 0;
+}
+
+.site-footer {
+    align-items: center;
+    border-top: 1px solid rgba(33, 37, 41, 0.10);
+    display: flex;
+    justify-content: center;
+    min-height: 3.5rem;
+    padding: 0.75rem 0;
+    text-align: center;
+}
+
+.site-footer__link {
+    color: #0077cc;
+}
+
+.site-footer__link:hover {
+    color: #005fa3;
+}
+
+.site-footer__link:focus-visible {
+    color: #005fa3;
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}
+
+[data-bs-theme="dark"] .site-footer {
+    border-top-color: rgba(248, 249, 250, 0.25);
+    color: #c9d1d9;
+}
+
+[data-bs-theme="dark"] .site-footer__link {
+    color: #6ea8fe;
+}
+
+[data-bs-theme="dark"] .site-footer__link:hover,
+[data-bs-theme="dark"] .site-footer__link:focus-visible {
+    color: #9ec5fe;
+}
+
+/* The standard shell supplies the available height instead of assuming a footer size. */
+.site-content #trip-view {
+    height: 100%;
+    min-height: 0;
+}
+
+@media (max-width: 575.98px) {
+    .site-footer {
+        min-height: 3rem;
+        padding: 0.625rem 0;
+    }
+
+    .site-footer .container {
+        overflow-wrap: anywhere;
+    }
+}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -338,11 +338,12 @@ thead th {
 
 .landing-container {
     display: flex;
+    flex: 1 0 auto;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     padding: 2rem 1rem;
-    min-height: calc(100vh - 120px);
+    min-height: 0;
     box-sizing: border-box;
     background: linear-gradient(to bottom right, #f0f2f5, #ffffff);
 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -12,34 +12,6 @@ html {
     box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
 }
 
-html {
-    position: relative;
-    min-height: 100%;
-}
-html, body {
-    height: 100%; /* Ensure the page takes full height */
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-}
-body {
-    margin-bottom: 60px;
-    flex: 1;
-}
-footer {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: relative;
-    bottom: 0;
-    width: 100%;
-    height: 60px;
-    text-align: center;
-    margin-top: auto;
-    border-top: 1px solid rgba(33, 37, 41, 0.10);
-}
-
 /* Back to top button */
 .back-to-top-btn {
     position: fixed;
@@ -130,13 +102,6 @@ footer {
 [data-bs-theme="dark"] .navbar-dark .navbar-nav .nav-link.active:hover,
 .navbar-light .navbar-nav .nav-link.active:hover {
     color: #0056b3; /* Same as hover color for active link */
-}
-[data-bs-theme="dark"] footer > * {
-    color: #c9d1d9!important;
-}
-
-[data-bs-theme="dark"] footer  {
-    border-top: 1px solid rgba(248, 249, 250, 0.25) !important;
 }
 /* Theme Toggle Button in Dark and Light Modes */
 #themeToggle {
@@ -1339,11 +1304,6 @@ thead th {
     display:flex; align-items:center; justify-content:center;
     border-radius:.25rem;
     z-index:1060;
-}
-
-/* #trip-view already sits between navbar (≈56 px) and footer (60 px)   */
-#trip-view {                       /* 56 + 60  ≅  116 → round to 120   */
-    height: calc(100vh - 120px);   /* reaches footer, no bottom gap     */
 }
 
 /* floating MAP-LEGEND handle (only visible when sidebar is collapsed) */


### PR DESCRIPTION
## Summary\n- establish a compact flex-based standard footer shell and consistent footer link styling\n- exclude the shared footer stylesheet from embed routes\n- add isolated rendered footer coverage and compact the footer after manual review\n\nCloses #365\n\n## Validation\n- 
pm run test:e2e:shared-layout\n- dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600\n- git diff --check main...HEAD\n- manual dark /Home/Privacy verification after the compact footer correction\n\n## Notes\nThe existing mobile /User/Trip table overflow is unrelated to the footer shell and remains out of scope.