### PR TITLE
fix(imports): contain location import table on phones

### DIFF
--- a/Areas/User/Views/LocationImport/Index.cshtml
+++ b/Areas/User/Views/LocationImport/Index.cshtml
@@ -2,7 +2,7 @@
 @{
     ViewData["BodyClass"] = "container-fluid";
 }
-<div class="d-flex justify-content-between align-items-center mb-3">
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
     <h2>@ViewData["Title"]</h2>
     <a asp-controller="LocationImport" asp-action="Upload" class="btn btn-primary">
         <i class="bi bi-upload"></i> Upload New File
@@ -15,7 +15,9 @@
     Large files are processed in the background - you can leave this page and check back later.
 </div>
 
-<table class="table table-striped table-responsive" id="locationImport" data-user-id="@ViewData["UserId"]">
+<!-- Keep the dense import-history table inside its own horizontal scroll surface on phones. -->
+<div class="table-responsive">
+<table class="table table-striped" id="locationImport" data-user-id="@ViewData["UserId"]">
     <thead>
         <tr>
             <th>File Name</th>
@@ -138,6 +140,7 @@
     }
     </tbody>
 </table>
+</div>
 
 @if (!Model.Any())
 {


### PR DESCRIPTION
## Summary
- contain the Location Import history table in a local responsive wrapper
- allow the page heading and Upload action to wrap on phones

## Validation
- Manual phone verification at 390px and 430px: no page-level horizontal overflow; table actions remain reachable
- `dotnet build --no-restore`
- `dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600`
- `git diff --check main...HEAD`

## Notes
- Links #372
- No migration, API, job, parser, or data behavior changes.