### PR TITLE
fix(groups): contain group surfaces on phones

### DIFF
--- a/Areas/Manager/Views/Groups/Index.cshtml
+++ b/Areas/Manager/Views/Groups/Index.cshtml
@@ -3,7 +3,7 @@
     ViewData["Title"] = "Groups";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-3">
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
     <h2>Groups</h2>
     <a class="btn btn-primary" asp-area="Manager" asp-controller="Groups" asp-action="Create">New Group</a>
   </div>
@@ -14,6 +14,7 @@
     Members can see each other's locations on the group map.
 </div>
 
+<div class="table-responsive">
 <table class="table table-striped">
     <thead>
     <tr>
@@ -55,6 +56,7 @@
     }
     </tbody>
   </table>
+</div>
 
 @section Scripts {
     @Html.FrontendViewScripts()

--- a/Areas/Manager/Views/Groups/Map.cshtml
+++ b/Areas/Manager/Views/Groups/Map.cshtml
@@ -6,7 +6,7 @@
     ViewData["BodyClass"] = "container-fluid d-flex flex-column flex-fill px-3 overflow-hidden";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-2">
+<div class="group-map-header d-flex justify-content-between align-items-center mb-2">
   <h2>@ViewData["Title"]</h2>
   <a class="btn btn-secondary" asp-area="Manager" asp-controller="Groups" asp-action="Index">Back</a>
   <input type="hidden" id="groupId" value="@groupId" />
@@ -28,7 +28,7 @@
           <i class="bi bi-arrow-left"></i> Day
         </button>
 
-        <div class="d-flex align-items-center gap-2 mx-3">
+        <div class="group-map-date-controls d-flex align-items-center gap-2 mx-3">
           <button id="btnToday" class="btn btn-sm btn-success" title="Today">Today</button>
           <input type="date" id="datePicker" class="form-control form-control-sm" style="width: auto;">
           <input type="month" id="monthPicker" class="form-control form-control-sm" style="width: auto; display:none;">
@@ -45,7 +45,7 @@
           Year <i class="bi bi-chevron-double-right"></i>
         </button>
 
-        <div class="ms-auto d-flex gap-2">
+        <div class="group-map-view-controls ms-auto d-flex gap-2">
           <label class="form-label mb-0 align-self-center">View:</label>
           <div class="btn-group btn-group-sm" role="group">
             <input type="radio" class="btn-check" name="viewType" id="viewDay" value="day" checked>
@@ -68,9 +68,17 @@
   
 </div>
 
-<div id="group-map-view" class="position-relative d-flex flex-grow-1 w-100 overflow-hidden" style="min-height:0;">
-  <aside class="flex-shrink-0 border-end overflow-auto" style="width:460px;">
-    <h5>Members</h5>
+<div id="group-map-view" class="group-map-view position-relative d-flex flex-grow-1 w-100 overflow-hidden" style="min-height:0;">
+  <button type="button" class="group-map-members-toggle btn btn-sm btn-primary" aria-controls="group-map-members" aria-expanded="false">
+    <i class="bi bi-people" aria-hidden="true"></i> Members
+  </button>
+  <aside id="group-map-members" class="group-map-sidebar flex-shrink-0 border-end overflow-auto" aria-hidden="true">
+    <div class="group-map-sidebar-heading d-flex align-items-center justify-content-between">
+      <h5 class="mb-0">Members</h5>
+      <button type="button" class="group-map-members-close btn btn-sm btn-outline-secondary" aria-label="Close members panel">
+        <i class="bi bi-x-lg" aria-hidden="true"></i>
+      </button>
+    </div>
 
     @using (Html.BeginForm())
     {
@@ -124,12 +132,16 @@
       }
     </div>
   </aside>
-  <main class="flex-grow-1 overflow-hidden" style="min-height:0;">
+  <main class="group-map-canvas flex-grow-1 overflow-hidden" style="min-height:0;">
     <div id="groupMap" class="w-100" style="height: calc(100vh - 220px); min-height: calc(100vh - 220px);"></div>
   </main>
 </div>
 
 <input type="hidden" id="groupType" value="@group.GroupType" />
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/group-map.css" asp-append-version="true" />
+}
 
 <!-- Location Details Modal (reused from timeline) -->
 <div class="modal fade" id="locationModal" tabindex="-1" aria-labelledby="locationModalLabel" data-bs-backdrop="static">
@@ -148,4 +160,5 @@
 
 @section Scripts {
     @Html.FrontendViewScripts()
+    <script src="~/js/group-map-drawer.js" asp-append-version="true" defer></script>
 }

--- a/Areas/Manager/Views/Groups/Members.cshtml
+++ b/Areas/Manager/Views/Groups/Members.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = $"Members - {group.Name}";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-3">
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
   <h2>@ViewData["Title"]</h2>
   <a class="btn btn-secondary" asp-area="Manager" asp-controller="Groups" asp-action="Index">Back</a>
 </div>
@@ -40,6 +40,7 @@
         var mgrRoles = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { Wayfarer.Models.GroupMember.Roles.Owner, Wayfarer.Models.GroupMember.Roles.Manager };
         var managerCount = members.Count(x => mgrRoles.Contains((string)x.m.Role) && string.Equals((string)x.m.Status, Wayfarer.Models.GroupMember.MembershipStatuses.Active, StringComparison.OrdinalIgnoreCase));
     }
+    <div class="table-responsive">
     <table id="rosterTable" class="table table-striped">
       <thead>
       <tr>
@@ -77,6 +78,7 @@
       }
       </tbody>
     </table>
+    </div>
   </div>
 
   <div class="col-md-5">
@@ -112,6 +114,7 @@
     </form>
 
     <h4 class="mt-4">Pending Invites</h4>
+    <div class="table-responsive">
     <table id="invitesTable" class="table">
       <thead>
       <tr>
@@ -150,6 +153,7 @@
       }
       </tbody>
     </table>
+    </div>
   </div>
 </div>
 

--- a/Areas/User/Views/Groups/Index.cshtml
+++ b/Areas/User/Views/Groups/Index.cshtml
@@ -3,7 +3,7 @@
     ViewData["BodyClass"] = "container";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-3">
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
     <h2>@ViewData["Title"]</h2>
     <a class="btn btn-primary" asp-area="User" asp-controller="Groups" asp-action="Create">New Group</a>
 </div>
@@ -14,6 +14,7 @@
     Members can see each other's locations on the group map.
 </div>
 
+<div class="table-responsive">
 <table class="table table-striped">
     <thead>
     <tr>
@@ -62,6 +63,7 @@
     }
     </tbody>
 </table>
+</div>
 
 @section Scripts {
     @Html.FrontendViewScripts()

--- a/Areas/User/Views/Groups/Map.cshtml
+++ b/Areas/User/Views/Groups/Map.cshtml
@@ -6,7 +6,7 @@
     ViewData["BodyClass"] = "container-fluid d-flex flex-column flex-fill px-3 overflow-hidden";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-2">
+<div class="group-map-header d-flex justify-content-between align-items-center mb-2">
   <h2>@ViewData["Title"]</h2>
   <a class="btn btn-secondary" asp-area="User" asp-controller="Groups" asp-action="Index">Back</a>
   <input type="hidden" id="groupId" value="@groupId" />
@@ -29,7 +29,7 @@
           <i class="bi bi-arrow-left"></i> Day
         </button>
 
-        <div class="d-flex align-items-center gap-2 mx-3">
+        <div class="group-map-date-controls d-flex align-items-center gap-2 mx-3">
           <button id="btnToday" class="btn btn-sm btn-success" title="Today">Today</button>
           <input type="date" id="datePicker" class="form-control form-control-sm" style="width: auto;">
           <input type="month" id="monthPicker" class="form-control form-control-sm" style="width: auto; display:none;">
@@ -46,7 +46,7 @@
           Year <i class="bi bi-chevron-double-right"></i>
         </button>
 
-        <div class="ms-auto d-flex gap-2">
+        <div class="group-map-view-controls ms-auto d-flex gap-2">
           <label class="form-label mb-0 align-self-center">View:</label>
           <div class="btn-group btn-group-sm" role="group">
             <input type="radio" class="btn-check" name="viewType" id="viewDay" value="day" checked>
@@ -69,9 +69,17 @@
   
 </div>
 
-<div id="group-map-view" class="position-relative d-flex flex-grow-1 w-100 overflow-hidden" style="min-height:0;">
-  <aside class="flex-shrink-0 border-end overflow-auto" style="width:460px;">
-    <h5>Members</h5>
+<div id="group-map-view" class="group-map-view position-relative d-flex flex-grow-1 w-100 overflow-hidden" style="min-height:0;">
+  <button type="button" class="group-map-members-toggle btn btn-sm btn-primary" aria-controls="group-map-members" aria-expanded="false">
+    <i class="bi bi-people" aria-hidden="true"></i> Members
+  </button>
+  <aside id="group-map-members" class="group-map-sidebar flex-shrink-0 border-end overflow-auto" aria-hidden="true">
+    <div class="group-map-sidebar-heading d-flex align-items-center justify-content-between">
+      <h5 class="mb-0">Members</h5>
+      <button type="button" class="group-map-members-close btn btn-sm btn-outline-secondary" aria-label="Close members panel">
+        <i class="bi bi-x-lg" aria-hidden="true"></i>
+      </button>
+    </div>
 
     @using (Html.BeginForm())
     {
@@ -138,13 +146,17 @@
       }
     </div>
   </aside>
-  <main class="flex-grow-1 overflow-hidden" style="min-height:0;">
+  <main class="group-map-canvas flex-grow-1 overflow-hidden" style="min-height:0;">
     <div id="groupMap" class="w-100" style="height: calc(100vh - 220px); min-height: calc(100vh - 220px);"></div>
   </main>
 </div>
 
 <input type="hidden" id="groupType" value="@group.GroupType" />
 <input type="hidden" id="peerVisibilityDisabled" value="@((bool)ViewBag.MyPeerVisibilityDisabled ? "true" : "false")" />
+
+@section Styles {
+    <link rel="stylesheet" href="~/css/group-map.css" asp-append-version="true" />
+}
 
 <!-- Location Details Modal (reused from timeline) -->
 <div class="modal fade" id="locationModal" tabindex="-1" aria-labelledby="locationModalLabel" data-bs-backdrop="static">
@@ -163,4 +175,5 @@
 
 @section Scripts {
     @Html.FrontendViewScripts()
+    <script src="~/js/group-map-drawer.js" asp-append-version="true" defer></script>
 }

--- a/Areas/User/Views/Groups/Members.cshtml
+++ b/Areas/User/Views/Groups/Members.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = $"Members - {group.Name}";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-3">
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
   <h2>@ViewData["Title"]</h2>
   <a class="btn btn-secondary" asp-area="User" asp-controller="Groups" asp-action="Index">Back</a>
   </div>
@@ -13,6 +13,7 @@
 <div class="row">
   <div class="col-md-7">
     <h4>Roster</h4>
+    <div class="table-responsive">
     <table id="rosterTable" class="table table-striped">
       <thead>
       <tr>
@@ -52,6 +53,7 @@
       }
       </tbody>
     </table>
+    </div>
   </div>
 
   <div class="col-md-5">
@@ -88,6 +90,7 @@
     </form>
 
     <h4 class="mt-4">Pending Invites</h4>
+    <div class="table-responsive">
     <table id="invitesTable" class="table">
       <thead>
       <tr>
@@ -126,6 +129,7 @@
       }
       </tbody>
     </table>
+    </div>
   </div>
 </div>
 

--- a/wwwroot/css/group-map.css
+++ b/wwwroot/css/group-map.css
@@ -1,0 +1,70 @@
+/* Keep group map controls and the fixed member panel within phone viewports. */
+.group-map-sidebar {
+    width: 460px;
+}
+
+.group-map-members-toggle,
+.group-map-members-close {
+    display: none;
+}
+
+@media (max-width: 575.98px) {
+    .group-map-header,
+    .group-map-date-controls,
+    .group-map-view-controls {
+        flex-wrap: wrap;
+    }
+
+    .group-map-date-controls {
+        margin-inline: 0 !important;
+    }
+
+    .group-map-view-controls {
+        margin-left: 0 !important;
+    }
+
+    .group-map-sidebar {
+        position: absolute;
+        z-index: 1100;
+        inset: 0 auto 0 0;
+        width: min(22rem, calc(100% - 2rem));
+        max-height: none;
+        padding: 0.75rem;
+        background: var(--bs-body-bg);
+        border-right: 1px solid var(--bs-border-color) !important;
+        border-bottom: 0;
+        box-shadow: 0 0.5rem 1rem rgb(0 0 0 / 20%);
+        transform: translateX(-105%);
+        transition: transform 0.2s ease;
+    }
+
+    .group-map-view.group-map-members-open .group-map-sidebar {
+        transform: translateX(0);
+    }
+
+    .group-map-members-toggle {
+        display: inline-flex;
+        position: absolute;
+        z-index: 1101;
+        top: 0.75rem;
+        left: 2.9375rem;
+        align-items: center;
+        gap: 0.35rem;
+    }
+
+    .group-map-members-open .group-map-members-toggle {
+        display: none;
+    }
+
+    .group-map-members-close {
+        display: inline-flex;
+    }
+
+    .group-map-sidebar-heading {
+        margin-bottom: 0.75rem;
+    }
+
+    .group-map-canvas {
+        min-width: 0;
+    }
+}

--- a/wwwroot/js/group-map-drawer.js
+++ b/wwwroot/js/group-map-drawer.js
@@ -1,0 +1,39 @@
+/* Controls the existing group member sidebar as a phone-only map overlay. */
+(() => {
+    const view = document.querySelector('.group-map-view');
+    const toggle = document.querySelector('.group-map-members-toggle');
+    const panel = document.querySelector('.group-map-sidebar');
+    const close = document.querySelector('.group-map-members-close');
+    const phoneViewport = window.matchMedia('(max-width: 575.98px)');
+
+    if (!view || !toggle || !panel || !close) {
+        return;
+    }
+
+    const setOpen = open => {
+        const isPhone = phoneViewport.matches;
+        view.classList.toggle('group-map-members-open', isPhone && open);
+        toggle.setAttribute('aria-expanded', String(isPhone && open));
+        panel.setAttribute('aria-hidden', String(isPhone && !open));
+    };
+
+    toggle.addEventListener('click', () => {
+        setOpen(true);
+        close.focus();
+    });
+
+    close.addEventListener('click', () => {
+        setOpen(false);
+        toggle.focus();
+    });
+
+    document.addEventListener('keydown', event => {
+        if (event.key === 'Escape' && view.classList.contains('group-map-members-open')) {
+            setOpen(false);
+            toggle.focus();
+        }
+    });
+
+    phoneViewport.addEventListener('change', () => setOpen(false));
+    setOpen(false);
+})();


### PR DESCRIPTION
## Summary
- contain user and manager group tables locally on phone viewports
- make group maps map-first on phones with an accessible Members drawer
- preserve the existing desktop and tablet panel layout

Fixes #371

## Validation
- manual phone verification for user group list and map drawer
- dotnet build --no-restore
- dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600
- git diff --check origin/main...HEAD

Existing dependency advisories and Trip Editor LOC warnings are unchanged.