### PR TITLE
chore(release): prepare v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # CHANGELOG
 
-## [Unreleased]
+## [1.5.0] - 2026-07-18
+
+### Added
+- Added an optional custom timeline heading in user settings, with a clear fallback to the existing display-name heading (#356)
 
 ### Changed
+- Standardized the shared footer's responsive layout and link styling across standard pages (#365)
+- Improved phone containment for account settings, API tokens, location imports, and user/manager group tables and maps (#370, #371, #372)
 - Updated Vite to 7.3.6 and transitive esbuild to 0.28.1 to resolve Windows development-server security advisories (#360)
+
+### Fixed
+- Reconciled global tags safely during trip imports and replaced raw import-error output with safe user-facing feedback (#354)
+- Made public timeline sharing fail closed for invalid thresholds and stopped active SSE streams after eligibility is revoked (#363)
 
 ## [1.4.1] - 2026-05-21
 

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <WayfarerVersion>1.4.1</WayfarerVersion>
+    <WayfarerVersion>1.5.0</WayfarerVersion>
     <Version>$(WayfarerVersion)</Version>
     <PackageVersion>$(WayfarerVersion)</PackageVersion>
     <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>

--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -5,7 +5,7 @@ file contains the manually edited `WayfarerVersion` value and maps the standard
 MSBuild metadata directly from it:
 
 ```xml
-<WayfarerVersion>1.4.1</WayfarerVersion>
+<WayfarerVersion>1.5.0</WayfarerVersion>
 <Version>$(WayfarerVersion)</Version>
 <PackageVersion>$(WayfarerVersion)</PackageVersion>
 <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
@@ -19,7 +19,7 @@ assembly through `IAppVersionProvider`. Runtime surfaces such as
 separate constants.
 
 Use `dotnet run --no-launch-profile -- version` when validating exact CLI
-output. The app writes exactly `Wayfarer 1.4.1`; `--no-launch-profile` avoids
+output. The app writes exactly `Wayfarer 1.5.0`; `--no-launch-profile` avoids
 .NET SDK launch-profile messages so validation stays focused on app output.
 
 ## Release helper

--- a/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
@@ -13,7 +13,7 @@ public class AppVersionProviderTests
     {
         var provider = new AppVersionProvider();
 
-        provider.Version.Should().Be("1.4.1");
+        provider.Version.Should().Be("1.5.0");
     }
 
     [Fact]


### PR DESCRIPTION
## Release preparation\n- bumps the runtime and release source of truth to 1.5.0\n- records merged work since v1.4.1 in CHANGELOG.md\n- aligns the compiled-version test and versioning documentation\n\n## Validation\n- python tools/release/version.py check\n- dotnet run --no-launch-profile -- version (Wayfarer 1.5.0)\n- versioning tests: 26 passed\n- dotnet build --no-restore\n- npm run build\n- LOC check and git diff --check\n\nThe local full-suite transport did not return an aggregate result after execution. The PR CI test job is the merge gate. Existing AngleSharp/SQLite advisory warnings and Trip Editor LOC warnings are unchanged.