### PR TITLE
fix(timeline): reflect live sharing confirmation

### DIFF
--- a/Models/ViewModels/TimelineSettingsViewModel.cs
+++ b/Models/ViewModels/TimelineSettingsViewModel.cs
@@ -50,6 +50,7 @@
                 DefaultTimelineTitle = user.ResolveDefaultTimelineTitle(),
                 TimelineTitle = user.TimelineTitle,
                 PublicTimelineTimeThreshold = eligibility.IsThresholdValid ? user.PublicTimelineTimeThreshold : string.Empty,
+                ConfirmLivePublicTimeline = eligibility.IsEffectivelyPublic && eligibility.IsLive,
                 PublicTimelineStatus = eligibility.IsEffectivelyPublic
                     ? eligibility.IsLive
                         ? "Public timeline: live"

--- a/tests/Wayfarer.Tests/Controllers/TimelineSettingsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TimelineSettingsControllerTests.cs
@@ -71,6 +71,32 @@ public class TimelineSettingsControllerTests : TestBase
         Assert.Equal("Public timeline unavailable until a valid threshold is selected and saved.", model.PublicTimelineStatus);
     }
 
+    /// <summary>
+    /// Verifies that an already-public live timeline reflects its previously accepted acknowledgement.
+    /// </summary>
+    [Fact]
+    public async Task Settings_ChecksLiveConfirmation_ForExistingPublicLiveTimeline()
+    {
+        var (db, user) = await CreateUserAsync("now", isPublic: true);
+        var result = await BuildController(db, user).Settings();
+        var model = Assert.IsType<TimelineSettingsViewModel>(Assert.IsType<ViewResult>(result).Model);
+        Assert.True(model.ConfirmLivePublicTimeline);
+    }
+
+    /// <summary>
+    /// Verifies that a stored live threshold alone does not imply acknowledgement unless sharing is public and live.
+    /// </summary>
+    [Theory]
+    [InlineData("now", false)]
+    [InlineData("1d", true)]
+    public async Task Settings_DoesNotCheckLiveConfirmation_WhenTimelineIsNotPublicAndLive(string threshold, bool isPublic)
+    {
+        var (db, user) = await CreateUserAsync(threshold, isPublic);
+        var result = await BuildController(db, user).Settings();
+        var model = Assert.IsType<TimelineSettingsViewModel>(Assert.IsType<ViewResult>(result).Model);
+        Assert.False(model.ConfirmLivePublicTimeline);
+    }
+
     private async Task<(ApplicationDbContext Db, ApplicationUser User)> CreateUserAsync(string? threshold = null, bool isPublic = false)
     {
         var db = CreateDbContext();


### PR DESCRIPTION
## Summary

- reflect the live-sharing confirmation checkbox for an already-public timeline using the `now` threshold
- keep the confirmation unchecked for private timelines and delayed public thresholds
- retain the existing server-side requirement that every public `now` POST includes an explicit true confirmation

## Root cause

The settings GET restored the persisted visibility and threshold but left `ConfirmLivePublicTimeline` at its default false value. As a result, reopening an already-live public timeline and saving an unrelated field such as Timeline Title was rejected by the POST privacy validation.

## User impact

Owners with an already-public live timeline can now reopen settings and save unrelated changes without rechecking a confirmation that their persisted effective state already proves was accepted. Private and delayed timelines do not receive an implied confirmation.

## Validation

- focused timeline tests: 43 passed
- full test suite: 1,677 passed, 8 PostgreSQL-dependent tests skipped
- `dotnet build --no-restore`
- LOC policy check passed; only unrelated existing Trip Editor warnings
- `git diff --check`
- authenticated Chromium smoke: public + `now` rendered the confirmation visible and checked; saving the unchanged title succeeded; redirected settings retained the checked confirmation

## Database migration

None.

## Screenshots

No visual layout change. The behavior was verified through the authenticated browser smoke described above.