### PR TITLE
chore(release): prepare v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [1.5.1] - 2026-07-18
+
+### Fixed
+- Reflected the previously accepted live-sharing confirmation in timeline settings so unrelated changes, such as the timeline title, can be saved normally (#377)
+
 ## [1.5.0] - 2026-07-18
 
 ### Added

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <WayfarerVersion>1.5.0</WayfarerVersion>
+    <WayfarerVersion>1.5.1</WayfarerVersion>
     <Version>$(WayfarerVersion)</Version>
     <PackageVersion>$(WayfarerVersion)</PackageVersion>
     <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>

--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -5,7 +5,7 @@ file contains the manually edited `WayfarerVersion` value and maps the standard
 MSBuild metadata directly from it:
 
 ```xml
-<WayfarerVersion>1.5.0</WayfarerVersion>
+<WayfarerVersion>1.5.1</WayfarerVersion>
 <Version>$(WayfarerVersion)</Version>
 <PackageVersion>$(WayfarerVersion)</PackageVersion>
 <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
@@ -19,7 +19,7 @@ assembly through `IAppVersionProvider`. Runtime surfaces such as
 separate constants.
 
 Use `dotnet run --no-launch-profile -- version` when validating exact CLI
-output. The app writes exactly `Wayfarer 1.5.0`; `--no-launch-profile` avoids
+output. The app writes exactly `Wayfarer 1.5.1`; `--no-launch-profile` avoids
 .NET SDK launch-profile messages so validation stays focused on app output.
 
 ## Release helper

--- a/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
@@ -13,7 +13,7 @@ public class AppVersionProviderTests
     {
         var provider = new AppVersionProvider();
 
-        provider.Version.Should().Be("1.5.0");
+        provider.Version.Should().Be("1.5.1");
     }
 
     [Fact]


### PR DESCRIPTION
## Release preparation

- bumps the runtime and release source of truth to 1.5.1
- records the public live-confirmation settings fix merged after v1.5.0
- aligns the compiled-version expectation and versioning documentation

## Release scope

This patch release contains PR #377. Timeline settings now reflect an already-accepted live-sharing confirmation for an effectively public `now` timeline, allowing unrelated settings such as Timeline Title to save normally while preserving the server-side confirmation requirement.

## Validation

- `python tools/release/version.py check`
- `dotnet run --no-launch-profile --no-build -- version` returned `Wayfarer 1.5.1`
- versioning tests: 26 passed
- full test suite: 1,677 passed, 8 PostgreSQL-dependent tests skipped
- `dotnet build --no-restore`
- `npm run build`
- LOC check passed with only unchanged Trip Editor warnings
- `git diff --check`

Existing AngleSharp and SQLite package advisory warnings are unchanged.

## Database migration

None.