### PR TITLE
chore(release): prepare v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [1.5.2] - 2026-07-20
+
+### Fixed
+- Restored the public Trip Viewer map across phone, tablet, and desktop layouts, contained the phone sidebar within the viewport, and kept the trip area centered through sidebar collapse and expansion (#379)
+
 ## [1.5.1] - 2026-07-18
 
 ### Fixed

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <WayfarerVersion>1.5.1</WayfarerVersion>
+    <WayfarerVersion>1.5.2</WayfarerVersion>
     <Version>$(WayfarerVersion)</Version>
     <PackageVersion>$(WayfarerVersion)</PackageVersion>
     <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>

--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -5,7 +5,7 @@ file contains the manually edited `WayfarerVersion` value and maps the standard
 MSBuild metadata directly from it:
 
 ```xml
-<WayfarerVersion>1.5.1</WayfarerVersion>
+<WayfarerVersion>1.5.2</WayfarerVersion>
 <Version>$(WayfarerVersion)</Version>
 <PackageVersion>$(WayfarerVersion)</PackageVersion>
 <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
@@ -19,7 +19,7 @@ assembly through `IAppVersionProvider`. Runtime surfaces such as
 separate constants.
 
 Use `dotnet run --no-launch-profile -- version` when validating exact CLI
-output. The app writes exactly `Wayfarer 1.5.1`; `--no-launch-profile` avoids
+output. The app writes exactly `Wayfarer 1.5.2`; `--no-launch-profile` avoids
 .NET SDK launch-profile messages so validation stays focused on app output.
 
 ## Release helper

--- a/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
@@ -13,7 +13,7 @@ public class AppVersionProviderTests
     {
         var provider = new AppVersionProvider();
 
-        provider.Version.Should().Be("1.5.1");
+        provider.Version.Should().Be("1.5.2");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- prepare Wayfarer v1.5.2 using the repository release helper
- document the public Trip Viewer responsive fixes from #379
- align runtime version metadata, versioning documentation, and exact-version tests

## Release validation

- `python tools/release/version.py check`
- release helper tests: 21 passed
- exact CLI output: `Wayfarer 1.5.2`
- focused versioning tests: 3 passed
- `dotnet build Wayfarer.csproj --no-restore --nologo`
- `npm run build`
- full .NET suite: 1,677 passed, 8 environment-guarded PostgreSQL tests skipped
- LOC policy: passed; unchanged Trip Editor baseline warnings only
- `git diff --check`

## Database changes

None.