### PR TITLE
feat(trips): add derived itinerary numbering

### DIFF
--- a/ClientApps/trip-editor/src/components/RegionPlaceList.vue
+++ b/ClientApps/trip-editor/src/components/RegionPlaceList.vue
@@ -50,6 +50,16 @@ let sortable: { destroy: () => void } | null = null;
 let reorderSnapshotIds: Guid[] | null = null;
 let placeReorderSnapshot: { regionId: Guid; ids: Guid[] } | null = null;
 let areaReorderSnapshot: { regionId: Guid; ids: Guid[] } | null = null;
+let reorderEmissionLocked = false;
+
+watch(
+  () => props.isOrdering,
+  value => {
+    if (!value) {
+      reorderEmissionLocked = false;
+    }
+  }
+);
 
 watch(
   () => props.state.regionOrder.join('|'),
@@ -128,7 +138,7 @@ function attachRegionSortable(): void {
     draggable: '.trip-editor-region-card--normal',
     handle: '.trip-editor-drag-handle',
     onStart: () => {
-      if (props.isOrdering) {
+      if (reorderLocked()) {
         reorderSnapshotIds = null;
         return;
       }
@@ -136,7 +146,7 @@ function attachRegionSortable(): void {
       reorderSnapshotIds = normalRegionIds();
     },
     onEnd: () => {
-      if (props.isOrdering || !regionList.value) {
+      if (reorderLocked() || !regionList.value) {
         reorderSnapshotIds = null;
         return;
       }
@@ -145,6 +155,7 @@ function attachRegionSortable(): void {
       reorderSnapshotIds = null;
       const ids = Array.from(regionList.value.querySelectorAll<HTMLElement>('[data-region-id][data-reorderable="true"]')).map(element => element.dataset.regionId!);
       if (ids.join('|') !== previousIds.join('|')) {
+        reorderEmissionLocked = true;
         optimisticRegionIds.value = ids;
         emit('regionReorder', ids, previousIds);
       }
@@ -165,7 +176,7 @@ function attachPlaceSortables(): void {
       draggable: '.trip-editor-place-row',
       handle: '.trip-editor-place-drag-handle',
       onStart: () => {
-        if (props.isOrdering) {
+        if (reorderLocked()) {
           placeReorderSnapshot = null;
           return;
         }
@@ -173,7 +184,7 @@ function attachPlaceSortables(): void {
         placeReorderSnapshot = { regionId, ids: [...(props.state.placeOrderByRegionId[regionId] ?? [])] };
       },
       onEnd: () => {
-        if (props.isOrdering) {
+        if (reorderLocked()) {
           placeReorderSnapshot = null;
           return;
         }
@@ -182,6 +193,7 @@ function attachPlaceSortables(): void {
         placeReorderSnapshot = null;
         const ids = Array.from(element.querySelectorAll<HTMLElement>('[data-place-id]')).map(row => row.dataset.placeId!);
         if (ids.join('|') !== previousIds.join('|')) {
+          reorderEmissionLocked = true;
           optimisticPlaceIdsByRegionId.value = { ...optimisticPlaceIdsByRegionId.value, [regionId]: ids };
           emit('placeReorder', regionId, ids, previousIds);
         }
@@ -208,7 +220,7 @@ function attachAreaSortables(): void {
       draggable: '.trip-editor-area-row',
       handle: '.trip-editor-area-drag-handle',
       onStart: () => {
-        if (props.isOrdering) {
+        if (reorderLocked()) {
           areaReorderSnapshot = null;
           return;
         }
@@ -216,7 +228,7 @@ function attachAreaSortables(): void {
         areaReorderSnapshot = { regionId, ids: [...(props.state.areaOrderByRegionId[regionId] ?? [])] };
       },
       onEnd: () => {
-        if (props.isOrdering) {
+        if (reorderLocked()) {
           areaReorderSnapshot = null;
           return;
         }
@@ -225,6 +237,7 @@ function attachAreaSortables(): void {
         areaReorderSnapshot = null;
         const ids = Array.from(element.querySelectorAll<HTMLElement>('[data-area-id]')).map(row => row.dataset.areaId!);
         if (ids.join('|') !== previousIds.join('|')) {
+          reorderEmissionLocked = true;
           emit('areaReorder', regionId, ids, previousIds);
         }
       }
@@ -239,6 +252,11 @@ function destroyAreaSortables(): void {
 
 function normalRegionIds(): Guid[] {
   return props.state.regionOrder.filter(id => !props.state.regionsById[id]?.isShadow);
+}
+
+/// Blocks same-turn callbacks before the parent ordering prop has rendered.
+function reorderLocked(): boolean {
+  return props.isOrdering || reorderEmissionLocked;
 }
 
 /// Resolves a visible region label from the complete authoritative or transient normal-region order.

--- a/ClientApps/trip-editor/src/components/RegionPlaceList.vue
+++ b/ClientApps/trip-editor/src/components/RegionPlaceList.vue
@@ -42,12 +42,28 @@ const emit = defineEmits<{
 const regionList = ref<HTMLElement | null>(null);
 const collapsedRegionIds = ref<Set<Guid>>(new Set());
 const searchCollapsedSnapshot = ref<Set<Guid> | null>(null);
+const optimisticRegionIds = ref<Guid[] | null>(null);
+const optimisticPlaceIdsByRegionId = ref<Record<Guid, Guid[]>>({});
 const placeSortables = new Map<string, { destroy: () => void }>();
 const areaSortables = new Map<string, { destroy: () => void }>();
 let sortable: { destroy: () => void } | null = null;
 let reorderSnapshotIds: Guid[] | null = null;
 let placeReorderSnapshot: { regionId: Guid; ids: Guid[] } | null = null;
 let areaReorderSnapshot: { regionId: Guid; ids: Guid[] } | null = null;
+
+watch(
+  () => props.state.regionOrder.join('|'),
+  () => {
+    optimisticRegionIds.value = null;
+  }
+);
+
+watch(
+  () => Object.entries(props.state.placeOrderByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|'),
+  () => {
+    optimisticPlaceIdsByRegionId.value = {};
+  }
+);
 
 watch(
   () => `${props.searchActive}|${props.regions.map(region => region.id).join('|')}|${Object.entries(props.placeIdsByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}|${Object.entries(props.areaIdsByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}`,
@@ -123,6 +139,7 @@ function attachRegionSortable(): void {
       reorderSnapshotIds = null;
       const ids = Array.from(regionList.value.querySelectorAll<HTMLElement>('[data-region-id][data-reorderable="true"]')).map(element => element.dataset.regionId!);
       if (ids.join('|') !== previousIds.join('|')) {
+        optimisticRegionIds.value = ids;
         emit('regionReorder', ids, previousIds);
       }
     }
@@ -149,6 +166,7 @@ function attachPlaceSortables(): void {
         placeReorderSnapshot = null;
         const ids = Array.from(element.querySelectorAll<HTMLElement>('[data-place-id]')).map(row => row.dataset.placeId!);
         if (ids.join('|') !== previousIds.join('|')) {
+          optimisticPlaceIdsByRegionId.value = { ...optimisticPlaceIdsByRegionId.value, [regionId]: ids };
           emit('placeReorder', regionId, ids, previousIds);
         }
       }
@@ -194,7 +212,26 @@ function destroyAreaSortables(): void {
 }
 
 function normalRegionIds(): Guid[] {
-  return props.regions.filter(region => !region.isShadow).map(region => region.id);
+  return props.state.regionOrder.filter(id => !props.state.regionsById[id]?.isShadow);
+}
+
+/// Resolves a visible region label from the complete authoritative or transient normal-region order.
+function regionLabel(region: EditorRegion): string {
+  if (region.isShadow) {
+    return `0-${region.name}`;
+  }
+
+  const ids = optimisticRegionIds.value
+    ?? props.state.regionOrder.filter(id => !props.state.regionsById[id]?.isShadow);
+  return `${ids.indexOf(region.id) + 1}-${region.name}`;
+}
+
+/// Resolves a place label from its complete authoritative or transient parent-region order.
+function placeLabel(place: EditorPlace): string {
+  const ids = optimisticPlaceIdsByRegionId.value[place.regionId]
+    ?? props.state.placeOrderByRegionId[place.regionId]
+    ?? [];
+  return `${ids.indexOf(place.id) + 1}-${place.name}`;
 }
 
 function orderedPlaces(regionId: Guid): EditorPlace[] {
@@ -269,6 +306,7 @@ function moveAreaByKeyboard(regionId: Guid, areaId: Guid, offset: number): void 
         'trip-editor-region-card--shadow': region.isShadow
       }"
       :data-region-id="region.id"
+      :data-region-name="region.name"
       :data-reorderable="!region.isShadow"
     >
       <header class="trip-editor-region-card__header">
@@ -283,7 +321,7 @@ function moveAreaByKeyboard(regionId: Guid, areaId: Guid, offset: number): void 
           <span aria-hidden="true">::</span>
         </button>
         <div>
-          <h3>{{ region.name }}</h3>
+          <h3 class="itinerary-region-label">{{ regionLabel(region) }}</h3>
         </div>
         <div class="trip-editor-region-card__actions">
           <button
@@ -308,6 +346,7 @@ function moveAreaByKeyboard(regionId: Guid, areaId: Guid, offset: number): void 
             class="trip-editor-place-row"
             :class="{ 'trip-editor-place-row--active': props.activePlaceId === place.id }"
             :data-place-id="place.id"
+            :data-place-name="place.name"
             tabindex="0"
             @click="emit('selectPlace', place)"
             @keydown.enter.prevent="emit('selectPlace', place)"
@@ -327,7 +366,7 @@ function moveAreaByKeyboard(regionId: Guid, areaId: Guid, offset: number): void 
               <span v-if="place.visitSummary.isVisited" class="trip-editor-place-row__visit-badge">{{ place.visitSummary.visitCount === 1 ? '✓' : place.visitSummary.visitCount }}</span>
             </span>
             <span class="trip-editor-place-row__content">
-              <span class="trip-editor-place-row__name">{{ place.name }}</span>
+              <span class="trip-editor-place-row__name itinerary-place-label">{{ placeLabel(place) }}</span>
               <small v-if="place.visitSummary.isVisited">{{ placeMarkerLabel(place) }}</small>
             </span>
             <button type="button" class="btn btn-outline-light btn-sm" :disabled="props.isSaving || props.isOrdering" @click.stop="emit('editPlace', place)">Edit</button>

--- a/ClientApps/trip-editor/src/components/RegionPlaceList.vue
+++ b/ClientApps/trip-editor/src/components/RegionPlaceList.vue
@@ -66,7 +66,7 @@ watch(
 );
 
 watch(
-  () => `${props.searchActive}|${props.regions.map(region => region.id).join('|')}|${Object.entries(props.placeIdsByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}|${Object.entries(props.areaIdsByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}`,
+  () => `${props.searchActive}|${props.isOrdering}|${props.regions.map(region => region.id).join('|')}|${Object.entries(props.placeIdsByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}|${Object.entries(props.areaIdsByRegionId).map(([regionId, ids]) => `${regionId}:${ids.join(',')}`).join('|')}`,
   async () => {
     await nextTick();
     attachSortables();
@@ -119,7 +119,7 @@ function attachSortables(): void {
 function attachRegionSortable(): void {
   sortable?.destroy();
   sortable = null;
-  if (props.searchActive || !regionList.value || !window.Sortable) {
+  if (props.searchActive || props.isOrdering || !regionList.value || !window.Sortable) {
     return;
   }
 
@@ -128,10 +128,16 @@ function attachRegionSortable(): void {
     draggable: '.trip-editor-region-card--normal',
     handle: '.trip-editor-drag-handle',
     onStart: () => {
+      if (props.isOrdering) {
+        reorderSnapshotIds = null;
+        return;
+      }
+
       reorderSnapshotIds = normalRegionIds();
     },
     onEnd: () => {
-      if (!regionList.value) {
+      if (props.isOrdering || !regionList.value) {
+        reorderSnapshotIds = null;
         return;
       }
 
@@ -148,7 +154,7 @@ function attachRegionSortable(): void {
 
 function attachPlaceSortables(): void {
   destroyPlaceSortables();
-  if (props.searchActive || !window.Sortable) {
+  if (props.searchActive || props.isOrdering || !window.Sortable) {
     return;
   }
 
@@ -159,9 +165,19 @@ function attachPlaceSortables(): void {
       draggable: '.trip-editor-place-row',
       handle: '.trip-editor-place-drag-handle',
       onStart: () => {
+        if (props.isOrdering) {
+          placeReorderSnapshot = null;
+          return;
+        }
+
         placeReorderSnapshot = { regionId, ids: [...(props.state.placeOrderByRegionId[regionId] ?? [])] };
       },
       onEnd: () => {
+        if (props.isOrdering) {
+          placeReorderSnapshot = null;
+          return;
+        }
+
         const previousIds = placeReorderSnapshot?.ids ?? [...(props.state.placeOrderByRegionId[regionId] ?? [])];
         placeReorderSnapshot = null;
         const ids = Array.from(element.querySelectorAll<HTMLElement>('[data-place-id]')).map(row => row.dataset.placeId!);
@@ -181,7 +197,7 @@ function destroyPlaceSortables(): void {
 
 function attachAreaSortables(): void {
   destroyAreaSortables();
-  if (props.searchActive || !window.Sortable) {
+  if (props.searchActive || props.isOrdering || !window.Sortable) {
     return;
   }
 
@@ -192,9 +208,19 @@ function attachAreaSortables(): void {
       draggable: '.trip-editor-area-row',
       handle: '.trip-editor-area-drag-handle',
       onStart: () => {
+        if (props.isOrdering) {
+          areaReorderSnapshot = null;
+          return;
+        }
+
         areaReorderSnapshot = { regionId, ids: [...(props.state.areaOrderByRegionId[regionId] ?? [])] };
       },
       onEnd: () => {
+        if (props.isOrdering) {
+          areaReorderSnapshot = null;
+          return;
+        }
+
         const previousIds = areaReorderSnapshot?.ids ?? [...(props.state.areaOrderByRegionId[regionId] ?? [])];
         areaReorderSnapshot = null;
         const ids = Array.from(element.querySelectorAll<HTMLElement>('[data-area-id]')).map(row => row.dataset.areaId!);
@@ -316,7 +342,7 @@ function moveAreaByKeyboard(regionId: Guid, areaId: Guid, offset: number): void 
           class="trip-editor-icon-button trip-editor-drag-handle"
           title="Drag to reorder region"
           aria-label="Drag to reorder region"
-          :disabled="props.searchActive"
+          :disabled="props.searchActive || props.isOrdering"
         >
           <span aria-hidden="true">::</span>
         </button>
@@ -357,7 +383,7 @@ function moveAreaByKeyboard(regionId: Guid, areaId: Guid, offset: number): void 
               class="trip-editor-icon-button trip-editor-place-drag-handle"
               title="Drag to reorder place"
               aria-label="Drag to reorder place"
-              :disabled="props.searchActive"
+              :disabled="props.searchActive || props.isOrdering"
             >
               <span aria-hidden="true">::</span>
             </button>

--- a/ClientApps/trip-editor/src/components/areaEditorActions.ts
+++ b/ClientApps/trip-editor/src/components/areaEditorActions.ts
@@ -107,6 +107,11 @@ export function useAreaEditorActions(context: any) {
   };
 
   const reorderAreas = async (regionId: Guid, ids: Guid[], previousIds: Guid[]): Promise<void> => {
+    if (context.isOrdering.value) {
+      await context.restoreRegionOrder(previousIds);
+      return;
+    }
+
     if (context.isDirty.value && !(await context.confirmDiscard('Discard unsaved draft changes before reordering areas?'))) {
       await context.restoreRegionOrder(previousIds);
       return;
@@ -114,6 +119,11 @@ export function useAreaEditorActions(context: any) {
 
     if (context.isDirty.value) {
       context.clearAllDraftsAndBaselines();
+    }
+
+    if (context.isOrdering.value) {
+      await context.restoreRegionOrder(previousIds);
+      return;
     }
 
     context.isOrdering.value = true;

--- a/ClientApps/trip-editor/src/components/placeEditorActions.ts
+++ b/ClientApps/trip-editor/src/components/placeEditorActions.ts
@@ -165,6 +165,11 @@ export function usePlaceEditorActions(context: any) {
   };
 
   const reorderPlaces = async (regionId: Guid, ids: Guid[], previousIds: Guid[]): Promise<void> => {
+    if (context.isOrdering.value) {
+      await context.restoreRegionOrder(previousIds);
+      return;
+    }
+
     if (context.isDirty.value && !(await context.confirmDiscard('Discard unsaved draft changes before reordering places?'))) {
       await context.restoreRegionOrder(previousIds);
       return;
@@ -172,6 +177,11 @@ export function usePlaceEditorActions(context: any) {
 
     if (context.isDirty.value) {
       context.clearAllDraftsAndBaselines();
+    }
+
+    if (context.isOrdering.value) {
+      await context.restoreRegionOrder(previousIds);
+      return;
     }
 
     context.isOrdering.value = true;

--- a/ClientApps/trip-editor/src/components/regionEditorActions.ts
+++ b/ClientApps/trip-editor/src/components/regionEditorActions.ts
@@ -110,6 +110,11 @@ export function useRegionEditorActions(context: any) {
   };
 
   const reorderRegions = async (ids: Guid[], previousIds: Guid[]): Promise<void> => {
+    if (context.isOrdering.value) {
+      await context.restoreRegionOrder(previousIds);
+      return;
+    }
+
     if (context.isDirty.value && !(await context.confirmDiscard('Discard unsaved draft changes before reordering?'))) {
       await context.restoreRegionOrder(previousIds);
       return;
@@ -117,6 +122,11 @@ export function useRegionEditorActions(context: any) {
 
     if (context.isDirty.value) {
       context.clearAllDraftsAndBaselines();
+    }
+
+    if (context.isOrdering.value) {
+      await context.restoreRegionOrder(previousIds);
+      return;
     }
 
     context.isOrdering.value = true;

--- a/Models/Dtos/Editor/EditorTripStateMapper.cs
+++ b/Models/Dtos/Editor/EditorTripStateMapper.cs
@@ -37,7 +37,12 @@ public static class EditorTripStateMapper
             RegionsById = regions.ToDictionary(r => r.Id, ToRegion),
             RegionOrder = regions.Select(r => r.Id).ToList(),
             PlacesById = places.ToDictionary(p => p.Place.Id, p => ToPlace(trip.Id, p.Region.Id, p.Place, visitSummaries[p.Place.Id])),
-            PlaceOrderByRegionId = regions.ToDictionary(r => r.Id, r => (IReadOnlyList<Guid>)r.Places.OrderBy(p => p.DisplayOrder).ThenBy(p => p.Id).Select(p => p.Id).ToList()),
+            PlaceOrderByRegionId = regions.ToDictionary(r => r.Id, r => (IReadOnlyList<Guid>)r.Places
+                .OrderBy(p => p.DisplayOrder.HasValue ? 0 : 1)
+                .ThenBy(p => p.DisplayOrder)
+                .ThenBy(p => p.Id)
+                .Select(p => p.Id)
+                .ToList()),
             AreasById = areas.ToDictionary(a => a.Area.Id, a => ToArea(trip.Id, a.Region.Id, a.Area)),
             AreaOrderByRegionId = regions.ToDictionary(r => r.Id, r => (IReadOnlyList<Guid>)r.Areas.OrderBy(a => a.DisplayOrder).ThenBy(a => a.Name).Select(a => a.Id).ToList()),
             SegmentsById = segments.ToDictionary(s => s.Id, s => ToSegment(trip.Id, s)),

--- a/Models/Dtos/Editor/EditorTripStateMapper.cs
+++ b/Models/Dtos/Editor/EditorTripStateMapper.cs
@@ -24,7 +24,7 @@ public static class EditorTripStateMapper
     {
         ArgumentNullException.ThrowIfNull(trip);
 
-        var regions = trip.Regions.OrderBy(r => r.DisplayOrder).ThenBy(r => r.Name).ToList();
+        var regions = trip.Regions.OrderBy(r => r.DisplayOrder).ThenBy(r => r.Id).ToList();
         var places = regions.SelectMany(r => r.Places.Select(p => (Region: r, Place: p))).ToList();
         var areas = regions.SelectMany(r => r.Areas.Select(a => (Region: r, Area: a))).ToList();
         var segments = trip.Segments.OrderBy(s => s.DisplayOrder).ThenBy(s => s.Id).ToList();
@@ -37,7 +37,7 @@ public static class EditorTripStateMapper
             RegionsById = regions.ToDictionary(r => r.Id, ToRegion),
             RegionOrder = regions.Select(r => r.Id).ToList(),
             PlacesById = places.ToDictionary(p => p.Place.Id, p => ToPlace(trip.Id, p.Region.Id, p.Place, visitSummaries[p.Place.Id])),
-            PlaceOrderByRegionId = regions.ToDictionary(r => r.Id, r => (IReadOnlyList<Guid>)r.Places.OrderBy(p => p.DisplayOrder).ThenBy(p => p.Name).Select(p => p.Id).ToList()),
+            PlaceOrderByRegionId = regions.ToDictionary(r => r.Id, r => (IReadOnlyList<Guid>)r.Places.OrderBy(p => p.DisplayOrder).ThenBy(p => p.Id).Select(p => p.Id).ToList()),
             AreasById = areas.ToDictionary(a => a.Area.Id, a => ToArea(trip.Id, a.Region.Id, a.Area)),
             AreaOrderByRegionId = regions.ToDictionary(r => r.Id, r => (IReadOnlyList<Guid>)r.Areas.OrderBy(a => a.DisplayOrder).ThenBy(a => a.Name).Select(a => a.Id).ToList()),
             SegmentsById = segments.ToDictionary(s => s.Id, s => ToSegment(trip.Id, s)),

--- a/Services/TripEditorPlaceMutationReader.cs
+++ b/Services/TripEditorPlaceMutationReader.cs
@@ -97,7 +97,8 @@ public sealed class TripEditorPlaceMutationReader
         await _dbContext.Places
             .AsNoTracking()
             .Where(p => p.RegionId == regionId)
-            .OrderBy(p => p.DisplayOrder)
+            .OrderBy(p => p.DisplayOrder.HasValue ? 0 : 1)
+            .ThenBy(p => p.DisplayOrder)
             .ThenBy(p => p.Id)
             .Select(p => p.Id)
             .ToListAsync(cancellationToken);

--- a/Services/TripEditorPlaceMutationReader.cs
+++ b/Services/TripEditorPlaceMutationReader.cs
@@ -98,7 +98,7 @@ public sealed class TripEditorPlaceMutationReader
             .AsNoTracking()
             .Where(p => p.RegionId == regionId)
             .OrderBy(p => p.DisplayOrder)
-            .ThenBy(p => p.Name)
+            .ThenBy(p => p.Id)
             .Select(p => p.Id)
             .ToListAsync(cancellationToken);
 
@@ -135,7 +135,7 @@ public sealed class TripEditorPlaceMutationReader
             .Include(r => r.Places)
             .Where(r => r.TripId == tripId && r.UserId == userId)
             .OrderBy(r => r.DisplayOrder)
-            .ThenBy(r => r.Name)
+            .ThenBy(r => r.Id)
             .ToListAsync(cancellationToken);
         var places = regions.SelectMany(r => r.Places.Select(p => (Region: r, Place: p))).ToList();
         var summaries = await LoadVisitSummariesAsync(places.Select(p => p.Place).ToList(), userId, cancellationToken);

--- a/Services/TripEditorPlaceMutationService.cs
+++ b/Services/TripEditorPlaceMutationService.cs
@@ -259,7 +259,12 @@ public sealed class TripEditorPlaceMutationService
             return EditorRegionMutationOutcome<EditorMutationResult<EditorPlaceOrderResult>>.ValidationFailed(errors);
         }
 
-        var currentIds = region.Places.OrderBy(p => p.DisplayOrder).ThenBy(p => p.Id).Select(p => p.Id).ToList();
+        var currentIds = region.Places
+            .OrderBy(p => p.DisplayOrder.HasValue ? 0 : 1)
+            .ThenBy(p => p.DisplayOrder)
+            .ThenBy(p => p.Id)
+            .Select(p => p.Id)
+            .ToList();
         if (orderRequest.PlaceIds.Count != currentIds.Count
             || orderRequest.PlaceIds.Distinct().Count() != orderRequest.PlaceIds.Count
             || orderRequest.PlaceIds.Any(id => !currentIds.Contains(id)))

--- a/Services/TripEditorPlaceMutationService.cs
+++ b/Services/TripEditorPlaceMutationService.cs
@@ -259,7 +259,7 @@ public sealed class TripEditorPlaceMutationService
             return EditorRegionMutationOutcome<EditorMutationResult<EditorPlaceOrderResult>>.ValidationFailed(errors);
         }
 
-        var currentIds = region.Places.OrderBy(p => p.DisplayOrder).ThenBy(p => p.Name).Select(p => p.Id).ToList();
+        var currentIds = region.Places.OrderBy(p => p.DisplayOrder).ThenBy(p => p.Id).Select(p => p.Id).ToList();
         if (orderRequest.PlaceIds.Count != currentIds.Count
             || orderRequest.PlaceIds.Distinct().Count() != orderRequest.PlaceIds.Count
             || orderRequest.PlaceIds.Any(id => !currentIds.Contains(id)))

--- a/Services/TripEditorPlaceRouteEffects.cs
+++ b/Services/TripEditorPlaceRouteEffects.cs
@@ -65,7 +65,7 @@ public sealed class TripEditorPlaceRouteEffects
         var places = await _dbContext.Places
             .Where(p => p.RegionId == regionId)
             .OrderBy(p => p.DisplayOrder)
-            .ThenBy(p => p.Name)
+            .ThenBy(p => p.Id)
             .ToListAsync(cancellationToken);
         for (var i = 0; i < places.Count; i++)
         {

--- a/Services/TripEditorPlaceRouteEffects.cs
+++ b/Services/TripEditorPlaceRouteEffects.cs
@@ -64,7 +64,8 @@ public sealed class TripEditorPlaceRouteEffects
     {
         var places = await _dbContext.Places
             .Where(p => p.RegionId == regionId)
-            .OrderBy(p => p.DisplayOrder)
+            .OrderBy(p => p.DisplayOrder.HasValue ? 0 : 1)
+            .ThenBy(p => p.DisplayOrder)
             .ThenBy(p => p.Id)
             .ToListAsync(cancellationToken);
         for (var i = 0; i < places.Count; i++)

--- a/Services/TripEditorRegionMutationService.cs
+++ b/Services/TripEditorRegionMutationService.cs
@@ -261,7 +261,7 @@ public sealed class TripEditorRegionMutationService
             return EditorRegionMutationOutcome<EditorMutationResult<EditorRegionOrderResult>>.Forbidden("The shadow region cannot be reordered.");
         }
 
-        var normalRegions = trip.Regions.Where(r => !IsShadowRegion(r)).OrderBy(r => r.DisplayOrder).ThenBy(r => r.Name).ToList();
+        var normalRegions = trip.Regions.Where(r => !IsShadowRegion(r)).OrderBy(r => r.DisplayOrder).ThenBy(r => r.Id).ToList();
         var normalIds = normalRegions.Select(r => r.Id).ToList();
         if (orderRequest.RegionIds.Count != normalIds.Count
             || orderRequest.RegionIds.Distinct().Count() != orderRequest.RegionIds.Count
@@ -313,7 +313,7 @@ public sealed class TripEditorRegionMutationService
             .AsNoTracking()
             .Where(r => r.TripId == tripId && r.UserId == userId)
             .OrderBy(r => r.DisplayOrder)
-            .ThenBy(r => r.Name)
+            .ThenBy(r => r.Id)
             .Select(r => r.Id)
             .ToListAsync(cancellationToken);
 
@@ -360,7 +360,7 @@ public sealed class TripEditorRegionMutationService
             .Include(r => r.Places)
             .Where(r => r.TripId == tripId && r.UserId == userId)
             .OrderBy(r => r.DisplayOrder)
-            .ThenBy(r => r.Name)
+            .ThenBy(r => r.Id)
             .ToListAsync(cancellationToken);
         var places = regions.SelectMany(r => r.Places.Select(p => (Region: r, Place: p))).ToList();
         var placeIds = places.Select(p => p.Place.Id).ToArray();
@@ -381,7 +381,7 @@ public sealed class TripEditorRegionMutationService
         var regions = await _dbContext.Regions
             .Where(r => r.TripId == tripId && r.UserId == userId)
             .OrderBy(r => r.DisplayOrder)
-            .ThenBy(r => r.Name)
+            .ThenBy(r => r.Id)
             .ToListAsync(cancellationToken);
         var shadow = regions.FirstOrDefault(IsShadowRegion);
         if (shadow != null)

--- a/Util/ItineraryPresentation.cs
+++ b/Util/ItineraryPresentation.cs
@@ -13,9 +13,13 @@ public static class ItineraryPresentation
     public static IReadOnlyList<Region> OrderRegions(IEnumerable<Region>? regions) =>
         (regions ?? []).OrderBy(region => region.DisplayOrder).ThenBy(region => region.Id).ToList();
 
-    /// <summary>Orders complete sibling places by persisted order and stable identifier.</summary>
+    /// <summary>Orders complete sibling places by non-null persisted order, then stable identifier, with null orders last.</summary>
     public static IReadOnlyList<Place> OrderPlaces(IEnumerable<Place>? places) =>
-        (places ?? []).OrderBy(place => place.DisplayOrder).ThenBy(place => place.Id).ToList();
+        (places ?? [])
+            .OrderBy(place => place.DisplayOrder.HasValue ? 0 : 1)
+            .ThenBy(place => place.DisplayOrder)
+            .ThenBy(place => place.Id)
+            .ToList();
 
     /// <summary>Resolves the displayed region ordinal without letting the shadow region consume a normal number.</summary>
     public static int RegionOrdinal(Region region, IReadOnlyList<Region> orderedRegions) =>

--- a/Util/ItineraryPresentation.cs
+++ b/Util/ItineraryPresentation.cs
@@ -1,0 +1,32 @@
+using Wayfarer.Models;
+
+namespace Wayfarer.Util;
+
+/// <summary>
+/// Provides deterministic, presentation-only itinerary ordering and labels for Razor views.
+/// </summary>
+public static class ItineraryPresentation
+{
+    private const string ShadowRegionName = "Unassigned Places";
+
+    /// <summary>Orders complete region entities by persisted order and stable identifier.</summary>
+    public static IReadOnlyList<Region> OrderRegions(IEnumerable<Region>? regions) =>
+        (regions ?? []).OrderBy(region => region.DisplayOrder).ThenBy(region => region.Id).ToList();
+
+    /// <summary>Orders complete sibling places by persisted order and stable identifier.</summary>
+    public static IReadOnlyList<Place> OrderPlaces(IEnumerable<Place>? places) =>
+        (places ?? []).OrderBy(place => place.DisplayOrder).ThenBy(place => place.Id).ToList();
+
+    /// <summary>Resolves the displayed region ordinal without letting the shadow region consume a normal number.</summary>
+    public static int RegionOrdinal(Region region, IReadOnlyList<Region> orderedRegions) =>
+        IsShadowRegion(region)
+            ? 0
+            : orderedRegions.TakeWhile(candidate => candidate.Id != region.Id).Count(candidate => !IsShadowRegion(candidate)) + 1;
+
+    /// <summary>Formats an ordinal and untouched entity name using the itinerary display contract.</summary>
+    public static string Label(int ordinal, string name) => $"{ordinal}-{name}";
+
+    /// <summary>Identifies the built-in shadow region using the viewer's existing name contract.</summary>
+    public static bool IsShadowRegion(Region region) =>
+        string.Equals(region.Name, ShadowRegionName, StringComparison.Ordinal);
+}

--- a/Views/Trip/Partials/_RegionReadonly.cshtml
+++ b/Views/Trip/Partials/_RegionReadonly.cshtml
@@ -15,6 +15,8 @@
     var isOwner = ViewBag.IsOwner == true;
     var shareProgressEnabled = ViewBag.ShareProgressEnabled == true;
     var showVisitStatus = isOwner || shareProgressEnabled;
+    var regionOrdinal = ViewData["RegionOrdinal"] as int? ?? 0;
+    var orderedPlaces = ItineraryPresentation.OrderPlaces(Model.Places);
 }
 
 <div class="accordion-item"
@@ -32,8 +34,8 @@
                 type="button"
                 data-bs-toggle="collapse"
                 data-bs-target="#reg-body-@Model.Id">
-            <span class="fw-semibold">
-                @Model.Name
+            <span class="fw-semibold itinerary-region-label">
+                @ItineraryPresentation.Label(regionOrdinal, Model.Name)
             </span>
         </button>
 
@@ -62,9 +64,9 @@
             }
             <ul class="list-group list-group-flush">
 
-                @foreach (var p in Model.Places?.OrderBy(pl => pl.DisplayOrder)
-                                   ?? Enumerable.Empty<Wayfarer.Models.Place>())
+                @for (var placeIndex = 0; placeIndex < orderedPlaces.Count; placeIndex++)
                 {
+                    var p = orderedPlaces[placeIndex];
                     var iconName = SafeIcon(p.IconName);
                     var bgClass = SafeBg(p.MarkerColor);
                     var iconUrl = Png(iconName, bgClass);
@@ -104,7 +106,7 @@
                                     <span class="sidebar-visit-badge" title="@(visitCount == 1 ? "Visited" : $"Visited {visitCount} times")">@(visitCount == 1 ? "✓" : visitCount)</span>
                                 }
                             </span>
-                            <span class="flex-grow-1">@p.Name</span>
+                            <span class="flex-grow-1 itinerary-place-label">@ItineraryPresentation.Label(placeIndex + 1, p.Name)</span>
 
                             <div class="d-none place-notes">
                                 @Html.LinkifyHtml(p.Notes)

--- a/Views/Trip/Viewer.cshtml
+++ b/Views/Trip/Viewer.cshtml
@@ -28,6 +28,8 @@
 
     // Place visit counts for public progress display
     var placeVisitCounts = ViewBag.PlaceVisitCounts as Dictionary<Guid, int> ?? new Dictionary<Guid, int>();
+    // Canonical presentation order shared by the normal and readable hierarchies.
+    var itineraryRegions = ItineraryPresentation.OrderRegions(Model.Regions);
 }
 
 <!-- wrapper that stretches between navbar & footer -->
@@ -342,15 +344,17 @@
         <!-- regions accordion -->
         <div id="regions-accordion" class="accordion accordion-flush ">
             @{
-                var unassignedRegion = @Model.Regions?.Where(r => r.Name == "Unassigned Places").FirstOrDefault();
+                var unassignedRegion = itineraryRegions.FirstOrDefault(ItineraryPresentation.IsShadowRegion);
                 if (unassignedRegion?.Places?.Any() == true)
                 {
-                    @await Html.PartialAsync("~/Views/Trip/Partials/_RegionReadonly.cshtml", unassignedRegion)
+                    var shadowViewData = new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["RegionOrdinal"] = 0 };
+                    @await Html.PartialAsync("~/Views/Trip/Partials/_RegionReadonly.cshtml", unassignedRegion, shadowViewData)
                 }
             }
-            @foreach (var r in (Model.Regions ?? Enumerable.Empty<Region>()).Where(r => r.Name != "Unassigned Places").OrderBy(r => r.DisplayOrder))
+            @foreach (var r in itineraryRegions.Where(region => !ItineraryPresentation.IsShadowRegion(region)))
             {
-                @await Html.PartialAsync("~/Views/Trip/Partials/_RegionReadonly.cshtml", r)
+                var regionViewData = new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["RegionOrdinal"] = ItineraryPresentation.RegionOrdinal(r, itineraryRegions) };
+                @await Html.PartialAsync("~/Views/Trip/Partials/_RegionReadonly.cshtml", r, regionViewData)
             }
         </div>
 
@@ -476,14 +480,14 @@
                 <!-- Regions -->
                 <div class="regions-readable">
                     <h6 class="text-muted mb-3">Regions & Places</h6>
-                    @foreach (var region in (Model.Regions ?? Enumerable.Empty<Region>()).OrderBy(r => r.DisplayOrder))
+                    @foreach (var region in itineraryRegions)
                     {
                         @if (region.Name == "Unassigned Places" && (region.Places == null || !region.Places.Any()))
                         {
                             continue;
                         }
                         <div class="region-readable mb-4 pb-3 border-bottom">
-                            <h5 class="mb-2">@region.Name</h5>
+                            <h5 class="mb-2 itinerary-region-label">@ItineraryPresentation.Label(ItineraryPresentation.RegionOrdinal(region, itineraryRegions), region.Name)</h5>
 
                             @if (!string.IsNullOrWhiteSpace(region.CoverImageUrl))
                             {
@@ -502,8 +506,10 @@
                             @if (region.Places?.Count > 0)
                             {
                                 <div class="places-list">
-                                    @foreach (var place in region.Places.OrderBy(p => p.DisplayOrder))
+                                    @{ var readablePlaces = ItineraryPresentation.OrderPlaces(region.Places); }
+                                    @for (var placeIndex = 0; placeIndex < readablePlaces.Count; placeIndex++)
                                     {
+                                        var place = readablePlaces[placeIndex];
                                         var iconName = string.IsNullOrWhiteSpace(place.IconName) ? "marker" : place.IconName.Trim();
                                         var bgClass = string.IsNullOrWhiteSpace(place.MarkerColor) ? "bg-blue" : place.MarkerColor.Trim();
 
@@ -511,7 +517,7 @@
                                             <div class="d-flex align-items-start">
                                                 @await Html.PartialAsync("~/Areas/User/Views/Trip/Partials/_MapIcon.cshtml", (iconName, bgClass))
                                                 <div class="flex-grow-1">
-                                                    <strong>@place.Name</strong>
+                                                    <strong class="itinerary-place-label">@ItineraryPresentation.Label(placeIndex + 1, place.Name)</strong>
                                                     @if (!string.IsNullOrWhiteSpace(place.Notes))
                                                     {
                                                         <div class="small text-muted mt-1">

--- a/Views/Trip/Viewer.cshtml
+++ b/Views/Trip/Viewer.cshtml
@@ -591,7 +591,7 @@
                     <div id="visitHistoryRegions">
                         @foreach (var region in Model.Regions?.OrderBy(r => r.DisplayOrder) ?? Enumerable.Empty<Region>())
                         {
-                            var regionPlaces = region.Places?.OrderBy(p => p.DisplayOrder).ToList() ?? new List<Place>();
+                            var regionPlaces = ItineraryPresentation.OrderPlaces(region.Places);
                             var regionVisitedCount = regionPlaces.Count(p => visitsByPlace.ContainsKey(p.Id));
                             var regionPercent = regionPlaces.Count > 0 ? (int)Math.Round((double)regionVisitedCount / regionPlaces.Count * 100) : 0;
 
@@ -723,7 +723,7 @@
                     <h6 class="text-muted mb-3">Progress by Region</h6>
                     @foreach (var region in Model.Regions?.OrderBy(r => r.DisplayOrder) ?? Enumerable.Empty<Region>())
                     {
-                        var regionPlaces = region.Places?.OrderBy(p => p.DisplayOrder).ToList() ?? new List<Place>();
+                        var regionPlaces = ItineraryPresentation.OrderPlaces(region.Places);
                         var regionVisitedCount = regionPlaces.Count(p => placeVisitCounts.ContainsKey(p.Id));
                         var regionPercent = regionPlaces.Count > 0 ? (int)Math.Round((double)regionVisitedCount / regionPlaces.Count * 100) : 0;
 

--- a/Views/Trip/Viewer.cshtml
+++ b/Views/Trip/Viewer.cshtml
@@ -28,7 +28,6 @@
 
     // Place visit counts for public progress display
     var placeVisitCounts = ViewBag.PlaceVisitCounts as Dictionary<Guid, int> ?? new Dictionary<Guid, int>();
-    // Canonical presentation order shared by the normal and readable hierarchies.
     var itineraryRegions = ItineraryPresentation.OrderRegions(Model.Regions);
 }
 
@@ -347,14 +346,12 @@
                 var unassignedRegion = itineraryRegions.FirstOrDefault(ItineraryPresentation.IsShadowRegion);
                 if (unassignedRegion?.Places?.Any() == true)
                 {
-                    var shadowViewData = new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["RegionOrdinal"] = 0 };
-                    @await Html.PartialAsync("~/Views/Trip/Partials/_RegionReadonly.cshtml", unassignedRegion, shadowViewData)
+                    @await Html.PartialAsync("~/Views/Trip/Partials/_RegionReadonly.cshtml", unassignedRegion, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["RegionOrdinal"] = 0 })
                 }
             }
             @foreach (var r in itineraryRegions.Where(region => !ItineraryPresentation.IsShadowRegion(region)))
             {
-                var regionViewData = new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["RegionOrdinal"] = ItineraryPresentation.RegionOrdinal(r, itineraryRegions) };
-                @await Html.PartialAsync("~/Views/Trip/Partials/_RegionReadonly.cshtml", r, regionViewData)
+                @await Html.PartialAsync("~/Views/Trip/Partials/_RegionReadonly.cshtml", r, new Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary(ViewData) { ["RegionOrdinal"] = ItineraryPresentation.RegionOrdinal(r, itineraryRegions) })
             }
         </div>
 
@@ -477,7 +474,6 @@
                     </div>
                 }
 
-                <!-- Regions -->
                 <div class="regions-readable">
                     <h6 class="text-muted mb-3">Regions & Places</h6>
                     @foreach (var region in itineraryRegions)
@@ -506,10 +502,8 @@
                             @if (region.Places?.Count > 0)
                             {
                                 <div class="places-list">
-                                    @{ var readablePlaces = ItineraryPresentation.OrderPlaces(region.Places); }
-                                    @for (var placeIndex = 0; placeIndex < readablePlaces.Count; placeIndex++)
+                                    @foreach (var (place, placeIndex) in ItineraryPresentation.OrderPlaces(region.Places).Select((place, index) => (place, index)))
                                     {
-                                        var place = readablePlaces[placeIndex];
                                         var iconName = string.IsNullOrWhiteSpace(place.IconName) ? "marker" : place.IconName.Trim();
                                         var bgClass = string.IsNullOrWhiteSpace(place.MarkerColor) ? "bg-blue" : place.MarkerColor.Trim();
 

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -13,6 +13,7 @@ using Wayfarer.Models.Dtos.Editor;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
+using Wayfarer.Util;
 using PublicTripViewerController = Wayfarer.Areas.Public.Controllers.TripViewerController;
 using Xunit;
 
@@ -112,7 +113,7 @@ public sealed class TripEditorControllerTests : TestBase
     }
 
     [Fact]
-    public async Task GetEditorStateBreaksEqualDisplayOrderByAscendingEntityId()
+    public async Task GetEditorStateBreaksEqualDisplayOrderByIdAndMatchesViewerPresentationOrder()
     {
         using var db = CreateDbContext();
         var trip = SeedTrip(db, "owner-user");
@@ -159,9 +160,13 @@ public sealed class TripEditorControllerTests : TestBase
         var state = Assert.IsType<EditorTripStateDto>(Assert.IsType<OkObjectResult>(result).Value);
         var regionOrder = state.RegionOrder.ToList();
         Assert.True(regionOrder.IndexOf(earlierRegion.Id) < regionOrder.IndexOf(laterRegion.Id));
+        Assert.Equal(regionOrder, ItineraryPresentation.OrderRegions(trip.Regions).Select(region => region.Id));
         Assert.Equal(
             [Guid.Parse("00000000-0000-0000-0000-000000000021"), Guid.Parse("00000000-0000-0000-0000-000000000022")],
             state.PlaceOrderByRegionId[laterRegion.Id]);
+        Assert.Equal(
+            state.PlaceOrderByRegionId[laterRegion.Id],
+            ItineraryPresentation.OrderPlaces(laterRegion.Places).Select(place => place.Id));
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -132,24 +132,24 @@ public sealed class TripEditorControllerTests : TestBase
             Name = "Alphabetically Last",
             DisplayOrder = 7
         };
-        laterRegion.Places.Add(new Place
+        var laterPlace = new Place
         {
             Id = Guid.Parse("00000000-0000-0000-0000-000000000022"),
             RegionId = laterRegion.Id,
             UserId = "owner-user",
             Name = "Alphabetically First",
             DisplayOrder = 4
-        });
-        laterRegion.Places.Add(new Place
+        };
+        var earlierPlace = new Place
         {
             Id = Guid.Parse("00000000-0000-0000-0000-000000000021"),
             RegionId = laterRegion.Id,
             UserId = "owner-user",
             Name = "Alphabetically Last",
             DisplayOrder = 4
-        });
-        trip.Regions.Add(laterRegion);
-        trip.Regions.Add(earlierRegion);
+        };
+        db.Regions.AddRange(laterRegion, earlierRegion);
+        db.Places.AddRange(laterPlace, earlierPlace);
         db.SaveChanges();
         var controller = BuildController(db);
         ConfigureControllerWithUserRole(controller, "owner-user");

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -112,6 +112,59 @@ public sealed class TripEditorControllerTests : TestBase
     }
 
     [Fact]
+    public async Task GetEditorStateBreaksEqualDisplayOrderByAscendingEntityId()
+    {
+        using var db = CreateDbContext();
+        var trip = SeedTrip(db, "owner-user");
+        var laterRegion = new Region
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000012"),
+            TripId = trip.Id,
+            UserId = "owner-user",
+            Name = "Alphabetically First",
+            DisplayOrder = 7
+        };
+        var earlierRegion = new Region
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000011"),
+            TripId = trip.Id,
+            UserId = "owner-user",
+            Name = "Alphabetically Last",
+            DisplayOrder = 7
+        };
+        laterRegion.Places.Add(new Place
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000022"),
+            RegionId = laterRegion.Id,
+            UserId = "owner-user",
+            Name = "Alphabetically First",
+            DisplayOrder = 4
+        });
+        laterRegion.Places.Add(new Place
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000021"),
+            RegionId = laterRegion.Id,
+            UserId = "owner-user",
+            Name = "Alphabetically Last",
+            DisplayOrder = 4
+        });
+        trip.Regions.Add(laterRegion);
+        trip.Regions.Add(earlierRegion);
+        db.SaveChanges();
+        var controller = BuildController(db);
+        ConfigureControllerWithUserRole(controller, "owner-user");
+
+        var result = await controller.GetEditorState(trip.Id, CancellationToken.None);
+
+        var state = Assert.IsType<EditorTripStateDto>(Assert.IsType<OkObjectResult>(result).Value);
+        var regionOrder = state.RegionOrder.ToList();
+        Assert.True(regionOrder.IndexOf(earlierRegion.Id) < regionOrder.IndexOf(laterRegion.Id));
+        Assert.Equal(
+            [Guid.Parse("00000000-0000-0000-0000-000000000021"), Guid.Parse("00000000-0000-0000-0000-000000000022")],
+            state.PlaceOrderByRegionId[laterRegion.Id]);
+    }
+
+    [Fact]
     public async Task GetEditorStateForPrivateTripReturnsNullPublicUrls()
     {
         using var db = CreateDbContext();

--- a/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/TripEditorControllerTests.cs
@@ -113,7 +113,7 @@ public sealed class TripEditorControllerTests : TestBase
     }
 
     [Fact]
-    public async Task GetEditorStateBreaksEqualDisplayOrderByIdAndMatchesViewerPresentationOrder()
+    public async Task GetEditorStateUsesTheSameNullLastPlaceOrderAsViewerAndMutationReader()
     {
         using var db = CreateDbContext();
         var trip = SeedTrip(db, "owner-user");
@@ -149,8 +149,32 @@ public sealed class TripEditorControllerTests : TestBase
             Name = "Alphabetically Last",
             DisplayOrder = 4
         };
+        var gapPlace = new Place
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000023"),
+            RegionId = laterRegion.Id,
+            UserId = "owner-user",
+            Name = "Order gap",
+            DisplayOrder = 20
+        };
+        var laterNullPlace = new Place
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000025"),
+            RegionId = laterRegion.Id,
+            UserId = "owner-user",
+            Name = "Later null",
+            DisplayOrder = null
+        };
+        var earlierNullPlace = new Place
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000024"),
+            RegionId = laterRegion.Id,
+            UserId = "owner-user",
+            Name = "Earlier null",
+            DisplayOrder = null
+        };
         db.Regions.AddRange(laterRegion, earlierRegion);
-        db.Places.AddRange(laterPlace, earlierPlace);
+        db.Places.AddRange(laterPlace, earlierPlace, gapPlace, laterNullPlace, earlierNullPlace);
         db.SaveChanges();
         var controller = BuildController(db);
         ConfigureControllerWithUserRole(controller, "owner-user");
@@ -161,12 +185,11 @@ public sealed class TripEditorControllerTests : TestBase
         var regionOrder = state.RegionOrder.ToList();
         Assert.True(regionOrder.IndexOf(earlierRegion.Id) < regionOrder.IndexOf(laterRegion.Id));
         Assert.Equal(regionOrder, ItineraryPresentation.OrderRegions(trip.Regions).Select(region => region.Id));
-        Assert.Equal(
-            [Guid.Parse("00000000-0000-0000-0000-000000000021"), Guid.Parse("00000000-0000-0000-0000-000000000022")],
-            state.PlaceOrderByRegionId[laterRegion.Id]);
-        Assert.Equal(
-            state.PlaceOrderByRegionId[laterRegion.Id],
-            ItineraryPresentation.OrderPlaces(laterRegion.Places).Select(place => place.Id));
+        var expectedPlaceOrder = new[] { earlierPlace.Id, laterPlace.Id, gapPlace.Id, earlierNullPlace.Id, laterNullPlace.Id };
+        var mutationReaderOrder = await new TripEditorPlaceMutationReader(db).LoadPlaceOrderAsync(laterRegion.Id, CancellationToken.None);
+        Assert.Equal(expectedPlaceOrder, state.PlaceOrderByRegionId[laterRegion.Id]);
+        Assert.Equal(expectedPlaceOrder, ItineraryPresentation.OrderPlaces(laterRegion.Places).Select(place => place.Id));
+        Assert.Equal(expectedPlaceOrder, mutationReaderOrder);
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Services/TripEditorPlaceOrderingPostgresTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripEditorPlaceOrderingPostgresTests.cs
@@ -1,0 +1,45 @@
+using Wayfarer.Models;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>Verifies PostgreSQL applies the canonical null-last Trip Editor place order.</summary>
+[Collection(PostgresImportTestCollection.Name)]
+public sealed class TripEditorPlaceOrderingPostgresTests(PostgresImportTestFixture fixture)
+{
+    [PostgresFact]
+    public async Task MutationReaderOrdersNullableDisplayOrderAfterOrderedPlaces()
+    {
+        var user = await fixture.CreateUserAsync();
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = user.Id, Name = "Nullable place order", UpdatedAt = DateTime.UtcNow };
+        var region = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = user.Id, Name = "Region", DisplayOrder = 1 };
+        var expected = new[]
+        {
+            Guid.Parse("00000000-0000-0000-0000-000000000021"),
+            Guid.Parse("00000000-0000-0000-0000-000000000022"),
+            Guid.Parse("00000000-0000-0000-0000-000000000023"),
+            Guid.Parse("00000000-0000-0000-0000-000000000024"),
+            Guid.Parse("00000000-0000-0000-0000-000000000025")
+        };
+        region.Places.Add(Place(expected[4], user.Id, region, "Later null", null));
+        region.Places.Add(Place(expected[2], user.Id, region, "Order gap", 20));
+        region.Places.Add(Place(expected[1], user.Id, region, "Later equal", 9));
+        region.Places.Add(Place(expected[3], user.Id, region, "Earlier null", null));
+        region.Places.Add(Place(expected[0], user.Id, region, "Earlier equal", 9));
+        trip.Regions.Add(region);
+
+        await using var context = fixture.CreateContext();
+        context.Trips.Add(trip);
+        await context.SaveChangesAsync();
+        fixture.RegisterTrip(trip.Id);
+
+        var actual = await new TripEditorPlaceMutationReader(context).LoadPlaceOrderAsync(region.Id, CancellationToken.None);
+
+        Assert.Equal(expected, actual);
+    }
+
+    private static Place Place(Guid id, string userId, Region region, string name, int? displayOrder) =>
+        new() { Id = id, UserId = userId, Region = region, RegionId = region.Id, Name = name, DisplayOrder = displayOrder };
+}

--- a/tests/Wayfarer.Tests/Util/ItineraryPresentationTests.cs
+++ b/tests/Wayfarer.Tests/Util/ItineraryPresentationTests.cs
@@ -1,0 +1,51 @@
+using Wayfarer.Models;
+using Wayfarer.Util;
+using Xunit;
+
+namespace Wayfarer.Tests.Util;
+
+/// <summary>
+/// Verifies presentation-only itinerary ordering and label formatting.
+/// </summary>
+public sealed class ItineraryPresentationTests
+{
+    [Fact]
+    public void OrderRegionsUsesDisplayOrderThenIdAndExcludesShadowFromNormalOrdinals()
+    {
+        var shadow = Region("00000000-0000-0000-0000-000000000010", "Unassigned Places", 0);
+        var laterId = Region("00000000-0000-0000-0000-000000000003", "First by input", 5);
+        var earlierId = Region("00000000-0000-0000-0000-000000000002", "2-Legitimate numeric name", 5);
+
+        var ordered = ItineraryPresentation.OrderRegions([laterId, shadow, earlierId]);
+
+        Assert.Equal([shadow.Id, earlierId.Id, laterId.Id], ordered.Select(region => region.Id));
+        Assert.Equal(0, ItineraryPresentation.RegionOrdinal(shadow, ordered));
+        Assert.Equal(1, ItineraryPresentation.RegionOrdinal(earlierId, ordered));
+        Assert.Equal(2, ItineraryPresentation.RegionOrdinal(laterId, ordered));
+        Assert.Equal("0-Unassigned Places", ItineraryPresentation.Label(0, shadow.Name));
+        Assert.Equal("1-2-Legitimate numeric name", ItineraryPresentation.Label(1, earlierId.Name));
+        Assert.Equal("2-Legitimate numeric name", earlierId.Name);
+    }
+
+    [Fact]
+    public void OrderPlacesUsesDisplayOrderThenIdWhileCallersRestartOrdinalsPerRegion()
+    {
+        var laterId = Place("00000000-0000-0000-0000-000000000022", "Colombo", 9);
+        var earlierId = Place("00000000-0000-0000-0000-000000000021", "Kandy", 9);
+
+        var firstRegion = ItineraryPresentation.OrderPlaces([laterId, earlierId]);
+        var secondRegion = ItineraryPresentation.OrderPlaces([Place("00000000-0000-0000-0000-000000000030", "Galle", 20)]);
+
+        Assert.Equal([earlierId.Id, laterId.Id], firstRegion.Select(place => place.Id));
+        Assert.Equal("1-Kandy", ItineraryPresentation.Label(1, firstRegion[0].Name));
+        Assert.Equal("2-Colombo", ItineraryPresentation.Label(2, firstRegion[1].Name));
+        Assert.Equal("1-Galle", ItineraryPresentation.Label(1, secondRegion[0].Name));
+        Assert.Equal("Colombo", laterId.Name);
+    }
+
+    private static Region Region(string id, string name, int displayOrder) =>
+        new() { Id = Guid.Parse(id), Name = name, DisplayOrder = displayOrder };
+
+    private static Place Place(string id, string name, int displayOrder) =>
+        new() { Id = Guid.Parse(id), Name = name, DisplayOrder = displayOrder };
+}

--- a/tests/Wayfarer.Tests/Util/ItineraryPresentationTests.cs
+++ b/tests/Wayfarer.Tests/Util/ItineraryPresentationTests.cs
@@ -28,15 +28,18 @@ public sealed class ItineraryPresentationTests
     }
 
     [Fact]
-    public void OrderPlacesUsesDisplayOrderThenIdWhileCallersRestartOrdinalsPerRegion()
+    public void OrderPlacesUsesExplicitNullLastDisplayOrderThenIdWhileCallersRestartOrdinalsPerRegion()
     {
+        var gap = Place("00000000-0000-0000-0000-000000000023", "Galle", 20);
         var laterId = Place("00000000-0000-0000-0000-000000000022", "Colombo", 9);
         var earlierId = Place("00000000-0000-0000-0000-000000000021", "Kandy", 9);
+        var laterNullId = Place("00000000-0000-0000-0000-000000000025", "Jaffna", null);
+        var earlierNullId = Place("00000000-0000-0000-0000-000000000024", "Negombo", null);
 
-        var firstRegion = ItineraryPresentation.OrderPlaces([laterId, earlierId]);
+        var firstRegion = ItineraryPresentation.OrderPlaces([laterNullId, gap, laterId, earlierNullId, earlierId]);
         var secondRegion = ItineraryPresentation.OrderPlaces([Place("00000000-0000-0000-0000-000000000030", "Galle", 20)]);
 
-        Assert.Equal([earlierId.Id, laterId.Id], firstRegion.Select(place => place.Id));
+        Assert.Equal([earlierId.Id, laterId.Id, gap.Id, earlierNullId.Id, laterNullId.Id], firstRegion.Select(place => place.Id));
         Assert.Equal("1-Kandy", ItineraryPresentation.Label(1, firstRegion[0].Name));
         Assert.Equal("2-Colombo", ItineraryPresentation.Label(2, firstRegion[1].Name));
         Assert.Equal("1-Galle", ItineraryPresentation.Label(1, secondRegion[0].Name));
@@ -46,6 +49,6 @@ public sealed class ItineraryPresentationTests
     private static Region Region(string id, string name, int displayOrder) =>
         new() { Id = Guid.Parse(id), Name = name, DisplayOrder = displayOrder };
 
-    private static Place Place(string id, string name, int displayOrder) =>
+    private static Place Place(string id, string name, int? displayOrder) =>
         new() { Id = Guid.Parse(id), Name = name, DisplayOrder = displayOrder };
 }

--- a/tests/Wayfarer.Tests/Views/TripViewerItineraryRenderingTests.cs
+++ b/tests/Wayfarer.Tests/Views/TripViewerItineraryRenderingTests.cs
@@ -70,8 +70,9 @@ public sealed class TripViewerItineraryRenderingTests
         var routeData = new RouteData();
         routeData.Routers.Add(new RouteCollection());
         var actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
+        // Render the target view and its partials without _ViewStart so the test does not depend on built frontend assets.
         var viewResult = services.GetRequiredService<ICompositeViewEngine>()
-            .GetView(null, "/Views/Trip/Viewer.cshtml", isMainPage: true);
+            .GetView(null, "/Views/Trip/Viewer.cshtml", isMainPage: false);
         Assert.True(viewResult.Success, string.Join(Environment.NewLine, viewResult.SearchedLocations ?? []));
         var view = Assert.IsAssignableFrom<IView>(viewResult.View);
         var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())

--- a/tests/Wayfarer.Tests/Views/TripViewerItineraryRenderingTests.cs
+++ b/tests/Wayfarer.Tests/Views/TripViewerItineraryRenderingTests.cs
@@ -1,0 +1,141 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MvcFrontendKit.Extensions;
+using Wayfarer.Models;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Xunit;
+
+namespace Wayfarer.Tests.Views;
+
+/// <summary>Verifies canonical itinerary collisions through the compiled normal and readable Razor markup.</summary>
+public sealed class TripViewerItineraryRenderingTests
+{
+    [Fact]
+    public async Task ViewerRendersEqualAndNullableOrdersIdenticallyAcrossNormalAndReadableMarkup()
+    {
+        using var host = BuildRazorHost();
+        using var scope = host.Services.CreateScope();
+        var trip = CollisionTrip();
+
+        var html = await RenderViewerAsync(scope.ServiceProvider, trip);
+        var document = await new HtmlParser().ParseDocumentAsync(html);
+
+        var normalLabels = Labels(document.QuerySelectorAll("#regions-accordion .itinerary-region-label, #regions-accordion .itinerary-place-label"));
+        var readableLabels = Labels(document.QuerySelectorAll("#readable-modal-body .itinerary-region-label, #readable-modal-body .itinerary-place-label"));
+        Assert.Equal(
+            ["1-Earlier region", "1-Earlier equal", "2-Later equal", "3-Ordered gap", "4-Earlier null", "5-Later null", "2-Later region"],
+            normalLabels);
+        Assert.Equal(normalLabels, readableLabels);
+        Assert.Equal(["Earlier region", "Later region"], document.QuerySelectorAll("#regions-accordion .accordion-item").Select(element => element.GetAttribute("data-region-name")));
+        Assert.Equal(
+            ["Earlier equal", "Later equal", "Ordered gap", "Earlier null", "Later null"],
+            document.QuerySelectorAll("#regions-accordion .place-list-item").Select(element => element.GetAttribute("data-place-name")));
+        Assert.All(document.QuerySelectorAll("#readable-modal-body .places-list"), list => Assert.Equal("DIV", list.TagName));
+    }
+
+    private static IHost BuildRazorHost() =>
+        Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(webHost => webHost
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseSetting(WebHostDefaults.ApplicationKey, typeof(Trip).Assembly.GetName().Name)
+                .ConfigureServices(services =>
+                {
+                    services.AddLogging();
+                    services.AddHttpContextAccessor();
+                    services.AddControllersWithViews().AddApplicationPart(typeof(Trip).Assembly);
+                    services.AddMvcFrontendKit();
+                    services.AddSingleton<IAppVersionProvider, AppVersionProvider>();
+                    services.AddSingleton<IApplicationSettingsService, EmptyApplicationSettingsService>();
+                    services.AddSingleton<ITempDataProvider, EmptyTempDataProvider>();
+                })
+                .Configure(_ => { }))
+            .Build();
+
+    private static async Task<string> RenderViewerAsync(IServiceProvider services, Trip trip)
+    {
+        var httpContext = new DefaultHttpContext { RequestServices = services };
+        var routeData = new RouteData();
+        routeData.Routers.Add(new RouteCollection());
+        var actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
+        var viewResult = services.GetRequiredService<ICompositeViewEngine>()
+            .GetView(null, "/Views/Trip/Viewer.cshtml", isMainPage: true);
+        Assert.True(viewResult.Success, string.Join(Environment.NewLine, viewResult.SearchedLocations ?? []));
+        var view = Assert.IsAssignableFrom<IView>(viewResult.View);
+        var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
+        {
+            Model = trip,
+            ["IsEmbed"] = true,
+            ["IsOwner"] = false,
+            ["ShareProgressEnabled"] = false,
+            ["PlaceVisitCounts"] = new Dictionary<Guid, int>(),
+            ["VisitEvents"] = new List<PlaceVisitEvent>()
+        };
+        var tempData = new TempDataDictionary(httpContext, services.GetRequiredService<ITempDataProvider>());
+        await using var writer = new StringWriter();
+        var viewContext = new ViewContext(actionContext, view, viewData, tempData, writer, new HtmlHelperOptions());
+        await view.RenderAsync(viewContext);
+        return writer.ToString();
+    }
+
+    private sealed class EmptyApplicationSettingsService : IApplicationSettingsService
+    {
+        /// <inheritdoc />
+        public ApplicationSettings GetSettings() => new();
+
+        /// <inheritdoc />
+        public string GetUploadsDirectoryPath() => Path.GetTempPath();
+
+        /// <inheritdoc />
+        public void RefreshSettings()
+        {
+        }
+    }
+
+    private static Trip CollisionTrip()
+    {
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = "owner", Name = "Collision trip", UpdatedAt = DateTime.UtcNow };
+        var laterRegion = Region("00000000-0000-0000-0000-000000000012", "Later region", 7, trip);
+        var earlierRegion = Region("00000000-0000-0000-0000-000000000011", "Earlier region", 7, trip);
+        earlierRegion.Places.Add(Place("00000000-0000-0000-0000-000000000025", "Later null", null, earlierRegion));
+        earlierRegion.Places.Add(Place("00000000-0000-0000-0000-000000000023", "Ordered gap", 20, earlierRegion));
+        earlierRegion.Places.Add(Place("00000000-0000-0000-0000-000000000022", "Later equal", 9, earlierRegion));
+        earlierRegion.Places.Add(Place("00000000-0000-0000-0000-000000000024", "Earlier null", null, earlierRegion));
+        earlierRegion.Places.Add(Place("00000000-0000-0000-0000-000000000021", "Earlier equal", 9, earlierRegion));
+        trip.Regions.Add(laterRegion);
+        trip.Regions.Add(earlierRegion);
+        return trip;
+    }
+
+    private static Region Region(string id, string name, int displayOrder, Trip trip) =>
+        new() { Id = Guid.Parse(id), Trip = trip, TripId = trip.Id, UserId = trip.UserId, Name = name, DisplayOrder = displayOrder };
+
+    private static Place Place(string id, string name, int? displayOrder, Region region) =>
+        new() { Id = Guid.Parse(id), Region = region, RegionId = region.Id, UserId = region.UserId, Name = name, DisplayOrder = displayOrder };
+
+    private static string[] Labels(IHtmlCollection<IElement> elements) =>
+        elements.Select(element => element.TextContent.Trim()).ToArray();
+
+    private sealed class EmptyTempDataProvider : ITempDataProvider
+    {
+        /// <inheritdoc />
+        public IDictionary<string, object> LoadTempData(Microsoft.AspNetCore.Http.HttpContext context) => new Dictionary<string, object>();
+
+        /// <inheritdoc />
+        public void SaveTempData(Microsoft.AspNetCore.Http.HttpContext context, IDictionary<string, object> values)
+        {
+        }
+    }
+}

--- a/tests/Wayfarer.Tests/Views/TripViewerItineraryRenderingTests.cs
+++ b/tests/Wayfarer.Tests/Views/TripViewerItineraryRenderingTests.cs
@@ -36,12 +36,12 @@ public sealed class TripViewerItineraryRenderingTests
         var normalLabels = Labels(document.QuerySelectorAll("#regions-accordion .itinerary-region-label, #regions-accordion .itinerary-place-label"));
         var readableLabels = Labels(document.QuerySelectorAll("#readable-modal-body .itinerary-region-label, #readable-modal-body .itinerary-place-label"));
         Assert.Equal(
-            ["1-Earlier region", "1-Earlier equal", "2-Later equal", "3-Ordered gap", "4-Earlier null", "5-Later null", "2-Later region"],
+            ["0-Unassigned Places", "1-Shadow child", "1-Zulu region", "1-Zulu equal", "2-Alpha equal", "3-Ordered gap", "4-Zulu null", "5-Alpha null", "2-Alpha region"],
             normalLabels);
         Assert.Equal(normalLabels, readableLabels);
-        Assert.Equal(["Earlier region", "Later region"], document.QuerySelectorAll("#regions-accordion .accordion-item").Select(element => element.GetAttribute("data-region-name")));
+        Assert.Equal(["Unassigned Places", "Zulu region", "Alpha region"], document.QuerySelectorAll("#regions-accordion .accordion-item").Select(element => element.GetAttribute("data-region-name")));
         Assert.Equal(
-            ["Earlier equal", "Later equal", "Ordered gap", "Earlier null", "Later null"],
+            ["Shadow child", "Zulu equal", "Alpha equal", "Ordered gap", "Zulu null", "Alpha null"],
             document.QuerySelectorAll("#regions-accordion .place-list-item").Select(element => element.GetAttribute("data-place-name")));
         Assert.All(document.QuerySelectorAll("#readable-modal-body .places-list"), list => Assert.Equal("DIV", list.TagName));
     }
@@ -107,15 +107,19 @@ public sealed class TripViewerItineraryRenderingTests
     private static Trip CollisionTrip()
     {
         var trip = new Trip { Id = Guid.NewGuid(), UserId = "owner", Name = "Collision trip", UpdatedAt = DateTime.UtcNow };
-        var laterRegion = Region("00000000-0000-0000-0000-000000000012", "Later region", 7, trip);
-        var earlierRegion = Region("00000000-0000-0000-0000-000000000011", "Earlier region", 7, trip);
-        earlierRegion.Places.Add(Place("00000000-0000-0000-0000-000000000025", "Later null", null, earlierRegion));
-        earlierRegion.Places.Add(Place("00000000-0000-0000-0000-000000000023", "Ordered gap", 20, earlierRegion));
-        earlierRegion.Places.Add(Place("00000000-0000-0000-0000-000000000022", "Later equal", 9, earlierRegion));
-        earlierRegion.Places.Add(Place("00000000-0000-0000-0000-000000000024", "Earlier null", null, earlierRegion));
-        earlierRegion.Places.Add(Place("00000000-0000-0000-0000-000000000021", "Earlier equal", 9, earlierRegion));
-        trip.Regions.Add(laterRegion);
-        trip.Regions.Add(earlierRegion);
+        var shadowRegion = Region("00000000-0000-0000-0000-000000000010", "Unassigned Places", 0, trip);
+        var alphaRegion = Region("00000000-0000-0000-0000-000000000012", "Alpha region", 7, trip);
+        var zuluRegion = Region("00000000-0000-0000-0000-000000000011", "Zulu region", 7, trip);
+        shadowRegion.Places.Add(Place("00000000-0000-0000-0000-000000000030", "Shadow child", 1, shadowRegion));
+        // Names intentionally reverse ID order so alphabetical tie-breakers cannot satisfy the expected labels.
+        zuluRegion.Places.Add(Place("00000000-0000-0000-0000-000000000025", "Alpha null", null, zuluRegion));
+        zuluRegion.Places.Add(Place("00000000-0000-0000-0000-000000000023", "Ordered gap", 20, zuluRegion));
+        zuluRegion.Places.Add(Place("00000000-0000-0000-0000-000000000022", "Alpha equal", 9, zuluRegion));
+        zuluRegion.Places.Add(Place("00000000-0000-0000-0000-000000000024", "Zulu null", null, zuluRegion));
+        zuluRegion.Places.Add(Place("00000000-0000-0000-0000-000000000021", "Zulu equal", 9, zuluRegion));
+        trip.Regions.Add(alphaRegion);
+        trip.Regions.Add(shadowRegion);
+        trip.Regions.Add(zuluRegion);
         return trip;
     }
 

--- a/tests/Wayfarer.Tests/Views/TripViewerItineraryRenderingTests.cs
+++ b/tests/Wayfarer.Tests/Views/TripViewerItineraryRenderingTests.cs
@@ -26,30 +26,42 @@ public sealed class TripViewerItineraryRenderingTests
     [Fact]
     public async Task ViewerRendersEqualAndNullableOrdersIdenticallyAcrossNormalAndReadableMarkup()
     {
-        using var host = BuildRazorHost();
-        using var scope = host.Services.CreateScope();
-        var trip = CollisionTrip();
+        var webRoot = Path.Combine(Path.GetTempPath(), $"wayfarer-itinerary-render-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(webRoot);
+        // Supply the production-only layout dependency without requiring frontend assets to be built by the test job.
+        await File.WriteAllTextAsync(Path.Combine(webRoot, "frontend.manifest.json"), "{}");
+        try
+        {
+            using var host = BuildRazorHost(webRoot);
+            using var scope = host.Services.CreateScope();
+            var trip = CollisionTrip();
 
-        var html = await RenderViewerAsync(scope.ServiceProvider, trip);
-        var document = await new HtmlParser().ParseDocumentAsync(html);
+            var html = await RenderViewerAsync(scope.ServiceProvider, trip);
+            var document = await new HtmlParser().ParseDocumentAsync(html);
 
-        var normalLabels = Labels(document.QuerySelectorAll("#regions-accordion .itinerary-region-label, #regions-accordion .itinerary-place-label"));
-        var readableLabels = Labels(document.QuerySelectorAll("#readable-modal-body .itinerary-region-label, #readable-modal-body .itinerary-place-label"));
-        Assert.Equal(
-            ["0-Unassigned Places", "1-Shadow child", "1-Zulu region", "1-Zulu equal", "2-Alpha equal", "3-Ordered gap", "4-Zulu null", "5-Alpha null", "2-Alpha region"],
-            normalLabels);
-        Assert.Equal(normalLabels, readableLabels);
-        Assert.Equal(["Unassigned Places", "Zulu region", "Alpha region"], document.QuerySelectorAll("#regions-accordion .accordion-item").Select(element => element.GetAttribute("data-region-name")));
-        Assert.Equal(
-            ["Shadow child", "Zulu equal", "Alpha equal", "Ordered gap", "Zulu null", "Alpha null"],
-            document.QuerySelectorAll("#regions-accordion .place-list-item").Select(element => element.GetAttribute("data-place-name")));
-        Assert.All(document.QuerySelectorAll("#readable-modal-body .places-list"), list => Assert.Equal("DIV", list.TagName));
+            var normalLabels = Labels(document.QuerySelectorAll("#regions-accordion .itinerary-region-label, #regions-accordion .itinerary-place-label"));
+            var readableLabels = Labels(document.QuerySelectorAll("#readable-modal-body .itinerary-region-label, #readable-modal-body .itinerary-place-label"));
+            Assert.Equal(
+                ["0-Unassigned Places", "1-Shadow child", "1-Zulu region", "1-Zulu equal", "2-Alpha equal", "3-Ordered gap", "4-Zulu null", "5-Alpha null", "2-Alpha region"],
+                normalLabels);
+            Assert.Equal(normalLabels, readableLabels);
+            Assert.Equal(["Unassigned Places", "Zulu region", "Alpha region"], document.QuerySelectorAll("#regions-accordion .accordion-item").Select(element => element.GetAttribute("data-region-name")));
+            Assert.Equal(
+                ["Shadow child", "Zulu equal", "Alpha equal", "Ordered gap", "Zulu null", "Alpha null"],
+                document.QuerySelectorAll("#regions-accordion .place-list-item").Select(element => element.GetAttribute("data-place-name")));
+            Assert.All(document.QuerySelectorAll("#readable-modal-body .places-list"), list => Assert.Equal("DIV", list.TagName));
+        }
+        finally
+        {
+            Directory.Delete(webRoot, recursive: true);
+        }
     }
 
-    private static IHost BuildRazorHost() =>
+    private static IHost BuildRazorHost(string webRoot) =>
         Host.CreateDefaultBuilder()
             .ConfigureWebHostDefaults(webHost => webHost
                 .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseWebRoot(webRoot)
                 .UseSetting(WebHostDefaults.ApplicationKey, typeof(Trip).Assembly.GetName().Name)
                 .ConfigureServices(services =>
                 {
@@ -70,9 +82,8 @@ public sealed class TripViewerItineraryRenderingTests
         var routeData = new RouteData();
         routeData.Routers.Add(new RouteCollection());
         var actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
-        // Render the target view and its partials without _ViewStart so the test does not depend on built frontend assets.
         var viewResult = services.GetRequiredService<ICompositeViewEngine>()
-            .GetView(null, "/Views/Trip/Viewer.cshtml", isMainPage: false);
+            .GetView(null, "/Views/Trip/Viewer.cshtml", isMainPage: true);
         Assert.True(viewResult.Success, string.Join(Environment.NewLine, viewResult.SearchedLocations ?? []));
         var view = Assert.IsAssignableFrom<IView>(viewResult.View);
         var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())

--- a/tests/e2e/trip-editor/tripEditor.spec.ts
+++ b/tests/e2e/trip-editor/tripEditor.spec.ts
@@ -95,7 +95,7 @@ test.describe.serial('Trip Editor dev verification', () => {
 
     try {
       const editableRegion = page.locator('.trip-editor-region-card--normal').first();
-      const regionHeading = (await editableRegion.getByRole('heading').innerText()).trim();
+      const regionHeading = (await editableRegion.getAttribute('data-region-name'))!;
       await regionEditButton(editableRegion).click();
       await expect(page.getByRole('heading', { name: new RegExp(`Edit Region - ${escapeRegex(regionHeading)}`) })).toBeVisible();
       await page.getByRole('button', { name: 'Expand Editor' }).click();
@@ -125,7 +125,7 @@ test.describe.serial('Trip Editor dev verification', () => {
       await expect(editableRegion).toContainText(placeName);
       await expectReverseGeocodeWarningIfPresent(page);
 
-      await editableRegion.getByText(placeName).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
+      await editableRegion.locator('.trip-editor-place-row').filter({ hasText: placeName }).getByRole('button', { name: 'Edit', exact: true }).click();
       await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(placeName)}`) })).toBeVisible();
       await expectUsableDockedPlaceEditor(page);
       await capture(page, testInfo, 'place-docked-layout');

--- a/tests/e2e/trip-editor/tripEditorErrorStateContracts.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorErrorStateContracts.spec.ts
@@ -22,6 +22,8 @@ test.describe.serial('Trip Editor Batch 3 error state contracts', () => {
     if (!fixture) {
       return;
     }
+    const placeOrdinal = initial.placeOrderByRegionId[fixture.place.regionId].indexOf(fixture.place.id) + 1;
+    const canonicalLabel = `${placeOrdinal}-${fixture.place.name}`;
 
     await editPlace(page, fixture.place.id);
     const form = page.locator('#trip-editor-place-form');
@@ -37,14 +39,15 @@ test.describe.serial('Trip Editor Batch 3 error state contracts', () => {
     await expectFailedStatus(page);
     await expect(form.getByLabel('Name')).toHaveValue(draftName);
     await expect(form.getByLabel('Address')).toHaveValue('PW failed place save address');
-    await expect(placeRow(page, fixture.place.id).locator('.trip-editor-place-row__name')).toHaveText(fixture.place.name);
+    await expect(placeRow(page, fixture.place.id)).toHaveAttribute('data-place-name', fixture.place.name);
+    await expect(placeRow(page, fixture.place.id).locator('.trip-editor-place-row__name')).toHaveText(canonicalLabel);
     await expectPersistedPlace(page, fixture.place.id, fixture.place.name, fixture.place.address);
 
     await staleSave.unroute();
     await activeEditorCancelButton(page).click();
     await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
     await expect(form).toHaveCount(0);
-    await expect(placeRow(page, fixture.place.id).locator('.trip-editor-place-row__name')).toHaveText(fixture.place.name);
+    await expect(placeRow(page, fixture.place.id).locator('.trip-editor-place-row__name')).toHaveText(canonicalLabel);
     await expectPersistedPlace(page, fixture.place.id, fixture.place.name, fixture.place.address);
   });
 

--- a/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMapNavigation.spec.ts
@@ -141,7 +141,7 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
     await focus.click();
     await expect(toolbar.locator('.trip-editor-toolbar__status')).toContainText('Focused region');
 
-    await region.getByText(fixture.placeName).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
+    await region.locator('.trip-editor-place-row').filter({ hasText: fixture.placeName }).getByRole('button', { name: 'Edit', exact: true }).click();
     await expect(focus).toBeDisabled();
 
     await region.getByRole('button', { name: 'Add Place' }).click();
@@ -166,7 +166,7 @@ test.describe.serial('Trip Editor map navigation toolbar', () => {
     const before = await readMapView(page);
 
     const region = regionCard(page, fixture.regionName);
-    await region.getByText(fixture.placeName).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
+    await region.locator('.trip-editor-place-row').filter({ hasText: fixture.placeName }).getByRole('button', { name: 'Edit', exact: true }).click();
     await expect(toolbar.getByRole('button', { name: 'Focus Active Entity' })).toBeEnabled();
     await toolbar.getByRole('button', { name: 'Focus Active Entity' }).click();
 

--- a/tests/e2e/trip-editor/tripEditorRealCrudContracts.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRealCrudContracts.spec.ts
@@ -36,17 +36,32 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
 
       let releaseRegionOrder!: () => void;
       const regionOrderRelease = new Promise<void>(resolve => { releaseRegionOrder = resolve; });
-      await page.route(/\/editor\/regions\/order$/, async route => {
+      const regionOrderRequests: string[][] = [];
+      const regionOrderPath = /\/editor\/regions\/order$/;
+      await page.route(regionOrderPath, async route => {
+        regionOrderRequests.push((await route.request().postDataJSON()).regionIds);
+        if (regionOrderRequests.length > 1) {
+          await route.abort();
+          return;
+        }
         const response = await route.fetch();
         await regionOrderRelease;
         await route.fulfill({ response });
-      }, { times: 1 });
+      });
       await regionCard(page, secondName).getByRole('button', { name: 'Drag to reorder region' }).dragTo(regionCard(page, firstName));
       await expect(regionLabel(page, secondName)).toHaveText(`${firstOrdinal}-${secondName}`);
       await expect(regionLabel(page, firstName)).toHaveText(`${secondOrdinal}-${firstName}`);
       await expect(page.locator('.trip-editor-save-state').filter({ hasText: 'Saving order...' }).first()).toBeVisible();
+      const blockedRegionHandle = regionCard(page, firstName).getByRole('button', { name: 'Drag to reorder region' });
+      await expect(blockedRegionHandle).toBeDisabled();
+      await dragByMouse(page, blockedRegionHandle, regionCard(page, secondName));
+      expect(regionOrderRequests, 'Only the first region order request may be emitted while ordering is pending.').toHaveLength(1);
+      await expect(regionLabel(page, secondName)).toHaveText(`${firstOrdinal}-${secondName}`);
+      await expect(regionLabel(page, firstName)).toHaveText(`${secondOrdinal}-${firstName}`);
       releaseRegionOrder();
       await expectSaved(page);
+      await expect(blockedRegionHandle).toBeEnabled();
+      await page.unroute(regionOrderPath);
       await expectRegionOrder(page, [secondName, firstName]);
       await page.reload();
       await expectMountedWorkspace(page);
@@ -70,12 +85,14 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
       await expect(regionLabel(page, firstName)).toHaveText(`${secondOrdinal}-${firstName}`);
 
       let noOpRequests = 0;
-      page.on('request', request => {
-        if (/\/editor\/regions\/order$/.test(new URL(request.url()).pathname)) noOpRequests += 1;
+      await page.route(regionOrderPath, async route => {
+        noOpRequests += 1;
+        await route.abort();
       });
       await regionCard(page, secondName).getByRole('button', { name: 'Drag to reorder region' }).dragTo(regionCard(page, secondName));
-      await page.waitForTimeout(250);
+      await settleCompletedDrag(page);
       expect(noOpRequests, 'A no-op region drop must not issue an order request.').toBe(0);
+      await page.unroute(regionOrderPath);
 
       await deleteRegion(page, secondName);
       await deleteRegion(page, firstName);
@@ -121,16 +138,34 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
       await expect(placeLabel(page, region.id, firstPlace)).toHaveText(`2-${firstPlace}`);
       let releasePlaceOrder!: () => void;
       const placeOrderRelease = new Promise<void>(resolve => { releasePlaceOrder = resolve; });
-      await page.route(new RegExp(`/editor/regions/${region.id}/places/order$`), async route => {
+      const placeOrderPath = new RegExp(`/editor/regions/${region.id}/places/order$`);
+      const placeOrderRequests: string[][] = [];
+      await page.route(placeOrderPath, async route => {
+        placeOrderRequests.push((await route.request().postDataJSON()).placeIds);
+        if (placeOrderRequests.length > 1) {
+          await route.abort();
+          return;
+        }
         const response = await route.fetch();
         await placeOrderRelease;
         await route.fulfill({ response });
-      }, { times: 1 });
+      });
       await placeRowByName(page, region.id, firstPlace).getByRole('button', { name: 'Drag to reorder place' }).dragTo(placeRowByName(page, region.id, secondPlace));
+      await expect(placeLabel(page, region.id, firstPlace)).toHaveText(`1-${firstPlace}`);
+      await expect(placeLabel(page, region.id, secondPlace)).toHaveText(`2-${secondPlace}`);
+      const blockedPlaceHandle = placeRowByName(page, region.id, secondPlace).getByRole('button', { name: 'Drag to reorder place' });
+      const blockedRegionHandle = regionCard(page, regionName).getByRole('button', { name: 'Drag to reorder region' });
+      await expect(blockedPlaceHandle).toBeDisabled();
+      await expect(blockedRegionHandle).toBeDisabled();
+      await dragByMouse(page, blockedPlaceHandle, placeRowByName(page, region.id, firstPlace));
+      expect(placeOrderRequests, 'Only the first place order request may be emitted while ordering is pending.').toHaveLength(1);
       await expect(placeLabel(page, region.id, firstPlace)).toHaveText(`1-${firstPlace}`);
       await expect(placeLabel(page, region.id, secondPlace)).toHaveText(`2-${secondPlace}`);
       releasePlaceOrder();
       await expectSaved(page);
+      await expect(blockedPlaceHandle).toBeEnabled();
+      await expect(blockedRegionHandle).toBeEnabled();
+      await page.unroute(placeOrderPath);
       await page.reload();
       await expectMountedWorkspace(page);
       const reloadedRegion = await requireRegion(page, regionName);
@@ -154,12 +189,15 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
       await expect(placeLabel(page, reloadedRegion.id, secondPlace)).toHaveText(`2-${secondPlace}`);
 
       let noOpRequests = 0;
-      page.on('request', request => {
-        if (new RegExp(`/editor/regions/${reloadedRegion.id}/places/order$`).test(new URL(request.url()).pathname)) noOpRequests += 1;
+      const noOpPlaceOrderPath = new RegExp(`/editor/regions/${reloadedRegion.id}/places/order$`);
+      await page.route(noOpPlaceOrderPath, async route => {
+        noOpRequests += 1;
+        await route.abort();
       });
       await placeRowByName(page, reloadedRegion.id, firstPlace).getByRole('button', { name: 'Drag to reorder place' }).dragTo(placeRowByName(page, reloadedRegion.id, firstPlace));
-      await page.waitForTimeout(250);
+      await settleCompletedDrag(page);
       expect(noOpRequests, 'A no-op place drop must not issue an order request.').toBe(0);
+      await page.unroute(noOpPlaceOrderPath);
 
       await expectViewerItineraryParity(page, regionName, firstPlace, secondPlace);
 
@@ -578,6 +616,24 @@ function areaByName(state: EditorState, name: string): any | null {
 
 function placeRowByName(page: Page, regionId: string, name: string): Locator {
   return page.locator(`[data-region-id="${regionId}"] [data-place-id]`).filter({ hasText: name });
+}
+
+/** Attempts a pointer drag without Playwright's enabled-control precondition. */
+async function dragByMouse(page: Page, source: Locator, target: Locator): Promise<void> {
+  await source.scrollIntoViewIfNeeded();
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+  expect(sourceBox, 'Drag source must have a rendered box.').not.toBeNull();
+  expect(targetBox, 'Drag target must have a rendered box.').not.toBeNull();
+  await page.mouse.move(sourceBox!.x + sourceBox!.width / 2, sourceBox!.y + sourceBox!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(targetBox!.x + targetBox!.width / 2, targetBox!.y + targetBox!.height / 2, { steps: 8 });
+  await page.mouse.up();
+}
+
+/** Waits for the completed drag event and its queued browser work without a timing window. */
+async function settleCompletedDrag(page: Page): Promise<void> {
+  await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))));
 }
 
 function areaRowByName(page: Page, regionId: string, name: string): Locator {

--- a/tests/e2e/trip-editor/tripEditorRealCrudContracts.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRealCrudContracts.spec.ts
@@ -140,6 +140,27 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
         expect(order.indexOf(placeByName(state, firstPlace).id)).toBeLessThan(order.indexOf(placeByName(state, secondPlace).id));
       });
 
+      let releaseFailedPlaceOrder!: () => void;
+      const failedPlaceOrderRelease = new Promise<void>(resolve => { releaseFailedPlaceOrder = resolve; });
+      await page.route(new RegExp(`/editor/regions/${reloadedRegion.id}/places/order$`), async route => {
+        await failedPlaceOrderRelease;
+        await route.fulfill({ status: 500, body: 'forced place reorder failure' });
+      }, { times: 1 });
+      await placeRowByName(page, reloadedRegion.id, secondPlace).getByRole('button', { name: 'Drag to reorder place' }).dragTo(placeRowByName(page, reloadedRegion.id, firstPlace));
+      await expect(placeLabel(page, reloadedRegion.id, secondPlace)).toHaveText(`1-${secondPlace}`);
+      releaseFailedPlaceOrder();
+      await expect(page.locator('.trip-editor-form-error')).toBeVisible();
+      await expect(placeLabel(page, reloadedRegion.id, firstPlace)).toHaveText(`1-${firstPlace}`);
+      await expect(placeLabel(page, reloadedRegion.id, secondPlace)).toHaveText(`2-${secondPlace}`);
+
+      let noOpRequests = 0;
+      page.on('request', request => {
+        if (new RegExp(`/editor/regions/${reloadedRegion.id}/places/order$`).test(new URL(request.url()).pathname)) noOpRequests += 1;
+      });
+      await placeRowByName(page, reloadedRegion.id, firstPlace).getByRole('button', { name: 'Drag to reorder place' }).dragTo(placeRowByName(page, reloadedRegion.id, firstPlace));
+      await page.waitForTimeout(250);
+      expect(noOpRequests, 'A no-op place drop must not issue an order request.').toBe(0);
+
       await expectViewerItineraryParity(page, regionName, firstPlace, secondPlace);
 
       await deletePlace(page, reloadedRegion.id, secondPlace);

--- a/tests/e2e/trip-editor/tripEditorRealCrudContracts.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRealCrudContracts.spec.ts
@@ -9,6 +9,7 @@ import {
   signIn,
   uniqueName
 } from './tripEditorTestUtils';
+import { expectViewerItineraryParity } from './tripViewerItineraryAssertions';
 
 type EditorState = Record<string, any>;
 
@@ -30,8 +31,22 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
         expect(regionByName(state, firstName)).toBeTruthy();
         expect(regionByName(state, secondName)).toBeTruthy();
       });
+      const firstOrdinal = itineraryOrdinal(await regionLabel(page, firstName).innerText());
+      const secondOrdinal = itineraryOrdinal(await regionLabel(page, secondName).innerText());
 
-      await dragRegion(page, secondName, firstName);
+      let releaseRegionOrder!: () => void;
+      const regionOrderRelease = new Promise<void>(resolve => { releaseRegionOrder = resolve; });
+      await page.route(/\/editor\/regions\/order$/, async route => {
+        const response = await route.fetch();
+        await regionOrderRelease;
+        await route.fulfill({ response });
+      }, { times: 1 });
+      await regionCard(page, secondName).getByRole('button', { name: 'Drag to reorder region' }).dragTo(regionCard(page, firstName));
+      await expect(regionLabel(page, secondName)).toHaveText(`${firstOrdinal}-${secondName}`);
+      await expect(regionLabel(page, firstName)).toHaveText(`${secondOrdinal}-${firstName}`);
+      await expect(page.locator('.trip-editor-save-state').filter({ hasText: 'Saving order...' }).first()).toBeVisible();
+      releaseRegionOrder();
+      await expectSaved(page);
       await expectRegionOrder(page, [secondName, firstName]);
       await page.reload();
       await expectMountedWorkspace(page);
@@ -40,6 +55,27 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
         const ids = state.regionOrder;
         expect(ids.indexOf(regionByName(state, secondName).id)).toBeLessThan(ids.indexOf(regionByName(state, firstName).id));
       });
+
+      let releaseFailedRegionOrder!: () => void;
+      const failedRegionOrderRelease = new Promise<void>(resolve => { releaseFailedRegionOrder = resolve; });
+      await page.route(/\/editor\/regions\/order$/, async route => {
+        await failedRegionOrderRelease;
+        await route.fulfill({ status: 500, body: 'forced reorder failure' });
+      }, { times: 1 });
+      await regionCard(page, firstName).getByRole('button', { name: 'Drag to reorder region' }).dragTo(regionCard(page, secondName));
+      await expect(regionLabel(page, firstName)).toHaveText(`${firstOrdinal}-${firstName}`);
+      releaseFailedRegionOrder();
+      await expect(page.locator('.trip-editor-form-error')).toBeVisible();
+      await expect(regionLabel(page, secondName)).toHaveText(`${firstOrdinal}-${secondName}`);
+      await expect(regionLabel(page, firstName)).toHaveText(`${secondOrdinal}-${firstName}`);
+
+      let noOpRequests = 0;
+      page.on('request', request => {
+        if (/\/editor\/regions\/order$/.test(new URL(request.url()).pathname)) noOpRequests += 1;
+      });
+      await regionCard(page, secondName).getByRole('button', { name: 'Drag to reorder region' }).dragTo(regionCard(page, secondName));
+      await page.waitForTimeout(250);
+      expect(noOpRequests, 'A no-op region drop must not issue an order request.').toBe(0);
 
       await deleteRegion(page, secondName);
       await deleteRegion(page, firstName);
@@ -68,16 +104,33 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
       await createPlace(page, regionName, secondPlace, '37.9841', '23.7280');
       await expect(placeRowByName(page, region.id, firstPlace)).toBeVisible();
       await expect(placeRowByName(page, region.id, secondPlace)).toBeVisible();
+      await expect(placeLabel(page, region.id, firstPlace)).toHaveText(`1-${firstPlace}`);
+      await expect(placeLabel(page, region.id, secondPlace)).toHaveText(`2-${secondPlace}`);
 
       await movePlace(page, region.id, firstPlace, shadow.id);
       await expect(placeRowByName(page, shadow.id, firstPlace)).toBeVisible();
+      await expect(regionLabel(page, shadow.name)).toHaveText('0-Unassigned Places');
       await expect(placeRowByName(page, region.id, firstPlace)).toHaveCount(0);
+      await expect(placeLabel(page, region.id, secondPlace)).toHaveText(`1-${secondPlace}`);
       await expectState(page, state => {
         expect(placeByName(state, firstPlace).regionId).toBe(shadow.id);
       });
 
       await movePlace(page, shadow.id, firstPlace, region.id);
-      await orderPlacesViaEndpoint(page, region.id, [firstPlace, secondPlace]);
+      await expect(placeLabel(page, region.id, secondPlace)).toHaveText(`1-${secondPlace}`);
+      await expect(placeLabel(page, region.id, firstPlace)).toHaveText(`2-${firstPlace}`);
+      let releasePlaceOrder!: () => void;
+      const placeOrderRelease = new Promise<void>(resolve => { releasePlaceOrder = resolve; });
+      await page.route(new RegExp(`/editor/regions/${region.id}/places/order$`), async route => {
+        const response = await route.fetch();
+        await placeOrderRelease;
+        await route.fulfill({ response });
+      }, { times: 1 });
+      await placeRowByName(page, region.id, firstPlace).getByRole('button', { name: 'Drag to reorder place' }).dragTo(placeRowByName(page, region.id, secondPlace));
+      await expect(placeLabel(page, region.id, firstPlace)).toHaveText(`1-${firstPlace}`);
+      await expect(placeLabel(page, region.id, secondPlace)).toHaveText(`2-${secondPlace}`);
+      releasePlaceOrder();
+      await expectSaved(page);
       await page.reload();
       await expectMountedWorkspace(page);
       const reloadedRegion = await requireRegion(page, regionName);
@@ -87,7 +140,10 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
         expect(order.indexOf(placeByName(state, firstPlace).id)).toBeLessThan(order.indexOf(placeByName(state, secondPlace).id));
       });
 
+      await expectViewerItineraryParity(page, regionName, firstPlace, secondPlace);
+
       await deletePlace(page, reloadedRegion.id, secondPlace);
+      await expect(placeLabel(page, reloadedRegion.id, firstPlace)).toHaveText(`1-${firstPlace}`);
       await deletePlace(page, reloadedRegion.id, firstPlace);
       await expectState(page, state => {
         expect(placeByName(state, firstPlace)).toBeNull();
@@ -340,17 +396,32 @@ async function dragRegion(page: Page, fromName: string, toName: string): Promise
   await expectSaved(page);
 }
 
+/** Locates the visible derived region label while retaining raw-name lookup. */
+function regionLabel(page: Page, name: string): Locator {
+  return regionCard(page, name).locator('.itinerary-region-label, h3').first();
+}
+
+/** Locates the visible derived place label under its authoritative parent region. */
+function placeLabel(page: Page, regionId: string, name: string): Locator {
+  return placeRowByName(page, regionId, name).locator('.trip-editor-place-row__name');
+}
+
+/** Reads the numeric prefix from a rendered itinerary label. */
+function itineraryOrdinal(label: string): number {
+  return Number(label.slice(0, label.indexOf('-')));
+}
+
 async function expectRegionOrder(page: Page, adjacentNames: [string, string]): Promise<void> {
   await expect.poll(async () => {
-    const names = await page.locator('.trip-editor-region-card--normal h3').allInnerTexts();
-    return adjacentInOrder(names.map(name => name.trim()), adjacentNames);
+    const names = await page.locator('.trip-editor-region-card--normal').evaluateAll(cards => cards.map(card => (card as HTMLElement).dataset.regionName));
+    return adjacentInOrder(names, adjacentNames);
   }).toBeTruthy();
 }
 
 async function expectPlaceOrder(page: Page, regionId: string, adjacentNames: [string, string]): Promise<void> {
   await expect.poll(async () => {
-    const names = await page.locator(`[data-place-list-region-id="${regionId}"] [data-place-id] .trip-editor-place-row__name`).allInnerTexts();
-    return adjacentInOrder(names.map(name => name.trim()), adjacentNames);
+    const names = await page.locator(`[data-place-list-region-id="${regionId}"] [data-place-id]`).evaluateAll(rows => rows.map(row => (row as HTMLElement).dataset.placeName));
+    return adjacentInOrder(names, adjacentNames);
   }).toBeTruthy();
 }
 
@@ -485,7 +556,7 @@ function areaByName(state: EditorState, name: string): any | null {
 }
 
 function placeRowByName(page: Page, regionId: string, name: string): Locator {
-  return page.locator(`[data-region-id="${regionId}"] [data-place-id]`).filter({ has: page.getByText(name, { exact: true }) });
+  return page.locator(`[data-region-id="${regionId}"] [data-place-id]`).filter({ hasText: name });
 }
 
 function areaRowByName(page: Page, regionId: string, name: string): Locator {

--- a/tests/e2e/trip-editor/tripEditorRealCrudContracts.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRealCrudContracts.spec.ts
@@ -112,17 +112,8 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
     const regionName = uniqueName('PW real place region');
     const firstPlace = `${regionName} A`;
     const secondPlace = `${regionName} B`;
-    const apiTokenName = uniqueName('PW itinerary collision token');
-    let apiToken = '';
-    let apiTokenCreationAttempted = false;
-    let originalApiTokenDeleteLinks: string[] = [];
 
     try {
-      originalApiTokenDeleteLinks = await apiTokenDeleteLinks(page);
-      apiTokenCreationAttempted = true;
-      apiToken = await createDisposableApiToken(page, apiTokenName);
-      await page.goto(absoluteUrl(editorPath));
-      await expectMountedWorkspace(page);
       await createRegion(page, regionName);
       const region = await requireRegion(page, regionName);
       const shadow = await requireUnassignedRegion(page);
@@ -208,15 +199,7 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
       expect(noOpRequests, 'A no-op place drop must not issue an order request.').toBe(0);
       await page.unroute(noOpPlaceOrderPath);
 
-      const collisionState = await loadEditorStateFixture(page);
-      const collisionPlaces = [placeByName(collisionState, firstPlace), placeByName(collisionState, secondPlace)];
-      for (const place of collisionPlaces) {
-        await updateLegacyPlaceOrder(page, apiToken, place.id, 17);
-      }
-      const expectedCollisionPlaces = [...collisionPlaces].sort((left, right) => left.id.localeCompare(right.id));
-      const authoritativeCollisionState = await loadEditorStateFixture(page);
-      expect(authoritativeCollisionState.placeOrderByRegionId[reloadedRegion.id]).toEqual(expectedCollisionPlaces.map(place => place.id));
-      await expectViewerItineraryParity(page, regionName, expectedCollisionPlaces[0].name, expectedCollisionPlaces[1].name);
+      await expectViewerItineraryParity(page, regionName, firstPlace, secondPlace);
 
       await deletePlace(page, reloadedRegion.id, secondPlace);
       await expect(placeLabel(page, reloadedRegion.id, firstPlace)).toHaveText(`1-${firstPlace}`);
@@ -226,14 +209,7 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
         expect(placeByName(state, secondPlace)).toBeNull();
       });
     } finally {
-      try {
-        await cleanupRegions(page, [regionName]);
-      } finally {
-        if (apiTokenCreationAttempted) {
-          await deleteDisposableApiToken(page, apiTokenName);
-          expect(await apiTokenDeleteLinks(page), 'API token state must be restored after the rendered collision fixture.').toEqual(originalApiTokenDeleteLinks);
-        }
-      }
+      await cleanupRegions(page, [regionName]);
     }
   });
 
@@ -614,47 +590,6 @@ async function deleteMutation(page: Page, path: string): Promise<void> {
 
 async function antiforgeryToken(page: Page): Promise<string> {
   return await page.locator('#trip-editor-antiforgery input[name="__RequestVerificationToken"]').inputValue();
-}
-
-/** Creates one disposable bearer token through the existing cookie-authenticated account endpoint. */
-async function createDisposableApiToken(page: Page, name: string): Promise<string> {
-  await page.goto(absoluteUrl('/User/ApiToken'));
-  const requestVerificationToken = await page.locator('input[name="__RequestVerificationToken"]').first().inputValue();
-  const response = await page.request.post(absoluteUrl('/User/ApiToken/Create'), {
-    form: { name, __RequestVerificationToken: requestVerificationToken }
-  });
-  expect(response.ok(), `Creating disposable API token returned ${response.status()}.`).toBeTruthy();
-  const match = (await response.text()).match(/id="new-token-display"[^>]*>([^<]+)</);
-  expect(match, 'The disposable API token must be returned once by the account page.').not.toBeNull();
-  return match![1].trim();
-}
-
-/** Deletes only the uniquely named API token created by this test. */
-async function deleteDisposableApiToken(page: Page, name: string): Promise<void> {
-  await page.goto(absoluteUrl('/User/ApiToken'));
-  const tokenRow = page.locator('.card-body > .d-flex').filter({ hasText: `Service: ${name}` });
-  if ((await tokenRow.count()) === 0) {
-    return;
-  }
-
-  await tokenRow.getByRole('link', { name: 'Delete' }).click();
-  await page.getByRole('button', { name: 'Delete' }).click();
-  await expect(page.getByText(`Service: ${name}`, { exact: false })).toHaveCount(0);
-}
-
-/** Captures all deletable account tokens so cleanup can prove exact restoration. */
-async function apiTokenDeleteLinks(page: Page): Promise<string[]> {
-  await page.goto(absoluteUrl('/User/ApiToken'));
-  return (await page.getByRole('link', { name: 'Delete' }).evaluateAll(links => links.map(link => (link as HTMLAnchorElement).href))).sort();
-}
-
-/** Applies a controlled legacy collision through the existing bearer-token API. */
-async function updateLegacyPlaceOrder(page: Page, apiToken: string, placeId: string, displayOrder: number): Promise<void> {
-  const response = await page.request.put(absoluteUrl(`/api/trips/places/${placeId}`), {
-    data: { displayOrder },
-    headers: { Authorization: `Bearer ${apiToken}` }
-  });
-  expect(response.ok(), `Legacy place update returned ${response.status()}: ${await response.text()}`).toBeTruthy();
 }
 
 function reorderedAdjacent(current: string[], firstId: string, secondId: string): string[] {

--- a/tests/e2e/trip-editor/tripEditorRealCrudContracts.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorRealCrudContracts.spec.ts
@@ -112,8 +112,17 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
     const regionName = uniqueName('PW real place region');
     const firstPlace = `${regionName} A`;
     const secondPlace = `${regionName} B`;
+    const apiTokenName = uniqueName('PW itinerary collision token');
+    let apiToken = '';
+    let apiTokenCreationAttempted = false;
+    let originalApiTokenDeleteLinks: string[] = [];
 
     try {
+      originalApiTokenDeleteLinks = await apiTokenDeleteLinks(page);
+      apiTokenCreationAttempted = true;
+      apiToken = await createDisposableApiToken(page, apiTokenName);
+      await page.goto(absoluteUrl(editorPath));
+      await expectMountedWorkspace(page);
       await createRegion(page, regionName);
       const region = await requireRegion(page, regionName);
       const shadow = await requireUnassignedRegion(page);
@@ -199,7 +208,15 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
       expect(noOpRequests, 'A no-op place drop must not issue an order request.').toBe(0);
       await page.unroute(noOpPlaceOrderPath);
 
-      await expectViewerItineraryParity(page, regionName, firstPlace, secondPlace);
+      const collisionState = await loadEditorStateFixture(page);
+      const collisionPlaces = [placeByName(collisionState, firstPlace), placeByName(collisionState, secondPlace)];
+      for (const place of collisionPlaces) {
+        await updateLegacyPlaceOrder(page, apiToken, place.id, 17);
+      }
+      const expectedCollisionPlaces = [...collisionPlaces].sort((left, right) => left.id.localeCompare(right.id));
+      const authoritativeCollisionState = await loadEditorStateFixture(page);
+      expect(authoritativeCollisionState.placeOrderByRegionId[reloadedRegion.id]).toEqual(expectedCollisionPlaces.map(place => place.id));
+      await expectViewerItineraryParity(page, regionName, expectedCollisionPlaces[0].name, expectedCollisionPlaces[1].name);
 
       await deletePlace(page, reloadedRegion.id, secondPlace);
       await expect(placeLabel(page, reloadedRegion.id, firstPlace)).toHaveText(`1-${firstPlace}`);
@@ -209,7 +226,14 @@ test.describe.serial('Trip Editor real endpoint CRUD persistence contracts', () 
         expect(placeByName(state, secondPlace)).toBeNull();
       });
     } finally {
-      await cleanupRegions(page, [regionName]);
+      try {
+        await cleanupRegions(page, [regionName]);
+      } finally {
+        if (apiTokenCreationAttempted) {
+          await deleteDisposableApiToken(page, apiTokenName);
+          expect(await apiTokenDeleteLinks(page), 'API token state must be restored after the rendered collision fixture.').toEqual(originalApiTokenDeleteLinks);
+        }
+      }
     }
   });
 
@@ -590,6 +614,47 @@ async function deleteMutation(page: Page, path: string): Promise<void> {
 
 async function antiforgeryToken(page: Page): Promise<string> {
   return await page.locator('#trip-editor-antiforgery input[name="__RequestVerificationToken"]').inputValue();
+}
+
+/** Creates one disposable bearer token through the existing cookie-authenticated account endpoint. */
+async function createDisposableApiToken(page: Page, name: string): Promise<string> {
+  await page.goto(absoluteUrl('/User/ApiToken'));
+  const requestVerificationToken = await page.locator('input[name="__RequestVerificationToken"]').first().inputValue();
+  const response = await page.request.post(absoluteUrl('/User/ApiToken/Create'), {
+    form: { name, __RequestVerificationToken: requestVerificationToken }
+  });
+  expect(response.ok(), `Creating disposable API token returned ${response.status()}.`).toBeTruthy();
+  const match = (await response.text()).match(/id="new-token-display"[^>]*>([^<]+)</);
+  expect(match, 'The disposable API token must be returned once by the account page.').not.toBeNull();
+  return match![1].trim();
+}
+
+/** Deletes only the uniquely named API token created by this test. */
+async function deleteDisposableApiToken(page: Page, name: string): Promise<void> {
+  await page.goto(absoluteUrl('/User/ApiToken'));
+  const tokenRow = page.locator('.card-body > .d-flex').filter({ hasText: `Service: ${name}` });
+  if ((await tokenRow.count()) === 0) {
+    return;
+  }
+
+  await tokenRow.getByRole('link', { name: 'Delete' }).click();
+  await page.getByRole('button', { name: 'Delete' }).click();
+  await expect(page.getByText(`Service: ${name}`, { exact: false })).toHaveCount(0);
+}
+
+/** Captures all deletable account tokens so cleanup can prove exact restoration. */
+async function apiTokenDeleteLinks(page: Page): Promise<string[]> {
+  await page.goto(absoluteUrl('/User/ApiToken'));
+  return (await page.getByRole('link', { name: 'Delete' }).evaluateAll(links => links.map(link => (link as HTMLAnchorElement).href))).sort();
+}
+
+/** Applies a controlled legacy collision through the existing bearer-token API. */
+async function updateLegacyPlaceOrder(page: Page, apiToken: string, placeId: string, displayOrder: number): Promise<void> {
+  const response = await page.request.put(absoluteUrl(`/api/trips/places/${placeId}`), {
+    data: { displayOrder },
+    headers: { Authorization: `Bearer ${apiToken}` }
+  });
+  expect(response.ok(), `Legacy place update returned ${response.status()}: ${await response.text()}`).toBeTruthy();
 }
 
 function reorderedAdjacent(current: string[], firstId: string, secondId: string): string[] {

--- a/tests/e2e/trip-editor/tripEditorSearchAddPersistence.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSearchAddPersistence.spec.ts
@@ -259,5 +259,5 @@ function placeByName(state: EditorState, name: string): any | null {
 }
 
 function placeRowByName(page: Page, regionId: string, name: string): Locator {
-  return page.locator(`[data-place-list-region-id="${regionId}"] [data-place-id]`).filter({ has: page.getByText(name, { exact: true }) });
+  return page.locator(`[data-place-list-region-id="${regionId}"] [data-place-id]`).filter({ hasText: name });
 }

--- a/tests/e2e/trip-editor/tripEditorSidebarSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSidebarSearch.spec.ts
@@ -67,7 +67,7 @@ test.describe.serial('Trip Editor sidebar search verification', () => {
     await closeDraftWithDiscard(page);
     await search.fill('');
 
-    await placeRegion.getByText(fixture.place.name).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
+    await placeRegion.locator('.trip-editor-place-row').filter({ hasText: fixture.place.name }).getByRole('button', { name: 'Edit', exact: true }).click();
     await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(fixture.place.name)}`) })).toBeVisible();
     await expect(page.locator('#trip-editor-place-form').getByLabel('Name')).toHaveValue(fixture.place.name);
     await search.fill(uniqueName('no matching place draft query'));

--- a/tests/e2e/trip-editor/tripEditorSidebarSearch.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSidebarSearch.spec.ts
@@ -24,6 +24,14 @@ test.describe.serial('Trip Editor sidebar search verification', () => {
     await page.goto(absoluteUrl(editorPath));
     await expectMountedWorkspace(page);
 
+    const fixtureRegion = Object.values(state.regionsById).find(region => region.name === fixture.region.name)!;
+    const placeRegionEntity = Object.values(state.regionsById).find(region => region.name === fixture.place.regionName)!;
+    const fixturePlace = Object.values(state.placesById).find(place => place.name === fixture.place.name)!;
+    const regionOrdinal = state.regionOrder.filter(id => !state.regionsById[id]?.isShadow).indexOf(fixtureRegion.id) + 1;
+    const placeOrdinal = state.placeOrderByRegionId[placeRegionEntity.id].indexOf(fixturePlace.id) + 1;
+    await expect(regionCard(page, fixture.region.name).getByRole('heading')).toHaveText(`${regionOrdinal}-${fixture.region.name}`);
+    await expect(regionCard(page, fixture.place.regionName).getByText(`${placeOrdinal}-${fixture.place.name}`, { exact: true })).toBeVisible();
+
     const requests = collectForbiddenSidebarSearchRequests(page);
     const search = page.getByLabel('Sidebar search');
     await expect(search).toBeVisible();
@@ -42,6 +50,7 @@ test.describe.serial('Trip Editor sidebar search verification', () => {
     await search.fill(fixture.place.name);
     await expect(placeRegion).toBeVisible();
     await expect(placeRegion).toContainText(fixture.place.name);
+    await expect(placeRegion.getByText(`${placeOrdinal}-${fixture.place.name}`, { exact: true })).toBeVisible();
     await expectNoSearchAddUi(page);
     expect(requests(), 'Sidebar search should not call Nominatim, geosearch, search-add, or search endpoints.').toEqual([]);
 
@@ -60,6 +69,7 @@ test.describe.serial('Trip Editor sidebar search verification', () => {
 
     await placeRegion.getByText(fixture.place.name).locator('xpath=ancestor::li[contains(@class, "trip-editor-place-row")]').getByRole('button', { name: 'Edit', exact: true }).click();
     await expect(page.getByRole('heading', { name: new RegExp(`Edit Place - ${escapeRegex(fixture.place.name)}`) })).toBeVisible();
+    await expect(page.locator('#trip-editor-place-form').getByLabel('Name')).toHaveValue(fixture.place.name);
     await search.fill(uniqueName('no matching place draft query'));
     await expect(placeRegion).toBeVisible();
     await expect(placeRegion).toContainText(fixture.place.name);
@@ -132,7 +142,15 @@ test.describe.serial('Trip Editor sidebar search verification', () => {
     await page.getByLabel('Sidebar search').fill(fixture!.childName);
     const shadowCard = regionCard(page, fixture!.regionName);
     await expect(shadowCard).toBeVisible();
-    await expect(shadowCard.getByText(fixture!.childName, { exact: true })).toBeVisible();
+    await expect(shadowCard.getByRole('heading')).toHaveText('0-Unassigned Places');
+    if (fixture!.childKind === 'place') {
+      const shadow = Object.values(state.regionsById).find(region => region.name === fixture!.regionName)!;
+      const placeId = Object.values(state.placesById).find(place => place.name === fixture!.childName)!.id;
+      const ordinal = state.placeOrderByRegionId[shadow.id].indexOf(placeId) + 1;
+      await expect(shadowCard.getByText(`${ordinal}-${fixture!.childName}`, { exact: true })).toBeVisible();
+    } else {
+      await expect(shadowCard.getByText(fixture!.childName, { exact: true })).toBeVisible();
+    }
     await expect(shadowCard.getByRole('button', { name: 'Add Place' })).toHaveCount(0);
     await expect(shadowCard.getByRole('button', { name: /add area/i })).toHaveCount(0);
     await expect(regionEditButton(shadowCard)).toHaveCount(0);

--- a/tests/e2e/trip-editor/tripViewerItineraryAssertions.ts
+++ b/tests/e2e/trip-editor/tripViewerItineraryAssertions.ts
@@ -1,0 +1,33 @@
+import { expect, type Page } from '@playwright/test';
+import { absoluteUrl, editorPath, expectMountedWorkspace } from './tripEditorTestUtils';
+
+/**
+ * Verifies normal, readable, and browser-print itinerary parity using disposable editor data.
+ */
+export async function expectViewerItineraryParity(page: Page, regionName: string, firstPlace: string, secondPlace: string): Promise<void> {
+  await page.goto(absoluteUrl(editorPath.replace('/Edit/', '/View/')));
+  const normalRegion = page.locator(`[data-region-name="${regionName}"]`);
+  await expect(normalRegion.locator('.itinerary-region-label')).toContainText(regionName);
+  await expect(normalRegion.locator('[data-place-name]').nth(0)).toHaveAttribute('data-place-name', firstPlace);
+  await expect(normalRegion.locator('[data-place-name]').nth(1)).toHaveAttribute('data-place-name', secondPlace);
+  const normalLabels = await page.locator('#regions-accordion .itinerary-region-label, #regions-accordion .itinerary-place-label').allInnerTexts();
+  const readableLabels = await page.locator('#readable-modal-body .itinerary-region-label, #readable-modal-body .itinerary-place-label').allInnerTexts();
+  expect(readableLabels).toEqual(normalLabels);
+
+  await page.locator('#btn-expand-readable').click();
+  await expect(page.locator('#readableViewModal')).toBeVisible();
+  const popupPromise = page.waitForEvent('popup');
+  await page.locator('#btn-print-modal').click();
+  const printPage = await popupPromise;
+  await expect(printPage.locator('.itinerary-region-label')).not.toHaveCount(0);
+  expect(await printPage.locator('.itinerary-region-label, .itinerary-place-label').allInnerTexts()).toEqual(readableLabels);
+  expect(await printPage.locator('.places-list').evaluateAll(lists => lists.every(list => list.tagName !== 'OL' && getComputedStyle(list).display !== 'list-item'))).toBeTruthy();
+  await printPage.close();
+
+  await page.setViewportSize({ width: 375, height: 667 });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(375);
+  await expect(page.locator('.area-list-item .itinerary-place-label, .segment-list-item .itinerary-place-label')).toHaveCount(0);
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto(absoluteUrl(editorPath));
+  await expectMountedWorkspace(page);
+}

--- a/tests/e2e/trip-editor/tripViewerItineraryAssertions.ts
+++ b/tests/e2e/trip-editor/tripViewerItineraryAssertions.ts
@@ -10,9 +10,16 @@ export async function expectViewerItineraryParity(page: Page, regionName: string
   await expect(normalRegion.locator('.itinerary-region-label')).toContainText(regionName);
   await expect(normalRegion.locator('[data-place-name]').nth(0)).toHaveAttribute('data-place-name', firstPlace);
   await expect(normalRegion.locator('[data-place-name]').nth(1)).toHaveAttribute('data-place-name', secondPlace);
+  await expect(normalRegion.locator('.itinerary-place-label').nth(0)).toHaveText(`1-${firstPlace}`);
+  await expect(normalRegion.locator('.itinerary-place-label').nth(1)).toHaveText(`2-${secondPlace}`);
   const normalLabels = await page.locator('#regions-accordion .itinerary-region-label, #regions-accordion .itinerary-place-label').allInnerTexts();
   const readableLabels = await page.locator('#readable-modal-body .itinerary-region-label, #readable-modal-body .itinerary-place-label').allInnerTexts();
   expect(readableLabels).toEqual(normalLabels);
+  const readableRegion = page.locator('#readable-modal-body .region-readable').filter({
+    has: page.locator('.itinerary-region-label').filter({ hasText: regionName })
+  });
+  await expect(readableRegion.locator('.itinerary-place-label').nth(0)).toHaveText(`1-${firstPlace}`);
+  await expect(readableRegion.locator('.itinerary-place-label').nth(1)).toHaveText(`2-${secondPlace}`);
 
   await page.locator('#btn-expand-readable').click();
   await expect(page.locator('#readableViewModal')).toBeVisible();


### PR DESCRIPTION
## Summary

- add derived `n-Name` itinerary labels to the Vue Trip Editor, normal Razor viewer, readable view, and readable browser-print output
- keep raw region/place names, API/DTO shapes, persistence, mobile, KML, map markers, areas, segments, and dedicated PDF export unchanged
- preserve canonical ordinals through filtering and optimistic drag-and-drop, with automatic save, authoritative reconciliation, rollback, and overlapping-reorder protection
- make legacy place ordering deterministic across in-memory and PostgreSQL paths using non-null `DisplayOrder` first, then `DisplayOrder`, then `Id`
- add focused editor, backend, compiled Razor, collision, shadow-region, search, persistence, rollback, no-op, and print-parity coverage

Closes #381.

## User impact

Trip owners can arrange regions and places as before and now see that persisted order as an indicative route. `Unassigned Places` remains fixed as region `0`; its places and every normal region's places restart at `1`. Searching raw names preserves their canonical displayed ordinals.

## Validation

- `npm run build` — passed; existing Vite large-chunk warning remains
- focused reorder, no-op, CRUD, search, viewer/readable, and print-window Playwright coverage — passed
- compiled Razor collision/shadow rendering coverage — passed
- `dotnet test --no-restore` — 1,681 passed, 9 environment-dependent skips, 0 failed
- `dotnet build --no-restore` — passed with 4 existing NuGet advisory warnings
- LOC policy gate — passed with warnings only and no hard failures
- `git diff --check` — passed
- dedicated PostgreSQL nullable-order test is present but skipped because `WAYFARER_TEST_POSTGRES_CONNECTION` was unavailable; offline Npgsql SQL verification confirmed explicit null-last, `DisplayOrder`, then `Id` ordering

## Tracked validation debt

The full Trip Editor suite exposed four responsive-containment failures. Independent like-for-like testing produced identical measurements on this branch and clean `main`, proving they are unrelated to itinerary numbering. All downstream serial tests were run separately, leaving none unexecuted.

Follow-up #382 records the exact failures and requires investigation to determine whether they reflect production layout, Playwright/test setup, environment geometry, or stale pixel assertions. Production currently appears usable, so #382 explicitly requires evidence before changing CSS or weakening tests.

## Scope notes

- No database migration
- No API/DTO shape or mobile changes
- No area/segment or map-marker numbering
- No KML changes
- No dedicated server-generated PDF changes
