### PR TITLE
chore(release): prepare v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [1.6.0] - 2026-07-22
 
-### Changed
-- TODO: Add release notes before publishing.
+### Added
+- Added deterministic route numbering for regions and places in the Trip Editor, normal trip viewer, readable view, and readable browser print output. Reordering updates and saves the numbering automatically, while raw names remain unchanged.
+- The visible Unassigned Places region is fixed at `0`, and place numbering restarts from `1` within every region.
 
 ## [1.5.2] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [1.6.0] - 2026-07-22
+
+### Changed
+- TODO: Add release notes before publishing.
+
 ## [1.5.2] - 2026-07-20
 
 ### Fixed

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <WayfarerVersion>1.5.2</WayfarerVersion>
+    <WayfarerVersion>1.6.0</WayfarerVersion>
     <Version>$(WayfarerVersion)</Version>
     <PackageVersion>$(WayfarerVersion)</PackageVersion>
     <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>

--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -5,7 +5,7 @@ file contains the manually edited `WayfarerVersion` value and maps the standard
 MSBuild metadata directly from it:
 
 ```xml
-<WayfarerVersion>1.5.2</WayfarerVersion>
+<WayfarerVersion>1.6.0</WayfarerVersion>
 <Version>$(WayfarerVersion)</Version>
 <PackageVersion>$(WayfarerVersion)</PackageVersion>
 <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
@@ -19,7 +19,7 @@ assembly through `IAppVersionProvider`. Runtime surfaces such as
 separate constants.
 
 Use `dotnet run --no-launch-profile -- version` when validating exact CLI
-output. The app writes exactly `Wayfarer 1.5.2`; `--no-launch-profile` avoids
+output. The app writes exactly `Wayfarer 1.6.0`; `--no-launch-profile` avoids
 .NET SDK launch-profile messages so validation stays focused on app output.
 
 ## Release helper

--- a/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
@@ -13,7 +13,7 @@ public class AppVersionProviderTests
     {
         var provider = new AppVersionProvider();
 
-        provider.Version.Should().Be("1.5.2");
+        provider.Version.Should().Be("1.6.0");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- prepare Wayfarer v1.6.0 using the repository release tool
- document derived itinerary numbering in the changelog
- align version documentation and compiled-version coverage with v1.6.0

## Validation

- \python tools/release/version.py check\
- \dotnet run --no-launch-profile --no-build -- version\ — \Wayfarer 1.6.0\
- \
pm run build\ — passed with the existing large-chunk warning
- \dotnet build --no-restore\ — passed with 4 existing dependency-advisory warnings
- \dotnet test --no-restore --no-build\ — 1,681 passed, 9 configured PostgreSQL skips, 0 failed
- \dotnet run --project tools/Wayfarer.LocCheck --no-build -- --warn 400 --fail 600\ — passed with branch-wide warnings only
- \git diff --check\

## Release notes

This release adds derived region/place route numbering to the Trip Editor, normal viewer, readable view, and readable browser print output. Raw names remain unchanged. Mobile, KML, areas/segments, map markers, and the dedicated PDF export are unchanged.

## Database migrations

None.

## Screenshots

Not applicable to this release-metadata PR; the user-facing UI was reviewed and merged in #383.