### PR TITLE
Add deterministic tile diagnostics and cold-cache baseline

### DIFF
--- a/Areas/Public/Controllers/TilesController.cs
+++ b/Areas/Public/Controllers/TilesController.cs
@@ -87,7 +87,7 @@ public class TilesController : Controller
         string? refererValue = Request.Headers["Referer"].ToString();
         if (string.IsNullOrEmpty(refererValue) || !IsValidReferer(refererValue))
         {
-            _logger.LogWarning("Unauthorized tile request. Referer: {Referer}", refererValue ?? "null");
+            _logger.LogWarning("Unauthorized tile request rejected by same-origin Referer policy.");
             return Unauthorized("Unauthorized request.");
         }
 
@@ -125,7 +125,8 @@ public class TilesController : Controller
                 // Authenticated user with a valid user ID — rate limit by userId.
                 if (RateLimitHelper.IsRateLimitExceeded(AuthRateLimitCache, userId, settings.TileRateLimitAuthenticatedPerMinute))
                 {
-                    _logger.LogWarning("Tile rate limit exceeded for authenticated user: {UserId}", userId);
+                    TileCacheDiagnostics.ClientBudgetRejected(_logger, "client");
+                    _logger.LogWarning("Tile request rate limit exceeded for an authenticated client.");
                     return StatusCode(429, "Too many requests. Please try again later.");
                 }
             }
@@ -142,7 +143,8 @@ public class TilesController : Controller
                 var clientIp = GetClientIpAddress();
                 if (RateLimitHelper.IsRateLimitExceeded(RateLimitCache, clientIp, settings.TileRateLimitPerMinute))
                 {
-                    _logger.LogWarning("Tile rate limit exceeded for IP: {ClientIp}", clientIp);
+                    TileCacheDiagnostics.ClientBudgetRejected(_logger, "client");
+                    _logger.LogWarning("Tile request rate limit exceeded for an anonymous client.");
                     return StatusCode(429, "Too many requests. Please try again later.");
                 }
             }

--- a/Areas/Public/Controllers/TilesController.cs
+++ b/Areas/Public/Controllers/TilesController.cs
@@ -125,7 +125,7 @@ public class TilesController : Controller
                 // Authenticated user with a valid user ID — rate limit by userId.
                 if (RateLimitHelper.IsRateLimitExceeded(AuthRateLimitCache, userId, settings.TileRateLimitAuthenticatedPerMinute))
                 {
-                    TileCacheDiagnostics.ClientBudgetRejected(_logger, "client");
+                    TileCacheDiagnostics.ClientBudgetRejected(_logger, "request-authenticated");
                     _logger.LogWarning("Tile request rate limit exceeded for an authenticated client.");
                     return StatusCode(429, "Too many requests. Please try again later.");
                 }
@@ -143,7 +143,7 @@ public class TilesController : Controller
                 var clientIp = GetClientIpAddress();
                 if (RateLimitHelper.IsRateLimitExceeded(RateLimitCache, clientIp, settings.TileRateLimitPerMinute))
                 {
-                    TileCacheDiagnostics.ClientBudgetRejected(_logger, "client");
+                    TileCacheDiagnostics.ClientBudgetRejected(_logger, "request-anonymous");
                     _logger.LogWarning("Tile request rate limit exceeded for an anonymous client.");
                     return StatusCode(429, "Too many requests. Please try again later.");
                 }

--- a/Services/TileCacheDiagnostics.cs
+++ b/Services/TileCacheDiagnostics.cs
@@ -1,0 +1,206 @@
+using Microsoft.Extensions.Logging;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Stable identifiers for structured tile-pipeline diagnostics.
+/// </summary>
+internal enum TileCacheDiagnosticEventIds
+{
+    /// <summary>A complete, unexpired tile was served locally.</summary>
+    FreshCacheHit = 38500,
+
+    /// <summary>An expired tile was served locally while refresh proceeded independently.</summary>
+    StaleCacheHit = 38501,
+
+    /// <summary>A new stale refresh series was scheduled.</summary>
+    StaleRefreshScheduled = 38502,
+
+    /// <summary>A stale hit joined an already-active refresh series.</summary>
+    StaleRefreshCoalesced = 38503,
+
+    /// <summary>A stale refresh could not make an upstream request.</summary>
+    StaleRefreshRejected = 38504,
+
+    /// <summary>A requested tile was absent from the local cache.</summary>
+    ColdCacheMiss = 38505,
+
+    /// <summary>The global outbound budget rejected an acquisition.</summary>
+    GlobalBudgetRejected = 38506,
+
+    /// <summary>The client outbound allowance rejected an acquisition.</summary>
+    ClientBudgetRejected = 38507,
+
+    /// <summary>An upstream HTTP request was attempted.</summary>
+    UpstreamAttempt = 38508,
+
+    /// <summary>An upstream HTTP status was received.</summary>
+    UpstreamStatus = 38509,
+
+    /// <summary>The current retry policy selected a delay.</summary>
+    RetryDelaySelected = 38510,
+
+    /// <summary>A global budget wait completed.</summary>
+    BudgetWait = 38511,
+
+    /// <summary>A pipeline operation was cancelled.</summary>
+    Cancellation = 38512,
+
+    /// <summary>A local cache-write operation completed.</summary>
+    CacheWriteOutcome = 38513,
+
+    /// <summary>A conditional upstream response was processed.</summary>
+    ConditionalResponseOutcome = 38514,
+
+    /// <summary>An upstream operation failed without an HTTP response.</summary>
+    UpstreamFailure = 38515
+}
+
+/// <summary>
+/// Result of one global outbound-budget acquisition, including deterministic wait evidence.
+/// </summary>
+/// <param name="Acquired">Whether the request acquired outbound capacity.</param>
+/// <param name="WaitDuration">How long acquisition waited before completing.</param>
+internal readonly record struct OutboundBudgetAcquisition(bool Acquired, TimeSpan WaitDuration);
+
+/// <summary>
+/// Emits privacy-safe structured events without coupling diagnostics to scheduling policy.
+/// </summary>
+internal static partial class TileCacheDiagnostics
+{
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.FreshCacheHit,
+        EventName = nameof(TileCacheDiagnosticEventIds.FreshCacheHit),
+        Level = LogLevel.Debug,
+        Message = "Tile cache lookup completed with {CacheOutcome} outcome at zoom {Zoom}.")]
+    public static partial void FreshCacheHit(ILogger logger, string cacheOutcome, int zoom);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.StaleCacheHit,
+        EventName = nameof(TileCacheDiagnosticEventIds.StaleCacheHit),
+        Level = LogLevel.Debug,
+        Message = "Tile cache lookup completed with {CacheOutcome} outcome at zoom {Zoom}.")]
+    public static partial void StaleCacheHit(ILogger logger, string cacheOutcome, int zoom);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.StaleRefreshScheduled,
+        EventName = nameof(TileCacheDiagnosticEventIds.StaleRefreshScheduled),
+        Level = LogLevel.Debug,
+        Message = "Stale tile refresh was {RefreshOutcome} at zoom {Zoom}.")]
+    public static partial void StaleRefreshScheduled(ILogger logger, string refreshOutcome, int zoom);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.StaleRefreshCoalesced,
+        EventName = nameof(TileCacheDiagnosticEventIds.StaleRefreshCoalesced),
+        Level = LogLevel.Debug,
+        Message = "Stale tile refresh was {RefreshOutcome} at zoom {Zoom}.")]
+    public static partial void StaleRefreshCoalesced(ILogger logger, string refreshOutcome, int zoom);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.StaleRefreshRejected,
+        EventName = nameof(TileCacheDiagnosticEventIds.StaleRefreshRejected),
+        Level = LogLevel.Debug,
+        Message = "Stale tile refresh was {RefreshOutcome} at zoom {Zoom}.")]
+    public static partial void StaleRefreshRejected(ILogger logger, string refreshOutcome, int zoom);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.ColdCacheMiss,
+        EventName = nameof(TileCacheDiagnosticEventIds.ColdCacheMiss),
+        Level = LogLevel.Debug,
+        Message = "Tile cache lookup completed with {CacheOutcome} outcome at zoom {Zoom}.")]
+    public static partial void ColdCacheMiss(ILogger logger, string cacheOutcome, int zoom);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.GlobalBudgetRejected,
+        EventName = nameof(TileCacheDiagnosticEventIds.GlobalBudgetRejected),
+        Level = LogLevel.Warning,
+        Message = "{BudgetScope} outbound budget rejected tile work after {WaitMilliseconds} ms.")]
+    public static partial void GlobalBudgetRejected(
+        ILogger logger,
+        string budgetScope,
+        double waitMilliseconds);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.ClientBudgetRejected,
+        EventName = nameof(TileCacheDiagnosticEventIds.ClientBudgetRejected),
+        Level = LogLevel.Warning,
+        Message = "{BudgetScope} outbound allowance rejected tile work.")]
+    public static partial void ClientBudgetRejected(ILogger logger, string budgetScope);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.UpstreamAttempt,
+        EventName = nameof(TileCacheDiagnosticEventIds.UpstreamAttempt),
+        Level = LogLevel.Debug,
+        Message = "Tile upstream {RequestKind} request attempt {AttemptNumber} started.")]
+    public static partial void UpstreamAttempt(
+        ILogger logger,
+        string requestKind,
+        int attemptNumber);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.UpstreamStatus,
+        EventName = nameof(TileCacheDiagnosticEventIds.UpstreamStatus),
+        Level = LogLevel.Debug,
+        Message = "Tile upstream {RequestKind} request attempt {AttemptNumber} returned status {StatusCode}.")]
+    public static partial void UpstreamStatus(
+        ILogger logger,
+        string requestKind,
+        int attemptNumber,
+        int statusCode);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.RetryDelaySelected,
+        EventName = nameof(TileCacheDiagnosticEventIds.RetryDelaySelected),
+        Level = LogLevel.Debug,
+        Message = "Tile retry delay selected as {RetryDelayMilliseconds} ms for {RetryKind}.")]
+    public static partial void RetryDelaySelected(
+        ILogger logger,
+        double retryDelayMilliseconds,
+        string retryKind);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.BudgetWait,
+        EventName = nameof(TileCacheDiagnosticEventIds.BudgetWait),
+        Level = LogLevel.Debug,
+        Message = "Global outbound budget wait completed with {BudgetOutcome} after {WaitMilliseconds} ms.")]
+    public static partial void BudgetWait(
+        ILogger logger,
+        string budgetOutcome,
+        double waitMilliseconds);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.Cancellation,
+        EventName = nameof(TileCacheDiagnosticEventIds.Cancellation),
+        Level = LogLevel.Debug,
+        Message = "Tile pipeline was cancelled during {CancellationStage}.")]
+    public static partial void Cancellation(ILogger logger, string cancellationStage);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.CacheWriteOutcome,
+        EventName = nameof(TileCacheDiagnosticEventIds.CacheWriteOutcome),
+        Level = LogLevel.Debug,
+        Message = "Tile cache write completed with {CacheWriteOutcome} outcome at zoom {Zoom}.")]
+    public static partial void CacheWriteOutcome(
+        ILogger logger,
+        string cacheWriteOutcome,
+        int zoom);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.ConditionalResponseOutcome,
+        EventName = nameof(TileCacheDiagnosticEventIds.ConditionalResponseOutcome),
+        Level = LogLevel.Debug,
+        Message = "Conditional tile response completed with {ConditionalOutcome} outcome and status {StatusCode}.")]
+    public static partial void ConditionalResponseOutcome(
+        ILogger logger,
+        string conditionalOutcome,
+        int statusCode);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.UpstreamFailure,
+        EventName = nameof(TileCacheDiagnosticEventIds.UpstreamFailure),
+        Level = LogLevel.Warning,
+        Message = "Tile upstream operation failed during {FailureStage}.")]
+    public static partial void UpstreamFailure(
+        ILogger logger,
+        string failureStage);
+}

--- a/Services/TileCacheRefreshCoordinator.cs
+++ b/Services/TileCacheRefreshCoordinator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
+using Wayfarer.Services;
 
 public partial class TileCacheService
 {
@@ -50,10 +51,12 @@ public partial class TileCacheService
         var activeSeries = _refreshSeries.GetOrAdd(tileKey, series);
         if (!ReferenceEquals(activeSeries, series))
         {
+            TileCacheDiagnostics.StaleRefreshCoalesced(_logger, "coalesced", zoom);
             _logger.LogDebug("Refresh already active for stale tile {TileKey}", tileKey);
             return;
         }
 
+        TileCacheDiagnostics.StaleRefreshScheduled(_logger, "scheduled", zoom);
         _ = Task.Run(() => RunBackgroundRefreshSeriesAsync(series), CancellationToken.None);
     }
 
@@ -78,9 +81,9 @@ public partial class TileCacheService
                         return;
                     }
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    _logger.LogWarning(ex, "Background refresh attempt {Attempt} failed for tile {TileKey}",
+                    _logger.LogWarning("Background refresh attempt {Attempt} failed for tile {TileKey}",
                         series.Attempts, series.TileKey);
                 }
 
@@ -96,11 +99,17 @@ public partial class TileCacheService
                 }
 
                 var delay = _refreshRetryDelayProvider(series.Attempts);
-                await Task.Delay(delay > remaining ? remaining : delay, series.CancellationToken).ConfigureAwait(false);
+                var selectedDelay = delay > remaining ? remaining : delay;
+                TileCacheDiagnostics.RetryDelaySelected(
+                    _logger,
+                    selectedDelay.TotalMilliseconds,
+                    "stale-refresh");
+                await Task.Delay(selectedDelay, series.CancellationToken).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)
         {
+            TileCacheDiagnostics.Cancellation(_logger, "stale-refresh");
             _logger.LogDebug("Background refresh cancelled for tile {TileKey}", series.TileKey);
         }
         finally
@@ -131,7 +140,7 @@ public partial class TileCacheService
         var tileCacheService = scope.ServiceProvider.GetRequiredService<TileCacheService>();
         return await tileCacheService.RevalidateTileAsync(series.TileUrl, series.TileFilePath,
             series.TileKey, series.Zoom, series.X, series.Y, series.ETag,
-            series.LastModified, series.ClientIp, series.CancellationToken);
+            series.LastModified, series.ClientIp, series.Attempts, series.CancellationToken);
     }
 
     /// <summary>

--- a/Services/TileCacheRefreshCoordinator.cs
+++ b/Services/TileCacheRefreshCoordinator.cs
@@ -71,6 +71,7 @@ public partial class TileCacheService
                    DateTime.UtcNow - series.StartedAtUtc < RefreshSeriesMaxDuration)
             {
                 series.Attempts++;
+                series.CancellationStage = "stale-refresh-attempt";
 
                 try
                 {
@@ -80,6 +81,11 @@ public partial class TileCacheService
                     {
                         return;
                     }
+                }
+                catch (OperationCanceledException)
+                {
+                    // The outer boundary owns cancellation classification and deterministic state removal.
+                    throw;
                 }
                 catch (Exception)
                 {
@@ -104,13 +110,18 @@ public partial class TileCacheService
                     _logger,
                     selectedDelay.TotalMilliseconds,
                     "stale-refresh");
+                series.CancellationStage = "stale-refresh-delay";
                 await Task.Delay(selectedDelay, series.CancellationToken).ConfigureAwait(false);
             }
         }
+        catch (OperationCanceledException) when (series.CancellationToken.IsCancellationRequested)
+        {
+            TileCacheDiagnostics.Cancellation(_logger, series.CancellationStage);
+            _logger.LogDebug("Background refresh cancelled for tile {TileKey}", series.TileKey);
+        }
         catch (OperationCanceledException)
         {
-            TileCacheDiagnostics.Cancellation(_logger, "stale-refresh");
-            _logger.LogDebug("Background refresh cancelled for tile {TileKey}", series.TileKey);
+            // The transport already emitted a privacy-safe upstream-failure diagnostic.
         }
         finally
         {
@@ -255,6 +266,9 @@ public partial class TileCacheService
         public DateTime StartedAtUtc { get; } = DateTime.UtcNow;
         public CancellationToken CancellationToken => _cancellationTokenSource.Token;
         public int Attempts { get; set; }
+
+        /// <summary>Gets or sets the bounded stage owned by the outer cancellation boundary.</summary>
+        public string CancellationStage { get; set; } = "stale-refresh-attempt";
 
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 

--- a/Services/TileCacheRefreshCoordinator.cs
+++ b/Services/TileCacheRefreshCoordinator.cs
@@ -57,7 +57,9 @@ public partial class TileCacheService
         }
 
         TileCacheDiagnostics.StaleRefreshScheduled(_logger, "scheduled", zoom);
-        _ = Task.Run(() => RunBackgroundRefreshSeriesAsync(series), CancellationToken.None);
+        series.SetCompletion(Task.Run(
+            () => RunBackgroundRefreshSeriesAsync(series),
+            CancellationToken.None));
     }
 
     /// <summary>
@@ -233,6 +235,29 @@ public partial class TileCacheService
         }
     }
 
+    /// <summary>Cancels and boundedly awaits all refresh work tracked by the test process.</summary>
+    internal static async Task<bool> CancelAndWaitForRefreshesForTestingAsync(TimeSpan timeout)
+    {
+        var activeSeries = _refreshSeries.Values.ToArray();
+        foreach (var series in activeSeries)
+        {
+            series.CancelForTesting();
+        }
+
+        try
+        {
+            await Task.WhenAll(activeSeries.Select(series => series.Completion))
+                .WaitAsync(timeout)
+                .ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+
+        return activeSeries.All(series => !_refreshSeries.ContainsKey(series.TileKey));
+    }
+
     /// <summary>
     /// Overrides refresh retry delay calculation for deterministic tests.
     /// </summary>
@@ -272,6 +297,9 @@ public partial class TileCacheService
 
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
+        /// <summary>Gets the scheduled series task so test cleanup can await its completion.</summary>
+        public Task Completion { get; private set; } = Task.CompletedTask;
+
         public TileRefreshSeries(string tileKey, string tileUrl, string tileFilePath,
             int zoom, int x, int y, string? etag, DateTime? lastModified, string? clientIp)
         {
@@ -287,5 +315,8 @@ public partial class TileCacheService
         }
 
         public void CancelForTesting() => _cancellationTokenSource.Cancel();
+
+        /// <summary>Records the single scheduled task for this series.</summary>
+        public void SetCompletion(Task completion) => Completion = completion;
     }
 }

--- a/Services/TileCacheService.cs
+++ b/Services/TileCacheService.cs
@@ -76,6 +76,13 @@ public partial class TileCacheService
     private static long _currentCacheSize = 0;
 
     /// <summary>
+    /// Delay seam for the current fixed cold-miss retry policy.
+    /// Production retains the existing 500 ms delay; tests may complete it without wall-clock waiting.
+    /// </summary>
+    private static Func<TimeSpan, CancellationToken, Task> _coldMissRetryDelay =
+        static (delay, cancellationToken) => Task.Delay(delay, cancellationToken);
+
+    /// <summary>
     /// Guards against concurrent eviction runs. Only one eviction can proceed at a time;
     /// concurrent callers skip eviction (the in-progress run will free enough space).
     /// Uses <see cref="Interlocked.CompareExchange(ref int, int, int)"/> for lock-free coalescing.
@@ -123,194 +130,6 @@ public partial class TileCacheService
     };
 
     /// <summary>
-    /// Token-bucket rate limiter for outbound requests to upstream tile providers (e.g., OSM).
-    /// Prevents cache-miss cascading from overwhelming the upstream server and risking a block
-    /// under OSM's fair use policy. Replenishes at a sustained rate of 2 tokens/sec with a
-    /// burst capacity of 10 queued requests. OSM's "maximum of 2 download threads" connection
-    /// policy is enforced at the transport layer via <c>SocketsHttpHandler.MaxConnectionsPerServer</c>
-    /// in Program.cs, not by this budget. The budget controls throughput (sustained request rate),
-    /// while MaxConnectionsPerServer controls concurrency (simultaneous TCP connections).
-    /// Thread-safe: uses <see cref="SemaphoreSlim"/> for token management and
-    /// <see cref="PeriodicTimer"/> for replenishment.
-    /// </summary>
-    internal static class OutboundBudget
-    {
-        /// <summary>
-        /// Maximum burst capacity — how many outbound requests can proceed without waiting
-        /// for replenishment. Set to 12 to allow initial map loads to proceed quickly on
-        /// a cold cache. OSM's 2-connection limit is enforced at the transport layer via
-        /// <c>SocketsHttpHandler.MaxConnectionsPerServer = 2</c> in Program.cs.
-        /// </summary>
-        internal const int BurstCapacity = 12;
-
-        /// <summary>
-        /// Replenishment interval — one token is released every this many milliseconds.
-        /// 500ms = 2 tokens/sec sustained rate, complying with OSM's fair use policy.
-        /// </summary>
-        internal const int ReplenishIntervalMs = 500;
-
-        /// <summary>
-        /// Maximum time to wait for a token before giving up. Callers that time out
-        /// serve stale cache or return 503 (graceful degradation).
-        /// Reduced from 10s to 3s to prevent thread pool starvation under sustained
-        /// cold-cache load, then raised to 3.5s to allow one extra token per wave
-        /// during cold-cache bootstrap without exceeding thread pool pressure.
-        /// </summary>
-        internal static readonly TimeSpan AcquireTimeout = TimeSpan.FromSeconds(3.5);
-
-        /// <summary>
-        /// Semaphore representing available outbound tokens. Initialized to <see cref="BurstCapacity"/>.
-        /// Each <see cref="AcquireAsync"/> call consumes one token; the replenishment task restores them.
-        /// </summary>
-        private static readonly SemaphoreSlim _tokens = new(BurstCapacity, BurstCapacity);
-
-        /// <summary>
-        /// Cancellation source for stopping the replenishment task during shutdown or testing.
-        /// Not disposed on stop — the replenisher task may still hold a reference to its token.
-        /// Old instances are abandoned for GC to avoid ObjectDisposedException races.
-        /// </summary>
-        private static volatile CancellationTokenSource _replenisherCts = new();
-
-        /// <summary>
-        /// Ensures the replenishment task is started exactly once, even under concurrent access.
-        /// Declared volatile so replacement in <see cref="StopReplenisher"/> is visible across threads.
-        /// </summary>
-        private static volatile Lazy<Task> _replenisher = new(
-            () => StartReplenisher(_replenisherCts.Token),
-            LazyThreadSafetyMode.ExecutionAndPublication);
-
-        /// <summary>
-        /// Attempts to acquire a token for an outbound request. Returns true if a token was
-        /// obtained within the timeout, false if the budget is exhausted.
-        /// Automatically starts the replenishment background task on first call.
-        /// </summary>
-        /// <param name="cancellationToken">Cancellation token for the calling request.</param>
-        /// <returns>True if a token was acquired and the outbound request may proceed.</returns>
-        internal static async Task<bool> AcquireAsync(CancellationToken cancellationToken = default)
-        {
-            // Ensure the replenishment task is running (no-op after first call).
-            _ = _replenisher.Value;
-            return await _tokens.WaitAsync(AcquireTimeout, cancellationToken).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Starts a long-running background task that releases one semaphore token every
-        /// <see cref="ReplenishIntervalMs"/> milliseconds, maintaining the sustained outbound rate.
-        /// Uses <see cref="PeriodicTimer"/> for efficient, non-blocking scheduling.
-        /// Stops cleanly when the <paramref name="ct"/> is cancelled (e.g., during app shutdown).
-        /// </summary>
-        /// <param name="ct">Cancellation token that stops the replenisher loop.</param>
-        private static Task StartReplenisher(CancellationToken ct)
-        {
-            return Task.Run(async () =>
-            {
-                using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(ReplenishIntervalMs));
-                try
-                {
-                    while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
-                    {
-                        // Release a token if below capacity. The catch handles the harmless race
-                        // where CurrentCount changes between the check and the Release.
-                        if (_tokens.CurrentCount < BurstCapacity)
-                        {
-                            try
-                            {
-                                _tokens.Release();
-                            }
-                            catch (SemaphoreFullException)
-                            {
-                                // Harmless race: another thread released between our check and Release().
-                            }
-                        }
-                    }
-                }
-                catch (OperationCanceledException)
-                {
-                    // Expected during shutdown or test reset — exit cleanly.
-                }
-            }, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Cancels the current replenishment task and prepares a fresh Lazy so a new replenisher
-        /// starts on the next <see cref="AcquireAsync"/> call. Cancels the old CTS first to stop
-        /// the running replenisher before creating replacements — this eliminates the brief window
-        /// where two replenishers could overlap and double-release tokens.
-        /// Uses <see cref="_stopLock"/> to prevent concurrent calls from interleaving the
-        /// cancel-then-replace sequence and orphaning a replenisher.
-        /// Does NOT dispose the old CTS — the replenisher task may still reference its token;
-        /// abandoned CTS instances are GC'd.
-        /// </summary>
-        private static readonly object _stopLock = new();
-
-        private static void StopReplenisher()
-        {
-            lock (_stopLock)
-            {
-                var oldCts = _replenisherCts;
-                oldCts.Cancel();
-                var newCts = new CancellationTokenSource();
-                _replenisherCts = newCts;
-                _replenisher = new Lazy<Task>(
-                    () => StartReplenisher(newCts.Token),
-                    LazyThreadSafetyMode.ExecutionAndPublication);
-            }
-        }
-
-        /// <summary>
-        /// Stops the replenishment task for clean application shutdown. Does not drain or refill
-        /// tokens — simply cancels the background task. Called from
-        /// <c>IHostApplicationLifetime.ApplicationStopping</c>.
-        /// </summary>
-        internal static void Stop()
-        {
-            _replenisherCts.Cancel();
-        }
-
-        /// <summary>
-        /// Resets the outbound budget for testing. Stops the replenisher, drains and refills
-        /// the semaphore to burst capacity, then prepares a fresh replenisher for the next acquire.
-        /// Must only be called when no concurrent <see cref="AcquireAsync"/> calls are in flight
-        /// (i.e., between tests in a single-threaded setup phase).
-        /// </summary>
-        internal static void ResetForTesting()
-        {
-            StopReplenisher();
-            // Drain all tokens.
-            while (_tokens.CurrentCount > 0)
-            {
-                _tokens.Wait(0);
-            }
-            // Refill to burst capacity.
-            try
-            {
-                _tokens.Release(BurstCapacity);
-            }
-            catch (SemaphoreFullException)
-            {
-                // Already at capacity after drain — safe to ignore.
-            }
-        }
-
-        /// <summary>
-        /// Drains all outbound budget tokens and stops replenishment for testing.
-        /// After this call, the next <see cref="AcquireAsync"/> will return false (budget exhausted).
-        /// Also pre-cancels the fresh CTS so the replenisher exits immediately when
-        /// <see cref="AcquireAsync"/> lazily starts it — prevents token refill during the test.
-        /// </summary>
-        internal static void DrainForTesting()
-        {
-            StopReplenisher();
-            while (_tokens.CurrentCount > 0)
-            {
-                _tokens.Wait(0);
-            }
-            // Pre-cancel the fresh CTS so the replenisher cannot refill tokens.
-            _replenisherCts.Cancel();
-        }
-    }
-
-    /// <summary>
     /// Stops the outbound budget replenishment task for clean application shutdown.
     /// Call from <c>IHostApplicationLifetime.ApplicationStopping</c> or equivalent.
     /// </summary>
@@ -352,6 +171,7 @@ public partial class TileCacheService
         _refreshSeries.Clear();
         _sidecarCache.Clear();
         SetRefreshRetryDelayForTesting(null);
+        SetColdMissRetryDelayForTesting(null);
         SetTileFileReplacerForTesting(null);
         Interlocked.Exchange(ref _currentCacheSize, 0);
         Interlocked.Exchange(ref _evictionInProgress, 0);
@@ -485,7 +305,8 @@ public partial class TileCacheService
     /// </summary>
     private async Task<HttpResponseMessage?> SendTileRequestCoreAsync(string tileUrl,
         Action<HttpRequestMessage>? configureRequest = null, bool skipBudget = false,
-        string? clientIp = null, bool allowHttpContext = true, CancellationToken cancellationToken = default)
+        string? clientIp = null, bool allowHttpContext = true, int attemptNumber = 1,
+        CancellationToken cancellationToken = default)
     {
         // Two-phase per-IP outbound budget: peek first (fast-fail without incrementing),
         // then record the hit only after the global budget is acquired. This prevents
@@ -515,9 +336,9 @@ public partial class TileCacheService
                 if (resolvedIpForBudget != null && RateLimitHelper.WouldExceedRateLimit(
                         TilesController.OutboundBudgetCache, resolvedIpForBudget, perIpLimit))
                 {
+                    TileCacheDiagnostics.ClientBudgetRejected(_logger, "client");
                     _logger.LogWarning(
-                        "Per-IP outbound budget exceeded for {ClientIp} — throttling upstream request for {TileUrl}",
-                        resolvedIpForBudget, TileProviderCatalog.RedactApiKey(tileUrl));
+                        "Per-client outbound tile allowance exceeded; upstream request rejected.");
                     return null;
                 }
             }
@@ -527,12 +348,22 @@ public partial class TileCacheService
         // so callers can gracefully degrade (serve stale cache or return 503).
         // skipBudget is true on retries — the budget was already acquired on the first attempt,
         // so retries should not consume additional tokens.
-        if (!skipBudget && !await OutboundBudget.AcquireAsync(cancellationToken).ConfigureAwait(false))
+        if (!skipBudget)
         {
-            _logger.LogWarning(
-                "Outbound request budget exhausted — throttling upstream request for {TileUrl}",
-                TileProviderCatalog.RedactApiKey(tileUrl));
-            return null;
+            var acquisition = await OutboundBudget.AcquireDetailedAsync(cancellationToken).ConfigureAwait(false);
+            TileCacheDiagnostics.BudgetWait(
+                _logger,
+                acquisition.Acquired ? "acquired" : "rejected",
+                acquisition.WaitDuration.TotalMilliseconds);
+            if (!acquisition.Acquired)
+            {
+                TileCacheDiagnostics.GlobalBudgetRejected(
+                    _logger,
+                    "global",
+                    acquisition.WaitDuration.TotalMilliseconds);
+                _logger.LogWarning("Global outbound tile budget exhausted; upstream request rejected.");
+                return null;
+            }
         }
 
         // Both budgets passed — record the per-IP hit now that an upstream fetch will proceed.
@@ -545,6 +376,7 @@ public partial class TileCacheService
         const int maxRedirects = 3;
         var initialUri = new Uri(tileUrl);
         var currentUri = initialUri;
+        var requestKind = configureRequest == null ? "unconditional" : "conditional";
 
         for (var redirectCount = 0; redirectCount <= maxRedirects; redirectCount++)
         {
@@ -562,14 +394,35 @@ public partial class TileCacheService
             // Let the caller add conditional headers (If-None-Match, If-Modified-Since, etc.)
             configureRequest?.Invoke(request);
 
-            var response = await _httpClient.SendAsync(request, cancellationToken);
+            TileCacheDiagnostics.UpstreamAttempt(_logger, requestKind, attemptNumber);
+            HttpResponseMessage response;
+            try
+            {
+                response = await _httpClient.SendAsync(request, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                TileCacheDiagnostics.Cancellation(_logger, "upstream");
+                throw;
+            }
+            catch (Exception)
+            {
+                TileCacheDiagnostics.UpstreamFailure(_logger, "transport");
+                throw;
+            }
+
+            TileCacheDiagnostics.UpstreamStatus(
+                _logger,
+                requestKind,
+                attemptNumber,
+                (int)response.StatusCode);
 
             if (IsRedirectStatus(response.StatusCode))
             {
                 var location = response.Headers.Location;
                 if (location == null)
                 {
-                    _logger.LogWarning("Tile response redirected without a Location header: {TileUrl}", TileProviderCatalog.RedactApiKey(tileUrl));
+                    _logger.LogWarning("Tile response redirected without a Location header.");
                     response.Dispose();
                     return null;
                 }
@@ -585,7 +438,7 @@ public partial class TileCacheService
 
                 if (!string.Equals(nextUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
                 {
-                    _logger.LogWarning("Rejected tile redirect to non-HTTPS URL: {RedirectUrl}", TileProviderCatalog.RedactApiKey(nextUri.ToString()));
+                    _logger.LogWarning("Rejected tile redirect to a non-HTTPS URL.");
                     response.Dispose();
                     return null;
                 }
@@ -598,7 +451,7 @@ public partial class TileCacheService
             return response;
         }
 
-        _logger.LogWarning("Rejected tile redirect chain exceeding {MaxRedirects} for {TileUrl}", maxRedirects, TileProviderCatalog.RedactApiKey(tileUrl));
+        _logger.LogWarning("Rejected tile redirect chain exceeding {MaxRedirects}.", maxRedirects);
         return null;
     }
 
@@ -609,9 +462,10 @@ public partial class TileCacheService
     /// <param name="tileUrl">The upstream tile URL.</param>
     /// <param name="skipBudget">If true, skips outbound budget acquisition (used on retries).</param>
     private Task<HttpResponseMessage?> SendTileRequestAsync(string tileUrl, bool skipBudget = false,
-        string? clientIp = null, CancellationToken cancellationToken = default)
+        string? clientIp = null, int attemptNumber = 1, CancellationToken cancellationToken = default)
     {
-        return SendTileRequestCoreAsync(tileUrl, skipBudget: skipBudget, clientIp: clientIp, cancellationToken: cancellationToken);
+        return SendTileRequestCoreAsync(tileUrl, skipBudget: skipBudget, clientIp: clientIp,
+            attemptNumber: attemptNumber, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -620,7 +474,7 @@ public partial class TileCacheService
     /// </summary>
     private Task<HttpResponseMessage?> SendConditionalTileRequestAsync(string tileUrl, string? etag,
         DateTime? lastModified, string? clientIp = null, bool allowHttpContext = true,
-        CancellationToken cancellationToken = default)
+        int attemptNumber = 1, CancellationToken cancellationToken = default)
     {
         return SendTileRequestCoreAsync(tileUrl, request =>
         {
@@ -637,7 +491,8 @@ public partial class TileCacheService
             {
                 request.Headers.IfModifiedSince = new DateTimeOffset(lastModified.Value, TimeSpan.Zero);
             }
-        }, clientIp: clientIp, allowHttpContext: allowHttpContext, cancellationToken: cancellationToken);
+        }, clientIp: clientIp, allowHttpContext: allowHttpContext, attemptNumber: attemptNumber,
+            cancellationToken: cancellationToken);
     }
 
     private static bool IsRedirectStatus(HttpStatusCode statusCode)
@@ -797,16 +652,20 @@ public partial class TileCacheService
 
             while (retryCount > 0)
             {
+                var attemptNumber = 4 - retryCount;
                 // On retries, skip budget acquisition — the token was already consumed
                 // on the first attempt. This prevents HTTP 5xx retries from exhausting
                 // the entire burst budget under upstream failures.
-                using var response = await SendTileRequestAsync(tileUrl, skipBudget: budgetAcquired, cancellationToken: cancellationToken);
+                using var response = await SendTileRequestAsync(
+                    tileUrl,
+                    skipBudget: budgetAcquired,
+                    attemptNumber: attemptNumber,
+                    cancellationToken: cancellationToken);
                 if (response == null)
                 {
                     // Budget exhaustion means the system is at capacity — retrying is futile
                     // and would only add latency (up to AcquireTimeout per attempt).
-                    _logger.LogWarning("Outbound budget exhausted, aborting fetch for: {TileUrl}",
-                        TileProviderCatalog.RedactApiKey(tileUrl));
+                    _logger.LogWarning("Outbound tile budget rejected cache fill.");
                     break;
                 }
                 budgetAcquired = true;
@@ -820,12 +679,14 @@ public partial class TileCacheService
                     lastModifiedUpstream = response.Content.Headers.LastModified?.UtcDateTime;
                     expiresAtUtc = ParseCacheExpiry(response);
 
+                    var cacheWriteOutcome = "preserved-existing";
                     await _cacheLock.WaitAsync();
                     try
                     {
                         if (!File.Exists(tileFilePath)) // Prevent overwriting existing files
                         {
                             await File.WriteAllBytesAsync(tileFilePath, tileData);
+                            cacheWriteOutcome = "stored";
                         }
 
                         // For zoom < DbMetadataZoomThreshold, write sidecar in the same lock acquisition as the tile file.
@@ -842,6 +703,7 @@ public partial class TileCacheService
                     }
                     catch (IOException ioEx)
                     {
+                        TileCacheDiagnostics.CacheWriteOutcome(_logger, "failed", zoom);
                         _logger.LogError(ioEx, "Failed to write tile data to file: {TileFilePath}", tileFilePath);
                         return true;
                     }
@@ -850,24 +712,27 @@ public partial class TileCacheService
                         _cacheLock.Release();
                     }
 
+                    TileCacheDiagnostics.CacheWriteOutcome(_logger, cacheWriteOutcome, zoom);
                     _logger.LogInformation("Tile cached at: {TileFilePath}", tileFilePath);
                     break;
                 }
 
-                _logger.LogWarning("Attempt failed with status code {StatusCode} for URL: {TileUrl}",
-                    response.StatusCode, TileProviderCatalog.RedactApiKey(tileUrl));
+                _logger.LogWarning("Tile upstream attempt failed with status code {StatusCode}.",
+                    response.StatusCode);
                 retryCount--;
                 if (retryCount == 0)
                 {
                     // Returns true (not budget-exhausted) so the controller sends 404 rather than 503.
                     // Upstream HTTP failures (500/502/504) are non-retryable at the client level —
                     // retrying would not help if OSM is down and would only pile up stale requests.
-                    _logger.LogError("Failed to download tile after multiple attempts: {TileUrl}", TileProviderCatalog.RedactApiKey(tileUrl));
+                    _logger.LogError("Failed to download tile after multiple attempts.");
                     return true;
                 }
 
                 // Optional: Delay between retries to avoid rate limiting
-                await Task.Delay(500, cancellationToken); // 500ms delay between retries
+                var retryDelay = TimeSpan.FromMilliseconds(500);
+                TileCacheDiagnostics.RetryDelaySelected(_logger, retryDelay.TotalMilliseconds, "cold-miss");
+                await _coldMissRetryDelay(retryDelay, cancellationToken);
             }
 
             // Budget was never acquired — signal throttling to caller.
@@ -1011,12 +876,25 @@ public partial class TileCacheService
 
             return true;
         }
-        catch (Exception ex)
+        catch (OperationCanceledException)
         {
-            _logger.LogError(ex, "Error caching tile from {TileUrl}.", TileProviderCatalog.RedactApiKey(tileUrl));
+            // The transport emits the stable cancellation event; preserve the existing local outcome in Phase 1.
+            return true;
+        }
+        catch (Exception)
+        {
+            _logger.LogError("Error caching tile without recording provider exception details.");
             return true;
         }
     }
+
+    /// <summary>
+    /// Overrides only the wait mechanism for the existing fixed cold-miss retry delay in tests.
+    /// </summary>
+    internal static void SetColdMissRetryDelayForTesting(
+        Func<TimeSpan, CancellationToken, Task>? delayProvider) =>
+        _coldMissRetryDelay = delayProvider ??
+            ((delay, cancellationToken) => Task.Delay(delay, cancellationToken));
 
     /// <summary>
     /// Retrieves a tile from the cache. If the tile exists on disk, checks whether it is
@@ -1186,6 +1064,7 @@ public partial class TileCacheService
                             await TouchLastAccessedFromHotHitAsync(zoomLvl, xVal, yVal);
                         }
 
+                        TileCacheDiagnostics.FreshCacheHit(_logger, "fresh", zoomLvl);
                         return TileRetrievalResult.Success(cachedTileData);
                     }
 
@@ -1228,6 +1107,7 @@ public partial class TileCacheService
                         await TouchLastAccessedFromHotHitAsync(zoomLvl, xVal, yVal);
                     }
 
+                    TileCacheDiagnostics.StaleCacheHit(_logger, "stale", zoomLvl);
                     return TileRetrievalResult.Success(staleTileData);
                 }
             }
@@ -1239,7 +1119,8 @@ public partial class TileCacheService
                 return TileRetrievalResult.NotFound();
             }
 
-            _logger.LogDebug("Tile not in cache. Fetching from: {TileUrl}", TileProviderCatalog.RedactApiKey(tileUrl));
+            TileCacheDiagnostics.ColdCacheMiss(_logger, "miss", zoomLvl);
+            _logger.LogDebug("Tile not in cache; starting controlled upstream fetch.");
             var cached = await CacheTileAsync(tileUrl, zoomLevel, xCoordinate, yCoordinate, cancellationToken);
 
             // After fetching, read the file. No lock needed for reads (see fast-path comment above).
@@ -1262,9 +1143,14 @@ public partial class TileCacheService
             // File doesn't exist after CacheTileAsync — distinguish budget exhaustion from other failures.
             return cached ? TileRetrievalResult.NotFound() : TileRetrievalResult.Throttled();
         }
-        catch (Exception ex)
+        catch (OperationCanceledException)
         {
-            _logger.LogError(ex, "Error retrieving tile from cache.");
+            TileCacheDiagnostics.Cancellation(_logger, "retrieval");
+            return TileRetrievalResult.NotFound();
+        }
+        catch (Exception)
+        {
+            _logger.LogError("Error retrieving tile from cache.");
             return TileRetrievalResult.NotFound();
         }
     }
@@ -1281,14 +1167,14 @@ public partial class TileCacheService
     /// </summary>
     private async Task<byte[]?> RevalidateTileAsync(string tileUrl, string tileFilePath, string tileKey,
         int zoom, int x, int y, string? etag, DateTime? lastModified,
-        string? clientIp = null, CancellationToken cancellationToken = default)
+        string? clientIp = null, int attemptNumber = 1, CancellationToken cancellationToken = default)
     {
         using var response = await SendConditionalTileRequestAsync(tileUrl, etag, lastModified, clientIp,
-            allowHttpContext: false, cancellationToken: cancellationToken);
+            allowHttpContext: false, attemptNumber: attemptNumber, cancellationToken: cancellationToken);
         if (response == null)
         {
-            _logger.LogWarning("Conditional tile request rejected for {TileUrl}",
-                TileProviderCatalog.RedactApiKey(tileUrl));
+            TileCacheDiagnostics.StaleRefreshRejected(_logger, "rejected", zoom);
+            _logger.LogWarning("Conditional tile request rejected before upstream transport.");
             return null;
         }
 
@@ -1305,8 +1191,6 @@ public partial class TileCacheService
                 var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
                 await UpdateTileExpiryScopedAsync(dbContext, zoom, x, y, newEtag, lastModified, newExpiry);
             }
-
-            _logger.LogDebug("Tile {TileKey} re-validated (304 Not Modified)", tileKey);
 
             byte[]? data = null;
             if (zoom < DbMetadataZoomThreshold)
@@ -1350,6 +1234,12 @@ public partial class TileCacheService
                 }
             }
 
+            TileCacheDiagnostics.ConditionalResponseOutcome(
+                _logger,
+                "not-modified",
+                (int)response.StatusCode);
+            TileCacheDiagnostics.CacheWriteOutcome(_logger, "revalidated", zoom);
+            _logger.LogDebug("Tile {TileKey} re-validated (304 Not Modified)", tileKey);
             return data;
         }
 
@@ -1397,12 +1287,20 @@ public partial class TileCacheService
                     newLastModified, newExpiry);
             }
 
+            TileCacheDiagnostics.ConditionalResponseOutcome(
+                _logger,
+                "replaced",
+                (int)response.StatusCode);
+            TileCacheDiagnostics.CacheWriteOutcome(_logger, "replaced", zoom);
             _logger.LogDebug("Tile {TileKey} re-validated (200 OK, replaced)", tileKey);
             return tileData;
         }
 
-        _logger.LogWarning("Conditional request returned {StatusCode} for {TileUrl}",
-            response.StatusCode, TileProviderCatalog.RedactApiKey(tileUrl));
+        TileCacheDiagnostics.ConditionalResponseOutcome(
+            _logger,
+            "rejected-status",
+            (int)response.StatusCode);
+        _logger.LogWarning("Conditional request returned {StatusCode}.", response.StatusCode);
         return null;
     }
 

--- a/Services/TileCacheService.cs
+++ b/Services/TileCacheService.cs
@@ -306,7 +306,7 @@ public partial class TileCacheService
     private async Task<HttpResponseMessage?> SendTileRequestCoreAsync(string tileUrl,
         Action<HttpRequestMessage>? configureRequest = null, bool skipBudget = false,
         string? clientIp = null, bool allowHttpContext = true, int attemptNumber = 1,
-        CancellationToken cancellationToken = default)
+        bool deferCancellationDiagnostic = false, CancellationToken cancellationToken = default)
     {
         // Two-phase per-IP outbound budget: peek first (fast-fail without incrementing),
         // then record the hit only after the global budget is acquired. This prevents
@@ -336,7 +336,7 @@ public partial class TileCacheService
                 if (resolvedIpForBudget != null && RateLimitHelper.WouldExceedRateLimit(
                         TilesController.OutboundBudgetCache, resolvedIpForBudget, perIpLimit))
                 {
-                    TileCacheDiagnostics.ClientBudgetRejected(_logger, "client");
+                    TileCacheDiagnostics.ClientBudgetRejected(_logger, "outbound-client");
                     _logger.LogWarning(
                         "Per-client outbound tile allowance exceeded; upstream request rejected.");
                     return null;
@@ -350,7 +350,21 @@ public partial class TileCacheService
         // so retries should not consume additional tokens.
         if (!skipBudget)
         {
-            var acquisition = await OutboundBudget.AcquireDetailedAsync(cancellationToken).ConfigureAwait(false);
+            OutboundBudgetAcquisition acquisition;
+            try
+            {
+                acquisition = await OutboundBudget.AcquireDetailedAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                if (!deferCancellationDiagnostic)
+                {
+                    TileCacheDiagnostics.Cancellation(_logger, "global-budget-wait");
+                }
+
+                throw;
+            }
+
             TileCacheDiagnostics.BudgetWait(
                 _logger,
                 acquisition.Acquired ? "acquired" : "rejected",
@@ -400,9 +414,18 @@ public partial class TileCacheService
             {
                 response = await _httpClient.SendAsync(request, cancellationToken);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                if (!deferCancellationDiagnostic)
+                {
+                    TileCacheDiagnostics.Cancellation(_logger, "upstream-transport");
+                }
+
+                throw;
+            }
             catch (OperationCanceledException)
             {
-                TileCacheDiagnostics.Cancellation(_logger, "upstream");
+                TileCacheDiagnostics.UpstreamFailure(_logger, "transport");
                 throw;
             }
             catch (Exception)
@@ -431,7 +454,7 @@ public partial class TileCacheService
 
                 if (!string.Equals(nextUri.Host, initialUri.Host, StringComparison.OrdinalIgnoreCase))
                 {
-                    _logger.LogWarning("Rejected tile redirect to a different host: {RedirectHost}", nextUri.Host);
+                    _logger.LogWarning("Rejected tile redirect to a different host.");
                     response.Dispose();
                     return null;
                 }
@@ -492,7 +515,7 @@ public partial class TileCacheService
                 request.Headers.IfModifiedSince = new DateTimeOffset(lastModified.Value, TimeSpan.Zero);
             }
         }, clientIp: clientIp, allowHttpContext: allowHttpContext, attemptNumber: attemptNumber,
-            cancellationToken: cancellationToken);
+            deferCancellationDiagnostic: true, cancellationToken: cancellationToken);
     }
 
     private static bool IsRedirectStatus(HttpStatusCode statusCode)
@@ -732,7 +755,15 @@ public partial class TileCacheService
                 // Optional: Delay between retries to avoid rate limiting
                 var retryDelay = TimeSpan.FromMilliseconds(500);
                 TileCacheDiagnostics.RetryDelaySelected(_logger, retryDelay.TotalMilliseconds, "cold-miss");
-                await _coldMissRetryDelay(retryDelay, cancellationToken);
+                try
+                {
+                    await _coldMissRetryDelay(retryDelay, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    TileCacheDiagnostics.Cancellation(_logger, "cold-miss-retry-delay");
+                    throw;
+                }
             }
 
             // Budget was never acquired — signal throttling to caller.

--- a/Services/TileOutboundBudget.cs
+++ b/Services/TileOutboundBudget.cs
@@ -1,0 +1,147 @@
+using System.Diagnostics;
+using Wayfarer.Services;
+
+public partial class TileCacheService
+{
+    /// <summary>
+    /// Enforces Wayfarer's current conservative global outbound tile-safety budget.
+    /// These constants characterize existing behavior and are not claims about provider policy.
+    /// </summary>
+    internal static class OutboundBudget
+    {
+        /// <summary>Maximum number of immediate outbound acquisitions.</summary>
+        internal const int BurstCapacity = 12;
+
+        /// <summary>Current interval between sustained outbound token replenishments.</summary>
+        internal const int ReplenishIntervalMs = 500;
+
+        /// <summary>Current maximum wait before a local scheduler-capacity rejection.</summary>
+        internal static readonly TimeSpan AcquireTimeout = TimeSpan.FromSeconds(3.5);
+
+        /// <summary>Available outbound tokens shared by all scoped tile services.</summary>
+        private static readonly SemaphoreSlim _tokens = new(BurstCapacity, BurstCapacity);
+
+        /// <summary>Optional deterministic acquisition implementation used only by controlled tests.</summary>
+        private static Func<CancellationToken, Task<OutboundBudgetAcquisition>>? _acquireOverride;
+
+        /// <summary>Stops the current replenisher without disposing state it may still reference.</summary>
+        private static volatile CancellationTokenSource _replenisherCts = new();
+
+        /// <summary>Starts exactly one replenisher for the current cancellation source.</summary>
+        private static volatile Lazy<Task> _replenisher = new(
+            () => StartReplenisher(_replenisherCts.Token),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        /// <summary>Serializes replenisher replacement so two loops cannot overlap.</summary>
+        private static readonly object _stopLock = new();
+
+        /// <summary>Attempts to acquire capacity under the current production budget.</summary>
+        internal static async Task<bool> AcquireAsync(CancellationToken cancellationToken = default)
+        {
+            var acquisition = await AcquireDetailedAsync(cancellationToken).ConfigureAwait(false);
+            return acquisition.Acquired;
+        }
+
+        /// <summary>Acquires capacity and returns test-observable wait evidence.</summary>
+        internal static async Task<OutboundBudgetAcquisition> AcquireDetailedAsync(
+            CancellationToken cancellationToken = default)
+        {
+            var acquireOverride = _acquireOverride;
+            if (acquireOverride != null)
+            {
+                return await acquireOverride(cancellationToken).ConfigureAwait(false);
+            }
+
+            _ = _replenisher.Value;
+            var stopwatch = Stopwatch.StartNew();
+            var acquired = await _tokens.WaitAsync(AcquireTimeout, cancellationToken).ConfigureAwait(false);
+            stopwatch.Stop();
+            return new OutboundBudgetAcquisition(acquired, stopwatch.Elapsed);
+        }
+
+        /// <summary>Releases one token per current replenishment interval up to burst capacity.</summary>
+        private static Task StartReplenisher(CancellationToken cancellationToken) =>
+            Task.Run(async () =>
+            {
+                using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(ReplenishIntervalMs));
+                try
+                {
+                    while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        if (_tokens.CurrentCount >= BurstCapacity)
+                        {
+                            continue;
+                        }
+
+                        try
+                        {
+                            _tokens.Release();
+                        }
+                        catch (SemaphoreFullException)
+                        {
+                            // Another thread won the harmless release race.
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected during shutdown and isolated test reset.
+                }
+            }, CancellationToken.None);
+
+        /// <summary>Cancels and replaces the replenisher state without overlapping loops.</summary>
+        private static void StopReplenisher()
+        {
+            lock (_stopLock)
+            {
+                var oldCts = _replenisherCts;
+                oldCts.Cancel();
+                var newCts = new CancellationTokenSource();
+                _replenisherCts = newCts;
+                _replenisher = new Lazy<Task>(
+                    () => StartReplenisher(newCts.Token),
+                    LazyThreadSafetyMode.ExecutionAndPublication);
+            }
+        }
+
+        /// <summary>Stops replenishment during application shutdown.</summary>
+        internal static void Stop() => _replenisherCts.Cancel();
+
+        /// <summary>Restores burst capacity and production acquisition for an isolated test.</summary>
+        internal static void ResetForTesting()
+        {
+            _acquireOverride = null;
+            StopReplenisher();
+            while (_tokens.CurrentCount > 0)
+            {
+                _tokens.Wait(0);
+            }
+
+            try
+            {
+                _tokens.Release(BurstCapacity);
+            }
+            catch (SemaphoreFullException)
+            {
+                // Capacity was already restored by a harmless concurrent release.
+            }
+        }
+
+        /// <summary>Drains capacity and prevents replenishment for an isolated rejection test.</summary>
+        internal static void DrainForTesting()
+        {
+            StopReplenisher();
+            while (_tokens.CurrentCount > 0)
+            {
+                _tokens.Wait(0);
+            }
+
+            _replenisherCts.Cancel();
+        }
+
+        /// <summary>Overrides acquisition without changing any production budget constant.</summary>
+        internal static void SetAcquireOverrideForTesting(
+            Func<CancellationToken, Task<OutboundBudgetAcquisition>>? acquireOverride) =>
+            _acquireOverride = acquireOverride;
+    }
+}

--- a/tests/Wayfarer.Tests/Infrastructure/TestLogProvider.cs
+++ b/tests/Wayfarer.Tests/Infrastructure/TestLogProvider.cs
@@ -17,8 +17,14 @@ public sealed class TestLogProvider : ILoggerProvider
     /// <inheritdoc />
     public void Dispose() { }
 
-    /// <summary>Represents one captured server log entry.</summary>
-    public sealed record TestLogEntry(LogLevel Level, string Category, string Message, Exception? Exception);
+    /// <summary>Represents one captured server log entry, including its stable identifier and structured fields.</summary>
+    public sealed record TestLogEntry(
+        LogLevel Level,
+        string Category,
+        EventId EventId,
+        IReadOnlyDictionary<string, object?> Fields,
+        string Message,
+        Exception? Exception);
 
     /// <summary>Writes entries to the owning provider without filtering them out.</summary>
     private sealed class TestLogger(string categoryName, ConcurrentQueue<TestLogEntry> entries) : ILogger
@@ -31,7 +37,21 @@ public sealed class TestLogProvider : ILoggerProvider
 
         /// <inheritdoc />
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-            Func<TState, Exception?, string> formatter) =>
-            entries.Enqueue(new TestLogEntry(logLevel, categoryName, formatter(state, exception), exception));
+            Func<TState, Exception?, string> formatter)
+        {
+            var fields = state is IEnumerable<KeyValuePair<string, object?>> structuredState
+                ? structuredState
+                    .Where(field => field.Key != "{OriginalFormat}")
+                    .ToDictionary(field => field.Key, field => field.Value)
+                : new Dictionary<string, object?>();
+
+            entries.Enqueue(new TestLogEntry(
+                logLevel,
+                categoryName,
+                eventId,
+                fields,
+                formatter(state, exception),
+                exception));
+        }
     }
 }

--- a/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
@@ -221,6 +221,27 @@ public sealed class TileCacheCancellationAndPrivacyTests
         Assert.Equal(expectedScope, diagnostic.Fields["BudgetScope"]);
     }
 
+    /// <summary>Proves the outbound-client gate retains the controller's 503 response and retry header.</summary>
+    [Fact]
+    public async Task OutboundClientThrottle_Retains503AndReportsBoundedScope()
+    {
+        using var harness = new TileCacheTestHarness();
+        harness.Settings.TileOutboundBudgetPerIpPerMinute = 1;
+        using var scope = harness.CreateScope();
+        var context = TileCacheTestHarness.CreateHttpContext();
+        var controller = CreateController(scope, context);
+
+        Assert.IsType<FileContentResult>(await controller.GetTile(5, 27, 1));
+        var rejected = Assert.IsType<ObjectResult>(await controller.GetTile(5, 28, 1));
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, rejected.StatusCode);
+        Assert.Equal(
+            TilesController.BudgetRetryAfterSeconds.ToString(),
+            context.Response.Headers.RetryAfter);
+        var diagnostic = AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.ClientBudgetRejected);
+        Assert.Equal("outbound-client", diagnostic.Fields["BudgetScope"]);
+    }
+
     /// <summary>Proves a literal-IP cross-host redirect is rejected without recording supplied data.</summary>
     [Fact]
     public async Task CrossHostRedirect_DoesNotRecordLiteralIpOrSecretUri()

--- a/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
@@ -1,0 +1,333 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Wayfarer.Areas.Public.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>
+/// Verifies cancellation classification, throttle scope, and redirect privacy for Phase 1 diagnostics.
+/// </summary>
+[Collection("OutboundBudget")]
+public sealed class TileCacheCancellationAndPrivacyTests
+{
+    /// <summary>Proves caller cancellation is the only transport path classified as cancellation.</summary>
+    [Fact]
+    public async Task CallerCancelledTransport_EmitsCancellationOnly()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var upstream = new RecordingTileHandler((_, token) =>
+        {
+            cancellation.Cancel();
+            throw new OperationCanceledException(token);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext(cancellation.Token));
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        var result = await service.RetrieveTileAsync(
+            "5", "18", "19", CanonicalTileUrl(5, 18, 19), cancellation.Token);
+
+        Assert.Null(result.TileData);
+        AssertCancellation(harness.Logs, "upstream-transport");
+        AssertNoUpstreamFailure(harness.Logs);
+        Assert.Single(harness.Upstream.Requests);
+    }
+
+    /// <summary>Proves an uncancelled transport timeout is classified as upstream failure.</summary>
+    [Fact]
+    public async Task UncancelledTransportTimeout_EmitsUpstreamFailureOnly()
+    {
+        var upstream = new RecordingTileHandler((_, token) =>
+            throw new OperationCanceledException(token));
+        using var harness = new TileCacheTestHarness(upstream);
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext());
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        var result = await service.RetrieveTileAsync("5", "18", "20", CanonicalTileUrl(5, 18, 20));
+
+        Assert.Null(result.TileData);
+        AssertNoCancellation(harness.Logs);
+        AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.UpstreamFailure);
+        Assert.Single(harness.Upstream.Requests);
+    }
+
+    /// <summary>Proves cancellation while waiting for global capacity has its bounded stage.</summary>
+    [Fact]
+    public async Task GlobalBudgetWaitCancellation_StopsBeforeUpstream()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var harness = new TileCacheTestHarness();
+        TileCacheService.OutboundBudget.SetAcquireOverrideForTesting(token =>
+        {
+            cancellation.Cancel();
+            return Task.FromCanceled<OutboundBudgetAcquisition>(token);
+        });
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext(cancellation.Token));
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        var result = await service.RetrieveTileAsync(
+            "5", "18", "21", CanonicalTileUrl(5, 18, 21), cancellation.Token);
+
+        Assert.Null(result.TileData);
+        Assert.False(result.BudgetExhausted);
+        AssertCancellation(harness.Logs, "global-budget-wait");
+        AssertNoUpstreamFailure(harness.Logs);
+        Assert.Empty(harness.Upstream.Requests);
+    }
+
+    /// <summary>Proves cancellation during the fixed cold-miss retry delay stops further attempts.</summary>
+    [Fact]
+    public async Task ColdMissRetryDelayCancellation_StopsFurtherAttempts()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var upstream = new RecordingTileHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var harness = new TileCacheTestHarness(upstream);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, token) =>
+        {
+            cancellation.Cancel();
+            return Task.FromCanceled(token);
+        });
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext(cancellation.Token));
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        var result = await service.RetrieveTileAsync(
+            "5", "18", "22", CanonicalTileUrl(5, 18, 22), cancellation.Token);
+
+        Assert.Null(result.TileData);
+        AssertCancellation(harness.Logs, "cold-miss-retry-delay");
+        AssertNoUpstreamFailure(harness.Logs);
+        Assert.Single(harness.Upstream.Requests);
+    }
+
+    /// <summary>Proves stale-refresh delay cancellation is stage-specific and removes series state.</summary>
+    [Fact]
+    public async Task StaleRefreshDelayCancellation_RemovesRefreshState()
+    {
+        var conditionalAttempted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var upstream = new RecordingTileHandler((request, _) =>
+        {
+            if (request.Headers.IfNoneMatch.Count > 0)
+            {
+                conditionalAttempted.TrySetResult();
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            }
+
+            return Task.FromResult(ExpiredPngResponse());
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext());
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+        await SeedExpiredTileAsync(service, harness.CacheDirectory, 5, 18, 23);
+        TileCacheService.SetRefreshRetryDelayForTesting(_ => TimeSpan.FromMinutes(1));
+
+        var result = await service.RetrieveTileAsync("5", "18", "23", CanonicalTileUrl(5, 18, 23));
+        await conditionalAttempted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        TileCacheService.CancelRefreshForTesting("5_18_23");
+
+        Assert.NotNull(result.TileData);
+        Assert.True(await TileCacheService.WaitForRefreshIdleForTestingAsync(
+            "5_18_23", TimeSpan.FromSeconds(2)));
+        AssertCancellation(harness.Logs, "stale-refresh-delay");
+        AssertNoUpstreamFailure(harness.Logs);
+        Assert.Equal(2, harness.Upstream.Requests.Count);
+    }
+
+    /// <summary>Proves cancellation of the final stale attempt reaches the outer boundary and stops.</summary>
+    [Fact]
+    public async Task StaleRefreshFinalAttemptCancellation_RemovesRefreshState()
+    {
+        var finalAttemptStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var conditionalAttempts = 0;
+        var upstream = new RecordingTileHandler(async (request, token) =>
+        {
+            if (request.Headers.IfNoneMatch.Count == 0)
+            {
+                return ExpiredPngResponse();
+            }
+
+            if (Interlocked.Increment(ref conditionalAttempts) < 3)
+            {
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+            }
+
+            finalAttemptStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            throw new InvalidOperationException("The cancelled final attempt must not continue.");
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext());
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+        await SeedExpiredTileAsync(service, harness.CacheDirectory, 5, 18, 24);
+        TileCacheService.SetRefreshRetryDelayForTesting(_ => TimeSpan.Zero);
+
+        var result = await service.RetrieveTileAsync("5", "18", "24", CanonicalTileUrl(5, 18, 24));
+        await finalAttemptStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        TileCacheService.CancelRefreshForTesting("5_18_24");
+
+        Assert.NotNull(result.TileData);
+        Assert.True(await TileCacheService.WaitForRefreshIdleForTestingAsync(
+            "5_18_24", TimeSpan.FromSeconds(2)));
+        AssertCancellation(harness.Logs, "stale-refresh-attempt");
+        AssertNoUpstreamFailure(harness.Logs);
+        Assert.Equal(3, conditionalAttempts);
+    }
+
+    /// <summary>Proves request rate-limit diagnostics distinguish authenticated and anonymous gates.</summary>
+    [Theory]
+    [InlineData(true, "request-authenticated")]
+    [InlineData(false, "request-anonymous")]
+    public async Task RequestThrottle_Retains429AndReportsBoundedScope(
+        bool authenticated,
+        string expectedScope)
+    {
+        using var harness = new TileCacheTestHarness();
+        harness.Settings.TileRateLimitEnabled = true;
+        harness.Settings.TileRateLimitPerMinute = 1;
+        harness.Settings.TileRateLimitAuthenticatedPerMinute = 1;
+        using var scope = harness.CreateScope();
+        var context = TileCacheTestHarness.CreateHttpContext();
+        if (authenticated)
+        {
+            var identity = new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, "phase1-user")],
+                "Phase1Test");
+            context.User = new ClaimsPrincipal(identity);
+        }
+        var controller = CreateController(scope, context);
+
+        Assert.IsType<FileContentResult>(await controller.GetTile(5, 25, 1));
+        var rejected = Assert.IsType<ObjectResult>(await controller.GetTile(5, 26, 1));
+
+        Assert.Equal(StatusCodes.Status429TooManyRequests, rejected.StatusCode);
+        var diagnostic = AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.ClientBudgetRejected);
+        Assert.Equal(expectedScope, diagnostic.Fields["BudgetScope"]);
+    }
+
+    /// <summary>Proves a literal-IP cross-host redirect is rejected without recording supplied data.</summary>
+    [Fact]
+    public async Task CrossHostRedirect_DoesNotRecordLiteralIpOrSecretUri()
+    {
+        const string suppliedIp = "192.0.2.123";
+        const string suppliedSecret = "redirect-secret";
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Redirect);
+            response.Headers.Location = new Uri($"https://{suppliedIp}/tiles.png?token={suppliedSecret}");
+            return Task.FromResult(response);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext());
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        var result = await service.RetrieveTileAsync("5", "18", "27", CanonicalTileUrl(5, 18, 27));
+
+        Assert.True(result.BudgetExhausted);
+        Assert.Contains(harness.Logs.Entries,
+            entry => entry.Level == LogLevel.Warning &&
+                     entry.Message.Contains("different host", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(harness.Logs.Entries, entry =>
+            Contains(entry, suppliedIp) || Contains(entry, suppliedSecret));
+    }
+
+    /// <summary>Seeds one expired low-zoom tile through the normal cache-write path.</summary>
+    private static async Task SeedExpiredTileAsync(
+        TileCacheService service,
+        string cacheDirectory,
+        int zoom,
+        int x,
+        int y)
+    {
+        Assert.True(await service.CacheTileAsync(CanonicalTileUrl(zoom, x, y),
+            zoom.ToString(), x.ToString(), y.ToString()));
+        await File.WriteAllTextAsync(
+            Path.Combine(cacheDirectory, $"{zoom}_{x}_{y}.png.meta"),
+            JsonSerializer.Serialize(new TileSidecarMetadata
+            {
+                ETag = "\"phase1-stale\"",
+                ExpiresAtUtc = DateTime.UtcNow.AddMinutes(-1)
+            }));
+        TileCacheService.ResetStaticStateForTesting();
+    }
+
+    /// <summary>Creates a controller and shares its request context with the scoped cache service.</summary>
+    private static TilesController CreateController(IServiceScope scope, DefaultHttpContext context)
+    {
+        SetHttpContext(scope, context);
+        return new TilesController(
+            scope.ServiceProvider.GetRequiredService<ILogger<TilesController>>(),
+            scope.ServiceProvider.GetRequiredService<TileCacheService>(),
+            scope.ServiceProvider.GetRequiredService<IApplicationSettingsService>())
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+    }
+
+    /// <summary>Assigns one request context to the scoped tile service.</summary>
+    private static void SetHttpContext(IServiceScope scope, DefaultHttpContext context) =>
+        scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext = context;
+
+    /// <summary>Returns the only diagnostic with the requested stable identifier.</summary>
+    private static TestLogProvider.TestLogEntry AssertDiagnostic(
+        TestLogProvider logs,
+        TileCacheDiagnosticEventIds eventId) =>
+        Assert.Single(logs.Entries, entry => entry.EventId.Id == (int)eventId);
+
+    /// <summary>Asserts exactly one cancellation event with the expected bounded stage.</summary>
+    private static void AssertCancellation(TestLogProvider logs, string expectedStage)
+    {
+        var diagnostic = AssertDiagnostic(logs, TileCacheDiagnosticEventIds.Cancellation);
+        Assert.Equal(expectedStage, diagnostic.Fields["CancellationStage"]);
+    }
+
+    /// <summary>Asserts cancellation was not emitted.</summary>
+    private static void AssertNoCancellation(TestLogProvider logs) =>
+        Assert.DoesNotContain(logs.Entries,
+            entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.Cancellation);
+
+    /// <summary>Asserts caller cancellation was not also classified as an upstream failure.</summary>
+    private static void AssertNoUpstreamFailure(TestLogProvider logs) =>
+        Assert.DoesNotContain(logs.Entries,
+            entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.UpstreamFailure);
+
+    /// <summary>Builds one canonical fake-intercepted tile URL.</summary>
+    private static string CanonicalTileUrl(int zoom, int x, int y) =>
+        $"https://tile.openstreetmap.org/{zoom}/{x}/{y}.png";
+
+    /// <summary>Builds an immediately expired cacheable tile response.</summary>
+    private static HttpResponseMessage ExpiredPngResponse()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1, 2, 3, 4])
+        };
+        response.Headers.ETag = EntityTagHeaderValue.Parse("\"phase1-stale\"");
+        response.Headers.CacheControl = new CacheControlHeaderValue { MaxAge = TimeSpan.Zero };
+        return response;
+    }
+
+    /// <summary>Checks every captured log surface for forbidden supplied redirect data.</summary>
+    private static bool Contains(TestLogProvider.TestLogEntry entry, string value) =>
+        entry.Message.Contains(value, StringComparison.Ordinal) ||
+        entry.Fields.Values.Any(field =>
+            field?.ToString()?.Contains(value, StringComparison.Ordinal) == true) ||
+        entry.Exception?.ToString().Contains(value, StringComparison.Ordinal) == true;
+}

--- a/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
@@ -248,6 +248,50 @@ public sealed class TileCacheCancellationAndPrivacyTests
             Contains(entry, suppliedIp) || Contains(entry, suppliedSecret));
     }
 
+    /// <summary>Proves harness disposal cancels and awaits background refresh before deleting cache data.</summary>
+    [Fact]
+    public async Task HarnessDisposal_AwaitsTrackedStaleRefresh()
+    {
+        var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var refreshCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var upstream = new RecordingTileHandler(async (request, token) =>
+        {
+            if (request.Headers.IfNoneMatch.Count == 0)
+            {
+                return ExpiredPngResponse();
+            }
+
+            refreshStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            }
+            catch (OperationCanceledException)
+            {
+                refreshCancelled.TrySetResult();
+                throw;
+            }
+
+            throw new InvalidOperationException("The refresh must be cancelled during cleanup.");
+        });
+        var harness = new TileCacheTestHarness(upstream);
+        using (var scope = harness.CreateScope())
+        {
+            SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext());
+            var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+            await SeedExpiredTileAsync(service, harness.CacheDirectory, 5, 18, 28);
+            await service.RetrieveTileAsync("5", "18", "28", CanonicalTileUrl(5, 18, 28));
+            await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        }
+
+        await harness.DisposeAsync();
+
+        await refreshCancelled.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.True(await TileCacheService.WaitForRefreshIdleForTestingAsync(
+            "5_18_28", TimeSpan.FromMilliseconds(100)));
+        Assert.False(Directory.Exists(harness.CacheDirectory));
+    }
+
     /// <summary>Seeds one expired low-zoom tile through the normal cache-write path.</summary>
     private static async Task SeedExpiredTileAsync(
         TileCacheService service,

--- a/tests/Wayfarer.Tests/Services/TileCacheColdCacheBaselineTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheColdCacheBaselineTests.cs
@@ -1,0 +1,188 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Wayfarer.Areas.Public.Controllers;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>
+/// Characterizes the current cold-cache burst and timeout behavior without defining its permanent contract.
+/// </summary>
+[Collection("OutboundBudget")]
+public sealed class TileCacheColdCacheBaselineTests
+{
+    private const int UniqueTileCount = 24;
+    private static readonly TimeSpan FakeUpstreamLatency = TimeSpan.FromMilliseconds(100);
+    private readonly ITestOutputHelper _output;
+
+    /// <summary>Creates the fixture with an output sink for the numeric baseline report.</summary>
+    public TileCacheColdCacheBaselineTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task ColdViewport_LargerThanBurst_RecordsCurrentBurstAndGapBaseline()
+    {
+        var budget = new ControlledCurrentBudget(
+            TileCacheService.OutboundBudget.BurstCapacity,
+            TimeSpan.FromMilliseconds(TileCacheService.OutboundBudget.ReplenishIntervalMs),
+            TileCacheService.OutboundBudget.AcquireTimeout);
+        var upstream = new RecordingTileHandler(startTimeProvider: budget.GetCurrentRequestStart);
+        using var harness = new TileCacheTestHarness(upstream);
+        TileCacheService.OutboundBudget.SetAcquireOverrideForTesting(budget.AcquireAsync);
+
+        var outcomes = await Task.WhenAll(
+            Enumerable.Range(0, UniqueTileCount)
+                .Select(tileX => RequestTileAsync(harness, tileX)));
+        var report = BuildReport(upstream.Requests, outcomes);
+
+        _output.WriteLine(JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
+
+        Assert.Equal(24, report.UniqueTiles);
+        Assert.Equal(12, report.BurstCapacity);
+        Assert.Equal(2d, report.SustainedAcquisitionsPerSecond);
+        Assert.Equal(100d, report.FakeUpstreamLatencyMilliseconds);
+        Assert.Equal(19, report.AcceptedRequests);
+        Assert.Equal(5, report.RejectedRequests);
+        Assert.Equal(19, report.StatusDistribution[200]);
+        Assert.Equal(5, report.StatusDistribution[503]);
+        Assert.Equal(100d, report.FirstCompletionMilliseconds);
+        Assert.Equal(3600d, report.LastCompletionMilliseconds);
+        Assert.Equal(7, report.PeriodsWithoutProgress);
+        Assert.Equal(500d, report.LongestPeriodWithoutProgressMilliseconds);
+        Assert.All(outcomes.Where(outcome => outcome.StatusCode == 503),
+            outcome => Assert.Equal(TilesController.BudgetRetryAfterSeconds, outcome.RetryAfterSeconds));
+    }
+
+    private static async Task<LocalTileOutcome> RequestTileAsync(TileCacheTestHarness harness, int tileX)
+    {
+        using var scope = harness.CreateScope();
+        var context = TileCacheTestHarness.CreateHttpContext();
+        scope.ServiceProvider.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>().HttpContext = context;
+        var controller = new TilesController(
+            scope.ServiceProvider.GetRequiredService<ILogger<TilesController>>(),
+            scope.ServiceProvider.GetRequiredService<TileCacheService>(),
+            scope.ServiceProvider.GetRequiredService<IApplicationSettingsService>())
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+
+        var actionResult = await controller.GetTile(5, tileX, 1);
+        var statusCode = actionResult switch
+        {
+            FileContentResult => 200,
+            ObjectResult objectResult => objectResult.StatusCode ?? 200,
+            StatusCodeResult statusResult => statusResult.StatusCode,
+            _ => throw new InvalidOperationException($"Unexpected tile result {actionResult.GetType().Name}.")
+        };
+        var retryAfter = int.TryParse(context.Response.Headers.RetryAfter, out var parsedRetryAfter)
+            ? parsedRetryAfter
+            : (int?)null;
+
+        return new LocalTileOutcome(tileX, statusCode, retryAfter);
+    }
+
+    private static ColdCacheBaselineReport BuildReport(
+        IReadOnlyCollection<RecordedTileRequest> requests,
+        IReadOnlyCollection<LocalTileOutcome> outcomes)
+    {
+        var successfulCompletions = requests
+            .Select(request => request.StartTime + FakeUpstreamLatency)
+            .OrderBy(completion => completion)
+            .ToArray();
+        var distinctCompletions = successfulCompletions.Distinct().ToArray();
+        var progressGaps = distinctCompletions
+            .Zip(distinctCompletions.Skip(1), (first, second) => second - first)
+            .Where(gap => gap > FakeUpstreamLatency)
+            .ToArray();
+        var rejectedCompletion = TileCacheService.OutboundBudget.AcquireTimeout;
+        var lastCompletion = successfulCompletions
+            .Append(rejectedCompletion)
+            .Max();
+
+        return new ColdCacheBaselineReport(
+            UniqueTiles: outcomes.Count,
+            BurstCapacity: TileCacheService.OutboundBudget.BurstCapacity,
+            SustainedAcquisitionsPerSecond:
+                1000d / TileCacheService.OutboundBudget.ReplenishIntervalMs,
+            FakeUpstreamLatencyMilliseconds: FakeUpstreamLatency.TotalMilliseconds,
+            AcceptedRequests: requests.Count,
+            RejectedRequests: outcomes.Count(outcome => outcome.StatusCode == 503),
+            StatusDistribution: outcomes
+                .GroupBy(outcome => outcome.StatusCode)
+                .ToDictionary(group => group.Key, group => group.Count()),
+            UpstreamStartMilliseconds: requests
+                .Select(request => request.StartTime.TotalMilliseconds)
+                .OrderBy(start => start)
+                .ToArray(),
+            RetryAfterSeconds: outcomes
+                .Where(outcome => outcome.RetryAfterSeconds.HasValue)
+                .Select(outcome => outcome.RetryAfterSeconds!.Value)
+                .ToArray(),
+            FirstCompletionMilliseconds: successfulCompletions.Min().TotalMilliseconds,
+            LastCompletionMilliseconds: lastCompletion.TotalMilliseconds,
+            PeriodsWithoutProgress: progressGaps.Length,
+            LongestPeriodWithoutProgressMilliseconds: progressGaps.Max().TotalMilliseconds);
+    }
+
+    /// <summary>
+    /// Deterministically reproduces the current burst, replenishment, and acquisition-timeout constants.
+    /// </summary>
+    private sealed class ControlledCurrentBudget
+    {
+        private readonly int _burstCapacity;
+        private readonly TimeSpan _replenishmentInterval;
+        private readonly TimeSpan _acquireTimeout;
+        private readonly AsyncLocal<TimeSpan> _currentRequestStart = new();
+        private int _requestSequence;
+
+        public ControlledCurrentBudget(
+            int burstCapacity,
+            TimeSpan replenishmentInterval,
+            TimeSpan acquireTimeout)
+        {
+            _burstCapacity = burstCapacity;
+            _replenishmentInterval = replenishmentInterval;
+            _acquireTimeout = acquireTimeout;
+        }
+
+        /// <summary>Assigns the nominal current-policy acquisition time for the next request.</summary>
+        public Task<OutboundBudgetAcquisition> AcquireAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var sequence = Interlocked.Increment(ref _requestSequence);
+            var wait = sequence <= _burstCapacity
+                ? TimeSpan.Zero
+                : _replenishmentInterval * (sequence - _burstCapacity);
+            var acquired = wait <= _acquireTimeout;
+            _currentRequestStart.Value = acquired ? wait : _acquireTimeout;
+            return Task.FromResult(new OutboundBudgetAcquisition(
+                acquired,
+                acquired ? wait : _acquireTimeout));
+        }
+
+        /// <summary>Gets the logical upstream start assigned to the current asynchronous request.</summary>
+        public TimeSpan GetCurrentRequestStart() => _currentRequestStart.Value;
+    }
+
+    private sealed record LocalTileOutcome(int TileX, int StatusCode, int? RetryAfterSeconds);
+
+    private sealed record ColdCacheBaselineReport(
+        int UniqueTiles,
+        int BurstCapacity,
+        double SustainedAcquisitionsPerSecond,
+        double FakeUpstreamLatencyMilliseconds,
+        int AcceptedRequests,
+        int RejectedRequests,
+        IReadOnlyDictionary<int, int> StatusDistribution,
+        IReadOnlyList<double> UpstreamStartMilliseconds,
+        IReadOnlyList<int> RetryAfterSeconds,
+        double FirstCompletionMilliseconds,
+        double LastCompletionMilliseconds,
+        int PeriodsWithoutProgress,
+        double LongestPeriodWithoutProgressMilliseconds);
+}

--- a/tests/Wayfarer.Tests/Services/TileCacheColdCacheBaselineTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheColdCacheBaselineTests.cs
@@ -24,6 +24,7 @@ public sealed class TileCacheColdCacheBaselineTests
     /// <summary>Creates the fixture with an output sink for the numeric baseline report.</summary>
     public TileCacheColdCacheBaselineTests(ITestOutputHelper output) => _output = output;
 
+    /// <summary>Records the nominal current-policy burst, replenishment gaps, and local rejections.</summary>
     [Fact]
     public async Task ColdViewport_LargerThanBurst_RecordsCurrentBurstAndGapBaseline()
     {
@@ -58,6 +59,7 @@ public sealed class TileCacheColdCacheBaselineTests
             outcome => Assert.Equal(TilesController.BudgetRetryAfterSeconds, outcome.RetryAfterSeconds));
     }
 
+    /// <summary>Runs one isolated controller request and captures its local status and Retry-After.</summary>
     private static async Task<LocalTileOutcome> RequestTileAsync(TileCacheTestHarness harness, int tileX)
     {
         using var scope = harness.CreateScope();
@@ -86,6 +88,7 @@ public sealed class TileCacheColdCacheBaselineTests
         return new LocalTileOutcome(tileX, statusCode, retryAfter);
     }
 
+    /// <summary>Derives a stable numerical report from fake-upstream starts and local controller outcomes.</summary>
     private static ColdCacheBaselineReport BuildReport(
         IReadOnlyCollection<RecordedTileRequest> requests,
         IReadOnlyCollection<LocalTileOutcome> outcomes)
@@ -137,7 +140,7 @@ public sealed class TileCacheColdCacheBaselineTests
         private readonly int _burstCapacity;
         private readonly TimeSpan _replenishmentInterval;
         private readonly TimeSpan _acquireTimeout;
-        private readonly AsyncLocal<TimeSpan> _currentRequestStart = new();
+        private readonly ConcurrentQueue<TimeSpan> _acceptedRequestStarts = new();
         private int _requestSequence;
 
         public ControlledCurrentBudget(
@@ -159,18 +162,26 @@ public sealed class TileCacheColdCacheBaselineTests
                 ? TimeSpan.Zero
                 : _replenishmentInterval * (sequence - _burstCapacity);
             var acquired = wait <= _acquireTimeout;
-            _currentRequestStart.Value = acquired ? wait : _acquireTimeout;
+            if (acquired)
+            {
+                _acceptedRequestStarts.Enqueue(wait);
+            }
             return Task.FromResult(new OutboundBudgetAcquisition(
                 acquired,
                 acquired ? wait : _acquireTimeout));
         }
 
         /// <summary>Gets the logical upstream start assigned to the current asynchronous request.</summary>
-        public TimeSpan GetCurrentRequestStart() => _currentRequestStart.Value;
+        public TimeSpan GetCurrentRequestStart() =>
+            _acceptedRequestStarts.TryDequeue(out var start)
+                ? start
+                : throw new InvalidOperationException("No controlled acquisition was assigned to this request.");
     }
 
+    /// <summary>Captures the local controller result for one unique visible tile.</summary>
     private sealed record LocalTileOutcome(int TileX, int StatusCode, int? RetryAfterSeconds);
 
+    /// <summary>Contains all numeric evidence required to reproduce the controlled baseline.</summary>
     private sealed record ColdCacheBaselineReport(
         int UniqueTiles,
         int BurstCapacity,

--- a/tests/Wayfarer.Tests/Services/TileCacheColdCacheBaselineTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheColdCacheBaselineTests.cs
@@ -46,6 +46,7 @@ public sealed class TileCacheColdCacheBaselineTests
         Assert.Equal(24, report.UniqueTiles);
         Assert.Equal(12, report.BurstCapacity);
         Assert.Equal(2d, report.SustainedAcquisitionsPerSecond);
+        Assert.Equal("none (unbounded waiters)", report.QueueCapacity);
         Assert.Equal(100d, report.FakeUpstreamLatencyMilliseconds);
         Assert.Equal(19, report.AcceptedRequests);
         Assert.Equal(5, report.RejectedRequests);
@@ -112,6 +113,7 @@ public sealed class TileCacheColdCacheBaselineTests
             BurstCapacity: TileCacheService.OutboundBudget.BurstCapacity,
             SustainedAcquisitionsPerSecond:
                 1000d / TileCacheService.OutboundBudget.ReplenishIntervalMs,
+            QueueCapacity: "none (unbounded waiters)",
             FakeUpstreamLatencyMilliseconds: FakeUpstreamLatency.TotalMilliseconds,
             AcceptedRequests: requests.Count,
             RejectedRequests: outcomes.Count(outcome => outcome.StatusCode == 503),
@@ -186,6 +188,7 @@ public sealed class TileCacheColdCacheBaselineTests
         int UniqueTiles,
         int BurstCapacity,
         double SustainedAcquisitionsPerSecond,
+        string QueueCapacity,
         double FakeUpstreamLatencyMilliseconds,
         int AcceptedRequests,
         int RejectedRequests,

--- a/tests/Wayfarer.Tests/Services/TileCacheColdCacheBaselineTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheColdCacheBaselineTests.cs
@@ -1,5 +1,8 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -12,23 +15,25 @@ using Xunit.Abstractions;
 namespace Wayfarer.Tests.Services;
 
 /// <summary>
-/// Characterizes the current cold-cache burst and timeout behavior without defining its permanent contract.
+/// Records a nominal analytical model and a broad production-budget characterization without defining a contract.
 /// </summary>
 [Collection("OutboundBudget")]
 public sealed class TileCacheColdCacheBaselineTests
 {
     private const int UniqueTileCount = 24;
-    private static readonly TimeSpan FakeUpstreamLatency = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan ModeledUpstreamLatency = TimeSpan.FromMilliseconds(100);
     private readonly ITestOutputHelper _output;
 
     /// <summary>Creates the fixture with an output sink for the numeric baseline report.</summary>
     public TileCacheColdCacheBaselineTests(ITestOutputHelper output) => _output = output;
 
-    /// <summary>Records the nominal current-policy burst, replenishment gaps, and local rejections.</summary>
+    /// <summary>
+    /// Analytically models the current constants; 100 ms latency and the exact 19/5 boundary are modeled inputs.
+    /// </summary>
     [Fact]
-    public async Task ColdViewport_LargerThanBurst_RecordsCurrentBurstAndGapBaseline()
+    public async Task NominalAnalyticalColdViewport_ModelsCurrentConstants()
     {
-        var budget = new ControlledCurrentBudget(
+        var budget = new AnalyticalCurrentBudgetModel(
             TileCacheService.OutboundBudget.BurstCapacity,
             TimeSpan.FromMilliseconds(TileCacheService.OutboundBudget.ReplenishIntervalMs),
             TileCacheService.OutboundBudget.AcquireTimeout);
@@ -46,8 +51,8 @@ public sealed class TileCacheColdCacheBaselineTests
         Assert.Equal(24, report.UniqueTiles);
         Assert.Equal(12, report.BurstCapacity);
         Assert.Equal(2d, report.SustainedAcquisitionsPerSecond);
-        Assert.Equal("none (unbounded waiters)", report.QueueCapacity);
-        Assert.Equal(100d, report.FakeUpstreamLatencyMilliseconds);
+        Assert.Equal("unbounded waiter set", report.QueueCapacity);
+        Assert.Equal(100d, report.ModeledUpstreamLatencyMilliseconds);
         Assert.Equal(19, report.AcceptedRequests);
         Assert.Equal(5, report.RejectedRequests);
         Assert.Equal(19, report.StatusDistribution[200]);
@@ -58,6 +63,44 @@ public sealed class TileCacheColdCacheBaselineTests
         Assert.Equal(500d, report.LongestPeriodWithoutProgressMilliseconds);
         Assert.All(outcomes.Where(outcome => outcome.StatusCode == 503),
             outcome => Assert.Equal(TilesController.BudgetRetryAfterSeconds, outcome.RetryAfterSeconds));
+    }
+
+    /// <summary>
+    /// Broadly characterizes real production-budget progress with actual fake latency and no public network.
+    /// </summary>
+    [Fact]
+    public async Task RealOutboundBudget_SpreadsStartsAndContinuesAfterInitialBurst()
+    {
+        const int productionPathTileCount = 16;
+        var stopwatch = Stopwatch.StartNew();
+        var upstream = new RecordingTileHandler(
+            async (_, cancellationToken) =>
+            {
+                await Task.Delay(ModeledUpstreamLatency, cancellationToken);
+                return PngResponse();
+            },
+            () => stopwatch.Elapsed);
+        using var harness = new TileCacheTestHarness(upstream);
+
+        var outcomes = await Task.WhenAll(
+            Enumerable.Range(0, productionPathTileCount)
+                .Select(tileX => RequestTileAsync(harness, tileX)));
+        var starts = upstream.Requests
+            .Select(request => request.StartTime)
+            .OrderBy(start => start)
+            .ToArray();
+        var initialBurstStarts = starts.Take(TileCacheService.OutboundBudget.BurstCapacity).ToArray();
+        var laterStarts = starts.Skip(TileCacheService.OutboundBudget.BurstCapacity).ToArray();
+
+        Assert.Equal(productionPathTileCount, outcomes.Length);
+        Assert.Equal(TileCacheService.OutboundBudget.BurstCapacity, initialBurstStarts.Length);
+        Assert.True(initialBurstStarts.Max() < TimeSpan.FromSeconds(1));
+        Assert.NotEmpty(laterStarts);
+        Assert.True(laterStarts.Max() - laterStarts.Min() >= TimeSpan.FromMilliseconds(500));
+        Assert.Contains(outcomes, outcome => outcome.StatusCode == StatusCodes.Status200OK);
+        Assert.True(
+            laterStarts.Any(start => start >= TimeSpan.FromMilliseconds(250)) ||
+            outcomes.Any(outcome => outcome.StatusCode == StatusCodes.Status503ServiceUnavailable));
     }
 
     /// <summary>Runs one isolated controller request and captures its local status and Retry-After.</summary>
@@ -95,13 +138,13 @@ public sealed class TileCacheColdCacheBaselineTests
         IReadOnlyCollection<LocalTileOutcome> outcomes)
     {
         var successfulCompletions = requests
-            .Select(request => request.StartTime + FakeUpstreamLatency)
+            .Select(request => request.StartTime + ModeledUpstreamLatency)
             .OrderBy(completion => completion)
             .ToArray();
         var distinctCompletions = successfulCompletions.Distinct().ToArray();
         var progressGaps = distinctCompletions
             .Zip(distinctCompletions.Skip(1), (first, second) => second - first)
-            .Where(gap => gap > FakeUpstreamLatency)
+            .Where(gap => gap > ModeledUpstreamLatency)
             .ToArray();
         var rejectedCompletion = TileCacheService.OutboundBudget.AcquireTimeout;
         var lastCompletion = successfulCompletions
@@ -113,8 +156,8 @@ public sealed class TileCacheColdCacheBaselineTests
             BurstCapacity: TileCacheService.OutboundBudget.BurstCapacity,
             SustainedAcquisitionsPerSecond:
                 1000d / TileCacheService.OutboundBudget.ReplenishIntervalMs,
-            QueueCapacity: "none (unbounded waiters)",
-            FakeUpstreamLatencyMilliseconds: FakeUpstreamLatency.TotalMilliseconds,
+            QueueCapacity: "unbounded waiter set",
+            ModeledUpstreamLatencyMilliseconds: ModeledUpstreamLatency.TotalMilliseconds,
             AcceptedRequests: requests.Count,
             RejectedRequests: outcomes.Count(outcome => outcome.StatusCode == 503),
             StatusDistribution: outcomes
@@ -137,7 +180,7 @@ public sealed class TileCacheColdCacheBaselineTests
     /// <summary>
     /// Deterministically reproduces the current burst, replenishment, and acquisition-timeout constants.
     /// </summary>
-    private sealed class ControlledCurrentBudget
+    private sealed class AnalyticalCurrentBudgetModel
     {
         private readonly int _burstCapacity;
         private readonly TimeSpan _replenishmentInterval;
@@ -145,7 +188,7 @@ public sealed class TileCacheColdCacheBaselineTests
         private readonly ConcurrentQueue<TimeSpan> _acceptedRequestStarts = new();
         private int _requestSequence;
 
-        public ControlledCurrentBudget(
+        public AnalyticalCurrentBudgetModel(
             int burstCapacity,
             TimeSpan replenishmentInterval,
             TimeSpan acquireTimeout)
@@ -180,6 +223,18 @@ public sealed class TileCacheColdCacheBaselineTests
                 : throw new InvalidOperationException("No controlled acquisition was assigned to this request.");
     }
 
+    /// <summary>Builds one cacheable fake PNG response for the production-path characterization.</summary>
+    private static HttpResponseMessage PngResponse()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1, 2, 3, 4])
+        };
+        response.Headers.CacheControl =
+            new System.Net.Http.Headers.CacheControlHeaderValue { MaxAge = TimeSpan.FromHours(1) };
+        return response;
+    }
+
     /// <summary>Captures the local controller result for one unique visible tile.</summary>
     private sealed record LocalTileOutcome(int TileX, int StatusCode, int? RetryAfterSeconds);
 
@@ -189,7 +244,7 @@ public sealed class TileCacheColdCacheBaselineTests
         int BurstCapacity,
         double SustainedAcquisitionsPerSecond,
         string QueueCapacity,
-        double FakeUpstreamLatencyMilliseconds,
+        double ModeledUpstreamLatencyMilliseconds,
         int AcceptedRequests,
         int RejectedRequests,
         IReadOnlyDictionary<int, int> StatusDistribution,

--- a/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
@@ -193,26 +193,6 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
         Assert.Single(harness.Upstream.Requests);
     }
 
-    /// <summary>Proves transport cancellation has its own event and is not classified as upstream failure.</summary>
-    [Fact]
-    public async Task Cancellation_IsNotReportedAsUpstreamFailure()
-    {
-        var upstream = new RecordingTileHandler((_, cancellationToken) =>
-            throw new OperationCanceledException(cancellationToken));
-        using var harness = new TileCacheTestHarness(upstream);
-        using var scope = harness.CreateScope();
-        SetHttpContext(scope);
-        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
-
-        var result = await service.RetrieveTileAsync("5", "14", "15", CanonicalTileUrl(5, 14, 15));
-
-        Assert.Null(result.TileData);
-        var diagnostic = AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.Cancellation);
-        Assert.Equal("upstream", diagnostic.Fields["CancellationStage"]);
-        Assert.DoesNotContain(harness.Logs.Entries,
-            entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.UpstreamFailure);
-    }
-
     /// <summary>Proves current attempt numbering and fixed retry delay are observable without changing policy.</summary>
     [Fact]
     public async Task CurrentRetryDelay_IsReportedWithoutChangingRetryPolicy()

--- a/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Wayfarer.Areas.Public.Controllers;
@@ -16,6 +17,7 @@ namespace Wayfarer.Tests.Services;
 [Collection("OutboundBudget")]
 public sealed class TileCacheDiagnosticsAndPolicyTests
 {
+    /// <summary>Proves a fresh local tile emits a stable hit event and performs no upstream work.</summary>
     [Fact]
     public async Task FreshCacheHit_EmitsStableDiagnostic_WithoutUpstreamRequest()
     {
@@ -35,6 +37,7 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
         Assert.Equal("fresh", diagnostic.Fields["CacheOutcome"]);
     }
 
+    /// <summary>Proves stale bytes return immediately while refresh scheduling is observable and coalesced.</summary>
     [Fact]
     public async Task StaleCacheHit_ReturnsBeforeRefreshAndReportsScheduledThenCoalesced()
     {
@@ -62,6 +65,14 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
         var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
         var tileUrl = CanonicalTileUrl(5, 3, 4);
         Assert.True(await service.CacheTileAsync(tileUrl, "5", "3", "4"));
+        await File.WriteAllTextAsync(
+            Path.Combine(harness.CacheDirectory, "5_3_4.png.meta"),
+            JsonSerializer.Serialize(new TileSidecarMetadata
+            {
+                ETag = "\"stale-v1\"",
+                ExpiresAtUtc = DateTime.UtcNow.AddMinutes(-1)
+            }));
+        TileCacheService.ResetStaticStateForTesting();
 
         var first = await service.RetrieveTileAsync("5", "3", "4", tileUrl);
         await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
@@ -69,7 +80,8 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
 
         Assert.NotNull(first.TileData);
         Assert.NotNull(second.TileData);
-        AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.StaleCacheHit);
+        Assert.Contains(harness.Logs.Entries,
+            entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.StaleCacheHit);
         AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.StaleRefreshScheduled);
         AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.StaleRefreshCoalesced);
 
@@ -79,6 +91,7 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
             TimeSpan.FromSeconds(2)));
     }
 
+    /// <summary>Proves one canonical OSM request emits neither cache busting nor speculative prefetch traffic.</summary>
     [Fact]
     public async Task CanonicalOsmRequest_EmitsNoCacheBustingOrPrefetchTraffic()
     {
@@ -101,11 +114,14 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
         AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.CacheWriteOutcome);
     }
 
+    /// <summary>Proves provider credentials are absent from messages, structured fields, and exceptions.</summary>
     [Fact]
     public async Task ProviderSecret_DoesNotAppearInDiagnosticOutput()
     {
         const string secret = "phase1-super-secret";
-        using var harness = new TileCacheTestHarness();
+        var upstream = new RecordingTileHandler((_, _) =>
+            throw new HttpRequestException($"Fake provider failure contained {secret}."));
+        using var harness = new TileCacheTestHarness(upstream);
         using var scope = harness.CreateScope();
         SetHttpContext(scope);
         var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
@@ -116,7 +132,7 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
             "8",
             $"https://tiles.example.test/5/7/8.png?apiKey={secret}");
 
-        Assert.NotNull(result.TileData);
+        Assert.Null(result.TileData);
         Assert.NotEmpty(harness.Logs.Entries);
         Assert.DoesNotContain(harness.Logs.Entries, entry =>
             ContainsSecret(entry.Message, secret) ||
@@ -124,6 +140,7 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
             ContainsSecret(entry.Exception?.ToString(), secret));
     }
 
+    /// <summary>Proves global rejection includes a stable scope and deterministic budget-wait duration.</summary>
     [Fact]
     public async Task GlobalBudgetRejection_HasStableScopeAndWaitFields()
     {
@@ -145,6 +162,7 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
         Assert.Empty(harness.Upstream.Requests);
     }
 
+    /// <summary>Proves the per-client allowance is distinguishable from the global outbound budget.</summary>
     [Fact]
     public async Task PerClientBudgetRejection_IsDistinctFromGlobalRejection()
     {
@@ -175,6 +193,7 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
         Assert.Single(harness.Upstream.Requests);
     }
 
+    /// <summary>Proves transport cancellation has its own event and is not classified as upstream failure.</summary>
     [Fact]
     public async Task Cancellation_IsNotReportedAsUpstreamFailure()
     {
@@ -194,6 +213,7 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
             entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.UpstreamFailure);
     }
 
+    /// <summary>Proves current attempt numbering and fixed retry delay are observable without changing policy.</summary>
     [Fact]
     public async Task CurrentRetryDelay_IsReportedWithoutChangingRetryPolicy()
     {
@@ -209,6 +229,11 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
 
         Assert.Null(result.TileData);
         Assert.Equal(3, harness.Upstream.Requests.Count);
+        var attempts = harness.Logs.Entries
+            .Where(entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.UpstreamAttempt)
+            .Select(entry => Convert.ToInt32(entry.Fields["AttemptNumber"]))
+            .ToArray();
+        Assert.Equal([1, 2, 3], attempts);
         var delays = harness.Logs.Entries
             .Where(entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.RetryDelaySelected)
             .ToArray();
@@ -217,20 +242,24 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
             Assert.Equal(500d, Convert.ToDouble(delay.Fields["RetryDelayMilliseconds"])));
     }
 
+    /// <summary>Assigns the same-origin request context used by one scoped service.</summary>
     private static void SetHttpContext(IServiceScope scope)
     {
         scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext =
             TileCacheTestHarness.CreateHttpContext();
     }
 
+    /// <summary>Returns the only diagnostic with the requested stable identifier.</summary>
     private static TestLogProvider.TestLogEntry AssertDiagnostic(
         TestLogProvider logs,
         TileCacheDiagnosticEventIds eventId) =>
-        Assert.Single(logs.Entries.Where(entry => entry.EventId.Id == (int)eventId));
+        Assert.Single(logs.Entries, entry => entry.EventId.Id == (int)eventId);
 
+    /// <summary>Builds one canonical OSM Standard tile URL for the intercepting fake provider.</summary>
     private static string CanonicalTileUrl(int zoom, int x, int y) =>
         $"https://tile.openstreetmap.org/{zoom}/{x}/{y}.png";
 
+    /// <summary>Builds a deterministic cacheable PNG response.</summary>
     private static HttpResponseMessage PngResponse(TimeSpan maxAge)
     {
         var response = new HttpResponseMessage(HttpStatusCode.OK)
@@ -241,6 +270,7 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
         return response;
     }
 
+    /// <summary>Checks diagnostic text for a forbidden provider secret using ordinal comparison.</summary>
     private static bool ContainsSecret(string? value, string secret) =>
         value?.Contains(secret, StringComparison.Ordinal) == true;
 }

--- a/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
@@ -187,7 +187,7 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
         }
 
         var diagnostic = AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.ClientBudgetRejected);
-        Assert.Equal("client", diagnostic.Fields["BudgetScope"]);
+        Assert.Equal("outbound-client", diagnostic.Fields["BudgetScope"]);
         Assert.DoesNotContain(harness.Logs.Entries,
             entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.GlobalBudgetRejected);
         Assert.Single(harness.Upstream.Requests);

--- a/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
@@ -1,0 +1,246 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Wayfarer.Areas.Public.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>
+/// Verifies stable tile-pipeline diagnostics and durable provider-policy behavior.
+/// </summary>
+[Collection("OutboundBudget")]
+public sealed class TileCacheDiagnosticsAndPolicyTests
+{
+    [Fact]
+    public async Task FreshCacheHit_EmitsStableDiagnostic_WithoutUpstreamRequest()
+    {
+        using var harness = new TileCacheTestHarness();
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope);
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        Assert.True(await service.CacheTileAsync(CanonicalTileUrl(5, 1, 2), "5", "1", "2"));
+        var upstreamCallsAfterFill = harness.Upstream.Requests.Count;
+
+        var result = await service.RetrieveTileAsync("5", "1", "2", CanonicalTileUrl(5, 1, 2));
+
+        Assert.NotNull(result.TileData);
+        Assert.Equal(upstreamCallsAfterFill, harness.Upstream.Requests.Count);
+        var diagnostic = AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.FreshCacheHit);
+        Assert.Equal("fresh", diagnostic.Fields["CacheOutcome"]);
+    }
+
+    [Fact]
+    public async Task StaleCacheHit_ReturnsBeforeRefreshAndReportsScheduledThenCoalesced()
+    {
+        var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRefresh = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var upstream = new RecordingTileHandler(async (request, cancellationToken) =>
+        {
+            if (request.Headers.IfNoneMatch.Count > 0)
+            {
+                refreshStarted.TrySetResult();
+                await releaseRefresh.Task.WaitAsync(cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.NotModified)
+                {
+                    Headers = { CacheControl = new CacheControlHeaderValue { MaxAge = TimeSpan.FromHours(1) } }
+                };
+            }
+
+            var response = PngResponse(maxAge: TimeSpan.Zero);
+            response.Headers.ETag = EntityTagHeaderValue.Parse("\"stale-v1\"");
+            return response;
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope);
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+        var tileUrl = CanonicalTileUrl(5, 3, 4);
+        Assert.True(await service.CacheTileAsync(tileUrl, "5", "3", "4"));
+
+        var first = await service.RetrieveTileAsync("5", "3", "4", tileUrl);
+        await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var second = await service.RetrieveTileAsync("5", "3", "4", tileUrl);
+
+        Assert.NotNull(first.TileData);
+        Assert.NotNull(second.TileData);
+        AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.StaleCacheHit);
+        AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.StaleRefreshScheduled);
+        AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.StaleRefreshCoalesced);
+
+        releaseRefresh.TrySetResult();
+        Assert.True(await TileCacheService.WaitForRefreshIdleForTestingAsync(
+            "5_3_4",
+            TimeSpan.FromSeconds(2)));
+    }
+
+    [Fact]
+    public async Task CanonicalOsmRequest_EmitsNoCacheBustingOrPrefetchTraffic()
+    {
+        using var harness = new TileCacheTestHarness();
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope);
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+        var requestedUrl = CanonicalTileUrl(9, 120, 85);
+
+        var result = await service.RetrieveTileAsync("9", "120", "85", requestedUrl);
+
+        Assert.NotNull(result.TileData);
+        var request = Assert.Single(harness.Upstream.Requests);
+        Assert.Equal(requestedUrl, request.RequestUri?.ToString());
+        Assert.DoesNotContain("Cache-Control", request.Headers.Keys, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Pragma", request.Headers.Keys, StringComparer.OrdinalIgnoreCase);
+        AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.ColdCacheMiss);
+        AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.UpstreamAttempt);
+        AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.UpstreamStatus);
+        AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.CacheWriteOutcome);
+    }
+
+    [Fact]
+    public async Task ProviderSecret_DoesNotAppearInDiagnosticOutput()
+    {
+        const string secret = "phase1-super-secret";
+        using var harness = new TileCacheTestHarness();
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope);
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        var result = await service.RetrieveTileAsync(
+            "5",
+            "7",
+            "8",
+            $"https://tiles.example.test/5/7/8.png?apiKey={secret}");
+
+        Assert.NotNull(result.TileData);
+        Assert.NotEmpty(harness.Logs.Entries);
+        Assert.DoesNotContain(harness.Logs.Entries, entry =>
+            ContainsSecret(entry.Message, secret) ||
+            entry.Fields.Values.Any(value => ContainsSecret(value?.ToString(), secret)) ||
+            ContainsSecret(entry.Exception?.ToString(), secret));
+    }
+
+    [Fact]
+    public async Task GlobalBudgetRejection_HasStableScopeAndWaitFields()
+    {
+        using var harness = new TileCacheTestHarness();
+        TileCacheService.OutboundBudget.SetAcquireOverrideForTesting(_ =>
+            Task.FromResult(new OutboundBudgetAcquisition(
+                Acquired: false,
+                WaitDuration: TileCacheService.OutboundBudget.AcquireTimeout)));
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope);
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        var result = await service.RetrieveTileAsync("5", "9", "10", CanonicalTileUrl(5, 9, 10));
+
+        Assert.True(result.BudgetExhausted);
+        var diagnostic = AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.GlobalBudgetRejected);
+        Assert.Equal("global", diagnostic.Fields["BudgetScope"]);
+        Assert.Equal(3500d, Convert.ToDouble(diagnostic.Fields["WaitMilliseconds"]));
+        Assert.Empty(harness.Upstream.Requests);
+    }
+
+    [Fact]
+    public async Task PerClientBudgetRejection_IsDistinctFromGlobalRejection()
+    {
+        using var harness = new TileCacheTestHarness();
+        harness.Settings.TileOutboundBudgetPerIpPerMinute = 1;
+
+        using (var firstScope = harness.CreateScope())
+        {
+            SetHttpContext(firstScope);
+            var firstService = firstScope.ServiceProvider.GetRequiredService<TileCacheService>();
+            Assert.NotNull((await firstService.RetrieveTileAsync(
+                "5", "11", "12", CanonicalTileUrl(5, 11, 12))).TileData);
+        }
+
+        using (var secondScope = harness.CreateScope())
+        {
+            SetHttpContext(secondScope);
+            var secondService = secondScope.ServiceProvider.GetRequiredService<TileCacheService>();
+            var rejected = await secondService.RetrieveTileAsync(
+                "5", "11", "13", CanonicalTileUrl(5, 11, 13));
+            Assert.True(rejected.BudgetExhausted);
+        }
+
+        var diagnostic = AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.ClientBudgetRejected);
+        Assert.Equal("client", diagnostic.Fields["BudgetScope"]);
+        Assert.DoesNotContain(harness.Logs.Entries,
+            entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.GlobalBudgetRejected);
+        Assert.Single(harness.Upstream.Requests);
+    }
+
+    [Fact]
+    public async Task Cancellation_IsNotReportedAsUpstreamFailure()
+    {
+        var upstream = new RecordingTileHandler((_, cancellationToken) =>
+            throw new OperationCanceledException(cancellationToken));
+        using var harness = new TileCacheTestHarness(upstream);
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope);
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        var result = await service.RetrieveTileAsync("5", "14", "15", CanonicalTileUrl(5, 14, 15));
+
+        Assert.Null(result.TileData);
+        var diagnostic = AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.Cancellation);
+        Assert.Equal("upstream", diagnostic.Fields["CancellationStage"]);
+        Assert.DoesNotContain(harness.Logs.Entries,
+            entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.UpstreamFailure);
+    }
+
+    [Fact]
+    public async Task CurrentRetryDelay_IsReportedWithoutChangingRetryPolicy()
+    {
+        var upstream = new RecordingTileHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var harness = new TileCacheTestHarness(upstream);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, _) => Task.CompletedTask);
+        using var scope = harness.CreateScope();
+        SetHttpContext(scope);
+        var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        var result = await service.RetrieveTileAsync("5", "16", "17", CanonicalTileUrl(5, 16, 17));
+
+        Assert.Null(result.TileData);
+        Assert.Equal(3, harness.Upstream.Requests.Count);
+        var delays = harness.Logs.Entries
+            .Where(entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.RetryDelaySelected)
+            .ToArray();
+        Assert.Equal(2, delays.Length);
+        Assert.All(delays, delay =>
+            Assert.Equal(500d, Convert.ToDouble(delay.Fields["RetryDelayMilliseconds"])));
+    }
+
+    private static void SetHttpContext(IServiceScope scope)
+    {
+        scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext =
+            TileCacheTestHarness.CreateHttpContext();
+    }
+
+    private static TestLogProvider.TestLogEntry AssertDiagnostic(
+        TestLogProvider logs,
+        TileCacheDiagnosticEventIds eventId) =>
+        Assert.Single(logs.Entries.Where(entry => entry.EventId.Id == (int)eventId));
+
+    private static string CanonicalTileUrl(int zoom, int x, int y) =>
+        $"https://tile.openstreetmap.org/{zoom}/{x}/{y}.png";
+
+    private static HttpResponseMessage PngResponse(TimeSpan maxAge)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1, 2, 3, 4])
+        };
+        response.Headers.CacheControl = new CacheControlHeaderValue { MaxAge = maxAge };
+        return response;
+    }
+
+    private static bool ContainsSecret(string? value, string secret) =>
+        value?.Contains(secret, StringComparison.Ordinal) == true;
+}

--- a/tests/Wayfarer.Tests/Services/TileCacheTestHarness.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheTestHarness.cs
@@ -16,10 +16,12 @@ namespace Wayfarer.Tests.Services;
 /// <summary>
 /// Builds isolated tile-cache scopes around a recording in-memory upstream provider.
 /// </summary>
-internal sealed class TileCacheTestHarness : IDisposable
+internal sealed class TileCacheTestHarness : IDisposable, IAsyncDisposable
 {
+    private static readonly TimeSpan RefreshCleanupTimeout = TimeSpan.FromSeconds(2);
     private readonly ServiceProvider _rootProvider;
     private readonly TestTileSettingsService _settingsService;
+    private int _disposed;
 
     /// <summary>Gets the isolated cache directory owned by this harness.</summary>
     public string CacheDirectory { get; } =
@@ -86,11 +88,27 @@ internal sealed class TileCacheTestHarness : IDisposable
         return context;
     }
 
-    /// <summary>Disposes service scopes and removes only this harness's GUID-named temporary cache.</summary>
-    public void Dispose()
+    /// <summary>Cancels tracked refreshes before synchronously completing bounded test cleanup.</summary>
+    public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+    /// <summary>Awaits tracked refresh completion before disposing services and deleting temporary data.</summary>
+    public async ValueTask DisposeAsync()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        var refreshesStopped =
+            await TileCacheService.CancelAndWaitForRefreshesForTestingAsync(RefreshCleanupTimeout);
+        if (!refreshesStopped)
+        {
+            Interlocked.Exchange(ref _disposed, 0);
+            throw new TimeoutException("Tracked stale-tile refresh work exceeded the test cleanup timeout.");
+        }
+
         TileCacheService.ResetStaticStateForTesting();
-        _rootProvider.Dispose();
+        await _rootProvider.DisposeAsync();
 
         if (Directory.Exists(CacheDirectory))
         {

--- a/tests/Wayfarer.Tests/Services/TileCacheTestHarness.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheTestHarness.cs
@@ -1,0 +1,175 @@
+using System.Collections.Concurrent;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Wayfarer.Areas.Public.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>
+/// Builds isolated tile-cache scopes around a recording in-memory upstream provider.
+/// </summary>
+internal sealed class TileCacheTestHarness : IDisposable
+{
+    private readonly ServiceProvider _rootProvider;
+    private readonly TestTileSettingsService _settingsService;
+
+    /// <summary>Gets the isolated cache directory owned by this harness.</summary>
+    public string CacheDirectory { get; } =
+        Path.Combine(Path.GetTempPath(), "wayfarer-tile-tests", Guid.NewGuid().ToString("N"));
+
+    /// <summary>Gets structured logs emitted by services created through the harness.</summary>
+    public TestLogProvider Logs { get; } = new();
+
+    /// <summary>Gets the fake upstream provider used by the harness.</summary>
+    public RecordingTileHandler Upstream { get; }
+
+    /// <summary>Gets the mutable settings snapshot supplied to tile services and controllers.</summary>
+    public ApplicationSettings Settings => _settingsService.Settings;
+
+    /// <summary>Creates an isolated harness with the supplied fake upstream behavior.</summary>
+    public TileCacheTestHarness(RecordingTileHandler? upstream = null)
+    {
+        Directory.CreateDirectory(CacheDirectory);
+        Upstream = upstream ?? new RecordingTileHandler();
+        _settingsService = new TestTileSettingsService();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["CacheSettings:TileCacheDirectory"] = CacheDirectory,
+                ["Application:ContactEmail"] = "tiles@example.test"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSingleton<IApplicationSettingsService>(_settingsService);
+        services.AddScoped<IHttpContextAccessor, HttpContextAccessor>();
+        services.AddSingleton(new HttpClient(Upstream) { Timeout = TimeSpan.FromSeconds(10) });
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(Logs);
+        });
+        services.AddSingleton<TileMetadataHotCache>();
+        services.AddDbContext<ApplicationDbContext>(options =>
+            options.UseInMemoryDatabase($"tile-diagnostics-{Guid.NewGuid():N}"));
+        services.AddScoped<TileCacheService>();
+
+        _rootProvider = services.BuildServiceProvider();
+        TileCacheService.ResetStaticStateForTesting();
+        TilesController.OutboundBudgetCache.Clear();
+        TilesController.RateLimitCache.Clear();
+        TilesController.AuthRateLimitCache.Clear();
+    }
+
+    /// <summary>Creates a fresh service scope for one independent tile request.</summary>
+    public IServiceScope CreateScope() => _rootProvider.CreateScope();
+
+    /// <summary>Creates a same-origin HTTP context for a tile request.</summary>
+    public static DefaultHttpContext CreateHttpContext(CancellationToken cancellationToken = default)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("wayfarer.example.test");
+        context.Request.Headers.Referer = "https://wayfarer.example.test/trip";
+        context.Connection.RemoteIpAddress = IPAddress.Parse("192.0.2.10");
+        context.RequestAborted = cancellationToken;
+        return context;
+    }
+
+    /// <summary>Disposes service scopes and removes only this harness's GUID-named temporary cache.</summary>
+    public void Dispose()
+    {
+        TileCacheService.ResetStaticStateForTesting();
+        _rootProvider.Dispose();
+
+        if (Directory.Exists(CacheDirectory))
+        {
+            Directory.Delete(CacheDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>Supplies a mutable settings snapshot without persistence side effects.</summary>
+    private sealed class TestTileSettingsService : IApplicationSettingsService
+    {
+        public ApplicationSettings Settings { get; } = new()
+        {
+            Id = 1,
+            MaxCacheTileSizeInMB = 10,
+            TileMetadataHotCacheSizeMB = ApplicationSettings.DefaultTileMetadataHotCacheSizeMB,
+            TileProviderKey = ApplicationSettings.DefaultTileProviderKey,
+            TileProviderUrlTemplate = ApplicationSettings.DefaultTileProviderUrlTemplate,
+            TileRateLimitEnabled = false,
+            TileOutboundBudgetPerIpPerMinute = 0
+        };
+
+        /// <inheritdoc />
+        public ApplicationSettings GetSettings() => Settings;
+
+        /// <inheritdoc />
+        public string GetUploadsDirectoryPath() => Path.Combine(Path.GetTempPath(), "uploads");
+
+        /// <inheritdoc />
+        public void RefreshSettings() { }
+    }
+}
+
+/// <summary>
+/// Records every intercepted upstream request and returns deterministic local responses.
+/// </summary>
+internal sealed class RecordingTileHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responseFactory;
+    private readonly Func<TimeSpan>? _startTimeProvider;
+    private readonly ConcurrentQueue<RecordedTileRequest> _requests = new();
+
+    /// <summary>Gets all intercepted requests in start order.</summary>
+    public IReadOnlyCollection<RecordedTileRequest> Requests => _requests.ToArray();
+
+    /// <summary>Creates a handler that returns cacheable PNG bytes.</summary>
+    public RecordingTileHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? responseFactory = null,
+        Func<TimeSpan>? startTimeProvider = null)
+    {
+        _startTimeProvider = startTimeProvider;
+        _responseFactory = responseFactory ?? ((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3, 4])
+            };
+            response.Headers.CacheControl = new System.Net.Http.Headers.CacheControlHeaderValue
+            {
+                MaxAge = TimeSpan.FromHours(1)
+            };
+            return Task.FromResult(response);
+        });
+    }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        _requests.Enqueue(new RecordedTileRequest(
+            request.RequestUri,
+            _startTimeProvider?.Invoke() ?? TimeSpan.Zero,
+            request.Headers.ToDictionary(header => header.Key, header => header.Value.ToArray())));
+        return _responseFactory(request, cancellationToken);
+    }
+}
+
+/// <summary>Captures the non-secret request data needed by provider-policy assertions.</summary>
+internal sealed record RecordedTileRequest(
+    Uri? RequestUri,
+    TimeSpan StartTime,
+    IReadOnlyDictionary<string, string[]> Headers);


### PR DESCRIPTION
## Summary

Implements the first independently mergeable diagnostics and regression-coverage slice of #385.

- adds stable structured tile-pipeline event IDs for cache, stale refresh, cold misses, budget outcomes, upstream attempts/statuses, retry delays, cancellation, cache writes, conditional responses, and transport failures;
- keeps diagnostic fields bounded and removes provider URLs, redirect hosts, IP addresses, API keys, route/query paths, and user identities;
- distinguishes authenticated request throttling, anonymous request throttling, and outbound per-client allowance rejection;
- distinguishes caller cancellation from uncancelled upstream timeout/transport cancellation;
- extracts the existing outbound budget into a cohesive unit without changing burst, replenishment, timeout, response, or retry behavior;
- adds fake-upstream policy regressions, a nominal analytical cold-cache baseline, and a bounded behavioral characterization using the real production budget;
- makes stale-refresh test cleanup cancellation-aware and bounded.

## Why

Cold-cache viewports currently exhibit an initial burst followed by long gaps and local 503 responses. Before changing retry/status behavior or scheduling policy, this slice establishes privacy-safe diagnostics and deterministic evidence for the existing behavior.

The controlled baseline records:

- 24 unique cold tiles;
- burst capacity 12;
- sustained rate 2 acquisitions/second;
- an unbounded waiter set;
- nominal 100 ms upstream latency;
- 19 accepted requests and 5 local 503 rejections under the analytical model;
- `Retry-After: 6` for rejected requests.

This PR does **not** claim a speed improvement and does not define the current burst/gap behavior as permanent policy.

## Scope boundaries

This is Phase 1 only. It does not implement:

- upstream `Retry-After` or status-mapping corrections;
- new retry counts or delays;
- cold-miss coalescing;
- bounded or priority-aware queues;
- provider profiles or transport changes;
- historical 30/minute handling;
- attribution changes;
- browser or mobile changes.

Those remain later slices of #385. This PR is **part of #385** and must not close the parent issue.

## Validation

- remediation regressions: 11 passed, 0 failed;
- all Phase 1 tests: 20 passed, 0 failed;
- existing tile cache, stale refresh, controller, and provider tests: 80 passed, 0 failed;
- full .NET suite: 1,701 passed, 9 environment-gated PostgreSQL tests skipped, 0 failed;
- `dotnet build Wayfarer.sln --no-restore`: succeeded with 0 errors;
- LOC checker: passed; no warning in Phase 1 files;
- `git diff --check`: passed;
- tracked-artifact audit: clean;
- independent re-review: no findings, `PHASE 1 CODE READY`.

All upstream requests in automated coverage use a fake handler. No public tile provider was contacted.

## UI and database impact

- Screenshots: not applicable; no UI behavior changes.
- Database migration: none.
- Configuration changes: none.
- Existing AngleSharp and SQLitePCLRaw advisories remain unchanged; no package files were modified.
