### PR TITLE
Correct tile retry and upstream status handling

### DIFF
--- a/Areas/Public/Controllers/TilesController.cs
+++ b/Areas/Public/Controllers/TilesController.cs
@@ -127,6 +127,7 @@ public class TilesController : Controller
                 {
                     TileCacheDiagnostics.ClientBudgetRejected(_logger, "request-authenticated");
                     _logger.LogWarning("Tile request rate limit exceeded for an authenticated client.");
+                    Response.Headers["Retry-After"] = BudgetRetryAfterSeconds.ToString();
                     return StatusCode(429, "Too many requests. Please try again later.");
                 }
             }
@@ -145,6 +146,7 @@ public class TilesController : Controller
                 {
                     TileCacheDiagnostics.ClientBudgetRejected(_logger, "request-anonymous");
                     _logger.LogWarning("Tile request rate limit exceeded for an anonymous client.");
+                    Response.Headers["Retry-After"] = BudgetRetryAfterSeconds.ToString();
                     return StatusCode(429, "Too many requests. Please try again later.");
                 }
             }
@@ -164,17 +166,30 @@ public class TilesController : Controller
         // or indicate the tile was not found (404).
         var result = await _tileCacheService.RetrieveTileAsync(z.ToString(), x.ToString(), y.ToString(), tileUrl, HttpContext.RequestAborted);
 
-        if (result.BudgetExhausted)
+        if (result.Status is TileRetrievalStatus.BudgetRejected or TileRetrievalStatus.TransientFailure)
         {
-            _logger.LogWarning("Tile budget exhausted for {Z}/{X}/{Y}", z, x, y);
-            Response.Headers["Retry-After"] = BudgetRetryAfterSeconds.ToString();
+            var retryAfter = result.RetryAfterSeconds ?? BudgetRetryAfterSeconds;
+            _logger.LogWarning("Tile request ended with transient status {TileStatus}.", result.Status);
+            Response.Headers["Retry-After"] = retryAfter.ToString();
             return StatusCode(503, "Tile server busy. Please retry shortly.");
+        }
+
+        if (result.Status == TileRetrievalStatus.NotFound)
+        {
+            _logger.LogDebug("Tile provider confirmed tile absence.");
+            return NotFound("Tile not found.");
+        }
+
+        if (result.Status == TileRetrievalStatus.PermanentFailure)
+        {
+            _logger.LogWarning("Tile provider returned a permanent non-absence response.");
+            return StatusCode(StatusCodes.Status502BadGateway, "Tile provider rejected the request.");
         }
 
         if (result.TileData == null)
         {
-            _logger.LogError("Tile data not found for {Z}/{X}/{Y}", z, x, y);
-            return NotFound("Tile not found.");
+            _logger.LogError("Successful tile retrieval returned no tile data.");
+            return StatusCode(StatusCodes.Status500InternalServerError, "Tile retrieval failed.");
         }
 
         // Set browser cache headers. Tiles are stable and rarely change;

--- a/Services/TileCacheDiagnostics.cs
+++ b/Services/TileCacheDiagnostics.cs
@@ -53,7 +53,13 @@ internal enum TileCacheDiagnosticEventIds
     ConditionalResponseOutcome = 38514,
 
     /// <summary>An upstream operation failed without an HTTP response.</summary>
-    UpstreamFailure = 38515
+    UpstreamFailure = 38515,
+
+    /// <summary>A provider-wide delay gate was established, awaited, or rejected.</summary>
+    ProviderDelay = 38516,
+
+    /// <summary>An upstream outcome was classified for controller-safe handling.</summary>
+    UpstreamClassification = 38517
 }
 
 /// <summary>
@@ -203,4 +209,24 @@ internal static partial class TileCacheDiagnostics
     public static partial void UpstreamFailure(
         ILogger logger,
         string failureStage);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.ProviderDelay,
+        EventName = nameof(TileCacheDiagnosticEventIds.ProviderDelay),
+        Level = LogLevel.Warning,
+        Message = "Tile provider delay decision was {ProviderDelayOutcome} with {DelayMilliseconds} ms remaining.")]
+    public static partial void ProviderDelay(
+        ILogger logger,
+        string providerDelayOutcome,
+        double delayMilliseconds);
+
+    [LoggerMessage(
+        EventId = (int)TileCacheDiagnosticEventIds.UpstreamClassification,
+        EventName = nameof(TileCacheDiagnosticEventIds.UpstreamClassification),
+        Level = LogLevel.Debug,
+        Message = "Tile upstream outcome was classified as {UpstreamOutcome} at attempt {AttemptNumber}.")]
+    public static partial void UpstreamClassification(
+        ILogger logger,
+        string upstreamOutcome,
+        int attemptNumber);
 }

--- a/Services/TileCacheRefreshCoordinator.cs
+++ b/Services/TileCacheRefreshCoordinator.cs
@@ -68,9 +68,9 @@ public partial class TileCacheService
 
                 try
                 {
-                    var refreshed = await RevalidateTileInFreshScopeAsync(series);
-
-                    if (refreshed != null)
+                    var outcome = await RevalidateTileInFreshScopeAsync(series);
+                    if (outcome is StaleRefreshOutcome.Completed or StaleRefreshOutcome.Terminal ||
+                        series.ContactState.IsExhausted)
                     {
                         return;
                     }
@@ -132,13 +132,11 @@ public partial class TileCacheService
     /// Runs a background refresh attempt through a newly-created DI scope.
     /// The scheduled series carries only immutable primitive values from the request.
     /// </summary>
-    private async Task<byte[]?> RevalidateTileInFreshScopeAsync(TileRefreshSeries series)
+    private async Task<StaleRefreshOutcome> RevalidateTileInFreshScopeAsync(TileRefreshSeries series)
     {
         using var scope = _serviceScopeFactory.CreateScope();
         var tileCacheService = scope.ServiceProvider.GetRequiredService<TileCacheService>();
-        return await tileCacheService.RevalidateTileAsync(series.TileUrl, series.TileFilePath,
-            series.TileKey, series.Zoom, series.X, series.Y, series.ETag,
-            series.LastModified, series.ClientIp, series.Attempts, series.CancellationToken);
+        return await tileCacheService.RevalidateTileAsync(series);
     }
 
     /// <summary>
@@ -276,6 +274,12 @@ public partial class TileCacheService
         public DateTime StartedAtUtc { get; } = DateTime.UtcNow;
         public CancellationToken CancellationToken => _cancellationTokenSource.Token;
         public int Attempts { get; set; }
+
+        /// <summary>Gets shared actual-contact state for all redirects and retries in this series.</summary>
+        public TileContactState ContactState { get; } = new();
+
+        /// <summary>Gets or sets whether the initiating client's outbound allowance was recorded.</summary>
+        public bool ClientAllowanceCharged { get; set; }
 
         /// <summary>Gets or sets the bounded stage owned by the outer cancellation boundary.</summary>
         public string CancellationStage { get; set; } = "stale-refresh-attempt";

--- a/Services/TileCacheRefreshCoordinator.cs
+++ b/Services/TileCacheRefreshCoordinator.cs
@@ -16,19 +16,10 @@ public partial class TileCacheService
     private const int RefreshSeriesMaxAttempts = 3;
 
     /// <summary>
-    /// Maximum wall-clock lifetime for one stale-tile refresh series.
+    /// Maximum wall-clock lifetime for one stale-tile refresh series under the interim profile.
     /// </summary>
-    private static readonly TimeSpan RefreshSeriesMaxDuration = TimeSpan.FromMinutes(2);
-
-    /// <summary>
-    /// Initial delay before retrying a failed stale-tile refresh attempt.
-    /// </summary>
-    private static readonly TimeSpan RefreshRetryInitialDelay = TimeSpan.FromSeconds(5);
-
-    /// <summary>
-    /// Maximum delay before retrying a failed stale-tile refresh attempt.
-    /// </summary>
-    private static readonly TimeSpan RefreshRetryMaxDelay = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan RefreshSeriesMaxDuration =
+        TileProviderRetryPolicy.MaxInteractiveDuration;
 
     /// <summary>
     /// Test-overridable delay provider for bounded refresh retry backoff.
@@ -132,16 +123,10 @@ public partial class TileCacheService
     }
 
     /// <summary>
-    /// Calculates exponential refresh retry delay with jitter to avoid synchronized retries.
+    /// Uses the shared interim exponential retry delay with injectable jitter.
     /// </summary>
-    private static TimeSpan CalculateRefreshRetryDelay(int failedAttempts)
-    {
-        var exponent = Math.Max(0, failedAttempts - 1);
-        var delayMs = RefreshRetryInitialDelay.TotalMilliseconds * Math.Pow(2, exponent);
-        delayMs = Math.Min(delayMs, RefreshRetryMaxDelay.TotalMilliseconds);
-        delayMs *= 0.75 + Random.Shared.NextDouble() * 0.5;
-        return TimeSpan.FromMilliseconds(delayMs);
-    }
+    private static TimeSpan CalculateRefreshRetryDelay(int failedAttempts) =>
+        TileProviderRetryPolicy.GetFallbackDelay(failedAttempts);
 
     /// <summary>
     /// Runs a background refresh attempt through a newly-created DI scope.

--- a/Services/TileCacheRetry.cs
+++ b/Services/TileCacheRetry.cs
@@ -1,0 +1,205 @@
+using System.Net;
+using Wayfarer.Services;
+
+public partial class TileCacheService
+{
+    /// <summary>
+    /// Executes the interim cold-tile retry policy without taking ownership of cache persistence.
+    /// </summary>
+    private async Task<TileDownloadResult> DownloadTileWithRetryAsync(
+        string tileUrl,
+        CancellationToken cancellationToken)
+    {
+        var providerKey = TileProviderRetryPolicy.GetProviderKey(tileUrl);
+        var interactiveDeadline = TileProviderRetryPolicy.UtcNow +
+                                  TileProviderRetryPolicy.MaxInteractiveDuration;
+
+        for (var attemptNumber = 1;
+             attemptNumber <= TileProviderRetryPolicy.MaxAttempts;
+             attemptNumber++)
+        {
+            var attemptRemaining = interactiveDeadline - TileProviderRetryPolicy.UtcNow;
+            if (attemptRemaining <= TimeSpan.Zero)
+            {
+                return TileDownloadResult.Transient(TileProviderRetryPolicy.FallbackDelayCap);
+            }
+
+            using var attemptCancellation =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            attemptCancellation.CancelAfter(attemptRemaining);
+            TileRequestSendResult sendResult;
+            try
+            {
+                sendResult = await SendTileRequestAsync(
+                    tileUrl,
+                    chargeClientAllowance: attemptNumber == 1,
+                    attemptNumber: attemptNumber,
+                    interactiveDeadline: interactiveDeadline,
+                    callerCancellationToken: cancellationToken,
+                    cancellationToken: attemptCancellation.Token);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                TileCacheDiagnostics.UpstreamClassification(
+                    _logger, "transient-timeout", attemptNumber);
+                if (!await DelayForFallbackRetryAsync(
+                        attemptNumber, interactiveDeadline, cancellationToken))
+                {
+                    return TileDownloadResult.Transient(
+                        TileProviderRetryPolicy.GetFallbackDelay(attemptNumber));
+                }
+
+                continue;
+            }
+            catch (HttpRequestException)
+            {
+                TileCacheDiagnostics.UpstreamClassification(
+                    _logger, "transient-transport", attemptNumber);
+                if (!await DelayForFallbackRetryAsync(
+                        attemptNumber, interactiveDeadline, cancellationToken))
+                {
+                    return TileDownloadResult.Transient(
+                        TileProviderRetryPolicy.GetFallbackDelay(attemptNumber));
+                }
+
+                continue;
+            }
+
+            if (sendResult.Rejection is TileRequestRejection.ClientBudget or
+                TileRequestRejection.GlobalBudget)
+            {
+                _logger.LogWarning("Outbound tile budget rejected cache fill.");
+                return TileDownloadResult.BudgetRejected();
+            }
+
+            if (sendResult.Rejection == TileRequestRejection.ProviderDeferred)
+            {
+                return TileDownloadResult.Transient(sendResult.RetryAfter);
+            }
+
+            if (sendResult.Rejection == TileRequestRejection.InvalidProviderResponse)
+            {
+                TileCacheDiagnostics.UpstreamClassification(
+                    _logger, "transient-invalid-response", attemptNumber);
+                return TileDownloadResult.Transient(
+                    TileProviderRetryPolicy.GetFallbackDelay(attemptNumber));
+            }
+
+            using var response = sendResult.Response!;
+            if (response.IsSuccessStatusCode)
+            {
+                var tileData = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+                return TileDownloadResult.Downloaded(
+                    tileData,
+                    response.Headers.ETag?.Tag,
+                    response.Content.Headers.LastModified?.UtcDateTime,
+                    ParseCacheExpiry(response));
+            }
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                TileCacheDiagnostics.UpstreamClassification(
+                    _logger, "permanent-not-found", attemptNumber);
+                return TileDownloadResult.NotFound();
+            }
+
+            if (IsPermanentUpstreamClientFailure(response.StatusCode))
+            {
+                TileCacheDiagnostics.UpstreamClassification(
+                    _logger, "permanent-client-response", attemptNumber);
+                return TileDownloadResult.PermanentFailure();
+            }
+
+            TileCacheDiagnostics.UpstreamClassification(
+                _logger, "transient-response", attemptNumber);
+            if (response.StatusCode is HttpStatusCode.TooManyRequests or
+                HttpStatusCode.ServiceUnavailable)
+            {
+                var providerDelay = TileProviderRetryPolicy.ApplyRetryAfter(providerKey, response);
+                if (providerDelay.Kind == ProviderDelayKind.Valid)
+                {
+                    TileCacheDiagnostics.ProviderDelay(
+                        _logger, "provider-directed", providerDelay.Delay.TotalMilliseconds);
+                    var remaining = interactiveDeadline - TileProviderRetryPolicy.UtcNow;
+                    if (attemptNumber >= TileProviderRetryPolicy.MaxAttempts ||
+                        providerDelay.Delay > remaining ||
+                        providerDelay.Delay > TileProviderRetryPolicy.MaxIndividualWait)
+                    {
+                        return TileDownloadResult.Transient(providerDelay.Delay);
+                    }
+
+                    continue;
+                }
+
+                if (providerDelay.Kind == ProviderDelayKind.Invalid)
+                {
+                    TileCacheDiagnostics.ProviderDelay(
+                        _logger, "invalid-provider-value", providerDelay.Delay.TotalMilliseconds);
+                    _logger.LogError(
+                        "Tile provider supplied an unusable Retry-After value; bounded provider safety gate opened.");
+                    return TileDownloadResult.Transient(providerDelay.Delay);
+                }
+            }
+
+            if (attemptNumber >= TileProviderRetryPolicy.MaxAttempts)
+            {
+                TileCacheDiagnostics.UpstreamClassification(
+                    _logger, "transient-exhausted", attemptNumber);
+                return TileDownloadResult.Transient(
+                    TileProviderRetryPolicy.GetFallbackDelay(attemptNumber));
+            }
+
+            if (!await DelayForFallbackRetryAsync(
+                    attemptNumber, interactiveDeadline, cancellationToken))
+            {
+                return TileDownloadResult.Transient(
+                    TileProviderRetryPolicy.GetFallbackDelay(attemptNumber));
+            }
+        }
+
+        return TileDownloadResult.Transient(TileProviderRetryPolicy.FallbackDelayCap);
+    }
+
+    /// <summary>Waits for one bounded fallback retry delay while preserving caller cancellation.</summary>
+    private async Task<bool> DelayForFallbackRetryAsync(
+        int failedAttempts,
+        DateTimeOffset interactiveDeadline,
+        CancellationToken cancellationToken)
+    {
+        if (failedAttempts >= TileProviderRetryPolicy.MaxAttempts)
+        {
+            return false;
+        }
+
+        var retryDelay = TileProviderRetryPolicy.GetFallbackDelay(failedAttempts);
+        var remaining = interactiveDeadline - TileProviderRetryPolicy.UtcNow;
+        if (remaining <= TimeSpan.Zero || retryDelay > remaining)
+        {
+            return false;
+        }
+
+        TileCacheDiagnostics.RetryDelaySelected(
+            _logger,
+            retryDelay.TotalMilliseconds,
+            "fallback");
+        try
+        {
+            await _coldMissRetryDelay(retryDelay, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            TileCacheDiagnostics.Cancellation(_logger, "cold-miss-retry-delay");
+            throw;
+        }
+    }
+
+    /// <summary>Identifies permanent provider client responses that must never be retried.</summary>
+    private static bool IsPermanentUpstreamClientFailure(HttpStatusCode statusCode) =>
+        (int)statusCode is >= 400 and < 500 &&
+        statusCode is not HttpStatusCode.RequestTimeout and not HttpStatusCode.TooManyRequests;
+}

--- a/Services/TileCacheRetry.cs
+++ b/Services/TileCacheRetry.cs
@@ -13,6 +13,7 @@ public partial class TileCacheService
         var providerKey = TileProviderRetryPolicy.GetProviderKey(tileUrl);
         var interactiveDeadline = TileProviderRetryPolicy.UtcNow +
                                   TileProviderRetryPolicy.MaxInteractiveDuration;
+        var contactState = new TileContactState();
 
         for (var attemptNumber = 1;
              attemptNumber <= TileProviderRetryPolicy.MaxAttempts;
@@ -35,6 +36,7 @@ public partial class TileCacheService
                     chargeClientAllowance: attemptNumber == 1,
                     attemptNumber: attemptNumber,
                     interactiveDeadline: interactiveDeadline,
+                    contactState: contactState,
                     callerCancellationToken: cancellationToken,
                     cancellationToken: attemptCancellation.Token);
             }
@@ -46,6 +48,12 @@ public partial class TileCacheService
             {
                 TileCacheDiagnostics.UpstreamClassification(
                     _logger, "transient-timeout", attemptNumber);
+                if (contactState.IsExhausted)
+                {
+                    return TileDownloadResult.Transient(
+                        TileProviderRetryPolicy.GetFallbackDelay(attemptNumber));
+                }
+
                 if (!await DelayForFallbackRetryAsync(
                         attemptNumber, interactiveDeadline, cancellationToken))
                 {
@@ -59,6 +67,12 @@ public partial class TileCacheService
             {
                 TileCacheDiagnostics.UpstreamClassification(
                     _logger, "transient-transport", attemptNumber);
+                if (contactState.IsExhausted)
+                {
+                    return TileDownloadResult.Transient(
+                        TileProviderRetryPolicy.GetFallbackDelay(attemptNumber));
+                }
+
                 if (!await DelayForFallbackRetryAsync(
                         attemptNumber, interactiveDeadline, cancellationToken))
                 {
@@ -79,6 +93,14 @@ public partial class TileCacheService
             if (sendResult.Rejection == TileRequestRejection.ProviderDeferred)
             {
                 return TileDownloadResult.Transient(sendResult.RetryAfter);
+            }
+
+            if (sendResult.Rejection == TileRequestRejection.ContactLimit)
+            {
+                TileCacheDiagnostics.UpstreamClassification(
+                    _logger, "transient-exhausted", attemptNumber);
+                return TileDownloadResult.Transient(
+                    TileProviderRetryPolicy.GetFallbackDelay(attemptNumber));
             }
 
             if (sendResult.Rejection == TileRequestRejection.InvalidProviderResponse)
@@ -126,6 +148,7 @@ public partial class TileCacheService
                         _logger, "provider-directed", providerDelay.Delay.TotalMilliseconds);
                     var remaining = interactiveDeadline - TileProviderRetryPolicy.UtcNow;
                     if (attemptNumber >= TileProviderRetryPolicy.MaxAttempts ||
+                        contactState.IsExhausted ||
                         providerDelay.Delay > remaining ||
                         providerDelay.Delay > TileProviderRetryPolicy.MaxIndividualWait)
                     {
@@ -146,6 +169,14 @@ public partial class TileCacheService
             }
 
             if (attemptNumber >= TileProviderRetryPolicy.MaxAttempts)
+            {
+                TileCacheDiagnostics.UpstreamClassification(
+                    _logger, "transient-exhausted", attemptNumber);
+                return TileDownloadResult.Transient(
+                    TileProviderRetryPolicy.GetFallbackDelay(attemptNumber));
+            }
+
+            if (contactState.IsExhausted)
             {
                 TileCacheDiagnostics.UpstreamClassification(
                     _logger, "transient-exhausted", attemptNumber);

--- a/Services/TileCacheService.cs
+++ b/Services/TileCacheService.cs
@@ -1284,11 +1284,9 @@ public partial class TileCacheService
                     newExpiry);
             }
 
-            byte[]? data = null;
             if (series.Zoom < DbMetadataZoomThreshold)
             {
-                // Sidecar write + file read under the same lock to prevent a concurrent
-                // purge from deleting the sidecar between write and read (TOCTOU).
+                // Keep the low-zoom sidecar update serialized with other cache file operations.
                 await _cacheLock.WaitAsync();
                 try
                 {
@@ -1298,31 +1296,10 @@ public partial class TileCacheService
                         LastModifiedUpstream = series.LastModified,
                         ExpiresAtUtc = newExpiry
                     });
-
-                    if (File.Exists(series.TileFilePath))
-                    {
-                        data = await File.ReadAllBytesAsync(series.TileFilePath);
-                    }
                 }
                 finally
                 {
                     _cacheLock.Release();
-                }
-            }
-            else
-            {
-                // zoom >= 9: no sidecar write needed — lock-free read
-                // (consistent with other read paths in RetrieveTileAsync).
-                try
-                {
-                    if (File.Exists(series.TileFilePath))
-                    {
-                        data = await File.ReadAllBytesAsync(series.TileFilePath);
-                    }
-                }
-                catch (IOException)
-                {
-                    // File deleted by concurrent eviction/purge — treat as cache miss.
                 }
             }
 

--- a/Services/TileCacheService.cs
+++ b/Services/TileCacheService.cs
@@ -308,6 +308,7 @@ public partial class TileCacheService
         Action<HttpRequestMessage>? configureRequest = null, bool chargeClientAllowance = true,
         string? clientIp = null, bool allowHttpContext = true, int attemptNumber = 1,
         bool deferCancellationDiagnostic = false, DateTimeOffset? interactiveDeadline = null,
+        TileContactState? contactState = null, Action? onClientAllowanceCharged = null,
         CancellationToken callerCancellationToken = default,
         CancellationToken cancellationToken = default)
     {
@@ -352,9 +353,15 @@ public partial class TileCacheService
         var currentUri = initialUri;
         var providerKey = TileProviderRetryPolicy.GetProviderKey(tileUrl);
         var requestKind = configureRequest == null ? "unconditional" : "conditional";
+        contactState ??= new TileContactState();
 
         for (var redirectCount = 0; redirectCount <= maxRedirects; redirectCount++)
         {
+            if (contactState.IsExhausted)
+            {
+                return TileRequestSendResult.Rejected(TileRequestRejection.ContactLimit);
+            }
+
             var providerDelay = TileProviderRetryPolicy.GetRemainingProviderDelay(providerKey);
             if (providerDelay > TimeSpan.Zero)
             {
@@ -429,13 +436,6 @@ public partial class TileCacheService
                 return TileRequestSendResult.Rejected(TileRequestRejection.GlobalBudget);
             }
 
-            // Charge the initiating client's allowance once, immediately before its first contact.
-            if (resolvedIpForBudget != null)
-            {
-                RateLimitHelper.RecordRateLimitHit(TilesController.OutboundBudgetCache, resolvedIpForBudget);
-                resolvedIpForBudget = null;
-            }
-
             using var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
 
             // OSM requires a Referer header. Derive it from the incoming HTTP request
@@ -449,6 +449,20 @@ public partial class TileCacheService
 
             // Let the caller add conditional headers (If-None-Match, If-Modified-Since, etc.)
             configureRequest?.Invoke(request);
+
+            // Reserve immediately before transport so retries and redirects share one hard ceiling.
+            if (!contactState.TryReserveContact())
+            {
+                return TileRequestSendResult.Rejected(TileRequestRejection.ContactLimit);
+            }
+
+            // Charge once only after this series has admitted its first actual provider contact.
+            if (resolvedIpForBudget != null)
+            {
+                RateLimitHelper.RecordRateLimitHit(TilesController.OutboundBudgetCache, resolvedIpForBudget);
+                resolvedIpForBudget = null;
+                onClientAllowanceCharged?.Invoke();
+            }
 
             TileCacheDiagnostics.UpstreamAttempt(_logger, requestKind, attemptNumber);
             HttpResponseMessage response;
@@ -532,12 +546,14 @@ public partial class TileCacheService
         string? clientIp = null,
         int attemptNumber = 1,
         DateTimeOffset? interactiveDeadline = null,
+        TileContactState? contactState = null,
         CancellationToken callerCancellationToken = default,
         CancellationToken cancellationToken = default)
     {
         return SendTileRequestCoreAsync(tileUrl, chargeClientAllowance: chargeClientAllowance,
             clientIp: clientIp, attemptNumber: attemptNumber,
             interactiveDeadline: interactiveDeadline,
+            contactState: contactState,
             callerCancellationToken: callerCancellationToken,
             cancellationToken: cancellationToken);
     }
@@ -548,7 +564,9 @@ public partial class TileCacheService
     /// </summary>
     private Task<TileRequestSendResult> SendConditionalTileRequestAsync(string tileUrl, string? etag,
         DateTime? lastModified, string? clientIp = null, bool allowHttpContext = true,
-        int attemptNumber = 1, CancellationToken cancellationToken = default)
+        bool chargeClientAllowance = true, int attemptNumber = 1,
+        TileContactState? contactState = null, Action? onClientAllowanceCharged = null,
+        CancellationToken cancellationToken = default)
     {
         return SendTileRequestCoreAsync(tileUrl, request =>
         {
@@ -565,9 +583,11 @@ public partial class TileCacheService
             {
                 request.Headers.IfModifiedSince = new DateTimeOffset(lastModified.Value, TimeSpan.Zero);
             }
-        }, chargeClientAllowance: attemptNumber == 1, clientIp: clientIp,
+        }, chargeClientAllowance: chargeClientAllowance, clientIp: clientIp,
             allowHttpContext: allowHttpContext, attemptNumber: attemptNumber,
             deferCancellationDiagnostic: true,
+            contactState: contactState,
+            onClientAllowanceCharged: onClientAllowanceCharged,
             callerCancellationToken: cancellationToken,
             cancellationToken: cancellationToken);
     }
@@ -1199,29 +1219,38 @@ public partial class TileCacheService
     /// Re-validates an expired cached tile by sending a conditional HTTP request.
     /// On 304 Not Modified: updates metadata expiry and serves cached file.
     /// On 200 OK: replaces file on disk and updates all metadata.
-    /// On failure: returns null (caller will serve stale cached tile).
+    /// Returns a typed refresh outcome while callers continue serving stale cached bytes.
     /// Called from the bounded <see cref="_refreshSeries"/> coordinator to ensure at most
     /// one active refresh series exists per expired tile.
     /// Uses its own DB scope because the coalescing pattern means the originating request's
     /// scoped DbContext may be disposed while other callers are still awaiting the result.
     /// </summary>
-    private async Task<byte[]?> RevalidateTileAsync(string tileUrl, string tileFilePath, string tileKey,
-        int zoom, int x, int y, string? etag, DateTime? lastModified,
-        string? clientIp = null, int attemptNumber = 1, CancellationToken cancellationToken = default)
+    private async Task<StaleRefreshOutcome> RevalidateTileAsync(TileRefreshSeries series)
     {
-        var sendResult = await SendConditionalTileRequestAsync(tileUrl, etag, lastModified, clientIp,
-            allowHttpContext: false, attemptNumber: attemptNumber, cancellationToken: cancellationToken);
+        var sendResult = await SendConditionalTileRequestAsync(
+            series.TileUrl,
+            series.ETag,
+            series.LastModified,
+            series.ClientIp,
+            allowHttpContext: false,
+            chargeClientAllowance: !series.ClientAllowanceCharged,
+            attemptNumber: series.Attempts,
+            contactState: series.ContactState,
+            onClientAllowanceCharged: () => series.ClientAllowanceCharged = true,
+            cancellationToken: series.CancellationToken);
         if (sendResult.Response == null)
         {
-            TileCacheDiagnostics.StaleRefreshRejected(_logger, "rejected", zoom);
+            TileCacheDiagnostics.StaleRefreshRejected(_logger, "rejected", series.Zoom);
             _logger.LogWarning("Conditional tile request rejected before upstream transport.");
-            return null;
+            return sendResult.Rejection == TileRequestRejection.ContactLimit
+                ? StaleRefreshOutcome.Transient
+                : StaleRefreshOutcome.PreTransportRejected;
         }
 
         using var response = sendResult.Response;
         if (response.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
         {
-            var providerKey = TileProviderRetryPolicy.GetProviderKey(tileUrl);
+            var providerKey = TileProviderRetryPolicy.GetProviderKey(series.TileUrl);
             var providerDelay = TileProviderRetryPolicy.ApplyRetryAfter(providerKey, response);
             if (providerDelay.Kind != ProviderDelayKind.Missing)
             {
@@ -1238,34 +1267,41 @@ public partial class TileCacheService
         {
             // 304: tile hasn't changed. Update expiry from response headers.
             var newExpiry = ParseCacheExpiry(response);
-            var newEtag = response.Headers.ETag?.Tag ?? etag;
+            var newEtag = response.Headers.ETag?.Tag ?? series.ETag;
 
-            if (zoom >= DbMetadataZoomThreshold)
+            if (series.Zoom >= DbMetadataZoomThreshold)
             {
                 // Use own scope to avoid disposed DbContext from the originating request.
                 using var scope = _serviceScopeFactory.CreateScope();
                 var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-                await UpdateTileExpiryScopedAsync(dbContext, zoom, x, y, newEtag, lastModified, newExpiry);
+                await UpdateTileExpiryScopedAsync(
+                    dbContext,
+                    series.Zoom,
+                    series.X,
+                    series.Y,
+                    newEtag,
+                    series.LastModified,
+                    newExpiry);
             }
 
             byte[]? data = null;
-            if (zoom < DbMetadataZoomThreshold)
+            if (series.Zoom < DbMetadataZoomThreshold)
             {
                 // Sidecar write + file read under the same lock to prevent a concurrent
                 // purge from deleting the sidecar between write and read (TOCTOU).
                 await _cacheLock.WaitAsync();
                 try
                 {
-                    WriteSidecarMetadata(tileFilePath, new TileSidecarMetadata
+                    WriteSidecarMetadata(series.TileFilePath, new TileSidecarMetadata
                     {
                         ETag = newEtag,
-                        LastModifiedUpstream = lastModified,
+                        LastModifiedUpstream = series.LastModified,
                         ExpiresAtUtc = newExpiry
                     });
 
-                    if (File.Exists(tileFilePath))
+                    if (File.Exists(series.TileFilePath))
                     {
-                        data = await File.ReadAllBytesAsync(tileFilePath);
+                        data = await File.ReadAllBytesAsync(series.TileFilePath);
                     }
                 }
                 finally
@@ -1279,9 +1315,9 @@ public partial class TileCacheService
                 // (consistent with other read paths in RetrieveTileAsync).
                 try
                 {
-                    if (File.Exists(tileFilePath))
+                    if (File.Exists(series.TileFilePath))
                     {
-                        data = await File.ReadAllBytesAsync(tileFilePath);
+                        data = await File.ReadAllBytesAsync(series.TileFilePath);
                     }
                 }
                 catch (IOException)
@@ -1294,29 +1330,29 @@ public partial class TileCacheService
                 _logger,
                 "not-modified",
                 (int)response.StatusCode);
-            TileCacheDiagnostics.CacheWriteOutcome(_logger, "revalidated", zoom);
-            _logger.LogDebug("Tile {TileKey} re-validated (304 Not Modified)", tileKey);
-            return data;
+            TileCacheDiagnostics.CacheWriteOutcome(_logger, "revalidated", series.Zoom);
+            _logger.LogDebug("Tile {TileKey} re-validated (304 Not Modified)", series.TileKey);
+            return StaleRefreshOutcome.Completed;
         }
 
         if (response.IsSuccessStatusCode)
         {
             // 200: tile has changed. Replace file and update metadata.
-            var tileData = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            var tileData = await response.Content.ReadAsByteArrayAsync(series.CancellationToken);
             var newEtag = response.Headers.ETag?.Tag;
             var newLastModified = response.Content.Headers.LastModified?.UtcDateTime;
             var newExpiry = ParseCacheExpiry(response);
-            var tempFilePath = CreateTempTilePath(tileFilePath);
+            var tempFilePath = CreateTempTilePath(series.TileFilePath);
 
             await _cacheLock.WaitAsync();
             try
             {
-                await File.WriteAllBytesAsync(tempFilePath, tileData, cancellationToken);
-                ReplaceTileFileAtomically(tempFilePath, tileFilePath);
+                await File.WriteAllBytesAsync(tempFilePath, tileData, series.CancellationToken);
+                ReplaceTileFileAtomically(tempFilePath, series.TileFilePath);
 
-                if (zoom < DbMetadataZoomThreshold)
+                if (series.Zoom < DbMetadataZoomThreshold)
                 {
-                    WriteSidecarMetadata(tileFilePath, new TileSidecarMetadata
+                    WriteSidecarMetadata(series.TileFilePath, new TileSidecarMetadata
                     {
                         ETag = newEtag,
                         LastModifiedUpstream = newLastModified,
@@ -1334,30 +1370,40 @@ public partial class TileCacheService
                 _cacheLock.Release();
             }
 
-            if (zoom >= DbMetadataZoomThreshold)
+            if (series.Zoom >= DbMetadataZoomThreshold)
             {
                 // Use own scope to avoid disposed DbContext from the originating request.
                 using var scope = _serviceScopeFactory.CreateScope();
                 var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-                await UpdateTileAfterRevalidationScopedAsync(dbContext, zoom, x, y, tileData.Length, newEtag,
-                    newLastModified, newExpiry);
+                await UpdateTileAfterRevalidationScopedAsync(
+                    dbContext,
+                    series.Zoom,
+                    series.X,
+                    series.Y,
+                    tileData.Length,
+                    newEtag,
+                    newLastModified,
+                    newExpiry);
             }
 
             TileCacheDiagnostics.ConditionalResponseOutcome(
                 _logger,
                 "replaced",
                 (int)response.StatusCode);
-            TileCacheDiagnostics.CacheWriteOutcome(_logger, "replaced", zoom);
-            _logger.LogDebug("Tile {TileKey} re-validated (200 OK, replaced)", tileKey);
-            return tileData;
+            TileCacheDiagnostics.CacheWriteOutcome(_logger, "replaced", series.Zoom);
+            _logger.LogDebug("Tile {TileKey} re-validated (200 OK, replaced)", series.TileKey);
+            return StaleRefreshOutcome.Completed;
         }
 
+        var outcome = IsPermanentUpstreamClientFailure(response.StatusCode)
+            ? StaleRefreshOutcome.Terminal
+            : StaleRefreshOutcome.Transient;
         TileCacheDiagnostics.ConditionalResponseOutcome(
             _logger,
-            "rejected-status",
+            outcome == StaleRefreshOutcome.Terminal ? "terminal-status" : "transient-status",
             (int)response.StatusCode);
         _logger.LogWarning("Conditional request returned {StatusCode}.", response.StatusCode);
-        return null;
+        return outcome;
     }
 
     // ── DB metadata helpers (zoom >= 9) ─────────────────────────────────

--- a/Services/TileCacheService.cs
+++ b/Services/TileCacheService.cs
@@ -178,6 +178,7 @@ public partial class TileCacheService
         Interlocked.Exchange(ref _purgeInProgress, 0);
         _cacheSizeInitialized = false;
         OutboundBudget.ResetForTesting();
+        TileProviderRetryPolicy.ResetForTesting();
     }
 
     public TileCacheService(ILogger<TileCacheService> logger, IConfiguration configuration, HttpClient httpClient,
@@ -300,13 +301,15 @@ public partial class TileCacheService
     /// <summary>
     /// Core tile request method with same-host redirect policy and Referer header.
     /// Acquires an outbound budget token before sending to comply with OSM's fair use policy.
-    /// Returns null if the budget is exhausted (callers degrade gracefully with stale cache).
+    /// Returns a typed pre-transport rejection when provider or local capacity blocks the request.
     /// Accepts an optional delegate for customizing request headers (e.g., conditional headers).
     /// </summary>
-    private async Task<HttpResponseMessage?> SendTileRequestCoreAsync(string tileUrl,
-        Action<HttpRequestMessage>? configureRequest = null, bool skipBudget = false,
+    private async Task<TileRequestSendResult> SendTileRequestCoreAsync(string tileUrl,
+        Action<HttpRequestMessage>? configureRequest = null, bool chargeClientAllowance = true,
         string? clientIp = null, bool allowHttpContext = true, int attemptNumber = 1,
-        bool deferCancellationDiagnostic = false, CancellationToken cancellationToken = default)
+        bool deferCancellationDiagnostic = false, DateTimeOffset? interactiveDeadline = null,
+        CancellationToken callerCancellationToken = default,
+        CancellationToken cancellationToken = default)
     {
         // Two-phase per-IP outbound budget: peek first (fast-fail without incrementing),
         // then record the hit only after the global budget is acquired. This prevents
@@ -314,11 +317,11 @@ public partial class TileCacheService
         // caused cascading 503 rejections: on cold-cache loads with ~35 tiles, every
         // request (including those rejected by the global budget) incremented the per-IP
         // counter, so retries found the counter already past the limit and failed immediately.
-        // skipBudget is true on retries — the per-IP check was already passed on the first attempt.
+        // The initiating request charges this allowance once; retries do not charge it again.
         // clientIp may be passed explicitly by callers (e.g., coalesced revalidation) where
         // HttpContext is no longer available; falls back to HttpContext if not provided.
         string? resolvedIpForBudget = null;
-        if (!skipBudget)
+        if (chargeClientAllowance)
         {
             var perIpLimit = _applicationSettings.GetSettings().TileOutboundBudgetPerIpPerMinute;
             if (perIpLimit > 0)
@@ -339,23 +342,70 @@ public partial class TileCacheService
                     TileCacheDiagnostics.ClientBudgetRejected(_logger, "outbound-client");
                     _logger.LogWarning(
                         "Per-client outbound tile allowance exceeded; upstream request rejected.");
-                    return null;
+                    return TileRequestSendResult.Rejected(TileRequestRejection.ClientBudget);
                 }
             }
         }
 
-        // Acquire a global outbound request token. If the budget is exhausted, return null
-        // so callers can gracefully degrade (serve stale cache or return 503).
-        // skipBudget is true on retries — the budget was already acquired on the first attempt,
-        // so retries should not consume additional tokens.
-        if (!skipBudget)
+        const int maxRedirects = 3;
+        var initialUri = new Uri(tileUrl);
+        var currentUri = initialUri;
+        var providerKey = TileProviderRetryPolicy.GetProviderKey(tileUrl);
+        var requestKind = configureRequest == null ? "unconditional" : "conditional";
+
+        for (var redirectCount = 0; redirectCount <= maxRedirects; redirectCount++)
         {
+            var providerDelay = TileProviderRetryPolicy.GetRemainingProviderDelay(providerKey);
+            if (providerDelay > TimeSpan.Zero)
+            {
+                var allowedWait = TileProviderRetryPolicy.MaxIndividualWait;
+                if (interactiveDeadline.HasValue)
+                {
+                    var interactiveRemaining = interactiveDeadline.Value - TileProviderRetryPolicy.UtcNow;
+                    allowedWait = interactiveRemaining < allowedWait ? interactiveRemaining : allowedWait;
+                }
+
+                if (allowedWait <= TimeSpan.Zero || providerDelay > allowedWait)
+                {
+                    TileCacheDiagnostics.ProviderDelay(
+                        _logger,
+                        "gate-rejected",
+                        providerDelay.TotalMilliseconds);
+                    return TileRequestSendResult.ProviderDeferred(providerDelay);
+                }
+
+                TileCacheDiagnostics.ProviderDelay(
+                    _logger,
+                    "gate-wait",
+                    providerDelay.TotalMilliseconds);
+                try
+                {
+                    await _coldMissRetryDelay(providerDelay, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (callerCancellationToken.IsCancellationRequested)
+                {
+                    TileCacheDiagnostics.Cancellation(_logger, "provider-not-before-wait");
+                    throw;
+                }
+
+                var stillBlocked = TileProviderRetryPolicy.GetRemainingProviderDelay(providerKey);
+                if (stillBlocked > TimeSpan.Zero)
+                {
+                    TileCacheDiagnostics.ProviderDelay(
+                        _logger,
+                        "gate-still-active",
+                        stillBlocked.TotalMilliseconds);
+                    return TileRequestSendResult.ProviderDeferred(stillBlocked);
+                }
+            }
+
+            // Every actual provider contact, including redirects and retries, consumes global capacity.
             OutboundBudgetAcquisition acquisition;
             try
             {
                 acquisition = await OutboundBudget.AcquireDetailedAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (callerCancellationToken.IsCancellationRequested)
             {
                 if (!deferCancellationDiagnostic)
                 {
@@ -376,24 +426,16 @@ public partial class TileCacheService
                     "global",
                     acquisition.WaitDuration.TotalMilliseconds);
                 _logger.LogWarning("Global outbound tile budget exhausted; upstream request rejected.");
-                return null;
+                return TileRequestSendResult.Rejected(TileRequestRejection.GlobalBudget);
             }
-        }
 
-        // Both budgets passed — record the per-IP hit now that an upstream fetch will proceed.
-        // This ensures only actual upstream fetches count against the per-IP limit.
-        if (resolvedIpForBudget != null)
-        {
-            RateLimitHelper.RecordRateLimitHit(TilesController.OutboundBudgetCache, resolvedIpForBudget);
-        }
+            // Charge the initiating client's allowance once, immediately before its first contact.
+            if (resolvedIpForBudget != null)
+            {
+                RateLimitHelper.RecordRateLimitHit(TilesController.OutboundBudgetCache, resolvedIpForBudget);
+                resolvedIpForBudget = null;
+            }
 
-        const int maxRedirects = 3;
-        var initialUri = new Uri(tileUrl);
-        var currentUri = initialUri;
-        var requestKind = configureRequest == null ? "unconditional" : "conditional";
-
-        for (var redirectCount = 0; redirectCount <= maxRedirects; redirectCount++)
-        {
             using var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
 
             // OSM requires a Referer header. Derive it from the incoming HTTP request
@@ -414,7 +456,7 @@ public partial class TileCacheService
             {
                 response = await _httpClient.SendAsync(request, cancellationToken);
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (callerCancellationToken.IsCancellationRequested)
             {
                 if (!deferCancellationDiagnostic)
                 {
@@ -447,7 +489,7 @@ public partial class TileCacheService
                 {
                     _logger.LogWarning("Tile response redirected without a Location header.");
                     response.Dispose();
-                    return null;
+                    return TileRequestSendResult.Rejected(TileRequestRejection.InvalidProviderResponse);
                 }
 
                 var nextUri = location.IsAbsoluteUri ? location : new Uri(currentUri, location);
@@ -456,14 +498,14 @@ public partial class TileCacheService
                 {
                     _logger.LogWarning("Rejected tile redirect to a different host.");
                     response.Dispose();
-                    return null;
+                    return TileRequestSendResult.Rejected(TileRequestRejection.InvalidProviderResponse);
                 }
 
                 if (!string.Equals(nextUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogWarning("Rejected tile redirect to a non-HTTPS URL.");
                     response.Dispose();
-                    return null;
+                    return TileRequestSendResult.Rejected(TileRequestRejection.InvalidProviderResponse);
                 }
 
                 response.Dispose();
@@ -471,11 +513,11 @@ public partial class TileCacheService
                 continue;
             }
 
-            return response;
+            return TileRequestSendResult.Succeeded(response);
         }
 
         _logger.LogWarning("Rejected tile redirect chain exceeding {MaxRedirects}.", maxRedirects);
-        return null;
+        return TileRequestSendResult.Rejected(TileRequestRejection.InvalidProviderResponse);
     }
 
     /// <summary>
@@ -483,19 +525,28 @@ public partial class TileCacheService
     /// Sets the Referer header from the current HTTP request to comply with OSM's tile usage policy.
     /// </summary>
     /// <param name="tileUrl">The upstream tile URL.</param>
-    /// <param name="skipBudget">If true, skips outbound budget acquisition (used on retries).</param>
-    private Task<HttpResponseMessage?> SendTileRequestAsync(string tileUrl, bool skipBudget = false,
-        string? clientIp = null, int attemptNumber = 1, CancellationToken cancellationToken = default)
+    /// <param name="chargeClientAllowance">Whether this is the initiating request allowance charge.</param>
+    private Task<TileRequestSendResult> SendTileRequestAsync(
+        string tileUrl,
+        bool chargeClientAllowance = true,
+        string? clientIp = null,
+        int attemptNumber = 1,
+        DateTimeOffset? interactiveDeadline = null,
+        CancellationToken callerCancellationToken = default,
+        CancellationToken cancellationToken = default)
     {
-        return SendTileRequestCoreAsync(tileUrl, skipBudget: skipBudget, clientIp: clientIp,
-            attemptNumber: attemptNumber, cancellationToken: cancellationToken);
+        return SendTileRequestCoreAsync(tileUrl, chargeClientAllowance: chargeClientAllowance,
+            clientIp: clientIp, attemptNumber: attemptNumber,
+            interactiveDeadline: interactiveDeadline,
+            callerCancellationToken: callerCancellationToken,
+            cancellationToken: cancellationToken);
     }
 
     /// <summary>
     /// Sends a conditional tile request using ETag and/or Last-Modified headers.
     /// Returns the response (caller checks for 304 vs 200).
     /// </summary>
-    private Task<HttpResponseMessage?> SendConditionalTileRequestAsync(string tileUrl, string? etag,
+    private Task<TileRequestSendResult> SendConditionalTileRequestAsync(string tileUrl, string? etag,
         DateTime? lastModified, string? clientIp = null, bool allowHttpContext = true,
         int attemptNumber = 1, CancellationToken cancellationToken = default)
     {
@@ -514,8 +565,11 @@ public partial class TileCacheService
             {
                 request.Headers.IfModifiedSince = new DateTimeOffset(lastModified.Value, TimeSpan.Zero);
             }
-        }, clientIp: clientIp, allowHttpContext: allowHttpContext, attemptNumber: attemptNumber,
-            deferCancellationDiagnostic: true, cancellationToken: cancellationToken);
+        }, chargeClientAllowance: attemptNumber == 1, clientIp: clientIp,
+            allowHttpContext: allowHttpContext, attemptNumber: attemptNumber,
+            deferCancellationDiagnostic: true,
+            callerCancellationToken: cancellationToken,
+            cancellationToken: cancellationToken);
     }
 
     private static bool IsRedirectStatus(HttpStatusCode statusCode)
@@ -656,6 +710,19 @@ public partial class TileCacheService
     public async Task<bool> CacheTileAsync(string tileUrl, string zoomLevel, string xCoordinate, string yCoordinate,
         CancellationToken cancellationToken = default)
     {
+        var result = await CacheTileWithRetryAsync(
+            tileUrl, zoomLevel, xCoordinate, yCoordinate, cancellationToken);
+        return result.Status != TileCacheFillStatus.BudgetRejected;
+    }
+
+    /// <summary>Downloads and stores one cold tile while retaining its typed upstream outcome.</summary>
+    private async Task<TileCacheFillResult> CacheTileWithRetryAsync(
+        string tileUrl,
+        string zoomLevel,
+        string xCoordinate,
+        string yCoordinate,
+        CancellationToken cancellationToken)
+    {
         try
         {
             // Parse parameters
@@ -665,115 +732,49 @@ public partial class TileCacheService
             var tileFileName = $"{zoom}_{x}_{y}.png";
             var tileFilePath = Path.Combine(_cacheDirectory, tileFileName);
 
-            // Download the tile with retry logic.
-            int retryCount = 3;
-            byte[]? tileData = null;
-            string? etag = null;
-            DateTime? lastModifiedUpstream = null;
-            DateTime? expiresAtUtc = null;
-            bool budgetAcquired = false;
-
-            while (retryCount > 0)
+            var download = await DownloadTileWithRetryAsync(tileUrl, cancellationToken);
+            if (download.Status != TileCacheFillStatus.Cached)
             {
-                var attemptNumber = 4 - retryCount;
-                // On retries, skip budget acquisition — the token was already consumed
-                // on the first attempt. This prevents HTTP 5xx retries from exhausting
-                // the entire burst budget under upstream failures.
-                using var response = await SendTileRequestAsync(
-                    tileUrl,
-                    skipBudget: budgetAcquired,
-                    attemptNumber: attemptNumber,
-                    cancellationToken: cancellationToken);
-                if (response == null)
-                {
-                    // Budget exhaustion means the system is at capacity — retrying is futile
-                    // and would only add latency (up to AcquireTimeout per attempt).
-                    _logger.LogWarning("Outbound tile budget rejected cache fill.");
-                    break;
-                }
-                budgetAcquired = true;
-
-                if (response.IsSuccessStatusCode)
-                {
-                    tileData = await response.Content.ReadAsByteArrayAsync(cancellationToken);
-
-                    // Extract cache headers from upstream response for conditional request support.
-                    etag = response.Headers.ETag?.Tag;
-                    lastModifiedUpstream = response.Content.Headers.LastModified?.UtcDateTime;
-                    expiresAtUtc = ParseCacheExpiry(response);
-
-                    var cacheWriteOutcome = "preserved-existing";
-                    await _cacheLock.WaitAsync();
-                    try
-                    {
-                        if (!File.Exists(tileFilePath)) // Prevent overwriting existing files
-                        {
-                            await File.WriteAllBytesAsync(tileFilePath, tileData);
-                            cacheWriteOutcome = "stored";
-                        }
-
-                        // For zoom < DbMetadataZoomThreshold, write sidecar in the same lock acquisition as the tile file.
-                        // This eliminates TOCTOU where a concurrent reader sees the tile but no metadata.
-                        if (zoom < DbMetadataZoomThreshold)
-                        {
-                            WriteSidecarMetadata(tileFilePath, new TileSidecarMetadata
-                            {
-                                ETag = etag,
-                                LastModifiedUpstream = lastModifiedUpstream,
-                                ExpiresAtUtc = expiresAtUtc
-                            });
-                        }
-                    }
-                    catch (IOException ioEx)
-                    {
-                        TileCacheDiagnostics.CacheWriteOutcome(_logger, "failed", zoom);
-                        _logger.LogError(ioEx, "Failed to write tile data to file: {TileFilePath}", tileFilePath);
-                        return true;
-                    }
-                    finally
-                    {
-                        _cacheLock.Release();
-                    }
-
-                    TileCacheDiagnostics.CacheWriteOutcome(_logger, cacheWriteOutcome, zoom);
-                    _logger.LogInformation("Tile cached at: {TileFilePath}", tileFilePath);
-                    break;
-                }
-
-                _logger.LogWarning("Tile upstream attempt failed with status code {StatusCode}.",
-                    response.StatusCode);
-                retryCount--;
-                if (retryCount == 0)
-                {
-                    // Returns true (not budget-exhausted) so the controller sends 404 rather than 503.
-                    // Upstream HTTP failures (500/502/504) are non-retryable at the client level —
-                    // retrying would not help if OSM is down and would only pile up stale requests.
-                    _logger.LogError("Failed to download tile after multiple attempts.");
-                    return true;
-                }
-
-                // Optional: Delay between retries to avoid rate limiting
-                var retryDelay = TimeSpan.FromMilliseconds(500);
-                TileCacheDiagnostics.RetryDelaySelected(_logger, retryDelay.TotalMilliseconds, "cold-miss");
-                try
-                {
-                    await _coldMissRetryDelay(retryDelay, cancellationToken);
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    TileCacheDiagnostics.Cancellation(_logger, "cold-miss-retry-delay");
-                    throw;
-                }
+                return new TileCacheFillResult(download.Status, download.RetryAfter);
             }
 
-            // Budget was never acquired — signal throttling to caller.
-            if (tileData == null && !budgetAcquired)
-                return false;
+            var tileData = download.TileData!;
+            var etag = download.ETag;
+            var lastModifiedUpstream = download.LastModifiedUpstream;
+            var expiresAtUtc = download.ExpiresAtUtc;
+            var cacheWriteOutcome = "preserved-existing";
+            await _cacheLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (!File.Exists(tileFilePath))
+                {
+                    await File.WriteAllBytesAsync(tileFilePath, tileData, cancellationToken);
+                    cacheWriteOutcome = "stored";
+                }
 
-            // Upstream HTTP failure (all retries failed, but budget was acquired) — not budget-related,
-            // so return true to let the controller send 404 rather than 503.
-            if (tileData == null)
-                return true;
+                if (zoom < DbMetadataZoomThreshold)
+                {
+                    WriteSidecarMetadata(tileFilePath, new TileSidecarMetadata
+                    {
+                        ETag = etag,
+                        LastModifiedUpstream = lastModifiedUpstream,
+                        ExpiresAtUtc = expiresAtUtc
+                    });
+                }
+            }
+            catch (IOException ioEx)
+            {
+                TileCacheDiagnostics.CacheWriteOutcome(_logger, "failed", zoom);
+                _logger.LogError(ioEx, "Failed to write tile data to file: {TileFilePath}", tileFilePath);
+                return TileCacheFillResult.Cached();
+            }
+            finally
+            {
+                _cacheLock.Release();
+            }
+
+            TileCacheDiagnostics.CacheWriteOutcome(_logger, cacheWriteOutcome, zoom);
+            _logger.LogInformation("Tile cached at: {TileFilePath}", tileFilePath);
 
             // For zoom levels >= DbMetadataZoomThreshold, store or update metadata in the database.
             // tileData is guaranteed non-null here — the null cases (budget exhaustion, HTTP failure)
@@ -879,7 +880,7 @@ public partial class TileCacheService
                             if (databaseValues == null)
                             {
                                 _logger.LogError("Tile metadata was deleted by another process.");
-                                return true;
+                                return TileCacheFillResult.Cached();
                             }
 
                             await entry.ReloadAsync();
@@ -896,7 +897,7 @@ public partial class TileCacheService
                     {
                         _logger.LogError(
                             "Failed to update tile metadata after multiple attempts due to concurrency conflicts.");
-                        return true;
+                        return TileCacheFillResult.Cached();
                     }
 
                     // Adjust the in-memory cache size using the previously saved value.
@@ -905,17 +906,16 @@ public partial class TileCacheService
                 }
             }
 
-            return true;
+            return TileCacheFillResult.Cached();
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            // The transport emits the stable cancellation event; preserve the existing local outcome in Phase 1.
-            return true;
+            throw;
         }
         catch (Exception)
         {
             _logger.LogError("Error caching tile without recording provider exception details.");
-            return true;
+            return TileCacheFillResult.Transient(TileProviderRetryPolicy.FallbackDelayCap);
         }
     }
 
@@ -1152,7 +1152,8 @@ public partial class TileCacheService
 
             TileCacheDiagnostics.ColdCacheMiss(_logger, "miss", zoomLvl);
             _logger.LogDebug("Tile not in cache; starting controlled upstream fetch.");
-            var cached = await CacheTileAsync(tileUrl, zoomLevel, xCoordinate, yCoordinate, cancellationToken);
+            var fillResult = await CacheTileWithRetryAsync(
+                tileUrl, zoomLevel, xCoordinate, yCoordinate, cancellationToken);
 
             // After fetching, read the file. No lock needed for reads (see fast-path comment above).
             byte[]? fetchedTileData = null;
@@ -1171,18 +1172,26 @@ public partial class TileCacheService
             if (fetchedTileData != null)
                 return TileRetrievalResult.Success(fetchedTileData);
 
-            // File doesn't exist after CacheTileAsync — distinguish budget exhaustion from other failures.
-            return cached ? TileRetrievalResult.NotFound() : TileRetrievalResult.Throttled();
+            return fillResult.Status switch
+            {
+                TileCacheFillStatus.NotFound => TileRetrievalResult.NotFound(),
+                TileCacheFillStatus.PermanentFailure => TileRetrievalResult.PermanentFailure(),
+                TileCacheFillStatus.BudgetRejected => TileRetrievalResult.Throttled(
+                    TilesController.BudgetRetryAfterSeconds),
+                _ => TileRetrievalResult.TransientFailure(
+                    TileProviderRetryPolicy.GetBoundedRetryAfterSeconds(fillResult.RetryAfter))
+            };
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            TileCacheDiagnostics.Cancellation(_logger, "retrieval");
-            return TileRetrievalResult.NotFound();
+            throw;
         }
         catch (Exception)
         {
             _logger.LogError("Error retrieving tile from cache.");
-            return TileRetrievalResult.NotFound();
+            return TileRetrievalResult.TransientFailure(
+                TileProviderRetryPolicy.GetBoundedRetryAfterSeconds(
+                    TileProviderRetryPolicy.FallbackDelayCap));
         }
     }
 
@@ -1200,13 +1209,29 @@ public partial class TileCacheService
         int zoom, int x, int y, string? etag, DateTime? lastModified,
         string? clientIp = null, int attemptNumber = 1, CancellationToken cancellationToken = default)
     {
-        using var response = await SendConditionalTileRequestAsync(tileUrl, etag, lastModified, clientIp,
+        var sendResult = await SendConditionalTileRequestAsync(tileUrl, etag, lastModified, clientIp,
             allowHttpContext: false, attemptNumber: attemptNumber, cancellationToken: cancellationToken);
-        if (response == null)
+        if (sendResult.Response == null)
         {
             TileCacheDiagnostics.StaleRefreshRejected(_logger, "rejected", zoom);
             _logger.LogWarning("Conditional tile request rejected before upstream transport.");
             return null;
+        }
+
+        using var response = sendResult.Response;
+        if (response.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
+        {
+            var providerKey = TileProviderRetryPolicy.GetProviderKey(tileUrl);
+            var providerDelay = TileProviderRetryPolicy.ApplyRetryAfter(providerKey, response);
+            if (providerDelay.Kind != ProviderDelayKind.Missing)
+            {
+                TileCacheDiagnostics.ProviderDelay(
+                    _logger,
+                    providerDelay.Kind == ProviderDelayKind.Valid
+                        ? "provider-directed"
+                        : "invalid-provider-value",
+                    providerDelay.Delay.TotalMilliseconds);
+            }
         }
 
         if (response.StatusCode == HttpStatusCode.NotModified)

--- a/Services/TileProviderRetryPolicy.cs
+++ b/Services/TileProviderRetryPolicy.cs
@@ -42,8 +42,8 @@ internal static class TileProviderRetryPolicy
 
     /// <summary>
     /// Returns the remaining provider gate delay and performs one bounded opportunistic cleanup pass.
-    /// Each pass inspects at most eight queued provider entries; active entries return to the queue,
-    /// so normal gate traffic eventually visits abandoned expired providers without an unbounded scan.
+    /// Bounded cleanup exclusively removes expired entries; an expired read returns zero while
+    /// preserving its dictionary and queue pair until that cleanup inspects it.
     /// </summary>
     internal static TimeSpan GetRemainingProviderDelay(string providerKey)
     {
@@ -59,8 +59,6 @@ internal static class TileProviderRetryPolicy
             return remaining;
         }
 
-        _providerNotBefore.TryRemove(
-            new KeyValuePair<string, DateTimeOffset>(providerKey, notBefore));
         return TimeSpan.Zero;
     }
 
@@ -197,9 +195,9 @@ internal static class TileProviderRetryPolicy
 
     /// <summary>
     /// Inspects a fixed maximum of queued gates during normal reads and extensions.
-    /// Compare-by-value removal cannot delete a concurrently extended future gate. One queue entry
-    /// is retained per live provider, keeping memory proportional to realistic administrator-driven
-    /// provider changes while expired abandoned providers are removed over bounded later passes.
+    /// This is the exclusive expiry-removal path. Compare-by-value removal cannot delete a
+    /// concurrently extended future gate, and each retained dictionary entry reuses its one
+    /// cleanup record until a bounded later pass removes the pair.
     /// </summary>
     private static void CleanupExpiredProviderGates()
     {

--- a/Services/TileProviderRetryPolicy.cs
+++ b/Services/TileProviderRetryPolicy.cs
@@ -1,0 +1,201 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Holds Wayfarer's interim provider retry bounds and provider-wide not-before state.
+/// These limits are conservative Wayfarer safeguards, not provider requirements.
+/// </summary>
+internal static class TileProviderRetryPolicy
+{
+    internal const int MaxAttempts = 3;
+    internal static readonly TimeSpan FallbackBaseDelay = TimeSpan.FromMilliseconds(500);
+    internal static readonly TimeSpan FallbackDelayCap = TimeSpan.FromSeconds(4);
+    internal static readonly TimeSpan MaxIndividualWait = TimeSpan.FromSeconds(30);
+    internal static readonly TimeSpan MaxInteractiveDuration = TimeSpan.FromSeconds(45);
+    internal static readonly TimeSpan InvalidDelayHold = TimeSpan.FromSeconds(30);
+
+    private static readonly ConcurrentDictionary<string, DateTimeOffset> _providerNotBefore = new();
+    private static Func<DateTimeOffset> _utcNow = static () => DateTimeOffset.UtcNow;
+    private static Func<int, double> _jitter = static _ => (Random.Shared.NextDouble() * 2d) - 1d;
+
+    /// <summary>Gets the current UTC instant through the deterministic policy clock.</summary>
+    internal static DateTimeOffset UtcNow => _utcNow();
+
+    /// <summary>Returns a non-secret provider fingerprint based only on URI authority.</summary>
+    internal static string GetProviderKey(string tileUrl)
+    {
+        var authority = new Uri(tileUrl).GetLeftPart(UriPartial.Authority).ToUpperInvariant();
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(authority)));
+    }
+
+    /// <summary>Returns the remaining provider gate delay, removing expired state.</summary>
+    internal static TimeSpan GetRemainingProviderDelay(string providerKey)
+    {
+        if (!_providerNotBefore.TryGetValue(providerKey, out var notBefore))
+        {
+            return TimeSpan.Zero;
+        }
+
+        var remaining = notBefore - UtcNow;
+        if (remaining > TimeSpan.Zero)
+        {
+            return remaining;
+        }
+
+        _providerNotBefore.TryRemove(
+            new KeyValuePair<string, DateTimeOffset>(providerKey, notBefore));
+        return TimeSpan.Zero;
+    }
+
+    /// <summary>
+    /// Parses and stores provider Retry-After guidance without shortening an existing gate.
+    /// Missing headers select fallback retry; unusable headers open a bounded safety gate.
+    /// </summary>
+    internal static ProviderDelayDecision ApplyRetryAfter(
+        string providerKey,
+        HttpResponseMessage response)
+    {
+        if (!response.Headers.TryGetValues("Retry-After", out var values))
+        {
+            return ProviderDelayDecision.Missing;
+        }
+
+        var rawValue = values.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(rawValue) ||
+            !TryParseRetryAfter(rawValue, UtcNow, out var notBefore))
+        {
+            var invalidNotBefore = SafeAdd(UtcNow, InvalidDelayHold);
+            ExtendProviderGate(providerKey, invalidNotBefore);
+            return new ProviderDelayDecision(
+                ProviderDelayKind.Invalid,
+                invalidNotBefore - UtcNow);
+        }
+
+        ExtendProviderGate(providerKey, notBefore);
+        return new ProviderDelayDecision(
+            ProviderDelayKind.Valid,
+            notBefore - UtcNow);
+    }
+
+    /// <summary>Calculates bounded exponential fallback with deterministic injectable jitter.</summary>
+    internal static TimeSpan GetFallbackDelay(int failedAttempts)
+    {
+        var exponent = Math.Max(0, failedAttempts - 1);
+        var unjitteredMilliseconds = Math.Min(
+            FallbackBaseDelay.TotalMilliseconds * Math.Pow(2, exponent),
+            FallbackDelayCap.TotalMilliseconds);
+        var jitterSample = Math.Clamp(_jitter(failedAttempts), -1d, 1d);
+        var jitteredMilliseconds = unjitteredMilliseconds * (1d + (jitterSample * 0.2d));
+        return TimeSpan.FromMilliseconds(Math.Clamp(
+            jitteredMilliseconds,
+            1d,
+            FallbackDelayCap.TotalMilliseconds));
+    }
+
+    /// <summary>Converts a remaining delay to bounded whole-second local retry guidance.</summary>
+    internal static int GetBoundedRetryAfterSeconds(TimeSpan remainingDelay)
+    {
+        var bounded = Math.Clamp(
+            remainingDelay.TotalSeconds,
+            1d,
+            MaxIndividualWait.TotalSeconds);
+        return (int)Math.Ceiling(bounded);
+    }
+
+    /// <summary>Restores production policy state after each isolated test.</summary>
+    internal static void ResetForTesting()
+    {
+        _providerNotBefore.Clear();
+        _utcNow = static () => DateTimeOffset.UtcNow;
+        _jitter = static _ => (Random.Shared.NextDouble() * 2d) - 1d;
+    }
+
+    /// <summary>Overrides clock and jitter inputs for deterministic tests.</summary>
+    internal static void SetDeterminismForTesting(
+        Func<DateTimeOffset>? utcNow = null,
+        Func<int, double>? jitter = null)
+    {
+        _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
+        _jitter = jitter ?? (_ => 0d);
+    }
+
+    /// <summary>Parses delta-seconds or an HTTP-date into a future representable instant.</summary>
+    private static bool TryParseRetryAfter(
+        string rawValue,
+        DateTimeOffset now,
+        out DateTimeOffset notBefore)
+    {
+        if (long.TryParse(rawValue, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds))
+        {
+            if (seconds <= 0 || seconds > TimeSpan.MaxValue.TotalSeconds)
+            {
+                notBefore = default;
+                return false;
+            }
+
+            return TryAdd(now, TimeSpan.FromSeconds(seconds), out notBefore);
+        }
+
+        if (!DateTimeOffset.TryParseExact(
+                rawValue,
+                "r",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out notBefore))
+        {
+            return false;
+        }
+
+        return notBefore > now;
+    }
+
+    /// <summary>Extends provider state atomically and never shortens a provider-directed delay.</summary>
+    private static void ExtendProviderGate(string providerKey, DateTimeOffset candidate) =>
+        _providerNotBefore.AddOrUpdate(
+            providerKey,
+            candidate,
+            (_, current) => current >= candidate ? current : candidate);
+
+    /// <summary>Safely adds a known bounded interval to the current instant.</summary>
+    private static DateTimeOffset SafeAdd(DateTimeOffset instant, TimeSpan delay) =>
+        TryAdd(instant, delay, out var result) ? result : DateTimeOffset.MaxValue;
+
+    /// <summary>Attempts checked date arithmetic without exposing provider input.</summary>
+    private static bool TryAdd(
+        DateTimeOffset instant,
+        TimeSpan delay,
+        out DateTimeOffset result)
+    {
+        try
+        {
+            result = instant.Add(delay);
+            return result > instant;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            result = default;
+            return false;
+        }
+    }
+}
+
+/// <summary>Classifies provider Retry-After input without retaining the raw header.</summary>
+internal enum ProviderDelayKind
+{
+    Missing,
+    Valid,
+    Invalid
+}
+
+/// <summary>Describes the bounded decision produced from a provider Retry-After header.</summary>
+internal readonly record struct ProviderDelayDecision(
+    ProviderDelayKind Kind,
+    TimeSpan Delay)
+{
+    internal static ProviderDelayDecision Missing =>
+        new(ProviderDelayKind.Missing, TimeSpan.Zero);
+}

--- a/Services/TileProviderRetryPolicy.cs
+++ b/Services/TileProviderRetryPolicy.cs
@@ -19,22 +19,35 @@ internal static class TileProviderRetryPolicy
     internal static readonly TimeSpan InvalidDelayHold = TimeSpan.FromSeconds(30);
 
     private static readonly ConcurrentDictionary<string, DateTimeOffset> _providerNotBefore = new();
+    private static readonly ConcurrentQueue<string> _providerGateCleanupQueue = new();
+    private const int ProviderGateCleanupInspectionLimit = 8;
     private static Func<DateTimeOffset> _utcNow = static () => DateTimeOffset.UtcNow;
     private static Func<int, double> _jitter = static _ => (Random.Shared.NextDouble() * 2d) - 1d;
 
     /// <summary>Gets the current UTC instant through the deterministic policy clock.</summary>
     internal static DateTimeOffset UtcNow => _utcNow();
 
-    /// <summary>Returns a non-secret provider fingerprint based only on URI authority.</summary>
+    /// <summary>
+    /// Returns a non-secret provider fingerprint from normalized scheme, IDN host, and effective port.
+    /// User information, path, query, fragment, API-key values, and client identity are excluded.
+    /// </summary>
     internal static string GetProviderKey(string tileUrl)
     {
-        var authority = new Uri(tileUrl).GetLeftPart(UriPartial.Authority).ToUpperInvariant();
-        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(authority)));
+        var uri = new Uri(tileUrl);
+        var identity = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{uri.Scheme.ToLowerInvariant()}|{uri.IdnHost.TrimEnd('.').ToLowerInvariant()}|{uri.Port}");
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(identity)));
     }
 
-    /// <summary>Returns the remaining provider gate delay, removing expired state.</summary>
+    /// <summary>
+    /// Returns the remaining provider gate delay and performs one bounded opportunistic cleanup pass.
+    /// Each pass inspects at most eight queued provider entries; active entries return to the queue,
+    /// so normal gate traffic eventually visits abandoned expired providers without an unbounded scan.
+    /// </summary>
     internal static TimeSpan GetRemainingProviderDelay(string providerKey)
     {
+        CleanupExpiredProviderGates();
         if (!_providerNotBefore.TryGetValue(providerKey, out var notBefore))
         {
             return TimeSpan.Zero;
@@ -110,6 +123,10 @@ internal static class TileProviderRetryPolicy
     internal static void ResetForTesting()
     {
         _providerNotBefore.Clear();
+        while (_providerGateCleanupQueue.TryDequeue(out _))
+        {
+        }
+
         _utcNow = static () => DateTimeOffset.UtcNow;
         _jitter = static _ => (Random.Shared.NextDouble() * 2d) - 1d;
     }
@@ -154,11 +171,64 @@ internal static class TileProviderRetryPolicy
     }
 
     /// <summary>Extends provider state atomically and never shortens a provider-directed delay.</summary>
-    private static void ExtendProviderGate(string providerKey, DateTimeOffset candidate) =>
-        _providerNotBefore.AddOrUpdate(
-            providerKey,
-            candidate,
-            (_, current) => current >= candidate ? current : candidate);
+    private static void ExtendProviderGate(string providerKey, DateTimeOffset candidate)
+    {
+        CleanupExpiredProviderGates();
+        while (true)
+        {
+            if (_providerNotBefore.TryGetValue(providerKey, out var current))
+            {
+                if (current >= candidate ||
+                    _providerNotBefore.TryUpdate(providerKey, candidate, current))
+                {
+                    return;
+                }
+
+                continue;
+            }
+
+            if (_providerNotBefore.TryAdd(providerKey, candidate))
+            {
+                _providerGateCleanupQueue.Enqueue(providerKey);
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Inspects a fixed maximum of queued gates during normal reads and extensions.
+    /// Compare-by-value removal cannot delete a concurrently extended future gate. One queue entry
+    /// is retained per live provider, keeping memory proportional to realistic administrator-driven
+    /// provider changes while expired abandoned providers are removed over bounded later passes.
+    /// </summary>
+    private static void CleanupExpiredProviderGates()
+    {
+        var entriesToInspect = Math.Min(
+            ProviderGateCleanupInspectionLimit,
+            _providerGateCleanupQueue.Count);
+        var now = UtcNow;
+        for (var index = 0; index < entriesToInspect; index++)
+        {
+            if (!_providerGateCleanupQueue.TryDequeue(out var providerKey))
+            {
+                return;
+            }
+
+            if (!_providerNotBefore.TryGetValue(providerKey, out var notBefore))
+            {
+                continue;
+            }
+
+            if (notBefore <= now &&
+                _providerNotBefore.TryRemove(
+                    new KeyValuePair<string, DateTimeOffset>(providerKey, notBefore)))
+            {
+                continue;
+            }
+
+            _providerGateCleanupQueue.Enqueue(providerKey);
+        }
+    }
 
     /// <summary>Safely adds a known bounded interval to the current instant.</summary>
     private static DateTimeOffset SafeAdd(DateTimeOffset instant, TimeSpan delay) =>

--- a/Services/TileRetrievalResult.cs
+++ b/Services/TileRetrievalResult.cs
@@ -129,6 +129,7 @@ internal enum TileRequestRejection
     ClientBudget,
     GlobalBudget,
     ProviderDeferred,
+    ContactLimit,
     InvalidProviderResponse
 }
 
@@ -146,4 +147,40 @@ internal sealed record TileRequestSendResult(
 
     internal static TileRequestSendResult ProviderDeferred(TimeSpan retryAfter) =>
         new(null, TileRequestRejection.ProviderDeferred, retryAfter);
+}
+
+/// <summary>Tracks actual provider contacts across every retry and redirect in one tile operation.</summary>
+internal sealed class TileContactState
+{
+    private int _contacts;
+
+    /// <summary>Indicates whether the interim operation-wide contact ceiling is exhausted.</summary>
+    internal bool IsExhausted => Volatile.Read(ref _contacts) >= TileProviderRetryPolicy.MaxAttempts;
+
+    /// <summary>Atomically reserves one actual provider contact without allowing a fourth.</summary>
+    internal bool TryReserveContact()
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _contacts);
+            if (current >= TileProviderRetryPolicy.MaxAttempts)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _contacts, current + 1, current) == current)
+            {
+                return true;
+            }
+        }
+    }
+}
+
+/// <summary>Classifies one stale revalidation attempt without conflating it with cold-cache retrieval.</summary>
+internal enum StaleRefreshOutcome
+{
+    Completed,
+    Terminal,
+    Transient,
+    PreTransportRejected
 }

--- a/Services/TileRetrievalResult.cs
+++ b/Services/TileRetrievalResult.cs
@@ -1,23 +1,149 @@
 namespace Wayfarer.Services;
 
 /// <summary>
-/// Result of a tile retrieval attempt, distinguishing successful data,
-/// genuine absence, and transient throttling so the controller can
-/// return the appropriate HTTP status code.
+/// Classifies the production outcome of one tile retrieval operation.
 /// </summary>
-/// <param name="TileData">Tile image bytes when retrieval succeeded, null otherwise.</param>
-/// <param name="BudgetExhausted">
-/// True when the tile could not be fetched because the outbound request budget
-/// was exhausted. The controller should return 503 with Retry-After.
-/// </param>
-public sealed record TileRetrievalResult(byte[]? TileData, bool BudgetExhausted)
+public enum TileRetrievalStatus
 {
+    /// <summary>Tile bytes were served from cache or a successful provider response.</summary>
+    Success,
+
+    /// <summary>The provider confirmed that the tile is permanently absent.</summary>
+    NotFound,
+
+    /// <summary>The provider returned a permanent response other than confirmed absence.</summary>
+    PermanentFailure,
+
+    /// <summary>A transient provider failure exhausted the bounded retry policy.</summary>
+    TransientFailure,
+
+    /// <summary>Local client allowance or global outbound capacity rejected the request.</summary>
+    BudgetRejected
+}
+
+/// <summary>
+/// Result of a tile retrieval attempt. Caller cancellation propagates as
+/// <see cref="OperationCanceledException"/> and is never converted into a result status.
+/// </summary>
+/// <param name="Status">Typed production outcome used by the controller.</param>
+/// <param name="TileData">Tile image bytes when retrieval succeeded, null otherwise.</param>
+/// <param name="RetryAfterSeconds">Bounded client retry guidance for transient outcomes.</param>
+public sealed record TileRetrievalResult(
+    TileRetrievalStatus Status,
+    byte[]? TileData = null,
+    int? RetryAfterSeconds = null)
+{
+    /// <summary>Compatibility indicator for callers that specifically observe local budget rejection.</summary>
+    public bool BudgetExhausted => Status == TileRetrievalStatus.BudgetRejected;
+
     /// <summary>Tile data retrieved successfully.</summary>
-    public static TileRetrievalResult Success(byte[] data) => new(data, false);
+    public static TileRetrievalResult Success(byte[] data) =>
+        new(TileRetrievalStatus.Success, data);
 
-    /// <summary>Tile not found (genuine absence or unrecoverable error).</summary>
-    public static TileRetrievalResult NotFound() => new(null, false);
+    /// <summary>Tile absence confirmed locally or by an upstream 404 response.</summary>
+    public static TileRetrievalResult NotFound() =>
+        new(TileRetrievalStatus.NotFound);
 
-    /// <summary>Upstream budget exhausted — transient, client should retry.</summary>
-    public static TileRetrievalResult Throttled() => new(null, true);
+    /// <summary>Permanent provider rejection that must not be retried.</summary>
+    public static TileRetrievalResult PermanentFailure() =>
+        new(TileRetrievalStatus.PermanentFailure);
+
+    /// <summary>Bounded provider retries exhausted or were deferred by a provider gate.</summary>
+    public static TileRetrievalResult TransientFailure(int retryAfterSeconds) =>
+        new(TileRetrievalStatus.TransientFailure, RetryAfterSeconds: retryAfterSeconds);
+
+    /// <summary>Local outbound allowance or global capacity rejected the request.</summary>
+    public static TileRetrievalResult Throttled(int retryAfterSeconds) =>
+        new(TileRetrievalStatus.BudgetRejected, RetryAfterSeconds: retryAfterSeconds);
+}
+
+/// <summary>Internal typed outcome of one cold-cache fill series.</summary>
+internal enum TileCacheFillStatus
+{
+    Cached,
+    NotFound,
+    PermanentFailure,
+    TransientFailure,
+    BudgetRejected
+}
+
+/// <summary>Internal cache-fill outcome and its unbounded provider delay evidence.</summary>
+internal readonly record struct TileCacheFillResult(
+    TileCacheFillStatus Status,
+    TimeSpan RetryAfter)
+{
+    internal static TileCacheFillResult Cached() =>
+        new(TileCacheFillStatus.Cached, TimeSpan.Zero);
+
+    internal static TileCacheFillResult NotFound() =>
+        new(TileCacheFillStatus.NotFound, TimeSpan.Zero);
+
+    internal static TileCacheFillResult PermanentFailure() =>
+        new(TileCacheFillStatus.PermanentFailure, TimeSpan.Zero);
+
+    internal static TileCacheFillResult Transient(TimeSpan retryAfter) =>
+        new(TileCacheFillStatus.TransientFailure, retryAfter);
+
+    internal static TileCacheFillResult BudgetRejected() =>
+        new(TileCacheFillStatus.BudgetRejected, TimeSpan.Zero);
+}
+
+/// <summary>Typed transport result passed to cache persistence after a retry series.</summary>
+internal sealed record TileDownloadResult(
+    TileCacheFillStatus Status,
+    byte[]? TileData = null,
+    string? ETag = null,
+    DateTime? LastModifiedUpstream = null,
+    DateTime? ExpiresAtUtc = null,
+    TimeSpan RetryAfter = default)
+{
+    internal static TileDownloadResult Downloaded(
+        byte[] tileData,
+        string? etag,
+        DateTime? lastModifiedUpstream,
+        DateTime? expiresAtUtc) =>
+        new(
+            TileCacheFillStatus.Cached,
+            tileData,
+            etag,
+            lastModifiedUpstream,
+            expiresAtUtc);
+
+    internal static TileDownloadResult NotFound() =>
+        new(TileCacheFillStatus.NotFound);
+
+    internal static TileDownloadResult PermanentFailure() =>
+        new(TileCacheFillStatus.PermanentFailure);
+
+    internal static TileDownloadResult Transient(TimeSpan retryAfter) =>
+        new(TileCacheFillStatus.TransientFailure, RetryAfter: retryAfter);
+
+    internal static TileDownloadResult BudgetRejected() =>
+        new(TileCacheFillStatus.BudgetRejected);
+}
+
+/// <summary>Classifies a request that was rejected before receiving a usable provider response.</summary>
+internal enum TileRequestRejection
+{
+    None,
+    ClientBudget,
+    GlobalBudget,
+    ProviderDeferred,
+    InvalidProviderResponse
+}
+
+/// <summary>Captures either one owned provider response or a bounded pre-transport rejection.</summary>
+internal sealed record TileRequestSendResult(
+    HttpResponseMessage? Response,
+    TileRequestRejection Rejection,
+    TimeSpan RetryAfter)
+{
+    internal static TileRequestSendResult Succeeded(HttpResponseMessage response) =>
+        new(response, TileRequestRejection.None, TimeSpan.Zero);
+
+    internal static TileRequestSendResult Rejected(TileRequestRejection rejection) =>
+        new(null, rejection, TimeSpan.Zero);
+
+    internal static TileRequestSendResult ProviderDeferred(TimeSpan retryAfter) =>
+        new(null, TileRequestRejection.ProviderDeferred, retryAfter);
 }

--- a/Util/TileProviderCatalog.cs
+++ b/Util/TileProviderCatalog.cs
@@ -94,6 +94,12 @@ public static class TileProviderCatalog
             return false;
         }
 
+        if (!string.IsNullOrEmpty(templateUri.UserInfo))
+        {
+            error = "Tile URL template must not include user information.";
+            return false;
+        }
+
         if (!string.Equals(Path.GetExtension(templateUri.AbsolutePath), ".png", StringComparison.OrdinalIgnoreCase))
         {
             error = "Tile URL template must point to a .png resource.";

--- a/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
@@ -36,10 +36,10 @@ public sealed class TileCacheCancellationAndPrivacyTests
         SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext(cancellation.Token));
         var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
 
-        var result = await service.RetrieveTileAsync(
-            "5", "18", "19", CanonicalTileUrl(5, 18, 19), cancellation.Token);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.RetrieveTileAsync(
+                "5", "18", "19", CanonicalTileUrl(5, 18, 19), cancellation.Token));
 
-        Assert.Null(result.TileData);
         AssertCancellation(harness.Logs, "upstream-transport");
         AssertNoUpstreamFailure(harness.Logs);
         Assert.Single(harness.Upstream.Requests);
@@ -60,8 +60,9 @@ public sealed class TileCacheCancellationAndPrivacyTests
 
         Assert.Null(result.TileData);
         AssertNoCancellation(harness.Logs);
-        AssertDiagnostic(harness.Logs, TileCacheDiagnosticEventIds.UpstreamFailure);
-        Assert.Single(harness.Upstream.Requests);
+        Assert.Equal(3, harness.Logs.Entries.Count(
+            entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.UpstreamFailure));
+        Assert.Equal(3, harness.Upstream.Requests.Count);
     }
 
     /// <summary>Proves cancellation while waiting for global capacity has its bounded stage.</summary>
@@ -79,11 +80,10 @@ public sealed class TileCacheCancellationAndPrivacyTests
         SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext(cancellation.Token));
         var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
 
-        var result = await service.RetrieveTileAsync(
-            "5", "18", "21", CanonicalTileUrl(5, 18, 21), cancellation.Token);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.RetrieveTileAsync(
+                "5", "18", "21", CanonicalTileUrl(5, 18, 21), cancellation.Token));
 
-        Assert.Null(result.TileData);
-        Assert.False(result.BudgetExhausted);
         AssertCancellation(harness.Logs, "global-budget-wait");
         AssertNoUpstreamFailure(harness.Logs);
         Assert.Empty(harness.Upstream.Requests);
@@ -106,10 +106,10 @@ public sealed class TileCacheCancellationAndPrivacyTests
         SetHttpContext(scope, TileCacheTestHarness.CreateHttpContext(cancellation.Token));
         var service = scope.ServiceProvider.GetRequiredService<TileCacheService>();
 
-        var result = await service.RetrieveTileAsync(
-            "5", "18", "22", CanonicalTileUrl(5, 18, 22), cancellation.Token);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.RetrieveTileAsync(
+                "5", "18", "22", CanonicalTileUrl(5, 18, 22), cancellation.Token));
 
-        Assert.Null(result.TileData);
         AssertCancellation(harness.Logs, "cold-miss-retry-delay");
         AssertNoUpstreamFailure(harness.Logs);
         Assert.Single(harness.Upstream.Requests);
@@ -261,7 +261,7 @@ public sealed class TileCacheCancellationAndPrivacyTests
 
         var result = await service.RetrieveTileAsync("5", "18", "27", CanonicalTileUrl(5, 18, 27));
 
-        Assert.True(result.BudgetExhausted);
+        Assert.Equal(TileRetrievalStatus.TransientFailure, result.Status);
         Assert.Contains(harness.Logs.Entries,
             entry => entry.Level == LogLevel.Warning &&
                      entry.Message.Contains("different host", StringComparison.OrdinalIgnoreCase));

--- a/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
@@ -200,6 +200,7 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
         var upstream = new RecordingTileHandler((_, _) =>
             Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
         using var harness = new TileCacheTestHarness(upstream);
+        TileProviderRetryPolicy.SetDeterminismForTesting(jitter: _ => 0d);
         TileCacheService.SetColdMissRetryDelayForTesting((_, _) => Task.CompletedTask);
         using var scope = harness.CreateScope();
         SetHttpContext(scope);
@@ -218,8 +219,11 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
             .Where(entry => entry.EventId.Id == (int)TileCacheDiagnosticEventIds.RetryDelaySelected)
             .ToArray();
         Assert.Equal(2, delays.Length);
-        Assert.All(delays, delay =>
-            Assert.Equal(500d, Convert.ToDouble(delay.Fields["RetryDelayMilliseconds"])));
+        Assert.Equal(
+            [500d, 1000d],
+            delays.Select(delay =>
+                Convert.ToDouble(delay.Fields["RetryDelayMilliseconds"])).ToArray());
+        Assert.All(delays, delay => Assert.Equal("fallback", delay.Fields["RetryKind"]));
     }
 
     /// <summary>Assigns the same-origin request context used by one scoped service.</summary>

--- a/tests/Wayfarer.Tests/Services/TileCachePhase2AProductionReviewTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCachePhase2AProductionReviewTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Wayfarer.Areas.Public.Controllers;
 using Wayfarer.Models;
 using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
 using Wayfarer.Util;
 using Xunit;
 
@@ -155,6 +156,49 @@ public sealed partial class TileCacheRetryStatusTests
         Assert.DoesNotContain(secondCredential, first, StringComparison.Ordinal);
     }
 
+    /// <summary>Proves equivalent credential forms share one gate without entering diagnostics.</summary>
+    [Fact]
+    public async Task ProviderGateDiagnostics_ExcludeCredentialsAcrossEquivalentUrls()
+    {
+        const string firstCredential = "diagnostic-alice";
+        const string secondCredential = "diagnostic-s3cret";
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            response.Headers.RetryAfter =
+                new RetryConditionHeaderValue(TimeSpan.FromSeconds(120));
+            return Task.FromResult(response);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        using var firstScope = harness.CreateScope();
+        firstScope.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext =
+            TileCacheTestHarness.CreateHttpContext();
+        var firstService = firstScope.ServiceProvider.GetRequiredService<TileCacheService>();
+
+        var first = await firstService.RetrieveTileAsync(
+            "5",
+            "26",
+            "1",
+            $"https://{firstCredential}:{secondCredential}@tiles.example.test/5/26/1.png");
+        using var secondScope = harness.CreateScope();
+        secondScope.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext =
+            TileCacheTestHarness.CreateHttpContext();
+        var secondService = secondScope.ServiceProvider.GetRequiredService<TileCacheService>();
+        var second = await secondService.RetrieveTileAsync(
+            "5",
+            "27",
+            "1",
+            "https://other:credential@tiles.example.test:443/5/27/1.png");
+
+        Assert.Equal(TileRetrievalStatus.TransientFailure, first.Status);
+        Assert.Equal(TileRetrievalStatus.TransientFailure, second.Status);
+        Assert.Single(harness.Upstream.Requests);
+        Assert.DoesNotContain(harness.Logs.Entries,
+            entry => ContainsDiagnosticValue(entry, firstCredential));
+        Assert.DoesNotContain(harness.Logs.Entries,
+            entry => ContainsDiagnosticValue(entry, secondCredential));
+    }
+
     /// <summary>Proves bounded normal gate operations eventually remove only expired providers.</summary>
     [Fact]
     public async Task ProviderGateCleanup_RemovesExpiredEntriesAndPreservesExtensions()
@@ -263,4 +307,13 @@ public sealed partial class TileCacheRetryStatusTests
             BindingFlags.NonPublic | BindingFlags.Static);
         return Assert.IsAssignableFrom<IDictionary>(field?.GetValue(null)).Count;
     }
+
+    /// <summary>Checks every captured diagnostic surface for one supplied credential.</summary>
+    private static bool ContainsDiagnosticValue(
+        TestLogProvider.TestLogEntry entry,
+        string value) =>
+        entry.Message.Contains(value, StringComparison.Ordinal) ||
+        entry.Fields.Values.Any(field =>
+            field?.ToString()?.Contains(value, StringComparison.Ordinal) == true) ||
+        entry.Exception?.ToString().Contains(value, StringComparison.Ordinal) == true;
 }

--- a/tests/Wayfarer.Tests/Services/TileCachePhase2AProductionReviewTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCachePhase2AProductionReviewTests.cs
@@ -236,6 +236,62 @@ public sealed partial class TileCacheRetryStatusTests
         Assert.True(TileProviderRetryPolicy.GetRemainingProviderDelay(extendedKey) > TimeSpan.Zero);
     }
 
+    /// <summary>Proves each live provider gate retains exactly one bounded cleanup record.</summary>
+    [Fact]
+    public async Task ProviderGateCleanup_KeepsOneQueueRecordPerDictionaryEntry()
+    {
+        TileCacheService.ResetStaticStateForTesting();
+        try
+        {
+            var now = new DateTimeOffset(2026, 7, 23, 12, 0, 0, TimeSpan.Zero);
+            TileProviderRetryPolicy.SetDeterminismForTesting(() => now, _ => 0d);
+            var activeKeys = Enumerable.Range(0, 15)
+                .Select(index => AddProviderGate(
+                    $"https://active.example.test:{4400 + index}/tile.png",
+                    3600))
+                .ToArray();
+            var extendedKey = AddProviderGate("https://extended.example.test/tile.png", 60);
+            var expiredKey = AddProviderGate("https://expired.example.test/tile.png", 1);
+
+            Assert.Equal(17, GetProviderGateCount());
+            Assert.DoesNotContain(expiredKey, GetProviderGateCleanupKeys().Take(16));
+            now = now.AddSeconds(2);
+
+            for (var cycle = 0; cycle < 4; cycle++)
+            {
+                Assert.Equal(
+                    TimeSpan.Zero,
+                    TileProviderRetryPolicy.GetRemainingProviderDelay(expiredKey));
+                Assert.Equal(GetProviderGateCount(), GetProviderGateCleanupKeys().Count);
+
+                AddProviderGate("https://expired.example.test/tile.png", 1);
+                Assert.Equal(GetProviderGateCount(), GetProviderGateCleanupKeys().Count);
+                now = now.AddSeconds(2);
+            }
+
+            await Task.WhenAll(Enumerable.Range(0, 32).Select(index => Task.Run(() =>
+            {
+                if (index == 0)
+                {
+                    AddProviderGate("https://extended.example.test/tile.png", 120);
+                }
+                else
+                {
+                    TileProviderRetryPolicy.GetRemainingProviderDelay(activeKeys[0]);
+                }
+            })));
+
+            Assert.Equal(16, GetProviderGateCount());
+            Assert.Equal(GetProviderGateCount(), GetProviderGateCleanupKeys().Count);
+            Assert.True(TileProviderRetryPolicy.GetRemainingProviderDelay(activeKeys[0]) > TimeSpan.Zero);
+            Assert.True(TileProviderRetryPolicy.GetRemainingProviderDelay(extendedKey) > TimeSpan.Zero);
+        }
+        finally
+        {
+            TileCacheService.ResetStaticStateForTesting();
+        }
+    }
+
     /// <summary>Proves provider templates cannot retain URI username or password data.</summary>
     [Fact]
     public void ProviderTemplateValidation_RejectsUserInformation()
@@ -306,6 +362,15 @@ public sealed partial class TileCacheRetryStatusTests
             "_providerNotBefore",
             BindingFlags.NonPublic | BindingFlags.Static);
         return Assert.IsAssignableFrom<IDictionary>(field?.GetValue(null)).Count;
+    }
+
+    /// <summary>Reads the bounded cleanup records for exact ownership verification.</summary>
+    private static IReadOnlyList<string> GetProviderGateCleanupKeys()
+    {
+        var field = typeof(TileProviderRetryPolicy).GetField(
+            "_providerGateCleanupQueue",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        return Assert.IsAssignableFrom<IEnumerable<string>>(field?.GetValue(null)).ToArray();
     }
 
     /// <summary>Checks every captured diagnostic surface for one supplied credential.</summary>

--- a/tests/Wayfarer.Tests/Services/TileCachePhase2AProductionReviewTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCachePhase2AProductionReviewTests.cs
@@ -1,0 +1,266 @@
+using System.Collections;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Wayfarer.Areas.Public.Controllers;
+using Wayfarer.Models;
+using Wayfarer.Services;
+using Wayfarer.Util;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>
+/// Holds the focused production-review regressions for the five Phase 2A corrections.
+/// </summary>
+public sealed partial class TileCacheRetryStatusTests
+{
+    /// <summary>Proves redirects share the operation-wide three-contact and global-budget ceiling.</summary>
+    [Fact]
+    public async Task RedirectChain_StopsAfterThreeTotalProviderContacts()
+    {
+        var acquisitions = 0;
+        var upstream = new RecordingTileHandler((request, _) =>
+        {
+            var path = request.RequestUri?.AbsolutePath;
+            var response = path switch
+            {
+                "/redirect-2" => RedirectTo("/redirect-3"),
+                "/redirect-3" => RedirectTo("/redirect-4"),
+                "/redirect-4" => PngResponse(),
+                _ => RedirectTo("/redirect-2")
+            };
+            return Task.FromResult(response);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        TileCacheService.OutboundBudget.SetAcquireOverrideForTesting(_ =>
+        {
+            Interlocked.Increment(ref acquisitions);
+            return Task.FromResult(new OutboundBudgetAcquisition(true, TimeSpan.Zero));
+        });
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        var result = Assert.IsType<ObjectResult>(await controller.GetTile(5, 22, 1));
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+        Assert.Equal(3, harness.Upstream.Requests.Count);
+        Assert.Equal(3, acquisitions);
+        Assert.DoesNotContain(harness.Upstream.Requests,
+            request => request.RequestUri?.AbsolutePath == "/redirect-4");
+        Assert.All(harness.Upstream.Requests,
+            request => Assert.Equal("tile.openstreetmap.org", request.RequestUri?.Host));
+    }
+
+    /// <summary>
+    /// Proves stale refresh charges the client on its first admitted contact, not its first loop attempt.
+    /// </summary>
+    [Fact]
+    public async Task StaleRefresh_PreTransportRejectionChargesFirstActualContactOnce()
+    {
+        var contacts = 0;
+        var upstream = new RecordingTileHandler((request, _) =>
+        {
+            contacts++;
+            return Task.FromResult(contacts switch
+            {
+                1 => RedirectTo("/stale-redirect"),
+                2 => new HttpResponseMessage(HttpStatusCode.InternalServerError),
+                _ => NotModifiedResponse()
+            });
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        harness.Settings.TileOutboundBudgetPerIpPerMinute = 10;
+        SeedExpiredLowZoomTile(harness.CacheDirectory, 5, 23, 1, [9, 8, 7]);
+        TileCacheService.SetRefreshRetryDelayForTesting(_ => TimeSpan.Zero);
+        var acquisitions = 0;
+        TileCacheService.OutboundBudget.SetAcquireOverrideForTesting(_ =>
+            Task.FromResult(new OutboundBudgetAcquisition(
+                Interlocked.Increment(ref acquisitions) != 1,
+                TimeSpan.Zero)));
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        var result = Assert.IsType<FileContentResult>(await controller.GetTile(5, 23, 1));
+        Assert.Equal(new byte[] { 9, 8, 7 }, result.FileContents);
+        Assert.True(await TileCacheService.WaitForRefreshIdleForTestingAsync(
+            "5_23_1", TimeSpan.FromSeconds(2)));
+
+        Assert.Equal(3, harness.Upstream.Requests.Count);
+        var allowance = Assert.Single(TilesController.OutboundBudgetCache);
+        Assert.Equal(1, allowance.Value.PeekCount(DateTime.UtcNow.Ticks));
+    }
+
+    /// <summary>Proves permanent stale revalidation responses stop without deleting stale bytes.</summary>
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public async Task StaleRefresh_Permanent4xxStopsAfterOneContact(HttpStatusCode statusCode)
+    {
+        using var harness = new TileCacheTestHarness(new RecordingTileHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(statusCode))));
+        var staleBytes = new byte[] { 4, 3, 2, 1 };
+        var x = statusCode == HttpStatusCode.NotFound ? 24 : 25;
+        SeedExpiredLowZoomTile(harness.CacheDirectory, 5, x, 1, staleBytes);
+        var retryDelays = 0;
+        TileCacheService.SetRefreshRetryDelayForTesting(_ =>
+        {
+            Interlocked.Increment(ref retryDelays);
+            return TimeSpan.Zero;
+        });
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+        var tileKey = $"5_{x}_1";
+
+        var result = Assert.IsType<FileContentResult>(
+            await controller.GetTile(5, x, 1));
+        Assert.Equal(staleBytes, result.FileContents);
+        Assert.True(await TileCacheService.WaitForRefreshIdleForTestingAsync(
+            tileKey, TimeSpan.FromSeconds(2)));
+
+        Assert.Single(harness.Upstream.Requests);
+        Assert.Equal(0, retryDelays);
+        Assert.Equal(staleBytes,
+            await File.ReadAllBytesAsync(Path.Combine(harness.CacheDirectory, $"{tileKey}.png")));
+    }
+
+    /// <summary>Proves credentials cannot partition provider identity or its active safety gate.</summary>
+    [Fact]
+    public void ProviderFingerprint_ExcludesCredentialsAndNormalizesAuthority()
+    {
+        var now = new DateTimeOffset(2026, 7, 23, 12, 0, 0, TimeSpan.Zero);
+        TileProviderRetryPolicy.SetDeterminismForTesting(() => now, _ => 0d);
+        const string firstCredential = "review-user";
+        const string secondCredential = "review-password";
+        var first = TileProviderRetryPolicy.GetProviderKey(
+            $"https://{firstCredential}:{secondCredential}@BÜCHER.example/tiles/1.png");
+        var equivalent = TileProviderRetryPolicy.GetProviderKey(
+            "https://other:secret@xn--bcher-kva.example:443/other/2.png?apiKey=value");
+        var differentPort = TileProviderRetryPolicy.GetProviderKey(
+            "https://xn--bcher-kva.example:444/tiles/1.png");
+        using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(20));
+
+        TileProviderRetryPolicy.ApplyRetryAfter(first, response);
+
+        Assert.Equal(first, equivalent);
+        Assert.NotEqual(first, differentPort);
+        Assert.Equal(TimeSpan.FromSeconds(20),
+            TileProviderRetryPolicy.GetRemainingProviderDelay(equivalent));
+        Assert.DoesNotContain(firstCredential, first, StringComparison.Ordinal);
+        Assert.DoesNotContain(secondCredential, first, StringComparison.Ordinal);
+    }
+
+    /// <summary>Proves bounded normal gate operations eventually remove only expired providers.</summary>
+    [Fact]
+    public async Task ProviderGateCleanup_RemovesExpiredEntriesAndPreservesExtensions()
+    {
+        var now = new DateTimeOffset(2026, 7, 23, 12, 0, 0, TimeSpan.Zero);
+        TileProviderRetryPolicy.SetDeterminismForTesting(() => now, _ => 0d);
+        for (var index = 0; index < 12; index++)
+        {
+            AddProviderGate($"https://tiles.example.test:{4400 + index}/tile.png", 1);
+        }
+
+        var activeKey = AddProviderGate("https://active.example.test/tile.png", 60);
+        var extendedKey = AddProviderGate("https://extended.example.test/tile.png", 1);
+        now = now.AddSeconds(2);
+
+        await Task.WhenAll(Enumerable.Range(0, 32).Select(index => Task.Run(() =>
+        {
+            if (index == 0)
+            {
+                AddProviderGate("https://extended.example.test/tile.png", 120);
+            }
+            else
+            {
+                TileProviderRetryPolicy.GetRemainingProviderDelay(activeKey);
+            }
+        })));
+
+        for (var pass = 0; pass < 4; pass++)
+        {
+            TileProviderRetryPolicy.GetRemainingProviderDelay(activeKey);
+        }
+
+        Assert.Equal(2, GetProviderGateCount());
+        Assert.True(TileProviderRetryPolicy.GetRemainingProviderDelay(activeKey) > TimeSpan.Zero);
+        Assert.True(TileProviderRetryPolicy.GetRemainingProviderDelay(extendedKey) > TimeSpan.Zero);
+    }
+
+    /// <summary>Proves provider templates cannot retain URI username or password data.</summary>
+    [Fact]
+    public void ProviderTemplateValidation_RejectsUserInformation()
+    {
+        var valid = TileProviderCatalog.TryValidateTemplate(
+            "https://user:password@tiles.example.test/{z}/{x}/{y}.png",
+            out var error);
+
+        Assert.False(valid);
+        Assert.False(string.IsNullOrWhiteSpace(error));
+        Assert.DoesNotContain("user", error, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("password", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Creates an owned same-host redirect response.</summary>
+    private static HttpResponseMessage RedirectTo(string location)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Found);
+        response.Headers.Location = new Uri(location, UriKind.Relative);
+        return response;
+    }
+
+    /// <summary>Creates an owned 304 response with a bounded fresh lifetime.</summary>
+    private static HttpResponseMessage NotModifiedResponse()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.NotModified);
+        response.Headers.CacheControl = new CacheControlHeaderValue
+        {
+            MaxAge = TimeSpan.FromHours(1)
+        };
+        return response;
+    }
+
+    /// <summary>Seeds an expired low-zoom tile without making any provider contact.</summary>
+    private static void SeedExpiredLowZoomTile(
+        string cacheDirectory,
+        int zoom,
+        int x,
+        int y,
+        byte[] bytes)
+    {
+        var tilePath = Path.Combine(cacheDirectory, $"{zoom}_{x}_{y}.png");
+        File.WriteAllBytes(tilePath, bytes);
+        File.WriteAllText(
+            tilePath + ".meta",
+            JsonSerializer.Serialize(new TileSidecarMetadata
+            {
+                ETag = "\"stale\"",
+                ExpiresAtUtc = DateTime.UtcNow.AddHours(-1)
+            }));
+    }
+
+    /// <summary>Adds or extends one provider gate and returns its non-secret key.</summary>
+    private static string AddProviderGate(string tileUrl, int retryAfterSeconds)
+    {
+        var key = TileProviderRetryPolicy.GetProviderKey(tileUrl);
+        using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter =
+            new RetryConditionHeaderValue(TimeSpan.FromSeconds(retryAfterSeconds));
+        TileProviderRetryPolicy.ApplyRetryAfter(key, response);
+        return key;
+    }
+
+    /// <summary>Reads provider gate count for cleanup verification without exposing production state.</summary>
+    private static int GetProviderGateCount()
+    {
+        var field = typeof(TileProviderRetryPolicy).GetField(
+            "_providerNotBefore",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        return Assert.IsAssignableFrom<IDictionary>(field?.GetValue(null)).Count;
+    }
+}

--- a/tests/Wayfarer.Tests/Services/TileCachePhase2AProductionReviewTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCachePhase2AProductionReviewTests.cs
@@ -197,13 +197,13 @@ public sealed partial class TileCacheRetryStatusTests
     public void ProviderTemplateValidation_RejectsUserInformation()
     {
         var valid = TileProviderCatalog.TryValidateTemplate(
-            "https://user:password@tiles.example.test/{z}/{x}/{y}.png",
+            "https://alice-review:s3cret-review@tiles.example.test/{z}/{x}/{y}.png",
             out var error);
 
         Assert.False(valid);
         Assert.False(string.IsNullOrWhiteSpace(error));
-        Assert.DoesNotContain("user", error, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("password", error, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("alice-review", error, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("s3cret-review", error, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>Creates an owned same-host redirect response.</summary>

--- a/tests/Wayfarer.Tests/Services/TileCacheRetryStatusTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheRetryStatusTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,7 +15,7 @@ namespace Wayfarer.Tests.Services;
 /// Proves the Phase 2A production retry, status, budget, and cancellation contract.
 /// </summary>
 [Collection("OutboundBudget")]
-public sealed class TileCacheRetryStatusTests
+public sealed partial class TileCacheRetryStatusTests
 {
     /// <summary>Proves a confirmed upstream absence is not retried and remains a local 404.</summary>
     [Fact]
@@ -38,8 +39,9 @@ public sealed class TileCacheRetryStatusTests
         using var scope = harness.CreateScope();
         var controller = CreateController(scope);
 
-        await controller.GetTile(5, 2, 1);
+        var result = Assert.IsType<ObjectResult>(await controller.GetTile(5, 2, 1));
 
+        Assert.Equal(StatusCodes.Status502BadGateway, result.StatusCode);
         Assert.Single(harness.Upstream.Requests);
     }
 
@@ -101,17 +103,289 @@ public sealed class TileCacheRetryStatusTests
         Assert.Single(harness.Upstream.Requests);
     }
 
+    /// <summary>Proves uncancelled transport timeouts exhaust as local 503 rather than 404.</summary>
+    [Fact]
+    public async Task TimeoutExhaustion_ReturnsLocal503()
+    {
+        var upstream = new RecordingTileHandler((_, token) =>
+            throw new OperationCanceledException(token));
+        using var harness = new TileCacheTestHarness(upstream);
+        TileProviderRetryPolicy.SetDeterminismForTesting(jitter: _ => 0d);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, _) => Task.CompletedTask);
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        var result = Assert.IsType<ObjectResult>(await controller.GetTile(5, 6, 1));
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+        Assert.Equal(3, harness.Upstream.Requests.Count);
+    }
+
+    /// <summary>Proves unusable provider delays open a gate and prevent an immediate second request.</summary>
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("-1")]
+    [InlineData("0")]
+    [InlineData("999999999999999999999999999999")]
+    [InlineData("Wed, 22 Jul 2026 12:00:00 GMT")]
+    public async Task UnusableRetryAfter_OpensProviderGate(string retryAfter)
+    {
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            response.Headers.TryAddWithoutValidation("Retry-After", retryAfter);
+            return Task.FromResult(response);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        TileProviderRetryPolicy.SetDeterminismForTesting(
+            () => new DateTimeOffset(2026, 7, 23, 12, 0, 0, TimeSpan.Zero),
+            _ => 0d);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, _) => Task.CompletedTask);
+        using var firstScope = harness.CreateScope();
+        var firstController = CreateController(firstScope);
+
+        var first = Assert.IsType<ObjectResult>(await firstController.GetTile(5, 9, 1));
+        using var secondScope = harness.CreateScope();
+        var secondController = CreateController(secondScope);
+        var second = Assert.IsType<ObjectResult>(await secondController.GetTile(5, 10, 1));
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, first.StatusCode);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, second.StatusCode);
+        Assert.Single(harness.Upstream.Requests);
+        Assert.Contains(harness.Logs.Entries, entry =>
+            entry.Level == LogLevel.Error &&
+            entry.Message.Contains("unusable Retry-After", StringComparison.Ordinal));
+    }
+
+    /// <summary>Proves a valid long provider delay is retained and blocks another request.</summary>
+    [Fact]
+    public async Task LongProviderDelay_PreventsEarlySecondRequest()
+    {
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(120));
+            return Task.FromResult(response);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        using var firstScope = harness.CreateScope();
+        var firstController = CreateController(firstScope);
+
+        var first = Assert.IsType<ObjectResult>(await firstController.GetTile(5, 11, 1));
+        using var secondScope = harness.CreateScope();
+        var secondController = CreateController(secondScope);
+        var second = Assert.IsType<ObjectResult>(await secondController.GetTile(5, 12, 1));
+
+        Assert.Equal("30", firstController.Response.Headers.RetryAfter);
+        Assert.Equal("30", secondController.Response.Headers.RetryAfter);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, first.StatusCode);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, second.StatusCode);
+        Assert.Single(harness.Upstream.Requests);
+    }
+
+    /// <summary>Proves final-attempt Retry-After still establishes the provider-wide gate.</summary>
+    [Fact]
+    public async Task FinalAttemptRetryAfter_IsRetainedForNextRequest()
+    {
+        var attempts = 0;
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) < 3)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway));
+            }
+
+            var response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(120));
+            return Task.FromResult(response);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        TileProviderRetryPolicy.SetDeterminismForTesting(jitter: _ => 0d);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, _) => Task.CompletedTask);
+        using var firstScope = harness.CreateScope();
+        var firstController = CreateController(firstScope);
+
+        Assert.IsType<ObjectResult>(await firstController.GetTile(5, 19, 1));
+        using var secondScope = harness.CreateScope();
+        var secondController = CreateController(secondScope);
+        Assert.IsType<ObjectResult>(await secondController.GetTile(5, 20, 1));
+
+        Assert.Equal(3, harness.Upstream.Requests.Count);
+        Assert.Equal("30", secondController.Response.Headers.RetryAfter);
+    }
+
+    /// <summary>Proves elapsed transport and delay time stop retries at the 45-second ceiling.</summary>
+    [Fact]
+    public async Task InteractiveDurationCeiling_StopsAnotherAttempt()
+    {
+        var now = new DateTimeOffset(2026, 7, 23, 12, 0, 0, TimeSpan.Zero);
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            now += TimeSpan.FromSeconds(44);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway));
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        TileProviderRetryPolicy.SetDeterminismForTesting(() => now, _ => 0d);
+        TileCacheService.SetColdMissRetryDelayForTesting((delay, _) =>
+        {
+            now += delay;
+            return Task.CompletedTask;
+        });
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        var result = Assert.IsType<ObjectResult>(await controller.GetTile(5, 21, 1));
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+        Assert.Equal(2, harness.Upstream.Requests.Count);
+    }
+
+    /// <summary>Proves cancellation during a provider not-before wait stops the retry series.</summary>
+    [Fact]
+    public async Task ProviderWaitCancellation_StopsBeforeSecondAttempt()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(2));
+            return Task.FromResult(response);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, token) =>
+        {
+            cancellation.Cancel();
+            return Task.FromCanceled(token);
+        });
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope, cancellation.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => controller.GetTile(5, 13, 1));
+
+        Assert.Single(harness.Upstream.Requests);
+        Assert.Single(harness.Logs.Entries, entry =>
+            entry.EventId.Id == (int)TileCacheDiagnosticEventIds.Cancellation &&
+            Equals(entry.Fields["CancellationStage"], "provider-not-before-wait"));
+    }
+
+    /// <summary>Proves a retry denied global capacity never reaches the provider.</summary>
+    [Fact]
+    public async Task RetryWithoutGlobalCapacity_DoesNotContactProvider()
+    {
+        var acquisitions = 0;
+        using var harness = CreateHarness(HttpStatusCode.InternalServerError);
+        TileProviderRetryPolicy.SetDeterminismForTesting(jitter: _ => 0d);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, _) => Task.CompletedTask);
+        TileCacheService.OutboundBudget.SetAcquireOverrideForTesting(_ =>
+        {
+            var acquired = Interlocked.Increment(ref acquisitions) == 1;
+            return Task.FromResult(new OutboundBudgetAcquisition(acquired, TimeSpan.Zero));
+        });
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        var result = Assert.IsType<ObjectResult>(await controller.GetTile(5, 14, 1));
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+        Assert.Single(harness.Upstream.Requests);
+        Assert.Equal(2, acquisitions);
+    }
+
+    /// <summary>Proves retries do not charge the initiating client's allowance repeatedly.</summary>
+    [Fact]
+    public async Task Retry_ChargesClientAllowanceOnce()
+    {
+        var attempts = 0;
+        var upstream = new RecordingTileHandler((_, _) =>
+            Task.FromResult(Interlocked.Increment(ref attempts) == 1
+                ? new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                : PngResponse()));
+        using var harness = new TileCacheTestHarness(upstream);
+        harness.Settings.TileOutboundBudgetPerIpPerMinute = 1;
+        TileProviderRetryPolicy.SetDeterminismForTesting(jitter: _ => 0d);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, _) => Task.CompletedTask);
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        var result = await controller.GetTile(5, 15, 1);
+
+        Assert.IsType<FileContentResult>(result);
+        Assert.Equal(2, harness.Upstream.Requests.Count);
+    }
+
+    /// <summary>Proves a successful retry writes the tile and the next request is a fresh cache hit.</summary>
+    [Fact]
+    public async Task SuccessfulRetry_WritesCacheForImmediateFreshHit()
+    {
+        var attempts = 0;
+        var upstream = new RecordingTileHandler((_, _) =>
+            Task.FromResult(Interlocked.Increment(ref attempts) == 1
+                ? new HttpResponseMessage(HttpStatusCode.BadGateway)
+                : PngResponse()));
+        using var harness = new TileCacheTestHarness(upstream);
+        TileProviderRetryPolicy.SetDeterminismForTesting(jitter: _ => 0d);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, _) => Task.CompletedTask);
+        using var firstScope = harness.CreateScope();
+        var firstController = CreateController(firstScope);
+
+        Assert.IsType<FileContentResult>(await firstController.GetTile(5, 16, 1));
+        using var secondScope = harness.CreateScope();
+        var secondController = CreateController(secondScope);
+        Assert.IsType<FileContentResult>(await secondController.GetTile(5, 16, 1));
+
+        Assert.Equal(2, harness.Upstream.Requests.Count);
+        Assert.True(File.Exists(Path.Combine(harness.CacheDirectory, "5_16_1.png")));
+    }
+
+    /// <summary>Proves local request-rate rejection retains 429 with bounded retry guidance.</summary>
+    [Fact]
+    public async Task LocalRequestRateLimit_Returns429WithRetryAfter()
+    {
+        using var harness = new TileCacheTestHarness();
+        harness.Settings.TileRateLimitEnabled = true;
+        harness.Settings.TileRateLimitPerMinute = 1;
+        using var scope = harness.CreateScope();
+        var context = TileCacheTestHarness.CreateHttpContext();
+        var controller = CreateController(scope, context);
+
+        Assert.IsType<FileContentResult>(await controller.GetTile(5, 17, 1));
+        var rejected = Assert.IsType<ObjectResult>(await controller.GetTile(5, 18, 1));
+
+        Assert.Equal(StatusCodes.Status429TooManyRequests, rejected.StatusCode);
+        Assert.Equal(TilesController.BudgetRetryAfterSeconds.ToString(), context.Response.Headers.RetryAfter);
+    }
+
     /// <summary>Creates a fake-only provider harness returning the requested status.</summary>
     private static TileCacheTestHarness CreateHarness(HttpStatusCode statusCode) =>
         new(new RecordingTileHandler((_, _) =>
             Task.FromResult(new HttpResponseMessage(statusCode))));
 
+    /// <summary>Builds deterministic cacheable PNG content.</summary>
+    private static HttpResponseMessage PngResponse()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1, 2, 3, 4])
+        };
+        response.Headers.CacheControl = new CacheControlHeaderValue
+        {
+            MaxAge = TimeSpan.FromHours(1)
+        };
+        return response;
+    }
+
     /// <summary>Creates a controller with a same-origin request and shared cancellation token.</summary>
     private static TilesController CreateController(
         IServiceScope scope,
         CancellationToken cancellationToken = default)
+        => CreateController(scope, TileCacheTestHarness.CreateHttpContext(cancellationToken));
+
+    /// <summary>Creates a controller over an explicit test HTTP context.</summary>
+    private static TilesController CreateController(
+        IServiceScope scope,
+        DefaultHttpContext context)
     {
-        var context = TileCacheTestHarness.CreateHttpContext(cancellationToken);
         scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext = context;
         return new TilesController(
             scope.ServiceProvider.GetRequiredService<ILogger<TilesController>>(),

--- a/tests/Wayfarer.Tests/Services/TileCacheRetryStatusTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheRetryStatusTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Wayfarer.Areas.Public.Controllers;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>
+/// Proves the Phase 2A production retry, status, budget, and cancellation contract.
+/// </summary>
+[Collection("OutboundBudget")]
+public sealed class TileCacheRetryStatusTests
+{
+    /// <summary>Proves a confirmed upstream absence is not retried and remains a local 404.</summary>
+    [Fact]
+    public async Task Upstream404_ReturnsLocal404AfterOneAttempt()
+    {
+        using var harness = CreateHarness(HttpStatusCode.NotFound);
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        var result = Assert.IsType<NotFoundObjectResult>(await controller.GetTile(5, 1, 1));
+
+        Assert.Equal(StatusCodes.Status404NotFound, result.StatusCode);
+        Assert.Single(harness.Upstream.Requests);
+    }
+
+    /// <summary>Proves permanent non-rate-limit client failures are never retried.</summary>
+    [Fact]
+    public async Task PermanentUpstream4xx_IsNotRetried()
+    {
+        using var harness = CreateHarness(HttpStatusCode.Forbidden);
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        await controller.GetTile(5, 2, 1);
+
+        Assert.Single(harness.Upstream.Requests);
+    }
+
+    /// <summary>Proves exhausted upstream server failures are exposed as temporary local failure.</summary>
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public async Task Upstream5xxExhaustion_ReturnsLocal503(HttpStatusCode statusCode)
+    {
+        using var harness = CreateHarness(statusCode);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, _) => Task.CompletedTask);
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        var result = Assert.IsType<ObjectResult>(await controller.GetTile(5, 3, 1));
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+        Assert.Equal(3, harness.Upstream.Requests.Count);
+    }
+
+    /// <summary>Proves every actual retry acquires global capacity independently.</summary>
+    [Fact]
+    public async Task EachUpstreamAttempt_ConsumesGlobalBudgetToken()
+    {
+        var acquisitions = 0;
+        using var harness = CreateHarness(HttpStatusCode.ServiceUnavailable);
+        TileCacheService.SetColdMissRetryDelayForTesting((_, _) => Task.CompletedTask);
+        TileCacheService.OutboundBudget.SetAcquireOverrideForTesting(_ =>
+        {
+            Interlocked.Increment(ref acquisitions);
+            return Task.FromResult(new OutboundBudgetAcquisition(true, TimeSpan.Zero));
+        });
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        await controller.GetTile(5, 4, 1);
+
+        Assert.Equal(3, harness.Upstream.Requests.Count);
+        Assert.Equal(3, acquisitions);
+    }
+
+    /// <summary>Proves caller cancellation propagates instead of becoming a provider response.</summary>
+    [Fact]
+    public async Task CallerCancellation_PropagatesFromController()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var upstream = new RecordingTileHandler((_, token) =>
+        {
+            cancellation.Cancel();
+            return Task.FromCanceled<HttpResponseMessage>(token);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope, cancellation.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => controller.GetTile(5, 5, 1));
+        Assert.Single(harness.Upstream.Requests);
+    }
+
+    /// <summary>Creates a fake-only provider harness returning the requested status.</summary>
+    private static TileCacheTestHarness CreateHarness(HttpStatusCode statusCode) =>
+        new(new RecordingTileHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(statusCode))));
+
+    /// <summary>Creates a controller with a same-origin request and shared cancellation token.</summary>
+    private static TilesController CreateController(
+        IServiceScope scope,
+        CancellationToken cancellationToken = default)
+    {
+        var context = TileCacheTestHarness.CreateHttpContext(cancellationToken);
+        scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext = context;
+        return new TilesController(
+            scope.ServiceProvider.GetRequiredService<ILogger<TilesController>>(),
+            scope.ServiceProvider.GetRequiredService<TileCacheService>(),
+            scope.ServiceProvider.GetRequiredService<IApplicationSettingsService>())
+        {
+            ControllerContext = new ControllerContext { HttpContext = context }
+        };
+    }
+}

--- a/tests/Wayfarer.Tests/Services/TileProviderRetryAfterTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileProviderRetryAfterTests.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Wayfarer.Services;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>Contains provider Retry-After parsing and controlled-wait cases for Phase 2A.</summary>
+public sealed partial class TileCacheRetryStatusTests
+{
+    /// <summary>Proves delta-seconds provider guidance is awaited before a successful retry.</summary>
+    [Theory]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task DeltaRetryAfter_DelaysProviderRetry(HttpStatusCode statusCode)
+    {
+        var now = new DateTimeOffset(2026, 7, 23, 12, 0, 0, TimeSpan.Zero);
+        var attempts = 0;
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                var response = new HttpResponseMessage(statusCode);
+                response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(2));
+                return Task.FromResult(response);
+            }
+
+            return Task.FromResult(PngResponse());
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        TileProviderRetryPolicy.SetDeterminismForTesting(() => now, _ => 0d);
+        TileCacheService.SetColdMissRetryDelayForTesting((delay, _) =>
+        {
+            now += delay;
+            return Task.CompletedTask;
+        });
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        var result = await controller.GetTile(5, 7, 1);
+
+        Assert.IsType<FileContentResult>(result);
+        Assert.Equal(2, harness.Upstream.Requests.Count);
+        Assert.Equal(new DateTimeOffset(2026, 7, 23, 12, 0, 2, TimeSpan.Zero), now);
+    }
+
+    /// <summary>Proves HTTP-date provider guidance is parsed and awaited before retry.</summary>
+    [Fact]
+    public async Task HttpDateRetryAfter_DelaysProviderRetry()
+    {
+        var now = new DateTimeOffset(2026, 7, 23, 12, 0, 0, TimeSpan.Zero);
+        var attempts = 0;
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+                response.Headers.RetryAfter = new RetryConditionHeaderValue(now.AddSeconds(3));
+                return Task.FromResult(response);
+            }
+
+            return Task.FromResult(PngResponse());
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        TileProviderRetryPolicy.SetDeterminismForTesting(() => now, _ => 0d);
+        TileCacheService.SetColdMissRetryDelayForTesting((delay, _) =>
+        {
+            now += delay;
+            return Task.CompletedTask;
+        });
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        Assert.IsType<FileContentResult>(await controller.GetTile(5, 8, 1));
+        Assert.Equal(2, harness.Upstream.Requests.Count);
+        Assert.Equal(new DateTimeOffset(2026, 7, 23, 12, 0, 3, TimeSpan.Zero), now);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 2A of #385: provider-respectful retry and local HTTP status correctness.

- replaces ambiguous tile-download outcomes with typed success, not-found, permanent-failure, transient-failure, and throttled results;
- maps confirmed upstream 404 to local 404, permanent non-retryable 4xx to 502, and timeout/408/429/5xx exhaustion to local 503 with bounded retry guidance;
- supports delta-seconds and HTTP-date `Retry-After` and retains provider-wide not-before state without contacting the provider early;
- applies the interim three-total-contact ceiling across initial requests, redirects, and retries;
- charges global capacity for every actual HTTP contact while charging the initiating client allowance once;
- propagates cancellation through provider waits, global-budget waits, transport, fallback delays, and stale refresh;
- stops stale refresh after terminal 4xx while preserving stale bytes and metadata;
- derives non-secret provider identity from normalized scheme, IDN host, and effective port, rejecting URI user-information;
- keeps provider-gate cleanup bounded without unbounded metadata growth.

## Why

Before this correction, transient provider failures could be returned locally as permanent 404 responses, upstream retries were not individually budgeted, redirects could bypass the intended attempt ceiling, and provider-directed retry delays were not honored.

This change makes provider failures and local throttling deterministic while preserving the existing conservative numeric limits.

## Local response contract

| Condition | Local response |
| --- | --- |
| Request/client rate limit | `429` with `Retry-After` |
| Global outbound-capacity rejection | `503` with `Retry-After` |
| Confirmed upstream 404 | `404`, one provider contact |
| Other permanent upstream 4xx | `502`, no retry |
| Timeout, 408, 429, or 5xx exhaustion | `503` with bounded `Retry-After` |
| Invalid provider `Retry-After` | `503` with bounded safety guidance |
| Caller cancellation | Propagated without rewriting |

## Retry bounds

Until Phase 4 introduces approved provider profiles, this PR retains the interim Wayfarer safety profile from #385:

- maximum three total provider contacts, including redirects and retries;
- 500 ms exponential fallback base, capped at four seconds;
- deterministic injectable ±20% jitter;
- 30-second individual wait ceiling;
- 45-second total interactive ceiling;
- provider-directed delays retained in full while local guidance is bounded to 1–30 seconds.

These are Wayfarer safety bounds, not claims about OSM requirements.

## Scope boundaries

This PR does not implement:

- Phase 2B dynamic attribution normalization;
- Phase 3 cold-miss coalescing, bounded queues, or foreground/background priority;
- Phase 4 provider profiles, transport defaults, or historical 30/minute handling;
- browser retry redesign;
- mobile provider-policy changes.

It does not claim to solve the cold-cache burst/gap speed problem. Progressive viewport completion remains Phase 3.

This PR is **part of #385** and must not close the parent issue.

## Validation

- final provider-gate ownership regression: 1 passed, 0 failed;
- Phase 2A retry/status/provider-gate tests: 33 passed, 0 failed;
- focused Phase 1 diagnostics/privacy/baseline tests: 20 passed, 0 failed;
- full .NET suite: 1,733 passed, 9 environment-gated PostgreSQL tests skipped, 0 failed;
- `dotnet build`: succeeded with 0 errors;
- LOC checker: passed; no warnings in changed files;
- `git diff --check`: passed;
- tracked-artifact and high-risk secret scans: clean;
- independent final re-review: no findings, `PHASE 2A CODE READY`.

All automated upstream traffic used fake in-memory handlers. No public tile provider was contacted.

## UI and database impact

- Screenshots: not applicable; no UI changes.
- Database migration: none.
- Configuration changes: none.
- Existing AngleSharp and SQLitePCLRaw advisories remain unchanged; no package files were modified.
