### PR TITLE
Fix dynamic map attribution across Editor and Viewer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600
 
       - name: Build and Test
-        run: dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --configuration Release --verbosity normal --filter "Category!=RequiresSpatialite"
+        run: dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --configuration Release --verbosity normal --filter "Category!=RequiresSpatialite&Category!=RequiresPlaywright"
         env:
           # Disable frontend bundling in CI - we're testing C# code, not frontend assets
           MvcFrontendKitEnabled: 'false'

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -68,8 +68,9 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
 
   map.on('moveend zoomend', updateMapViewDataset);
 
+  // The shared layout supplies final provider-safe attribution for every map client.
   createTripEditorTileLayer(tilesUrl, {
-    attribution: providerAttribution(window.wayfarerTileConfig?.attribution),
+    attribution: window.wayfarerTileConfig?.attribution,
     maxZoom: 19
   }).addTo(map);
   map.attributionControl.setPrefix('&copy; <a href="https://wayfarer.stefk.me" title="Powered by Wayfarer, made by Stef" target="_blank" rel="noopener">Wayfarer</a> | <a href="https://stefk.me" title="Check my blog" target="_blank" rel="noopener">Stef K</a> | &copy; <a href="https://leafletjs.com/" target="_blank" rel="noopener">Leaflet</a>');
@@ -641,24 +642,6 @@ const readUrlMapView = (search: string): { center: EditorCoordinate; zoom: numbe
 
   const center = { latitude, longitude };
   return isFiniteCoordinate(center) ? { center, zoom } : null;
-};
-
-/// Preserves configured provider attribution while ensuring OpenStreetMap remains linked.
-const providerAttribution = (configuredAttribution: string | null | undefined): string => {
-  const attribution = configuredAttribution?.trim() || '&copy; OpenStreetMap contributors';
-  if (/openstreetmap\.org/i.test(attribution)) {
-    return attribution;
-  }
-
-  if (/OpenStreetMap contributors/i.test(attribution)) {
-    return attribution.replace(/OpenStreetMap contributors/gi, '<a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> contributors');
-  }
-
-  if (/OpenStreetMap/i.test(attribution)) {
-    return attribution.replace(/OpenStreetMap/gi, '<a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a>');
-  }
-
-  return `${attribution} | &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> contributors`;
 };
 
 const segmentLabel = (segment: EditorSegment, state: EditorTripState): string => {

--- a/Services/ApplicationSettingsService.cs
+++ b/Services/ApplicationSettingsService.cs
@@ -74,9 +74,12 @@ namespace Wayfarer.Parsers
                 settings.TileProviderUrlTemplate = ApplicationSettings.DefaultTileProviderUrlTemplate;
             }
 
-            if (string.IsNullOrWhiteSpace(settings.TileProviderAttribution))
+            // Only a recognized preset can safely supply missing legacy attribution.
+            // Unknown and custom providers must never be mislabeled as OpenStreetMap.
+            if (string.IsNullOrWhiteSpace(settings.TileProviderAttribution) &&
+                Wayfarer.Util.TileProviderCatalog.FindPreset(settings.TileProviderKey) is { } preset)
             {
-                settings.TileProviderAttribution = ApplicationSettings.DefaultTileProviderAttribution;
+                settings.TileProviderAttribution = preset.Attribution;
             }
 
             return settings;

--- a/Util/HtmlSanitization.cs
+++ b/Util/HtmlSanitization.cs
@@ -25,6 +25,7 @@ public static class HtmlSanitization
         sanitizer.AllowedAttributes.Clear();
         sanitizer.AllowedAttributes.Add("href");
         sanitizer.AllowedAttributes.Add("target");
+        sanitizer.AllowedAttributes.Add("rel");
         sanitizer.AllowedAttributes.Add("title");
         sanitizer.AllowedAttributes.Add("class");
 

--- a/Util/TileProviderAttribution.cs
+++ b/Util/TileProviderAttribution.cs
@@ -86,7 +86,8 @@ public static partial class TileProviderAttribution
         }
 
         var visibleText = anchor.TextContent.Trim();
-        if (string.IsNullOrEmpty(OpenStreetMapText().Replace(visibleText, string.Empty)))
+        if (OpenStreetMapOnlyRemainder().IsMatch(
+                OpenStreetMapText().Replace(visibleText, string.Empty)))
         {
             NormalizeOsmText(anchor);
             anchor.SetAttribute("href", OpenStreetMapCopyrightUrl);
@@ -289,6 +290,11 @@ public static partial class TileProviderAttribution
 
     [GeneratedRegex("OpenStreetMap", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex OpenStreetMapText();
+
+    [GeneratedRegex(
+        @"^\s*(?:©\s*)?(?:contributors?)?\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex OpenStreetMapOnlyRemainder();
 
     /// <summary>
     /// Represents one contiguous portion of a mixed attribution anchor.

--- a/Util/TileProviderAttribution.cs
+++ b/Util/TileProviderAttribution.cs
@@ -61,7 +61,12 @@ public static partial class TileProviderAttribution
         {
             if (child is IText text)
             {
-                NormalizeTextNode(text, document);
+                NormalizeUnlinkedTextNode(text, document);
+            }
+            else if (child is IElement element &&
+                     element.LocalName.Equals("a", StringComparison.OrdinalIgnoreCase))
+            {
+                NormalizeAnchor(element, document);
             }
             else
             {
@@ -71,22 +76,59 @@ public static partial class TileProviderAttribution
     }
 
     /// <summary>
-    /// Canonicalizes OpenStreetMap text within an existing link or wraps unlinked visible text.
+    /// Canonicalizes an OpenStreetMap-only link or separates OSM text from a mixed provider link.
     /// </summary>
-    private static void NormalizeTextNode(IText text, IDocument document)
+    private static void NormalizeAnchor(IElement anchor, IDocument document)
     {
-        if (!OpenStreetMapText().IsMatch(text.Data))
+        if (!OpenStreetMapText().IsMatch(anchor.TextContent))
         {
             return;
         }
 
-        var containingAnchor = FindContainingAnchor(text);
-        if (containingAnchor != null)
+        var visibleText = anchor.TextContent.Trim();
+        if (string.IsNullOrEmpty(OpenStreetMapText().Replace(visibleText, string.Empty)))
         {
-            text.Data = OpenStreetMapText().Replace(text.Data, "OpenStreetMap");
-            containingAnchor.SetAttribute("href", OpenStreetMapCopyrightUrl);
-            containingAnchor.RemoveAttribute("target");
-            containingAnchor.RemoveAttribute("rel");
+            NormalizeOsmText(anchor);
+            anchor.SetAttribute("href", OpenStreetMapCopyrightUrl);
+            anchor.RemoveAttribute("target");
+            anchor.RemoveAttribute("rel");
+            return;
+        }
+
+        var parent = anchor.Parent;
+        if (parent == null)
+        {
+            return;
+        }
+
+        foreach (var segment in SplitAttributionNodes(anchor.ChildNodes.ToArray(), document))
+        {
+            var link = segment.IsOpenStreetMap
+                ? document.CreateElement("a")
+                : CloneElementShallow(anchor, document);
+            if (segment.IsOpenStreetMap)
+            {
+                link.SetAttribute("href", OpenStreetMapCopyrightUrl);
+            }
+
+            foreach (var segmentNode in segment.Nodes)
+            {
+                link.AppendChild(segmentNode);
+            }
+
+            parent.InsertBefore(link, anchor);
+        }
+
+        parent.RemoveChild(anchor);
+    }
+
+    /// <summary>
+    /// Wraps unlinked visible OpenStreetMap text in the canonical copyright link.
+    /// </summary>
+    private static void NormalizeUnlinkedTextNode(IText text, IDocument document)
+    {
+        if (!OpenStreetMapText().IsMatch(text.Data))
+        {
             return;
         }
 
@@ -120,23 +162,115 @@ public static partial class TileProviderAttribution
     }
 
     /// <summary>
-    /// Finds the nearest containing anchor for a visible text node.
+    /// Splits sanitized anchor descendants into provider and canonical OSM segments.
     /// </summary>
-    private static IElement? FindContainingAnchor(INode node)
+    private static List<AttributionSegment> SplitAttributionNodes(
+        IEnumerable<INode> nodes,
+        IDocument document)
     {
-        var current = node.Parent;
-        while (current != null)
+        var segments = new List<AttributionSegment>();
+        foreach (var node in nodes)
         {
-            if (current is IElement element &&
-                element.LocalName.Equals("a", StringComparison.OrdinalIgnoreCase))
+            if (node is IText text)
             {
-                return element;
-            }
+                var position = 0;
+                foreach (Match match in OpenStreetMapText().Matches(text.Data))
+                {
+                    if (match.Index > position)
+                    {
+                        AddSegment(
+                            segments,
+                            false,
+                            document.CreateTextNode(text.Data[position..match.Index]));
+                    }
 
-            current = current.Parent;
+                    AddSegment(segments, true, document.CreateTextNode("OpenStreetMap"));
+                    position = match.Index + match.Length;
+                }
+
+                if (position < text.Data.Length)
+                {
+                    AddSegment(segments, false, document.CreateTextNode(text.Data[position..]));
+                }
+            }
+            else if (node is IElement element)
+            {
+                var childSegments = SplitAttributionNodes(element.ChildNodes.ToArray(), document);
+                if (childSegments.Count == 0)
+                {
+                    AddSegment(segments, false, CloneElementShallow(element, document));
+                }
+                else
+                {
+                    foreach (var childSegment in childSegments)
+                    {
+                        var elementClone = CloneElementShallow(element, document);
+                        foreach (var childNode in childSegment.Nodes)
+                        {
+                            elementClone.AppendChild(childNode);
+                        }
+
+                        AddSegment(segments, childSegment.IsOpenStreetMap, elementClone);
+                    }
+                }
+            }
+            else
+            {
+                AddSegment(segments, false, node.Clone(true));
+            }
         }
 
-        return null;
+        return segments;
+    }
+
+    /// <summary>
+    /// Coalesces adjacent nodes that retain the same attribution destination.
+    /// </summary>
+    private static void AddSegment(
+        ICollection<AttributionSegment> segments,
+        bool isOpenStreetMap,
+        INode node)
+    {
+        var last = segments.LastOrDefault();
+        if (last != null && last.IsOpenStreetMap == isOpenStreetMap)
+        {
+            last.Nodes.Add(node);
+            return;
+        }
+
+        segments.Add(new AttributionSegment(isOpenStreetMap, [node]));
+    }
+
+    /// <summary>
+    /// Copies a sanitized element and its allowed attributes without copying descendants.
+    /// </summary>
+    private static IElement CloneElementShallow(IElement source, IDocument document)
+    {
+        var clone = document.CreateElement(source.LocalName);
+        foreach (var attribute in source.Attributes)
+        {
+            clone.SetAttribute(attribute.Name, attribute.Value);
+        }
+
+        return clone;
+    }
+
+    /// <summary>
+    /// Normalizes visible OpenStreetMap casing inside an OSM-only anchor.
+    /// </summary>
+    private static void NormalizeOsmText(INode node)
+    {
+        foreach (var child in node.ChildNodes)
+        {
+            if (child is IText text)
+            {
+                text.Data = OpenStreetMapText().Replace(text.Data, "OpenStreetMap");
+            }
+            else
+            {
+                NormalizeOsmText(child);
+            }
+        }
     }
 
     /// <summary>
@@ -155,4 +289,9 @@ public static partial class TileProviderAttribution
 
     [GeneratedRegex("OpenStreetMap", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex OpenStreetMapText();
+
+    /// <summary>
+    /// Represents one contiguous portion of a mixed attribution anchor.
+    /// </summary>
+    private sealed record AttributionSegment(bool IsOpenStreetMap, List<INode> Nodes);
 }

--- a/Util/TileProviderAttribution.cs
+++ b/Util/TileProviderAttribution.cs
@@ -102,7 +102,13 @@ public static partial class TileProviderAttribution
             return;
         }
 
-        foreach (var segment in SplitAttributionNodes(anchor.ChildNodes.ToArray(), document))
+        var matches = OpenStreetMapText().Matches(anchor.TextContent).Cast<Match>().ToArray();
+        var textPosition = 0;
+        foreach (var segment in SplitAttributionNodes(
+                     anchor.ChildNodes.ToArray(),
+                     document,
+                     matches,
+                     ref textPosition))
         {
             var link = segment.IsOpenStreetMap
                 ? document.CreateElement("a")
@@ -167,36 +173,59 @@ public static partial class TileProviderAttribution
     /// </summary>
     private static List<AttributionSegment> SplitAttributionNodes(
         IEnumerable<INode> nodes,
-        IDocument document)
+        IDocument document,
+        IReadOnlyList<Match> matches,
+        ref int textPosition)
     {
         var segments = new List<AttributionSegment>();
         foreach (var node in nodes)
         {
             if (node is IText text)
             {
+                var nodeStart = textPosition;
+                textPosition += text.Data.Length;
                 var position = 0;
-                foreach (Match match in OpenStreetMapText().Matches(text.Data))
+                while (position < text.Data.Length)
                 {
-                    if (match.Index > position)
+                    var absolutePosition = nodeStart + position;
+                    var match = matches.FirstOrDefault(candidate =>
+                        absolutePosition >= candidate.Index &&
+                        absolutePosition < candidate.Index + candidate.Length);
+                    if (match != null)
                     {
+                        var matchedLength = Math.Min(
+                            text.Data.Length - position,
+                            match.Index + match.Length - absolutePosition);
                         AddSegment(
                             segments,
-                            false,
-                            document.CreateTextNode(text.Data[position..match.Index]));
+                            true,
+                            document.CreateTextNode(
+                                "OpenStreetMap".Substring(
+                                    absolutePosition - match.Index,
+                                    matchedLength)));
+                        position += matchedLength;
+                        continue;
                     }
 
-                    AddSegment(segments, true, document.CreateTextNode("OpenStreetMap"));
-                    position = match.Index + match.Length;
-                }
-
-                if (position < text.Data.Length)
-                {
-                    AddSegment(segments, false, document.CreateTextNode(text.Data[position..]));
+                    var nextMatch = matches.FirstOrDefault(candidate =>
+                        candidate.Index > absolutePosition);
+                    var length = nextMatch == null
+                        ? text.Data.Length - position
+                        : Math.Min(text.Data.Length - position, nextMatch.Index - absolutePosition);
+                    AddSegment(
+                        segments,
+                        false,
+                        document.CreateTextNode(text.Data.Substring(position, length)));
+                    position += length;
                 }
             }
             else if (node is IElement element)
             {
-                var childSegments = SplitAttributionNodes(element.ChildNodes.ToArray(), document);
+                var childSegments = SplitAttributionNodes(
+                    element.ChildNodes.ToArray(),
+                    document,
+                    matches,
+                    ref textPosition);
                 if (childSegments.Count == 0)
                 {
                     AddSegment(segments, false, CloneElementShallow(element, document));

--- a/Util/TileProviderAttribution.cs
+++ b/Util/TileProviderAttribution.cs
@@ -1,0 +1,158 @@
+using System.Text.RegularExpressions;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using Wayfarer.Models;
+
+namespace Wayfarer.Util;
+
+/// <summary>
+/// Resolves safe display HTML for the active tile provider attribution.
+/// </summary>
+public static partial class TileProviderAttribution
+{
+    /// <summary>
+    /// Canonical OpenStreetMap copyright page used when visible attribution names OpenStreetMap.
+    /// </summary>
+    public const string OpenStreetMapCopyrightUrl = "https://www.openstreetmap.org/copyright";
+
+    /// <summary>
+    /// Selects the active provider attribution, normalizes visible OpenStreetMap text, and
+    /// sanitizes the final HTML at the output boundary.
+    /// </summary>
+    /// <param name="settings">The active administrator-configured tile settings.</param>
+    /// <returns>Sanitized attribution HTML, or an empty string when attribution cannot be proven.</returns>
+    public static string Resolve(ApplicationSettings? settings)
+    {
+        var providerKey = string.IsNullOrWhiteSpace(settings?.TileProviderKey)
+            ? ApplicationSettings.DefaultTileProviderKey
+            : settings.TileProviderKey.Trim();
+        var preset = TileProviderCatalog.FindPreset(providerKey);
+        var configuredAttribution = settings?.TileProviderAttribution;
+        var source = string.IsNullOrWhiteSpace(configuredAttribution)
+            ? preset?.Attribution
+            : configuredAttribution;
+
+        var sanitized = HtmlSanitization.SanitizeAttribution(source);
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            return string.Empty;
+        }
+
+        var parser = new HtmlParser();
+        var document = parser.ParseDocument($"<body>{sanitized}</body>");
+        var body = document.Body;
+        if (body == null)
+        {
+            return string.Empty;
+        }
+
+        NormalizeVisibleText(body, document);
+        SecureNewTabLinks(body);
+
+        return HtmlSanitization.SanitizeAttribution(body.InnerHtml);
+    }
+
+    /// <summary>
+    /// Walks parsed text nodes so HTML attributes are never considered attribution text.
+    /// </summary>
+    private static void NormalizeVisibleText(INode node, IDocument document)
+    {
+        foreach (var child in node.ChildNodes.ToArray())
+        {
+            if (child is IText text)
+            {
+                NormalizeTextNode(text, document);
+            }
+            else
+            {
+                NormalizeVisibleText(child, document);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Canonicalizes OpenStreetMap text within an existing link or wraps unlinked visible text.
+    /// </summary>
+    private static void NormalizeTextNode(IText text, IDocument document)
+    {
+        if (!OpenStreetMapText().IsMatch(text.Data))
+        {
+            return;
+        }
+
+        var containingAnchor = FindContainingAnchor(text);
+        if (containingAnchor != null)
+        {
+            text.Data = OpenStreetMapText().Replace(text.Data, "OpenStreetMap");
+            containingAnchor.SetAttribute("href", OpenStreetMapCopyrightUrl);
+            containingAnchor.RemoveAttribute("target");
+            containingAnchor.RemoveAttribute("rel");
+            return;
+        }
+
+        var parent = text.Parent;
+        if (parent == null)
+        {
+            return;
+        }
+
+        var position = 0;
+        foreach (Match match in OpenStreetMapText().Matches(text.Data))
+        {
+            if (match.Index > position)
+            {
+                parent.InsertBefore(document.CreateTextNode(text.Data[position..match.Index]), text);
+            }
+
+            var link = document.CreateElement("a");
+            link.SetAttribute("href", OpenStreetMapCopyrightUrl);
+            link.TextContent = "OpenStreetMap";
+            parent.InsertBefore(link, text);
+            position = match.Index + match.Length;
+        }
+
+        if (position < text.Data.Length)
+        {
+            parent.InsertBefore(document.CreateTextNode(text.Data[position..]), text);
+        }
+
+        parent.RemoveChild(text);
+    }
+
+    /// <summary>
+    /// Finds the nearest containing anchor for a visible text node.
+    /// </summary>
+    private static IElement? FindContainingAnchor(INode node)
+    {
+        var current = node.Parent;
+        while (current != null)
+        {
+            if (current is IElement element &&
+                element.LocalName.Equals("a", StringComparison.OrdinalIgnoreCase))
+            {
+                return element;
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Ensures administrator-supplied new-tab links cannot control the opener page.
+    /// </summary>
+    private static void SecureNewTabLinks(IElement root)
+    {
+        foreach (var link in root.QuerySelectorAll("a[target]"))
+        {
+            if (string.Equals(link.GetAttribute("target"), "_blank", StringComparison.OrdinalIgnoreCase))
+            {
+                link.SetAttribute("rel", "noopener noreferrer");
+            }
+        }
+    }
+
+    [GeneratedRegex("OpenStreetMap", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex OpenStreetMapText();
+}

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -1,6 +1,7 @@
 ﻿@using System.Text.Json
 @using Wayfarer.Models
 @using Wayfarer.Services
+@using Wayfarer.Util
 @using Wayfarer.Areas.Public.Controllers
 @inject Wayfarer.Parsers.IApplicationSettingsService ApplicationSettingsService
 @inject IAppVersionProvider AppVersionProvider
@@ -204,7 +205,7 @@
 
         @{
             var tileSettings = ApplicationSettingsService.GetSettings();
-            var tileAttribution = tileSettings?.TileProviderAttribution ?? ApplicationSettings.DefaultTileProviderAttribution;
+            var tileAttribution = TileProviderAttribution.Resolve(tileSettings);
         }
         <script>
             // Expose tile configuration for Leaflet maps that use the tile cache proxy.

--- a/Views/Trip/Print.cshtml
+++ b/Views/Trip/Print.cshtml
@@ -1,12 +1,14 @@
 @using System.Text.Json
 @using System.Text.Json.Serialization
 @using Wayfarer.Util
+@inject Wayfarer.Parsers.IApplicationSettingsService ApplicationSettingsService
 @model Wayfarer.Models.ViewModels.TripPrintViewModel
 @{
     Layout = null;
     var trip   = Model.Trip;
     var img    = Model.Snap;            // id → data-URI
     string Snap(string key) => img.TryGetValue(key, out var v) ? v : string.Empty;
+    var mapAttribution = TileProviderAttribution.Resolve(ApplicationSettingsService.GetSettings());
 
     var orderedRegions = Model.Regions
         .OrderBy(r => r.Name == "Unassigned Places" ? 1 : 0)
@@ -46,6 +48,8 @@
         .avoid-break{ break-inside:avoid; }
 
         .map,.notes img{width:100%;height:auto;object-fit:contain;}
+        .map-snapshot-attribution{font-size:.85rem;margin-top:.2rem;color:rgba(0,0,0,.7);}
+        .map-snapshot-attribution a{color:#004080;text-decoration:underline;}
 
         .toc a{color:#000;text-decoration:none;}
         .toc li{margin:.15rem 0;}
@@ -133,6 +137,11 @@
     @if (!string.IsNullOrWhiteSpace(Snap("trip")))
     {
         <img src="@Snap("trip")" class="map"/>
+        @if (!string.IsNullOrWhiteSpace(mapAttribution))
+        {
+            @* PDF captions retain the sanitized provider link outside the raster snapshot. *@
+            <div class="map-snapshot-attribution">@Html.Raw(mapAttribution)</div>
+        }
     }
 </section>
 
@@ -160,6 +169,10 @@
                     @if (!string.IsNullOrWhiteSpace(Snap($"segment_{s.Id}")))
                     {
                         <img src="@Snap($"segment_{s.Id}")" class="map"/>
+                        @if (!string.IsNullOrWhiteSpace(mapAttribution))
+                        {
+                            <div class="map-snapshot-attribution">@Html.Raw(mapAttribution)</div>
+                        }
                     }
 
                     @if (!string.IsNullOrWhiteSpace(s.Notes))
@@ -182,6 +195,10 @@
         @if (!string.IsNullOrWhiteSpace(Snap($"region_{r.Id}")))
         {
             <img src="@Snap($"region_{r.Id}")" class="map"/>
+            @if (!string.IsNullOrWhiteSpace(mapAttribution))
+            {
+                <div class="map-snapshot-attribution">@Html.Raw(mapAttribution)</div>
+            }
         }
 
         @if (!string.IsNullOrWhiteSpace(r.Notes))
@@ -212,6 +229,10 @@
                 @if (!string.IsNullOrWhiteSpace(Snap($"place_{p.Id}")))
                 {
                     <img src="@Snap($"place_{p.Id}")" class="map"/>
+                    @if (!string.IsNullOrWhiteSpace(mapAttribution))
+                    {
+                        <div class="map-snapshot-attribution">@Html.Raw(mapAttribution)</div>
+                    }
                 }
 
                 @if (!string.IsNullOrWhiteSpace(p.Notes))

--- a/Views/Trip/Viewer.cshtml
+++ b/Views/Trip/Viewer.cshtml
@@ -418,7 +418,7 @@
                              class="img-fluid w-100 rounded"
                              alt="Map of @Model.Name"
                              style="max-height: 400px; object-fit: cover;"/>
-                        @if (!string.IsNullOrWhiteSpace(mapAttribution)) { <div class="map-snapshot-attribution small text-muted mt-1">@Html.Raw(mapAttribution)</div> }
+                        @* Render only server-resolved, sanitized provider attribution. *@ @if (!string.IsNullOrWhiteSpace(mapAttribution)) { <div class="map-snapshot-attribution small text-muted mt-1">@Html.Raw(mapAttribution)</div> }
                     </div>
                 }
 

--- a/Views/Trip/Viewer.cshtml
+++ b/Views/Trip/Viewer.cshtml
@@ -8,7 +8,6 @@
     Layout = "_Layout";
     bool owner = ViewBag.IsOwner as bool? ?? false;
     bool hideSidebar = ViewContext.HttpContext.Request.Query["print"] == "1";
-    /* full-height flex container instead of .container */
     ViewData["BodyClass"] = "container-fluid d-flex flex-column flex-fill p-0";
     ViewBag.Title = Model.Name;
 
@@ -406,7 +405,6 @@
             </div>
             <div class="modal-body" id="readable-modal-body" style="max-width: 900px; margin: 0 auto; position: relative;">
 
-                <!-- Cover Image or Map Snapshot -->
                 @if (!string.IsNullOrWhiteSpace(Model.CoverImageUrl))
                 {
                     <div class="mb-3">
@@ -415,19 +413,12 @@
                 }
                 else if (Model.CenterLat.HasValue && Model.CenterLon.HasValue)
                 {
-                    <!-- Map snapshot using thumbnail service -->
                     <div class="mb-3">
                         <img src="/thumbs/trips/@Model.Id-800x450.jpg?v=@Model.UpdatedAt.Ticks"
                              class="img-fluid w-100 rounded"
                              alt="Map of @Model.Name"
                              style="max-height: 400px; object-fit: cover;"/>
-                        @if (!string.IsNullOrWhiteSpace(mapAttribution))
-                        {
-                            @* The shared server resolver owns provider selection and final sanitization. *@
-                            <div class="map-snapshot-attribution small text-muted mt-1">
-                                @Html.Raw(mapAttribution)
-                            </div>
-                        }
+                        @if (!string.IsNullOrWhiteSpace(mapAttribution)) { <div class="map-snapshot-attribution small text-muted mt-1">@Html.Raw(mapAttribution)</div> }
                     </div>
                 }
 
@@ -444,7 +435,6 @@
                     </div>
                 </div>
 
-                <!-- Map Snapshot (if not shown as cover) -->
                 @if (!string.IsNullOrWhiteSpace(Model.CoverImageUrl) && Model.CenterLat.HasValue && Model.CenterLon.HasValue)
                 {
                     <div class="mb-3">
@@ -452,13 +442,7 @@
                              class="img-fluid w-100 rounded"
                              alt="Map of @Model.Name"
                              style="max-height: 300px; object-fit: cover;"/>
-                        @if (!string.IsNullOrWhiteSpace(mapAttribution))
-                        {
-                            @* The shared server resolver owns provider selection and final sanitization. *@
-                            <div class="map-snapshot-attribution small text-muted mt-1">
-                                @Html.Raw(mapAttribution)
-                            </div>
-                        }
+                        @if (!string.IsNullOrWhiteSpace(mapAttribution)) { <div class="map-snapshot-attribution small text-muted mt-1">@Html.Raw(mapAttribution)</div> }
                     </div>
                 }
 

--- a/Views/Trip/Viewer.cshtml
+++ b/Views/Trip/Viewer.cshtml
@@ -1,6 +1,7 @@
 @using System.Linq
 @using Wayfarer.Util
 @using Wayfarer.Models
+@inject Wayfarer.Parsers.IApplicationSettingsService ApplicationSettingsService
 @model Wayfarer.Models.Trip
 @{
     ViewData["LoadLeaflet"] = true;
@@ -17,6 +18,7 @@
     var progressPercent = totalPlaces > 0 ? (int)Math.Round((double)visitedPlaces / totalPlaces * 100) : 0;
     var shareProgressEnabled = ViewBag.ShareProgressEnabled as bool? ?? false;
     var showProgress = owner || (shareProgressEnabled && visitedPlaces > 0);
+    var mapAttribution = TileProviderAttribution.Resolve(ApplicationSettingsService.GetSettings());
 
     // Get visit events and group by place (only available to owner)
     var rawVisitEvents = ViewBag.VisitEvents;
@@ -419,6 +421,13 @@
                              class="img-fluid w-100 rounded"
                              alt="Map of @Model.Name"
                              style="max-height: 400px; object-fit: cover;"/>
+                        @if (!string.IsNullOrWhiteSpace(mapAttribution))
+                        {
+                            @* The shared server resolver owns provider selection and final sanitization. *@
+                            <div class="map-snapshot-attribution small text-muted mt-1">
+                                @Html.Raw(mapAttribution)
+                            </div>
+                        }
                     </div>
                 }
 
@@ -443,6 +452,13 @@
                              class="img-fluid w-100 rounded"
                              alt="Map of @Model.Name"
                              style="max-height: 300px; object-fit: cover;"/>
+                        @if (!string.IsNullOrWhiteSpace(mapAttribution))
+                        {
+                            @* The shared server resolver owns provider selection and final sanitization. *@
+                            <div class="map-snapshot-attribution small text-muted mt-1">
+                                @Html.Raw(mapAttribution)
+                            </div>
+                        }
                     </div>
                 }
 

--- a/playwright.shared-layout.config.ts
+++ b/playwright.shared-layout.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
   use: {
     baseURL,
     ignoreHTTPSErrors: true,
+    // The isolated HTTPS host intentionally loads the local HTTP Vite server for Editor coverage.
+    launchOptions: { args: ['--disable-web-security'] },
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure'
   },

--- a/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
@@ -134,6 +134,65 @@ public class AdminSettingsControllerTests : TestBase
     }
 
     [Fact]
+    public async Task Update_ReappliesSelectedPresetAttribution()
+    {
+        var db = CreateDbContext();
+        db.ApplicationSettings.Add(new ApplicationSettings { Id = 1 });
+        await db.SaveChangesAsync();
+        var (controller, _, _) = BuildController(db);
+        var updatedSettings = new ApplicationSettings
+        {
+            Id = 1,
+            TileProviderKey = ApplicationSettings.DefaultTileProviderKey,
+            TileProviderUrlTemplate = "https://malicious.example/{z}/{x}/{y}.png",
+            TileProviderAttribution = "<script>wrong()</script>Wrong provider"
+        };
+
+        var result = await controller.Update(updatedSettings);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        var stored = await db.ApplicationSettings.FindAsync(1);
+        Assert.NotNull(stored);
+        Assert.Equal(ApplicationSettings.DefaultTileProviderUrlTemplate, stored.TileProviderUrlTemplate);
+        Assert.Contains("OpenStreetMap contributors", stored.TileProviderAttribution);
+        Assert.DoesNotContain("Wrong provider", stored.TileProviderAttribution);
+    }
+
+    [Fact]
+    public async Task Update_PreservesAndSanitizesCustomProviderAttribution()
+    {
+        const string customTemplate = "https://tiles.example.com/{z}/{x}/{y}.png";
+        var db = CreateDbContext();
+        db.ApplicationSettings.Add(new ApplicationSettings
+        {
+            Id = 1,
+            TileProviderKey = "custom",
+            TileProviderUrlTemplate = customTemplate,
+            TileProviderAttribution = "Example Maps"
+        });
+        await db.SaveChangesAsync();
+        var (controller, _, _) = BuildController(db);
+        var updatedSettings = new ApplicationSettings
+        {
+            Id = 1,
+            TileProviderKey = "custom",
+            TileProviderUrlTemplate = customTemplate,
+            TileProviderAttribution =
+                "<script>alert(1)</script>&copy; <a href=\"https://tiles.example.com/terms\" onclick=\"evil()\">Example Maps</a>"
+        };
+
+        var result = await controller.Update(updatedSettings);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        var stored = await db.ApplicationSettings.FindAsync(1);
+        Assert.NotNull(stored);
+        Assert.Contains("https://tiles.example.com/terms", stored.TileProviderAttribution);
+        Assert.Contains("Example Maps", stored.TileProviderAttribution);
+        Assert.DoesNotContain("script", stored.TileProviderAttribution, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("onclick", stored.TileProviderAttribution, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Update_DoesNotUpdate_WhenSettingsNotFound()
     {
         var db = CreateDbContext();

--- a/tests/Wayfarer.Tests/Services/ApplicationSettingsServiceTests.cs
+++ b/tests/Wayfarer.Tests/Services/ApplicationSettingsServiceTests.cs
@@ -65,6 +65,47 @@ public class ApplicationSettingsServiceTests : TestBase
     }
 
     [Fact]
+    public void GetSettings_UsesSelectedPresetAttributionWhenLegacyValueIsMissing()
+    {
+        var db = CreateDbContext();
+        db.ApplicationSettings.Add(new ApplicationSettings
+        {
+            Id = 1,
+            TileProviderKey = "opentopomap",
+            TileProviderAttribution = " "
+        });
+        db.SaveChanges();
+
+        var service = new ApplicationSettingsService(db, new MemoryCache(new MemoryCacheOptions()));
+
+        var settings = service.GetSettings();
+
+        Assert.Contains("OpenTopoMap", settings.TileProviderAttribution);
+        Assert.Contains("SRTM", settings.TileProviderAttribution);
+    }
+
+    [Theory]
+    [InlineData("custom")]
+    [InlineData("legacy-unknown")]
+    public void GetSettings_DoesNotApplyOsmAttributionToMissingUnknownProviderValue(string providerKey)
+    {
+        var db = CreateDbContext();
+        db.ApplicationSettings.Add(new ApplicationSettings
+        {
+            Id = 1,
+            TileProviderKey = providerKey,
+            TileProviderAttribution = " "
+        });
+        db.SaveChanges();
+
+        var service = new ApplicationSettingsService(db, new MemoryCache(new MemoryCacheOptions()));
+
+        var settings = service.GetSettings();
+
+        Assert.True(string.IsNullOrWhiteSpace(settings.TileProviderAttribution));
+    }
+
+    [Fact]
     public void CheckRegistration_RedirectsWhenClosed()
     {
         var db = CreateDbContext();

--- a/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
+++ b/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
@@ -151,7 +151,8 @@ public class TileProviderAttributionTests
     {
         var result = TileProviderAttribution.Resolve(Settings(
             TileProviderCatalog.CustomProviderKey,
-            "<a href=\"https://example.com/terms\">Example Maps using OpenStreetMap data</a>"));
+            "<a href=\"https://example.com/terms\" target=\"_blank\" title=\"Provider terms\" class=\"provider\">"
+            + "Example Maps using OpenStreetMap data</a>"));
         var document = new HtmlParser().ParseDocument($"<body>{result}</body>");
         var links = document.Body!.QuerySelectorAll("a");
 
@@ -163,7 +164,27 @@ public class TileProviderAttributionTests
         Assert.Equal("OpenStreetMap", links[1].TextContent);
         Assert.Equal("https://example.com/terms", links[2].GetAttribute("href"));
         Assert.Equal(" data", links[2].TextContent);
+        Assert.All([links[0], links[2]], link =>
+        {
+            Assert.Equal("_blank", link.GetAttribute("target"));
+            Assert.Equal("noopener noreferrer", link.GetAttribute("rel"));
+            Assert.Equal("Provider terms", link.GetAttribute("title"));
+            Assert.Equal("provider", link.GetAttribute("class"));
+        });
         Assert.Empty(document.Body.QuerySelectorAll("a a"));
+    }
+
+    [Fact]
+    public void Resolve_CanonicalizesAnchorRepresentingOnlyOsmAttribution()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            TileProviderCatalog.CustomProviderKey,
+            "<a href=\"https://example.com/wrong\">© OpenStreetMap contributors</a>"));
+        var document = new HtmlParser().ParseDocument($"<body>{result}</body>");
+        var link = Assert.Single(document.Body!.QuerySelectorAll("a"));
+
+        Assert.Equal("© OpenStreetMap contributors", link.TextContent);
+        Assert.Equal(OsmCopyrightUrl, link.GetAttribute("href"));
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
+++ b/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
@@ -175,6 +175,23 @@ public class TileProviderAttributionTests
     }
 
     [Fact]
+    public void Resolve_LinksOsmAcrossDescendantTextNodesWithoutNestingAnchors()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            TileProviderCatalog.CustomProviderKey,
+            "<a href=\"https://example.com/terms\">Example Maps using Open<strong>Street</strong>Map data</a>"));
+        var document = new HtmlParser().ParseDocument($"<body>{result}</body>");
+        var body = document.Body!;
+        var osmLink = Assert.Single(body.QuerySelectorAll($"a[href=\"{OsmCopyrightUrl}\"]"));
+        var providerLinks = body.QuerySelectorAll("a[href=\"https://example.com/terms\"]");
+
+        Assert.Equal("Example Maps using OpenStreetMap data", body.TextContent);
+        Assert.Equal("OpenStreetMap", osmLink.TextContent);
+        Assert.Equal("Example Maps using  data", string.Concat(providerLinks.Select(link => link.TextContent)));
+        Assert.Empty(body.QuerySelectorAll("a a"));
+    }
+
+    [Fact]
     public void Resolve_CanonicalizesAnchorRepresentingOnlyOsmAttribution()
     {
         var result = TileProviderAttribution.Resolve(Settings(

--- a/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
+++ b/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
@@ -103,6 +103,27 @@ public class TileProviderAttributionTests
     }
 
     [Theory]
+    [InlineData("carto-dark", "CARTO", null)]
+    [InlineData("opentopomap", "SRTM", "OpenTopoMap")]
+    [InlineData("thunderforest-cycle", "Thunderforest", null)]
+    public void Resolve_PreservesEveryPartyInBuiltInPresetAttribution(
+        string providerKey,
+        string expectedParty,
+        string? additionalParty)
+    {
+        var result = TileProviderAttribution.Resolve(Settings(providerKey, " "));
+
+        Assert.Contains("OpenStreetMap", result);
+        Assert.Contains(expectedParty, result);
+        if (additionalParty != null)
+        {
+            Assert.Contains(additionalParty, result);
+        }
+
+        Assert.Equal(1, CountOsmLinks(result));
+    }
+
+    [Theory]
     [InlineData("custom")]
     [InlineData("legacy-unknown")]
     public void Resolve_DoesNotUseOsmFallbackForUnknownOrCustomMissingAttribution(string providerKey)

--- a/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
+++ b/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
@@ -137,6 +137,18 @@ public class TileProviderAttributionTests
         Assert.Equal(1, CountOsmLinks(result));
     }
 
+    [Fact]
+    public void Resolve_SecuresAdministratorSuppliedNewTabLinks()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            TileProviderCatalog.CustomProviderKey,
+            "<a href=\"https://example.com\" target=\"_BLANK\" rel=\"opener\">Example Maps</a>"));
+
+        Assert.Contains("target=\"_BLANK\"", result);
+        Assert.Contains("rel=\"noopener noreferrer\"", result);
+        Assert.DoesNotContain("rel=\"opener\"", result);
+    }
+
     private static ApplicationSettings Settings(string providerKey, string attribution) => new()
     {
         TileProviderKey = providerKey,

--- a/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
+++ b/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
@@ -1,0 +1,151 @@
+using System.Text.RegularExpressions;
+using Wayfarer.Models;
+using Wayfarer.Util;
+using Xunit;
+
+namespace Wayfarer.Tests.Util;
+
+/// <summary>
+/// Verifies the server-authoritative provider-attribution display contract.
+/// </summary>
+public class TileProviderAttributionTests
+{
+    private const string OsmCopyrightUrl = "https://www.openstreetmap.org/copyright";
+
+    [Fact]
+    public void Resolve_LinksPlainOsmDefaultExactlyOnce()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            ApplicationSettings.DefaultTileProviderKey,
+            ApplicationSettings.DefaultTileProviderAttribution));
+
+        Assert.Contains($"href=\"{OsmCopyrightUrl}\"", result);
+        Assert.Contains(">OpenStreetMap</a> contributors", result);
+        Assert.Equal(1, CountOsmLinks(result));
+    }
+
+    [Fact]
+    public void Resolve_PreservesAlreadyLinkedOsmWithoutDuplication()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            TileProviderCatalog.CustomProviderKey,
+            $"&copy; <a href=\"{OsmCopyrightUrl}\">OpenStreetMap</a> contributors"));
+
+        Assert.Equal(1, CountOsmLinks(result));
+        Assert.DoesNotContain("<a href=\"https://www.openstreetmap.org/copyright\"><a", result);
+    }
+
+    [Fact]
+    public void Resolve_PreservesCartoStyleMultiPartyAttribution()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            "carto-positron",
+            "&copy; OpenStreetMap contributors &copy; <a href=\"https://carto.com/attributions\">CARTO</a>"));
+
+        Assert.Equal(1, CountOsmLinks(result));
+        Assert.Contains(">OpenStreetMap</a> contributors", result);
+        Assert.Contains("href=\"https://carto.com/attributions\"", result);
+        Assert.Contains(">CARTO</a>", result);
+    }
+
+    [Fact]
+    public void Resolve_DoesNotAddOsmToCustomNonOsmAttribution()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            TileProviderCatalog.CustomProviderKey,
+            "&copy; <a href=\"https://tiles.example.com/terms\">Example Maps</a>"));
+
+        Assert.Contains("href=\"https://tiles.example.com/terms\"", result);
+        Assert.Contains("Example Maps", result);
+        Assert.DoesNotContain("OpenStreetMap", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, CountOsmLinks(result));
+    }
+
+    [Fact]
+    public void Resolve_LinksOsmInCustomMultiPartyAttribution()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            TileProviderCatalog.CustomProviderKey,
+            "&copy; openstreetmap contributors | &copy; Example Tiles"));
+
+        Assert.Contains(">OpenStreetMap</a> contributors", result);
+        Assert.Contains("Example Tiles", result);
+        Assert.Equal(1, CountOsmLinks(result));
+    }
+
+    [Fact]
+    public void Resolve_SanitizesMaliciousStoredAttributionAtOutput()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            TileProviderCatalog.CustomProviderKey,
+            "<script>alert(1)</script><a href=\"javascript:alert(2)\" onclick=\"evil()\">OpenStreetMap</a>"
+            + "<a href=\"data:text/html,evil\">Unsafe</a><strong>Provider</strong>"));
+
+        Assert.DoesNotContain("script", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("onclick", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("javascript:", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("data:", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<strong>Provider</strong>", result);
+        Assert.Equal(1, CountOsmLinks(result));
+    }
+
+    [Fact]
+    public void Resolve_UsesActivePresetWhenStoredAttributionIsMissing()
+    {
+        var preset = TileProviderCatalog.FindPreset("opentopomap");
+
+        var result = TileProviderAttribution.Resolve(Settings("opentopomap", " "));
+
+        Assert.NotNull(preset);
+        Assert.Contains("OpenTopoMap", result);
+        Assert.Contains("SRTM", result);
+        Assert.Equal(1, CountOsmLinks(result));
+    }
+
+    [Theory]
+    [InlineData("custom")]
+    [InlineData("legacy-unknown")]
+    public void Resolve_DoesNotUseOsmFallbackForUnknownOrCustomMissingAttribution(string providerKey)
+    {
+        var result = TileProviderAttribution.Resolve(Settings(providerKey, " "));
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void Resolve_DoesNotRewriteOsmTextInsideAttributes()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            TileProviderCatalog.CustomProviderKey,
+            "<a href=\"https://example.com/OpenStreetMap\" title=\"OpenStreetMap mirror\">Example Maps</a>"));
+
+        Assert.Contains("href=\"https://example.com/OpenStreetMap\"", result);
+        Assert.Contains("title=\"OpenStreetMap mirror\"", result);
+        Assert.Equal(0, CountOsmLinks(result));
+    }
+
+    [Fact]
+    public void Resolve_PreservesSafeLinksAndRepairsMalformedNestedOsmAnchor()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            TileProviderCatalog.CustomProviderKey,
+            "<a href=\"https://example.com\">Example <a href=\"https://osm.example\">OpenStreetMap</a></a> contributors"));
+
+        Assert.Contains("href=\"https://example.com\"", result);
+        Assert.Contains("Example", result);
+        Assert.Contains(">OpenStreetMap</a>", result);
+        Assert.Equal(1, CountOsmLinks(result));
+    }
+
+    private static ApplicationSettings Settings(string providerKey, string attribution) => new()
+    {
+        TileProviderKey = providerKey,
+        TileProviderAttribution = attribution
+    };
+
+    private static int CountOsmLinks(string html) =>
+        Regex.Matches(
+            html,
+            $"<a\\s+[^>]*href=\"{Regex.Escape(OsmCopyrightUrl)}\"[^>]*>",
+            RegexOptions.IgnoreCase).Count;
+}

--- a/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
+++ b/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using AngleSharp.Html.Parser;
 using Wayfarer.Models;
 using Wayfarer.Util;
 using Xunit;
@@ -143,6 +144,26 @@ public class TileProviderAttributionTests
         Assert.Contains("href=\"https://example.com/OpenStreetMap\"", result);
         Assert.Contains("title=\"OpenStreetMap mirror\"", result);
         Assert.Equal(0, CountOsmLinks(result));
+    }
+
+    [Fact]
+    public void Resolve_SplitsMixedProviderAnchorWithoutLosingEitherDestination()
+    {
+        var result = TileProviderAttribution.Resolve(Settings(
+            TileProviderCatalog.CustomProviderKey,
+            "<a href=\"https://example.com/terms\">Example Maps using OpenStreetMap data</a>"));
+        var document = new HtmlParser().ParseDocument($"<body>{result}</body>");
+        var links = document.Body!.QuerySelectorAll("a");
+
+        Assert.Equal("Example Maps using OpenStreetMap data", document.Body.TextContent);
+        Assert.Equal(3, links.Length);
+        Assert.Equal("https://example.com/terms", links[0].GetAttribute("href"));
+        Assert.Equal("Example Maps using ", links[0].TextContent);
+        Assert.Equal(OsmCopyrightUrl, links[1].GetAttribute("href"));
+        Assert.Equal("OpenStreetMap", links[1].TextContent);
+        Assert.Equal("https://example.com/terms", links[2].GetAttribute("href"));
+        Assert.Equal(" data", links[2].TextContent);
+        Assert.Empty(document.Body.QuerySelectorAll("a a"));
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
+++ b/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MvcFrontendKit.Extensions;
 using Wayfarer.Models;
+using Wayfarer.Models.ViewModels;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
 using Wayfarer.Util;
@@ -76,6 +77,61 @@ public sealed class TileAttributionLayoutRenderingTests
         }
     }
 
+    [Fact]
+    public async Task SnapshotBackedViewerAndPrintOutputRenderResolvedProviderAttribution()
+    {
+        var webRoot = Path.Combine(Path.GetTempPath(), $"wayfarer-attribution-snapshot-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(webRoot);
+        await File.WriteAllTextAsync(Path.Combine(webRoot, "frontend.manifest.json"), "{}");
+        try
+        {
+            var settingsService = new MutableApplicationSettingsService();
+            using var host = BuildRazorHost(webRoot, settingsService);
+            using var scope = host.Services.CreateScope();
+
+            settingsService.Settings = new ApplicationSettings
+            {
+                TileProviderKey = ApplicationSettings.DefaultTileProviderKey,
+                TileProviderAttribution = ApplicationSettings.DefaultTileProviderAttribution
+            };
+            AssertSnapshotAttribution(
+                await RenderViewerAsync(scope.ServiceProvider),
+                TileProviderAttribution.OpenStreetMapCopyrightUrl,
+                "OpenStreetMap");
+            AssertSnapshotAttribution(
+                await RenderPrintAsync(scope.ServiceProvider),
+                TileProviderAttribution.OpenStreetMapCopyrightUrl,
+                "OpenStreetMap");
+
+            settingsService.Settings = new ApplicationSettings
+            {
+                TileProviderKey = TileProviderCatalog.CustomProviderKey,
+                TileProviderAttribution =
+                    "&copy; <a href=\"https://tiles.example.com/terms\">Example Maps</a>"
+            };
+            AssertSnapshotAttribution(
+                await RenderViewerAsync(scope.ServiceProvider),
+                "https://tiles.example.com/terms",
+                "Example Maps");
+            AssertSnapshotAttribution(
+                await RenderPrintAsync(scope.ServiceProvider),
+                "https://tiles.example.com/terms",
+                "Example Maps");
+
+            settingsService.Settings = new ApplicationSettings
+            {
+                TileProviderKey = TileProviderCatalog.CustomProviderKey,
+                TileProviderAttribution = string.Empty
+            };
+            AssertSnapshotAttributionIsEmpty(await RenderViewerAsync(scope.ServiceProvider));
+            AssertSnapshotAttributionIsEmpty(await RenderPrintAsync(scope.ServiceProvider));
+        }
+        finally
+        {
+            Directory.Delete(webRoot, recursive: true);
+        }
+    }
+
     /// <summary>
     /// Creates an isolated compiled-Razor host without requiring production frontend assets.
     /// </summary>
@@ -116,7 +172,9 @@ public sealed class TileAttributionLayoutRenderingTests
             Id = Guid.NewGuid(),
             UserId = "owner",
             Name = "Attribution fixture",
-            UpdatedAt = DateTime.UtcNow
+            UpdatedAt = DateTime.UtcNow,
+            CenterLat = 40,
+            CenterLon = 25
         };
         var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
         {
@@ -132,6 +190,73 @@ public sealed class TileAttributionLayoutRenderingTests
         var viewContext = new ViewContext(actionContext, view, viewData, tempData, writer, new HtmlHelperOptions());
         await view.RenderAsync(viewContext);
         return writer.ToString();
+    }
+
+    /// <summary>
+    /// Renders the production PDF template with a real snapshot-backed map slot.
+    /// </summary>
+    private static async Task<string> RenderPrintAsync(IServiceProvider services)
+    {
+        var httpContext = new DefaultHttpContext { RequestServices = services };
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var viewResult = services.GetRequiredService<ICompositeViewEngine>()
+            .GetView(null, "/Views/Trip/Print.cshtml", isMainPage: true);
+        Assert.True(viewResult.Success, string.Join(Environment.NewLine, viewResult.SearchedLocations ?? []));
+        var view = Assert.IsAssignableFrom<IView>(viewResult.View);
+        var model = new TripPrintViewModel
+        {
+            Trip = new Trip
+            {
+                Id = Guid.NewGuid(),
+                UserId = "owner",
+                User = new ApplicationUser { DisplayName = "Fixture owner" },
+                Name = "Attribution PDF fixture",
+                UpdatedAt = DateTime.UtcNow
+            },
+            Snap = new Dictionary<string, string>
+            {
+                ["trip"] = "data:image/png;base64,iVBORw0KGgo="
+            }
+        };
+        var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
+        {
+            Model = model
+        };
+        var tempData = new TempDataDictionary(httpContext, services.GetRequiredService<ITempDataProvider>());
+        await using var writer = new StringWriter();
+        var viewContext = new ViewContext(
+            actionContext,
+            view,
+            viewData,
+            tempData,
+            writer,
+            new HtmlHelperOptions());
+        await view.RenderAsync(viewContext);
+        return writer.ToString();
+    }
+
+    /// <summary>
+    /// Verifies a snapshot caption retains the expected provider link and visible text.
+    /// </summary>
+    private static void AssertSnapshotAttribution(string html, string href, string visibleText)
+    {
+        var document = new HtmlParser().ParseDocument(html);
+        var captions = document.QuerySelectorAll(".map-snapshot-attribution");
+        Assert.NotEmpty(captions);
+        Assert.All(captions, caption =>
+        {
+            Assert.Contains(visibleText, caption.TextContent);
+            Assert.Equal(href, caption.QuerySelector("a")?.GetAttribute("href"));
+        });
+    }
+
+    /// <summary>
+    /// Verifies an explicitly blank provider attribution produces no snapshot caption.
+    /// </summary>
+    private static void AssertSnapshotAttributionIsEmpty(string html)
+    {
+        var document = new HtmlParser().ParseDocument(html);
+        Assert.Empty(document.QuerySelectorAll(".map-snapshot-attribution"));
     }
 
     /// <summary>

--- a/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
+++ b/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using AngleSharp.Html.Parser;
@@ -13,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Playwright;
 using MvcFrontendKit.Extensions;
 using Wayfarer.Models;
 using Wayfarer.Models.ViewModels;
@@ -98,10 +100,12 @@ public sealed class TileAttributionLayoutRenderingTests
                 await RenderViewerAsync(scope.ServiceProvider),
                 TileProviderAttribution.OpenStreetMapCopyrightUrl,
                 "OpenStreetMap");
+            var osmPrintHtml = await RenderPrintAsync(scope.ServiceProvider);
             AssertSnapshotAttribution(
-                await RenderPrintAsync(scope.ServiceProvider),
+                osmPrintHtml,
                 TileProviderAttribution.OpenStreetMapCopyrightUrl,
                 "OpenStreetMap");
+            await AssertActualPdfArtifactAsync(osmPrintHtml);
 
             settingsService.Settings = new ApplicationSettings
             {
@@ -117,6 +121,21 @@ public sealed class TileAttributionLayoutRenderingTests
                 await RenderPrintAsync(scope.ServiceProvider),
                 "https://tiles.example.com/terms",
                 "Example Maps");
+
+            settingsService.Settings = new ApplicationSettings
+            {
+                TileProviderKey = TileProviderCatalog.CustomProviderKey,
+                TileProviderAttribution =
+                    "<a href=\"https://tiles.example.com/terms\">Example Maps using OpenStreetMap data</a>"
+            };
+            AssertSnapshotAttributionLinks(
+                await RenderViewerAsync(scope.ServiceProvider),
+                "https://tiles.example.com/terms",
+                TileProviderAttribution.OpenStreetMapCopyrightUrl);
+            AssertSnapshotAttributionLinks(
+                await RenderPrintAsync(scope.ServiceProvider),
+                "https://tiles.example.com/terms",
+                TileProviderAttribution.OpenStreetMapCopyrightUrl);
 
             settingsService.Settings = new ApplicationSettings
             {
@@ -203,6 +222,18 @@ public sealed class TileAttributionLayoutRenderingTests
             .GetView(null, "/Views/Trip/Print.cshtml", isMainPage: true);
         Assert.True(viewResult.Success, string.Join(Environment.NewLine, viewResult.SearchedLocations ?? []));
         var view = Assert.IsAssignableFrom<IView>(viewResult.View);
+        const string mapFixture = """
+            <svg xmlns="http://www.w3.org/2000/svg" width="800" height="450">
+              <rect width="800" height="450" fill="#dbeff5"/>
+              <path d="M0 90 L800 350 M80 450 L420 0 M0 310 L800 120"
+                    stroke="#ffffff" stroke-width="28" fill="none"/>
+              <path d="M90 360 C250 80 520 390 710 100"
+                    stroke="#2878b5" stroke-width="10" fill="none"/>
+              <circle cx="90" cy="360" r="16" fill="#d33"/>
+              <circle cx="710" cy="100" r="16" fill="#d33"/>
+              <text x="24" y="40" font-family="Arial" font-size="24">Local map snapshot fixture</text>
+            </svg>
+            """;
         var model = new TripPrintViewModel
         {
             Trip = new Trip
@@ -215,7 +246,9 @@ public sealed class TileAttributionLayoutRenderingTests
             },
             Snap = new Dictionary<string, string>
             {
-                ["trip"] = "data:image/png;base64,iVBORw0KGgo="
+                // The local fixture proves map-image output without requesting provider tiles.
+                ["trip"] = "data:image/svg+xml;base64," + Convert.ToBase64String(
+                    Encoding.UTF8.GetBytes(mapFixture))
             }
         };
         var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
@@ -257,6 +290,76 @@ public sealed class TileAttributionLayoutRenderingTests
     {
         var document = new HtmlParser().ParseDocument(html);
         Assert.Empty(document.QuerySelectorAll(".map-snapshot-attribution"));
+    }
+
+    /// <summary>
+    /// Verifies every snapshot caption preserves both provider and OSM destinations.
+    /// </summary>
+    private static void AssertSnapshotAttributionLinks(
+        string html,
+        string providerHref,
+        string osmHref)
+    {
+        var document = new HtmlParser().ParseDocument(html);
+        var captions = document.QuerySelectorAll(".map-snapshot-attribution");
+        Assert.NotEmpty(captions);
+        Assert.All(captions, caption =>
+        {
+            var hrefs = caption.QuerySelectorAll("a")
+                .Select(link => link.GetAttribute("href"))
+                .ToArray();
+            Assert.Contains(providerHref, hrefs);
+            Assert.Contains(osmHref, hrefs);
+        });
+    }
+
+    /// <summary>
+    /// Generates the production print HTML as a real Chromium PDF and verifies its linked caption.
+    /// </summary>
+    private static async Task AssertActualPdfArtifactAsync(string html)
+    {
+        var configuredArtifactDirectory =
+            Environment.GetEnvironmentVariable("WAYFARER_TEST_ARTIFACT_DIRECTORY");
+        var artifactDirectory = configuredArtifactDirectory ??
+            Path.Combine(Path.GetTempPath(), $"wayfarer-attribution-pdf-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(artifactDirectory);
+        var pdfPath = Path.Combine(artifactDirectory, "phase2b-map-attribution.pdf");
+        var screenshotPath = Path.Combine(artifactDirectory, "phase2b-map-attribution-print.png");
+        try
+        {
+            using var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+            await using var browser = await playwright.Chromium.LaunchAsync(
+                new BrowserTypeLaunchOptions { Headless = true });
+            var page = await browser.NewPageAsync();
+            await page.SetContentAsync(
+                html,
+                new PageSetContentOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+
+            var caption = page.Locator(".map-snapshot-attribution").First;
+            Assert.True(await caption.IsVisibleAsync());
+            Assert.Equal(
+                TileProviderAttribution.OpenStreetMapCopyrightUrl,
+                await caption.Locator("a").GetAttributeAsync("href"));
+            await page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                Path = screenshotPath,
+                FullPage = true
+            });
+            await page.PdfAsync(new PagePdfOptions { Path = pdfPath, PrintBackground = true });
+
+            var pdfBytes = await File.ReadAllBytesAsync(pdfPath);
+            Assert.StartsWith("%PDF", Encoding.ASCII.GetString(pdfBytes, 0, 4));
+            Assert.Contains(
+                TileProviderAttribution.OpenStreetMapCopyrightUrl,
+                Encoding.Latin1.GetString(pdfBytes));
+        }
+        finally
+        {
+            if (configuredArtifactDirectory == null)
+            {
+                Directory.Delete(artifactDirectory, recursive: true);
+            }
+        }
     }
 
     /// <summary>

--- a/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
+++ b/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using AngleSharp.Html.Parser;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MvcFrontendKit.Extensions;
+using Wayfarer.Models;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+using Wayfarer.Util;
+using Xunit;
+
+namespace Wayfarer.Tests.Views;
+
+/// <summary>
+/// Verifies that the compiled shared layout serializes only final provider-safe attribution.
+/// </summary>
+public sealed class TileAttributionLayoutRenderingTests
+{
+    [Fact]
+    public async Task LayoutReflectsProviderChangesAndSanitizesStoredAttributionOnEveryRender()
+    {
+        var webRoot = Path.Combine(Path.GetTempPath(), $"wayfarer-attribution-render-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(webRoot);
+        await File.WriteAllTextAsync(Path.Combine(webRoot, "frontend.manifest.json"), "{}");
+        try
+        {
+            var settingsService = new MutableApplicationSettingsService();
+            using var host = BuildRazorHost(webRoot, settingsService);
+            using var scope = host.Services.CreateScope();
+
+            settingsService.Settings = new ApplicationSettings
+            {
+                TileProviderKey = ApplicationSettings.DefaultTileProviderKey,
+                TileProviderAttribution =
+                    "<script>alert(1)</script>&copy; openstreetmap contributors"
+                    + "<a href=\"javascript:alert(2)\" onclick=\"evil()\">Unsafe</a>"
+            };
+            var osmHtml = await RenderViewerAsync(scope.ServiceProvider);
+            var osmAttribution = ExtractAttribution(osmHtml);
+
+            Assert.Contains("https://www.openstreetmap.org/copyright", osmAttribution);
+            Assert.Contains(">OpenStreetMap</a> contributors", osmAttribution);
+            Assert.DoesNotContain("script", osmAttribution, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("onclick", osmAttribution, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("javascript:", osmAttribution, StringComparison.OrdinalIgnoreCase);
+
+            settingsService.Settings = new ApplicationSettings
+            {
+                TileProviderKey = TileProviderCatalog.CustomProviderKey,
+                TileProviderAttribution =
+                    "&copy; <a href=\"https://tiles.example.com/terms\">Example Maps</a>",
+                TileProviderApiKey = "phase-2b-secret-must-not-render"
+            };
+            var customHtml = await RenderViewerAsync(scope.ServiceProvider);
+            var customAttribution = ExtractAttribution(customHtml);
+
+            Assert.Contains("https://tiles.example.com/terms", customAttribution);
+            Assert.Contains("Example Maps", customAttribution);
+            Assert.DoesNotContain("OpenStreetMap", customAttribution, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("phase-2b-secret-must-not-render", customHtml);
+        }
+        finally
+        {
+            Directory.Delete(webRoot, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Creates an isolated compiled-Razor host without requiring production frontend assets.
+    /// </summary>
+    private static IHost BuildRazorHost(string webRoot, IApplicationSettingsService settingsService) =>
+        Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(webHost => webHost
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseWebRoot(webRoot)
+                .UseSetting(WebHostDefaults.ApplicationKey, typeof(Trip).Assembly.GetName().Name)
+                .ConfigureServices(services =>
+                {
+                    services.AddLogging();
+                    services.AddHttpContextAccessor();
+                    services.AddControllersWithViews().AddApplicationPart(typeof(Trip).Assembly);
+                    services.AddMvcFrontendKit();
+                    services.AddSingleton<IAppVersionProvider, AppVersionProvider>();
+                    services.AddSingleton(settingsService);
+                    services.AddSingleton<ITempDataProvider, EmptyTempDataProvider>();
+                })
+                .Configure(_ => { }))
+            .Build();
+
+    /// <summary>
+    /// Renders the canonical Viewer through the production shared layout.
+    /// </summary>
+    private static async Task<string> RenderViewerAsync(IServiceProvider services)
+    {
+        var httpContext = new DefaultHttpContext { RequestServices = services };
+        var routeData = new RouteData();
+        routeData.Routers.Add(new RouteCollection());
+        var actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
+        var viewResult = services.GetRequiredService<ICompositeViewEngine>()
+            .GetView(null, "/Views/Trip/Viewer.cshtml", isMainPage: true);
+        Assert.True(viewResult.Success, string.Join(Environment.NewLine, viewResult.SearchedLocations ?? []));
+        var view = Assert.IsAssignableFrom<IView>(viewResult.View);
+        var trip = new Trip
+        {
+            Id = Guid.NewGuid(),
+            UserId = "owner",
+            Name = "Attribution fixture",
+            UpdatedAt = DateTime.UtcNow
+        };
+        var viewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
+        {
+            Model = trip,
+            ["IsEmbed"] = true,
+            ["IsOwner"] = false,
+            ["ShareProgressEnabled"] = false,
+            ["PlaceVisitCounts"] = new Dictionary<Guid, int>(),
+            ["VisitEvents"] = new List<PlaceVisitEvent>()
+        };
+        var tempData = new TempDataDictionary(httpContext, services.GetRequiredService<ITempDataProvider>());
+        await using var writer = new StringWriter();
+        var viewContext = new ViewContext(actionContext, view, viewData, tempData, writer, new HtmlHelperOptions());
+        await view.RenderAsync(viewContext);
+        return writer.ToString();
+    }
+
+    /// <summary>
+    /// Reads the serialized configuration emitted by the compiled layout.
+    /// </summary>
+    private static string ExtractAttribution(string html)
+    {
+        var document = new HtmlParser().ParseDocument(html);
+        var script = document.Scripts.Single(element =>
+            element.TextContent.Contains("window.wayfarerTileConfig", StringComparison.Ordinal));
+        var match = Regex.Match(
+            script.TextContent,
+            @"window\.wayfarerTileConfig\s*=\s*(\{.+\});",
+            RegexOptions.Singleline);
+        Assert.True(match.Success, "The layout should emit serialized shared tile configuration.");
+        using var json = JsonDocument.Parse(match.Groups[1].Value);
+        return json.RootElement.GetProperty("attribution").GetString() ?? string.Empty;
+    }
+
+    private sealed class MutableApplicationSettingsService : IApplicationSettingsService
+    {
+        /// <summary>Gets or sets the settings returned to the shared layout.</summary>
+        public ApplicationSettings Settings { get; set; } = new();
+
+        /// <inheritdoc />
+        public ApplicationSettings GetSettings() => Settings;
+
+        /// <inheritdoc />
+        public string GetUploadsDirectoryPath() => Path.GetTempPath();
+
+        /// <inheritdoc />
+        public void RefreshSettings()
+        {
+        }
+    }
+
+    private sealed class EmptyTempDataProvider : ITempDataProvider
+    {
+        /// <inheritdoc />
+        public IDictionary<string, object> LoadTempData(HttpContext context) => new Dictionary<string, object>();
+
+        /// <inheritdoc />
+        public void SaveTempData(HttpContext context, IDictionary<string, object> values)
+        {
+        }
+    }
+}

--- a/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
+++ b/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
@@ -80,6 +80,7 @@ public sealed class TileAttributionLayoutRenderingTests
     }
 
     [Fact]
+    [Trait("Category", "RequiresPlaywright")]
     public async Task SnapshotBackedViewerAndPrintOutputRenderResolvedProviderAttribution()
     {
         var webRoot = Path.Combine(Path.GetTempPath(), $"wayfarer-attribution-snapshot-{Guid.NewGuid():N}");

--- a/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
+++ b/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
@@ -119,6 +119,8 @@ test.describe('shared standard-layout footer', () => {
     // Intercept the local tile proxy so this proof cannot generate public-provider traffic.
     await page.route(/\/Public\/tiles\/\d+\/\d+\/\d+\.png/i, route =>
       route.fulfill({ status: 200, contentType: 'image/png', body: tinyPng }));
+    await page.route(/\/thumbs\/trips\/[^?]+/i, route =>
+      route.fulfill({ status: 200, contentType: 'image/png', body: tinyPng }));
 
     await signIn(page);
     await page.goto('/User/Trip');
@@ -142,6 +144,14 @@ test.describe('shared standard-layout footer', () => {
     await page.goto(publicViewerHref);
     await expectResolvedMapAttribution(page);
     await expectLinkedViewerEmergencyFallback(page);
+    await page.locator('#btn-expand-readable').click();
+    await expect(page.locator('#readableViewModal')).toBeVisible();
+    const readableAttribution = page.locator(
+      '#readable-modal-body .map-snapshot-attribution');
+    await expect(readableAttribution).toBeVisible();
+    await expect(readableAttribution.getByRole(
+      'link', { name: 'OpenStreetMap', exact: true }))
+      .toHaveAttribute('href', 'https://www.openstreetmap.org/copyright');
     await page.screenshot({
       fullPage: true,
       path: testInfo.outputPath('screenshots', 'viewer-provider-attribution.png')

--- a/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
+++ b/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
@@ -172,6 +172,13 @@ test.describe('shared standard-layout footer', () => {
 
     await signIn(page);
     await page.goto('/User/Trip');
+    const editorHref = await page.locator('a[href^="/User/Trip/Edit/"]').first().getAttribute('href');
+    expect(editorHref).toBeTruthy();
+    await page.goto(editorHref!);
+    await expect(page.locator('#trip-editor-app .leaflet-container')).toBeVisible();
+    await expectBlankMapAttribution(page);
+
+    await page.goto('/User/Trip');
     const authenticatedHref = await page.locator('a[href^="/User/Trip/View/"]').first().getAttribute('href');
     expect(authenticatedHref).toBeTruthy();
     await page.goto(authenticatedHref!);

--- a/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
+++ b/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
@@ -153,6 +153,27 @@ test.describe('shared standard-layout footer', () => {
     await page.goto(`${publicViewerHref}?embed=true&print=1`);
     await expectResolvedMapAttribution(page);
   });
+
+  test('preserves explicit blank provider attribution in every Viewer map', async ({ page }) => {
+    // Replace only the server-serialized contract while retaining production map bootstrapping.
+    await routeDocumentAttribution(page, '');
+    await page.route(/\/Public\/tiles\/\d+\/\d+\/\d+\.png/i, route =>
+      route.fulfill({ status: 200, contentType: 'image/png', body: tinyPng }));
+
+    await signIn(page);
+    await page.goto('/User/Trip');
+    const authenticatedHref = await page.locator('a[href^="/User/Trip/View/"]').first().getAttribute('href');
+    expect(authenticatedHref).toBeTruthy();
+    await page.goto(authenticatedHref!);
+    await expectBlankMapAttribution(page);
+
+    const publicViewerHref = await discoverPublicViewer(page);
+    await page.goto(publicViewerHref);
+    await expectBlankMapAttribution(page);
+
+    await page.goto(`${publicViewerHref}?embed=true`);
+    await expectBlankMapAttribution(page);
+  });
 });
 
 async function signIn(page: Page): Promise<void> {
@@ -161,7 +182,9 @@ async function signIn(page: Page): Promise<void> {
   await page.getByLabel('Username').fill(config.username);
   await page.getByLabel('Password').fill(config.password);
   await Promise.all([
-    page.waitForURL(url => !url.pathname.includes('/Identity/Account/Login')),
+    page.waitForURL(
+      url => !url.pathname.includes('/Identity/Account/Login'),
+      { waitUntil: 'domcontentloaded' }),
     page.getByRole('button', { name: 'Log in' }).click()
   ]);
 }
@@ -223,6 +246,35 @@ async function expectResolvedMapAttribution(page: Page): Promise<void> {
   }, configured);
   await expect(attribution).toContainText('OpenStreetMap contributors');
   expect(await attribution.innerHTML()).toContain(normalizedConfigured);
+}
+
+/** Verifies rendered Leaflet controls preserve an authoritative empty attribution value. */
+async function expectBlankMapAttribution(page: Page): Promise<void> {
+  const attribution = page.locator('.leaflet-control-attribution');
+  await expect(attribution).toBeVisible();
+  await expect(attribution.locator(
+    'a[href="https://www.openstreetmap.org/copyright"]')).toHaveCount(0);
+  const configured = await page.evaluate(() =>
+    (window as typeof window & { wayfarerTileConfig?: { attribution?: string } })
+      .wayfarerTileConfig?.attribution);
+  expect(configured).toBe('');
+}
+
+/** Rewrites the serialized server contract in document responses without changing persisted settings. */
+async function routeDocumentAttribution(page: Page, attribution: string): Promise<void> {
+  await page.route('**/*', async route => {
+    if (route.request().resourceType() !== 'document' || route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    const response = await route.fetch();
+    const body = await response.text();
+    const rewritten = body.replace(
+      /"attribution":"(?:\\.|[^"\\])*"/,
+      `"attribution":${JSON.stringify(attribution)}`);
+    await route.fulfill({ response, body: rewritten });
+  });
 }
 
 /** Verifies the Viewer module's emergency fallback without adding its layer to the map. */

--- a/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
+++ b/tests/e2e/shared-layout/sharedFooterLayout.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Locator, type Page } from '@playwright/test';
 import { loadSharedLayoutConfig } from './sharedLayoutConfig';
 
 const footerLinks = '.site-footer__link';
+const tinyPng = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=', 'base64');
 const viewports = {
   desktop: { width: 1440, height: 900 },
   tablet: { width: 768, height: 1024 },
@@ -113,6 +114,45 @@ test.describe('shared standard-layout footer', () => {
     await expect(page.locator('.site-footer')).toHaveCount(0);
     await expect(page.locator('link[href*="/css/shared-layout.css"]')).toHaveCount(0);
   });
+
+  test('uses equivalent resolved attribution in Editor and authenticated, public, embed, and print Viewer maps', async ({ page }, testInfo) => {
+    // Intercept the local tile proxy so this proof cannot generate public-provider traffic.
+    await page.route(/\/Public\/tiles\/\d+\/\d+\/\d+\.png/i, route =>
+      route.fulfill({ status: 200, contentType: 'image/png', body: tinyPng }));
+
+    await signIn(page);
+    await page.goto('/User/Trip');
+    const editorHref = await page.locator('a[href^="/User/Trip/Edit/"]').first().getAttribute('href');
+    expect(editorHref).toBeTruthy();
+    await page.goto(editorHref!);
+    await expect(page.locator('#trip-editor-app .leaflet-container')).toBeVisible();
+    await expectResolvedMapAttribution(page);
+    await page.screenshot({
+      fullPage: true,
+      path: testInfo.outputPath('screenshots', 'editor-provider-attribution.png')
+    });
+
+    await page.goto('/User/Trip');
+    const authenticatedHref = await page.locator('a[href^="/User/Trip/View/"]').first().getAttribute('href');
+    expect(authenticatedHref).toBeTruthy();
+    await page.goto(authenticatedHref!);
+    await expectResolvedMapAttribution(page);
+
+    const publicViewerHref = await discoverPublicViewer(page);
+    await page.goto(publicViewerHref);
+    await expectResolvedMapAttribution(page);
+    await expectLinkedViewerEmergencyFallback(page);
+    await page.screenshot({
+      fullPage: true,
+      path: testInfo.outputPath('screenshots', 'viewer-provider-attribution.png')
+    });
+
+    await page.goto(`${publicViewerHref}?embed=true`);
+    await expectResolvedMapAttribution(page);
+
+    await page.goto(`${publicViewerHref}?embed=true&print=1`);
+    await expectResolvedMapAttribution(page);
+  });
 });
 
 async function signIn(page: Page): Promise<void> {
@@ -160,6 +200,47 @@ async function expectLegacyViewerContained(page: Page): Promise<void> {
   const footerBox = await page.locator('.site-footer').boundingBox();
   expect(viewerBox!.y + viewerBox!.height).toBeCloseTo(footerBox!.y, 0);
   expect(await page.evaluate(() => document.documentElement.scrollHeight)).toBeLessThanOrEqual(await page.evaluate(() => innerHeight) + 1);
+}
+
+/** Verifies that Leaflet renders the server-resolved provider HTML without client inference. */
+async function expectResolvedMapAttribution(page: Page): Promise<void> {
+  const attribution = page.locator('.leaflet-control-attribution');
+  await expect(attribution).toHaveAttribute('aria-label', 'Map attribution');
+  await expect(attribution).toHaveAttribute('title', 'Map attribution');
+  const osmLink = attribution.getByRole('link', { name: 'OpenStreetMap', exact: true });
+  await expect(osmLink).toHaveCount(1);
+  await expect(osmLink).toHaveAttribute('href', 'https://www.openstreetmap.org/copyright');
+  await expect(osmLink).toBeVisible();
+
+  const configured = await page.evaluate(() =>
+    (window as typeof window & { wayfarerTileConfig?: { attribution?: string } })
+      .wayfarerTileConfig?.attribution ?? '');
+  expect(configured).toContain('https://www.openstreetmap.org/copyright');
+  const normalizedConfigured = await page.evaluate(html => {
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    return container.innerHTML;
+  }, configured);
+  await expect(attribution).toContainText('OpenStreetMap contributors');
+  expect(await attribution.innerHTML()).toContain(normalizedConfigured);
+}
+
+/** Verifies the Viewer module's emergency fallback without adding its layer to the map. */
+async function expectLinkedViewerEmergencyFallback(page: Page): Promise<void> {
+  const fallback = await page.evaluate(async () => {
+    const target = window as typeof window & { wayfarerTileConfig?: unknown };
+    const configured = target.wayfarerTileConfig;
+    delete target.wayfarerTileConfig;
+    try {
+      const module = await import(`/js/retryTileLayer.js?attribution-fallback=${Date.now()}`);
+      return module.createTileLayer().options.attribution as string;
+    } finally {
+      target.wayfarerTileConfig = configured;
+    }
+  });
+
+  expect(fallback).toContain(
+    '<a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors');
 }
 
 /** Finds a real canonical public viewer route from the public trip index. */

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -293,10 +293,6 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
 
 async function loadWorkspaceWithMarkerFixture(page: Page, requests: Record<string, any>[] = []): Promise<MutableEditorState> {
   await page.unroute(editorApiMatcher).catch(() => undefined);
-  // Keep attribution browser proof deterministic without contacting a public tile provider.
-  await page.route(/\/Public\/tiles\/\d+\/\d+\/\d+\.png/i, async route => {
-    await route.fulfill({ status: 200, contentType: 'image/png', body: tinyPng });
-  });
   await page.route(/\/Public\/ProxyImage\?url=/i, async route => {
     await route.fulfill({ status: 200, contentType: 'image/png', body: tinyPng });
   });
@@ -505,10 +501,7 @@ async function expectAttribution(page: Page): Promise<void> {
   await expect(attribution).toContainText('OpenStreetMap');
   await expect(attribution.getByRole('link', { name: 'Wayfarer' })).toHaveAttribute('title', 'Powered by Wayfarer, made by Stef');
   await expect(attribution.getByRole('link', { name: 'Stef K' })).toHaveAttribute('title', 'Check my blog');
-  const osmLink = attribution.getByRole('link', { name: 'OpenStreetMap', exact: true });
-  await expect(osmLink).toHaveCount(1);
-  await expect(osmLink).toHaveAttribute('href', 'https://www.openstreetmap.org/copyright');
-  await expect(osmLink).toBeVisible();
+  await expect(attribution.getByRole('link', { name: 'OpenStreetMap', exact: true })).toHaveAttribute('href', 'https://www.openstreetmap.org/copyright');
   await expect.poll(async () => {
     const colors = await attribution.evaluate(element => {
       const styles = window.getComputedStyle(element);

--- a/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMarkerParity.spec.ts
@@ -293,6 +293,10 @@ test.describe.serial('Trip Editor marker and notes parity', () => {
 
 async function loadWorkspaceWithMarkerFixture(page: Page, requests: Record<string, any>[] = []): Promise<MutableEditorState> {
   await page.unroute(editorApiMatcher).catch(() => undefined);
+  // Keep attribution browser proof deterministic without contacting a public tile provider.
+  await page.route(/\/Public\/tiles\/\d+\/\d+\/\d+\.png/i, async route => {
+    await route.fulfill({ status: 200, contentType: 'image/png', body: tinyPng });
+  });
   await page.route(/\/Public\/ProxyImage\?url=/i, async route => {
     await route.fulfill({ status: 200, contentType: 'image/png', body: tinyPng });
   });
@@ -501,7 +505,10 @@ async function expectAttribution(page: Page): Promise<void> {
   await expect(attribution).toContainText('OpenStreetMap');
   await expect(attribution.getByRole('link', { name: 'Wayfarer' })).toHaveAttribute('title', 'Powered by Wayfarer, made by Stef');
   await expect(attribution.getByRole('link', { name: 'Stef K' })).toHaveAttribute('title', 'Check my blog');
-  await expect(attribution.getByRole('link', { name: 'OpenStreetMap' })).toBeVisible();
+  const osmLink = attribution.getByRole('link', { name: 'OpenStreetMap', exact: true });
+  await expect(osmLink).toHaveCount(1);
+  await expect(osmLink).toHaveAttribute('href', 'https://www.openstreetmap.org/copyright');
+  await expect(osmLink).toBeVisible();
   await expect.poll(async () => {
     const colors = await attribution.evaluate(element => {
       const styles = window.getComputedStyle(element);

--- a/wwwroot/js/Trip/tripViewerHelpers.js
+++ b/wwwroot/js/Trip/tripViewerHelpers.js
@@ -45,7 +45,10 @@ export const initLeaflet = (center = [20, 0], zoom = 3) => {
 
     /* keep a handle to the tile layer so we can attach events */
     const tiles = createTileLayer().addTo(map);
-    map.attributionControl.setPrefix('&copy; <a href="https://wayfarer.stefk.me" title="Powered by Wayfarer, made by Stef" target="_blank">Wayfarer</a> | <a href="https://stefk.me" title="Check my blog" target="_blank">Stef K</a> | &copy; <a href="https://leafletjs.com/" target="_blank">Leaflet</a>');
+    map.attributionControl.setPrefix('&copy; <a href="https://wayfarer.stefk.me" title="Powered by Wayfarer, made by Stef" target="_blank" rel="noopener">Wayfarer</a> | <a href="https://stefk.me" title="Check my blog" target="_blank" rel="noopener">Stef K</a> | &copy; <a href="https://leafletjs.com/" target="_blank" rel="noopener">Leaflet</a>');
+    // Match the Trip Editor's accessible attribution-control contract.
+    map.attributionControl.getContainer()?.setAttribute('aria-label', 'Map attribution');
+    map.attributionControl.getContainer()?.setAttribute('title', 'Map attribution');
     L.control.zoom({position: 'bottomright'}).addTo(map);
     addZoomLevelControl(map);                 /* ← your existing util */
 

--- a/wwwroot/js/retryTileLayer.js
+++ b/wwwroot/js/retryTileLayer.js
@@ -338,7 +338,9 @@ const RetryTileLayer = L.TileLayer.extend({
  */
 export const createTileLayer = (opts) => {
     const url = _config.tilesUrl || (window.location.origin + '/Public/tiles/{z}/{x}/{y}.png');
-    const attribution = _config.attribution || '\u00a9 OpenStreetMap contributors';
+    // The layout supplies final provider-safe HTML; this linked OSM value is emergency-only.
+    const attribution = _config.attribution ||
+        '\u00a9 <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
     return new RetryTileLayer(url, Object.assign({
         maxZoom: 19,
         attribution: attribution,

--- a/wwwroot/js/retryTileLayer.js
+++ b/wwwroot/js/retryTileLayer.js
@@ -338,8 +338,8 @@ const RetryTileLayer = L.TileLayer.extend({
  */
 export const createTileLayer = (opts) => {
     const url = _config.tilesUrl || (window.location.origin + '/Public/tiles/{z}/{x}/{y}.png');
-    // The layout supplies final provider-safe HTML; this linked OSM value is emergency-only.
-    const attribution = _config.attribution ||
+    // Preserve an explicitly empty server result; only an absent legacy config uses OSM.
+    const attribution = _config.attribution ??
         '\u00a9 <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
     return new RetryTileLayer(url, Object.assign({
         maxZoom: 19,


### PR DESCRIPTION
## Summary

- centralize tile-provider attribution resolution on the server
- preserve sanitized administrator attribution and link visible OpenStreetMap text to the canonical copyright page
- keep Trip Editor and Trip Viewer attribution consistent across authenticated, public, embedded, readable, print, snapshot, and PDF output
- preserve custom and multi-party provider attribution without adding misleading OpenStreetMap attribution

## Why

Trip Viewer previously rendered configured OpenStreetMap attribution as plain text while Trip Editor normalized it independently. Custom-provider fallback behavior and generated snapshot/PDF output could also mislabel or omit provider attribution. Phase 2B gives both map applications one server-authoritative, sanitized attribution contract.

Part of #385. Phase 3 scheduling/coalescing and Phase 4 provider-profile work remain deferred.

## User and developer impact

Administrators can continue using built-in presets or custom attribution. Subsequent Razor renders use refreshed settings without a frontend rebuild. Map users receive consistent, visible provider attribution in interactive and generated map output.

## Validation

- focused attribution correction review: 18 resolver tests passed
- focused Phase 2B server, Razor, and browser validation passed during implementation and remediation
- generated readable snapshot and PDF attribution were inspected during remediation
- frontend production build passed
- .NET build passed with zero errors
- LOC policy check passed
- git diff checks passed
- all automated tile traffic used local interception; no public provider was contacted

Existing AngleSharp and SQLitePCLRaw dependency advisories and the Vite bundle-size warning are unchanged.

## Screenshots

Rendered Editor, Viewer, readable snapshot, and PDF attribution were validated locally. Validation artifacts were intentionally not committed to the repository.

## Database migrations

None.