### PR TITLE
Release Wayfarer v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## [1.7.0] - 2026-07-25
 
+### Added
+- Added provider-aware tile policies with distinct built-in profiles, bounded custom-provider controls, HTTP/2 preference with HTTP/1.1 fallback, and an explicit Admin notice for deployments retaining the historical 30-per-minute cold-miss allowance (#385, #394).
+
 ### Changed
-- TODO: Add release notes before publishing.
+- Increased Wayfarer's default interactive provider profile to 6 sustained requests per second, burst capacity 20, and concurrency 6 while retaining bounded queues, per-client protection, provider-directed backoff, caching, cancellation, and the prohibition on OSM prefetch or offline downloads (#385, #393, #394).
+- Prioritized visible cold tiles over stale background refresh, coalesced duplicate cold misses, isolated cache and in-flight work by provider identity, and made cold viewports fill progressively instead of entering synchronized 503 retry waves (#385, #393).
+
+### Fixed
+- Corrected upstream retry and status handling so every real contact consumes provider capacity, permanent responses are not retried, transient failures remain transient, and provider `Retry-After` instructions are honored without cancellation or privacy regressions (#385, #391).
+- Unified sanitized provider attribution across the Trip Editor, authenticated/public/embedded Trip Viewer maps, readable snapshots, and PDF output, including the required OpenStreetMap copyright link without mislabeling custom providers (#385, #392).
 
 ## [1.6.0] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [1.7.0] - 2026-07-25
+
+### Changed
+- TODO: Add release notes before publishing.
+
 ## [1.6.0] - 2026-07-22
 
 ### Added

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <WayfarerVersion>1.6.0</WayfarerVersion>
+    <WayfarerVersion>1.7.0</WayfarerVersion>
     <Version>$(WayfarerVersion)</Version>
     <PackageVersion>$(WayfarerVersion)</PackageVersion>
     <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>

--- a/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
@@ -92,6 +92,7 @@ public sealed class TileCacheCancellationAndPrivacyTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
             service.RetrieveTileAsync(
                 "5", "18", "21", CanonicalTileUrl(5, 18, 21), cancellation.Token));
+        await TileWorkScheduler.StopAndDrainAsync();
 
         AssertCancellation(harness.Logs, "global-budget-wait");
         AssertNoUpstreamFailure(harness.Logs);

--- a/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
@@ -13,7 +13,7 @@ public class AppVersionProviderTests
     {
         var provider = new AppVersionProvider();
 
-        provider.Version.Should().Be("1.6.0");
+        provider.Version.Should().Be("1.7.0");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Prepares Wayfarer v1.7.0 containing the completed #385 tile scheduling, provider-policy, retry, cache-isolation, and attribution work merged through PRs #390–#394.

- Updates the runtime version source from 1.6.0 to 1.7.0.
- Adds concise release notes for the user, administrator, and provider-compliance changes.
- Contains no additional production-code changes.

## Validation

- python tools/release/version.py check
- dotnet build Wayfarer.csproj --no-restore
- dotnet run --no-launch-profile --no-build -- version => Wayfarer 1.7.0
- LOC checker passed without hard failures
- git diff --check passed

Existing AngleSharp and SQLitePCLRaw dependency advisories are unchanged.