### PR TITLE
Redesign tile traffic modes for interactive use

### DIFF
--- a/Areas/Admin/Controllers/SettingsController.TileProviderPolicy.cs
+++ b/Areas/Admin/Controllers/SettingsController.TileProviderPolicy.cs
@@ -10,12 +10,25 @@ public partial class SettingsController
     /// <summary>Applies authoritative custom-provider cross-field validation.</summary>
     private void ValidateTileProviderPolicy(ApplicationSettings settings)
     {
-        if (!string.Equals(settings.TileProviderKey, TileProviderCatalog.CustomProviderKey,
-                StringComparison.OrdinalIgnoreCase) ||
-            !settings.TileProviderAdvancedLimitsEnabled)
+        if (settings.TileTrafficMode != TileTrafficMode.Custom)
         {
+            if (string.Equals(settings.TileProviderKey, TileProviderCatalog.CustomProviderKey,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                settings.TileProviderAdvancedLimitsEnabled = false;
+            }
             return;
         }
+
+        if (!string.Equals(settings.TileProviderKey, TileProviderCatalog.CustomProviderKey,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            ModelState.AddModelError(nameof(ApplicationSettings.TileTrafficMode),
+                "Provider Agreement mode requires a compatible Custom provider.");
+            return;
+        }
+
+        settings.TileProviderAdvancedLimitsEnabled = true;
 
         try
         {

--- a/Areas/Admin/Controllers/SettingsController.TileProviderPolicy.cs
+++ b/Areas/Admin/Controllers/SettingsController.TileProviderPolicy.cs
@@ -7,6 +7,28 @@ namespace Wayfarer.Areas.Admin.Controllers;
 /// <summary>Owns the provider-policy validation and historical-budget workflow.</summary>
 public partial class SettingsController
 {
+    /// <summary>Copies every persisted provider recovery field without normalization.</summary>
+    private static void PreserveTileProviderRecoveryState(
+        ApplicationSettings currentSettings,
+        ApplicationSettings updatedSettings)
+    {
+        updatedSettings.TileProviderKey = currentSettings.TileProviderKey;
+        updatedSettings.TileProviderUrlTemplate = currentSettings.TileProviderUrlTemplate;
+        updatedSettings.TileProviderAttribution = currentSettings.TileProviderAttribution;
+        updatedSettings.TileProviderApiKey = currentSettings.TileProviderApiKey;
+        updatedSettings.TileTrafficMode = currentSettings.TileTrafficMode;
+        updatedSettings.TileOutboundBudgetPerIpPerMinute = currentSettings.TileOutboundBudgetPerIpPerMinute;
+        updatedSettings.TileProviderAdvancedLimitsEnabled = currentSettings.TileProviderAdvancedLimitsEnabled;
+        updatedSettings.TileProviderSustainedRequestsPerSecond = currentSettings.TileProviderSustainedRequestsPerSecond;
+        updatedSettings.TileProviderBurstCapacity = currentSettings.TileProviderBurstCapacity;
+        updatedSettings.TileProviderMaxConcurrency = currentSettings.TileProviderMaxConcurrency;
+        updatedSettings.TileProviderMaxAttempts = currentSettings.TileProviderMaxAttempts;
+        updatedSettings.TileProviderFallbackBaseDelayMs = currentSettings.TileProviderFallbackBaseDelayMs;
+        updatedSettings.TileProviderFallbackDelayCapSeconds = currentSettings.TileProviderFallbackDelayCapSeconds;
+        updatedSettings.TileProviderMaxIndividualWaitSeconds = currentSettings.TileProviderMaxIndividualWaitSeconds;
+        updatedSettings.TileProviderTotalRetryCeilingSeconds = currentSettings.TileProviderTotalRetryCeilingSeconds;
+    }
+
     /// <summary>Formats the complete bounded non-secret effective policy for one audit transition.</summary>
     private static string DescribeTilePolicyForAudit(TileProviderPolicy policy) =>
         $"Mode={policy.TrafficMode}; " +

--- a/Areas/Admin/Controllers/SettingsController.TileProviderPolicy.cs
+++ b/Areas/Admin/Controllers/SettingsController.TileProviderPolicy.cs
@@ -29,7 +29,7 @@ public partial class SettingsController
         updatedSettings.TileProviderTotalRetryCeilingSeconds = currentSettings.TileProviderTotalRetryCeilingSeconds;
     }
 
-    /// <summary>Formats the complete bounded non-secret effective policy for one audit transition.</summary>
+    /// <summary>Formats the complete bounded non-secret policy state for one audit transition.</summary>
     private static string DescribeTilePolicyForAudit(TileProviderPolicy policy) =>
         $"Mode={policy.TrafficMode}; " +
         $"Compatibility={policy.Compatibility.Status}; " +
@@ -38,11 +38,12 @@ public partial class SettingsController
         $"TileEffectiveBurst={policy.BurstCapacity}; TileEffectiveBurstActive={policy.IsBurstActive}; " +
         $"TileEffectiveConcurrency={policy.MaxConcurrency}; TileEffectiveConcurrencyActive={policy.IsConcurrencyActive}; " +
         $"TileEffectiveClientAllowance={policy.ClientSeriesPerMinute}; TileEffectiveClientAllowanceActive={policy.IsClientSeriesAllowanceActive}; " +
-        $"TileEffectiveMaxAttempts={policy.MaxAttempts}; " +
-        $"TileEffectiveFallbackBaseDelayMs={policy.FallbackBaseDelay.TotalMilliseconds:0}; " +
-        $"TileEffectiveFallbackDelayCapSeconds={policy.FallbackDelayCap.TotalSeconds:0}; " +
-        $"TileEffectiveMaxIndividualWaitSeconds={policy.MaxIndividualWait.TotalSeconds:0}; " +
-        $"TileEffectiveTotalRetryCeilingSeconds={policy.TotalRetryCeiling.TotalSeconds:0}";
+        $"TileRetryControlsActive={policy.CanContactProvider}; " +
+        $"TileRetryMaxAttempts={policy.MaxAttempts}; " +
+        $"TileRetryFallbackBaseDelayMs={policy.FallbackBaseDelay.TotalMilliseconds:0}; " +
+        $"TileRetryFallbackDelayCapSeconds={policy.FallbackDelayCap.TotalSeconds:0}; " +
+        $"TileRetryMaxIndividualWaitSeconds={policy.MaxIndividualWait.TotalSeconds:0}; " +
+        $"TileRetryTotalCeilingSeconds={policy.TotalRetryCeiling.TotalSeconds:0}";
 
     /// <summary>Applies authoritative custom-provider cross-field validation.</summary>
     private void ValidateTileProviderPolicy(ApplicationSettings settings)

--- a/Areas/Admin/Controllers/SettingsController.TileProviderPolicy.cs
+++ b/Areas/Admin/Controllers/SettingsController.TileProviderPolicy.cs
@@ -7,6 +7,21 @@ namespace Wayfarer.Areas.Admin.Controllers;
 /// <summary>Owns the provider-policy validation and historical-budget workflow.</summary>
 public partial class SettingsController
 {
+    /// <summary>Formats the complete bounded non-secret effective policy for one audit transition.</summary>
+    private static string DescribeTilePolicyForAudit(TileProviderPolicy policy) =>
+        $"Mode={policy.TrafficMode}; " +
+        $"Compatibility={policy.Compatibility.Status}; " +
+        $"CompatibilitySource={policy.Compatibility.AuditSource}; " +
+        $"TileEffectiveRate={policy.SustainedRequestsPerSecond}; TileEffectiveRateActive={policy.IsRateActive}; " +
+        $"TileEffectiveBurst={policy.BurstCapacity}; TileEffectiveBurstActive={policy.IsBurstActive}; " +
+        $"TileEffectiveConcurrency={policy.MaxConcurrency}; TileEffectiveConcurrencyActive={policy.IsConcurrencyActive}; " +
+        $"TileEffectiveClientAllowance={policy.ClientSeriesPerMinute}; TileEffectiveClientAllowanceActive={policy.IsClientSeriesAllowanceActive}; " +
+        $"TileEffectiveMaxAttempts={policy.MaxAttempts}; " +
+        $"TileEffectiveFallbackBaseDelayMs={policy.FallbackBaseDelay.TotalMilliseconds:0}; " +
+        $"TileEffectiveFallbackDelayCapSeconds={policy.FallbackDelayCap.TotalSeconds:0}; " +
+        $"TileEffectiveMaxIndividualWaitSeconds={policy.MaxIndividualWait.TotalSeconds:0}; " +
+        $"TileEffectiveTotalRetryCeilingSeconds={policy.TotalRetryCeiling.TotalSeconds:0}";
+
     /// <summary>Applies authoritative custom-provider cross-field validation.</summary>
     private void ValidateTileProviderPolicy(ApplicationSettings settings)
     {

--- a/Areas/Admin/Controllers/SettingsController.cs
+++ b/Areas/Admin/Controllers/SettingsController.cs
@@ -195,13 +195,15 @@ namespace Wayfarer.Areas.Admin.Controllers
                     Track("ImageCacheExpiryDays", currentSettings.ImageCacheExpiryDays, updatedSettings.ImageCacheExpiryDays);
                     Track("MaxProxyImageDownloadMB", currentSettings.MaxProxyImageDownloadMB, updatedSettings.MaxProxyImageDownloadMB);
                     Track("UploadSizeLimitMB", currentSettings.UploadSizeLimitMB, updatedSettings.UploadSizeLimitMB);
-                    Track("TileProviderKey", currentSettings.TileProviderKey, updatedSettings.TileProviderKey);
-                    Track("TileProviderUrlTemplate", currentSettings.TileProviderUrlTemplate, updatedSettings.TileProviderUrlTemplate);
-                    Track("TileProviderAttribution", currentSettings.TileProviderAttribution, updatedSettings.TileProviderAttribution);
-                    if (!string.Equals(currentSettings.TileProviderApiKey, updatedSettings.TileProviderApiKey, StringComparison.Ordinal))
-                    {
-                        changes.Add("TileProviderApiKey: [updated]");
-                    }
+                    var oldTilePolicy = TileProviderPolicyResolver.Resolve(currentSettings);
+                    var newTilePolicy = TileProviderPolicyResolver.Resolve(updatedSettings);
+                    Track("TileTrafficMode", oldTilePolicy.TrafficMode, newTilePolicy.TrafficMode);
+                    Track("TileProviderCompatibility", oldTilePolicy.Compatibility.Status, newTilePolicy.Compatibility.Status);
+                    Track("TileProviderCompatibilitySource", oldTilePolicy.Compatibility.Source, newTilePolicy.Compatibility.Source);
+                    Track("TileEffectiveRate", oldTilePolicy.UsesRateTokens ? oldTilePolicy.SustainedRequestsPerSecond : 0, newTilePolicy.UsesRateTokens ? newTilePolicy.SustainedRequestsPerSecond : 0);
+                    Track("TileEffectiveBurst", oldTilePolicy.UsesRateTokens ? oldTilePolicy.BurstCapacity : 0, newTilePolicy.UsesRateTokens ? newTilePolicy.BurstCapacity : 0);
+                    Track("TileEffectiveConcurrency", oldTilePolicy.MaxConcurrency, newTilePolicy.MaxConcurrency);
+                    Track("TileEffectiveClientSeriesPerMinute", oldTilePolicy.ClientSeriesPerMinute, newTilePolicy.ClientSeriesPerMinute);
                     Track("TileRateLimitEnabled", currentSettings.TileRateLimitEnabled, updatedSettings.TileRateLimitEnabled);
                     Track("TileRateLimitPerMinute", currentSettings.TileRateLimitPerMinute, updatedSettings.TileRateLimitPerMinute);
                     Track("TileRateLimitAuthenticatedPerMinute", currentSettings.TileRateLimitAuthenticatedPerMinute, updatedSettings.TileRateLimitAuthenticatedPerMinute);
@@ -235,6 +237,7 @@ namespace Wayfarer.Areas.Admin.Controllers
                     currentSettings.TileProviderUrlTemplate = updatedSettings.TileProviderUrlTemplate;
                     currentSettings.TileProviderAttribution = updatedSettings.TileProviderAttribution;
                     currentSettings.TileProviderApiKey = updatedSettings.TileProviderApiKey;
+                    currentSettings.TileTrafficMode = updatedSettings.TileTrafficMode;
                     currentSettings.TileRateLimitEnabled = updatedSettings.TileRateLimitEnabled;
                     currentSettings.TileRateLimitPerMinute = updatedSettings.TileRateLimitPerMinute;
                     currentSettings.TileRateLimitAuthenticatedPerMinute = updatedSettings.TileRateLimitAuthenticatedPerMinute;

--- a/Areas/Admin/Controllers/SettingsController.cs
+++ b/Areas/Admin/Controllers/SettingsController.cs
@@ -201,7 +201,7 @@ namespace Wayfarer.Areas.Admin.Controllers
                     var oldTilePolicy = TileProviderPolicyResolver.Resolve(currentSettings);
                     var newTilePolicy = TileProviderPolicyResolver.Resolve(updatedSettings);
                     Track(
-                        "TileEffectivePolicy",
+                        "TilePolicy",
                         DescribeTilePolicyForAudit(oldTilePolicy),
                         DescribeTilePolicyForAudit(newTilePolicy));
                     Track("TileRateLimitEnabled", currentSettings.TileRateLimitEnabled, updatedSettings.TileRateLimitEnabled);

--- a/Areas/Admin/Controllers/SettingsController.cs
+++ b/Areas/Admin/Controllers/SettingsController.cs
@@ -535,28 +535,6 @@ namespace Wayfarer.Areas.Admin.Controllers
             return false;
         }
 
-        /// <summary>Copies every persisted provider recovery field without normalization.</summary>
-        private static void PreserveTileProviderRecoveryState(
-            ApplicationSettings currentSettings,
-            ApplicationSettings updatedSettings)
-        {
-            updatedSettings.TileProviderKey = currentSettings.TileProviderKey;
-            updatedSettings.TileProviderUrlTemplate = currentSettings.TileProviderUrlTemplate;
-            updatedSettings.TileProviderAttribution = currentSettings.TileProviderAttribution;
-            updatedSettings.TileProviderApiKey = currentSettings.TileProviderApiKey;
-            updatedSettings.TileTrafficMode = currentSettings.TileTrafficMode;
-            updatedSettings.TileOutboundBudgetPerIpPerMinute = currentSettings.TileOutboundBudgetPerIpPerMinute;
-            updatedSettings.TileProviderAdvancedLimitsEnabled = currentSettings.TileProviderAdvancedLimitsEnabled;
-            updatedSettings.TileProviderSustainedRequestsPerSecond = currentSettings.TileProviderSustainedRequestsPerSecond;
-            updatedSettings.TileProviderBurstCapacity = currentSettings.TileProviderBurstCapacity;
-            updatedSettings.TileProviderMaxConcurrency = currentSettings.TileProviderMaxConcurrency;
-            updatedSettings.TileProviderMaxAttempts = currentSettings.TileProviderMaxAttempts;
-            updatedSettings.TileProviderFallbackBaseDelayMs = currentSettings.TileProviderFallbackBaseDelayMs;
-            updatedSettings.TileProviderFallbackDelayCapSeconds = currentSettings.TileProviderFallbackDelayCapSeconds;
-            updatedSettings.TileProviderMaxIndividualWaitSeconds = currentSettings.TileProviderMaxIndividualWaitSeconds;
-            updatedSettings.TileProviderTotalRetryCeilingSeconds = currentSettings.TileProviderTotalRetryCeilingSeconds;
-        }
-
         /// <summary>
         /// Adds tile provider preset metadata needed by the settings view.
         /// </summary>

--- a/Areas/Admin/Controllers/SettingsController.cs
+++ b/Areas/Admin/Controllers/SettingsController.cs
@@ -200,13 +200,10 @@ namespace Wayfarer.Areas.Admin.Controllers
                     Track("UploadSizeLimitMB", currentSettings.UploadSizeLimitMB, updatedSettings.UploadSizeLimitMB);
                     var oldTilePolicy = TileProviderPolicyResolver.Resolve(currentSettings);
                     var newTilePolicy = TileProviderPolicyResolver.Resolve(updatedSettings);
-                    Track("TileTrafficMode", oldTilePolicy.TrafficMode, newTilePolicy.TrafficMode);
-                    Track("TileProviderCompatibility", oldTilePolicy.Compatibility.Status, newTilePolicy.Compatibility.Status);
-                    Track("TileProviderCompatibilitySource", oldTilePolicy.Compatibility.Source, newTilePolicy.Compatibility.Source);
-                    Track("TileEffectiveRate", oldTilePolicy.UsesRateTokens ? oldTilePolicy.SustainedRequestsPerSecond : 0, newTilePolicy.UsesRateTokens ? newTilePolicy.SustainedRequestsPerSecond : 0);
-                    Track("TileEffectiveBurst", oldTilePolicy.UsesRateTokens ? oldTilePolicy.BurstCapacity : 0, newTilePolicy.UsesRateTokens ? newTilePolicy.BurstCapacity : 0);
-                    Track("TileEffectiveConcurrency", oldTilePolicy.MaxConcurrency, newTilePolicy.MaxConcurrency);
-                    Track("TileEffectiveClientSeriesPerMinute", oldTilePolicy.ClientSeriesPerMinute, newTilePolicy.ClientSeriesPerMinute);
+                    Track(
+                        "TileEffectivePolicy",
+                        DescribeTilePolicyForAudit(oldTilePolicy),
+                        DescribeTilePolicyForAudit(newTilePolicy));
                     Track("TileRateLimitEnabled", currentSettings.TileRateLimitEnabled, updatedSettings.TileRateLimitEnabled);
                     Track("TileRateLimitPerMinute", currentSettings.TileRateLimitPerMinute, updatedSettings.TileRateLimitPerMinute);
                     Track("TileRateLimitAuthenticatedPerMinute", currentSettings.TileRateLimitAuthenticatedPerMinute, updatedSettings.TileRateLimitAuthenticatedPerMinute);

--- a/Areas/Admin/Controllers/SettingsController.cs
+++ b/Areas/Admin/Controllers/SettingsController.cs
@@ -164,8 +164,11 @@ namespace Wayfarer.Areas.Admin.Controllers
             if (currentSettings != null)
             {
                 // Validate tile provider settings before model validation.
-                NormalizeTileProviderSettings(currentSettings, updatedSettings);
-                ValidateTileProviderPolicy(updatedSettings);
+                var providerStatePreserved = NormalizeTileProviderSettings(currentSettings, updatedSettings);
+                if (!providerStatePreserved)
+                {
+                    ValidateTileProviderPolicy(updatedSettings);
+                }
             }
 
             if (!ValidateModelState())
@@ -459,17 +462,27 @@ namespace Wayfarer.Areas.Admin.Controllers
         /// <summary>
         /// Normalizes and validates tile provider settings, applying presets when selected.
         /// </summary>
-        private void NormalizeTileProviderSettings(ApplicationSettings currentSettings, ApplicationSettings updatedSettings)
+        private bool NormalizeTileProviderSettings(ApplicationSettings currentSettings, ApplicationSettings updatedSettings)
         {
             var providerKey = updatedSettings.TileProviderKey?.Trim();
+            var currentCompatibility = TileProviderCatalog.ResolveCompatibility(
+                currentSettings.TileProviderKey,
+                currentSettings.TileProviderUrlTemplate);
+            var preservesUnsupportedState =
+                currentCompatibility.Status != TileProviderCompatibility.Supported &&
+                (string.IsNullOrWhiteSpace(providerKey) ||
+                 string.Equals(providerKey, currentSettings.TileProviderKey?.Trim(),
+                     StringComparison.OrdinalIgnoreCase));
+            if (preservesUnsupportedState)
+            {
+                PreserveTileProviderRecoveryState(currentSettings, updatedSettings);
+                return true;
+            }
             if (string.IsNullOrWhiteSpace(providerKey))
             {
-                // Preserve existing settings when tile provider fields are not posted.
-                updatedSettings.TileProviderKey = currentSettings.TileProviderKey;
-                updatedSettings.TileProviderUrlTemplate = currentSettings.TileProviderUrlTemplate;
-                updatedSettings.TileProviderAttribution = currentSettings.TileProviderAttribution;
-                updatedSettings.TileProviderApiKey = currentSettings.TileProviderApiKey;
-                return;
+                // Preserve supported provider identity when an unrelated form omits this section.
+                PreserveTileProviderRecoveryState(currentSettings, updatedSettings);
+                return true;
             }
             var preset = TileProviderCatalog.FindPreset(providerKey);
             var isCustom = string.Equals(providerKey, TileProviderCatalog.CustomProviderKey, StringComparison.OrdinalIgnoreCase);
@@ -477,7 +490,7 @@ namespace Wayfarer.Areas.Admin.Controllers
             if (preset == null && !isCustom)
             {
                 ModelState.AddModelError(nameof(ApplicationSettings.TileProviderKey), "Unknown tile provider selection.");
-                return;
+                return false;
             }
 
             if (preset != null)
@@ -521,6 +534,30 @@ namespace Wayfarer.Areas.Admin.Controllers
             {
                 updatedSettings.TileProviderApiKey = null;
             }
+
+            return false;
+        }
+
+        /// <summary>Copies every persisted provider recovery field without normalization.</summary>
+        private static void PreserveTileProviderRecoveryState(
+            ApplicationSettings currentSettings,
+            ApplicationSettings updatedSettings)
+        {
+            updatedSettings.TileProviderKey = currentSettings.TileProviderKey;
+            updatedSettings.TileProviderUrlTemplate = currentSettings.TileProviderUrlTemplate;
+            updatedSettings.TileProviderAttribution = currentSettings.TileProviderAttribution;
+            updatedSettings.TileProviderApiKey = currentSettings.TileProviderApiKey;
+            updatedSettings.TileTrafficMode = currentSettings.TileTrafficMode;
+            updatedSettings.TileOutboundBudgetPerIpPerMinute = currentSettings.TileOutboundBudgetPerIpPerMinute;
+            updatedSettings.TileProviderAdvancedLimitsEnabled = currentSettings.TileProviderAdvancedLimitsEnabled;
+            updatedSettings.TileProviderSustainedRequestsPerSecond = currentSettings.TileProviderSustainedRequestsPerSecond;
+            updatedSettings.TileProviderBurstCapacity = currentSettings.TileProviderBurstCapacity;
+            updatedSettings.TileProviderMaxConcurrency = currentSettings.TileProviderMaxConcurrency;
+            updatedSettings.TileProviderMaxAttempts = currentSettings.TileProviderMaxAttempts;
+            updatedSettings.TileProviderFallbackBaseDelayMs = currentSettings.TileProviderFallbackBaseDelayMs;
+            updatedSettings.TileProviderFallbackDelayCapSeconds = currentSettings.TileProviderFallbackDelayCapSeconds;
+            updatedSettings.TileProviderMaxIndividualWaitSeconds = currentSettings.TileProviderMaxIndividualWaitSeconds;
+            updatedSettings.TileProviderTotalRetryCeilingSeconds = currentSettings.TileProviderTotalRetryCeilingSeconds;
         }
 
         /// <summary>

--- a/Areas/Admin/Views/Settings/Index.cshtml
+++ b/Areas/Admin/Views/Settings/Index.cshtml
@@ -546,7 +546,7 @@
 
                             <div class="col-md-6 mb-3">
                                 <div class="alert alert-info mb-0">
-                                    <strong>Cache note:</strong> Changing providers or API keys purges cached tiles so new imagery can load.
+                                    <strong>Cache note:</strong> Provider-scoped cached files are preserved when providers, credentials, or traffic modes change.
                                 </div>
                             </div>
 
@@ -629,18 +629,6 @@
                                 <span asp-validation-for="TileRateLimitAuthenticatedPerMinute" class="text-danger"></span>
                             </div>
 
-                            <div class="col-md-3 mb-3">
-                                <label asp-for="TileOutboundBudgetPerIpPerMinute" class="form-label">Cache miss budget (per IP)</label>
-                                <div class="input-group">
-                                    <input asp-for="TileOutboundBudgetPerIpPerMinute" class="form-control" type="number" min="0" max="1000" />
-                                    <span class="input-group-text">miss/min</span>
-                                </div>
-                                <small class="form-text text-muted">
-                                    Default: @ApplicationSettings.DefaultTileOutboundBudgetPerIpPerMinute. Max upstream fetches per IP per minute. 0 = disabled.
-                                </small>
-                                <span asp-validation-for="TileOutboundBudgetPerIpPerMinute" class="text-danger"></span>
-                            </div>
-                            <partial name="_HistoricalTileBudgetNotice" model="Model" />
                         </div>
                         <div class="row">
                             <div class="col-md-3 mb-3">

--- a/Areas/Admin/Views/Settings/Index.cshtml
+++ b/Areas/Admin/Views/Settings/Index.cshtml
@@ -3,6 +3,7 @@
     var tileMetadataHotCacheEntries = Wayfarer.Services.TileMetadataHotCache.GetApproximateEntryLimit(Model.TileMetadataHotCacheSizeMB);
 }
 @using Wayfarer.Util
+@using Wayfarer.Services
 @{
     var isRegistrationOpen = (ViewData["IsRegistrationOpen"] as bool?) ?? false;
     var tileProviderPresets = ViewData["TileProviderPresets"] as IReadOnlyList<TileProviderDefinition> ?? Array.Empty<TileProviderDefinition>();
@@ -527,6 +528,12 @@
                             <div class="col-md-6 mb-3">
                                 <label asp-for="TileProviderKey" class="form-label">Provider</label>
                                 <select asp-for="TileProviderKey" class="form-control" data-custom-key="@tileProviderCustomKey">
+                                    @if (TileProviderCatalog.ResolveCompatibility(Model.TileProviderKey, Model.TileProviderUrlTemplate).Status != TileProviderCompatibility.Supported)
+                                    {
+                                        <option value="@Model.TileProviderKey" data-preserved="true" data-requires-key="false">
+                                            Unsupported persisted provider: @(string.IsNullOrWhiteSpace(Model.TileProviderKey) ? "(blank)" : Model.TileProviderKey)
+                                        </option>
+                                    }
                                     @foreach (var preset in tileProviderPresets)
                                     {
                                         <option value="@preset.Key"

--- a/Areas/Admin/Views/Settings/_TileProviderPolicySettings.cshtml
+++ b/Areas/Admin/Views/Settings/_TileProviderPolicySettings.cshtml
@@ -1,30 +1,58 @@
 @model ApplicationSettings
+@using Wayfarer.Services
+@using Wayfarer.Util
+@{
+    // Resolve the same immutable policy shown to and enforced for newly admitted work.
+    var policy = TileProviderPolicyResolver.Resolve(Model);
+    var compatible = policy.Compatibility.Status == TileProviderCompatibility.Supported;
+}
 
-@* Custom limits are intentionally unavailable for built-in provider profiles. *@
-<div class="col-12 mb-3 d-none" id="tileProviderAdvancedRow">
-    <div class="form-check form-switch">
-        <input asp-for="TileProviderAdvancedLimitsEnabled" class="form-check-input" />
-        <label asp-for="TileProviderAdvancedLimitsEnabled" class="form-check-label">Advanced Provider Limits</label>
+<div class="col-12 mb-3">
+    @if (!compatible)
+    {
+        <div class="alert alert-danger" role="alert">
+            <strong>Provider blocked:</strong> @policy.Compatibility.Message
+            Select OSM Standard, OpenTopoMap, or a compatible Custom provider. Existing settings and cache are preserved for recovery; no upstream contact is made.
+        </div>
+    }
+    <div class="alert alert-secondary">
+        <strong>Compatibility:</strong> @policy.Compatibility.Status<br />
+        <strong>Authoritative source:</strong> @policy.Compatibility.Source
     </div>
+</div>
+
+<div class="col-md-6 mb-3">
+    <label asp-for="TileTrafficMode" class="form-label">Traffic mode</label>
+    <select asp-for="TileTrafficMode" asp-items="Html.GetEnumSelectList<TileTrafficMode>()" class="form-select"></select>
     <small class="form-text text-muted">
-        Configure these limits only according to your provider agreement. Wayfarer defaults
-        are 6 requests/second, burst 20, and concurrency 6; they are not provider-published allowances.
+        Interactive has no proactive Wayfarer contact-rate or client-series delay. Conservative applies Wayfarer safeguards.
+        Provider Agreement uses the preserved Custom values below. Provider requirements, Retry-After, caching, attribution, and no-prefetch rules always remain active.
     </small>
-    <span asp-validation-for="TileProviderAdvancedLimitsEnabled" class="text-danger"></span>
+    <span asp-validation-for="TileTrafficMode" class="text-danger"></span>
 </div>
-<div class="row d-none" id="tileProviderAdvancedFields">
-    <div class="col-md-3 mb-2"><label asp-for="TileProviderSustainedRequestsPerSecond">Sustained/sec</label><input asp-for="TileProviderSustainedRequestsPerSecond" class="form-control" min="1" max="20" /></div>
-    <div class="col-md-3 mb-2"><label asp-for="TileProviderBurstCapacity">Burst</label><input asp-for="TileProviderBurstCapacity" class="form-control" min="1" max="50" /></div>
+
+<div class="col-md-6 mb-3">
+    <div class="alert alert-info mb-0">
+        <strong>Effective active controls:</strong><br />
+        Rate: @(policy.UsesRateTokens ? $"{policy.SustainedRequestsPerSecond} actual contacts/sec" : "inactive")<br />
+        Burst: @(policy.UsesRateTokens ? $"{policy.BurstCapacity} contact tokens" : "inactive")<br />
+        Concurrency: @policy.MaxConcurrency simultaneous contacts (local resource protection)<br />
+        Client allowance: @(policy.ClientSeriesPerMinute > 0 ? $"{policy.ClientSeriesPerMinute} admitted series/client/min" : "inactive")
+    </div>
+</div>
+
+@* Values remain posted and recoverable even while their mode is inactive. *@
+<div class="col-12 mb-2"><strong>Preserved Provider Agreement values</strong></div>
+<input asp-for="TileProviderAdvancedLimitsEnabled" type="hidden" />
+<div class="row" id="tileProviderAdvancedFields">
+    <div class="col-md-3 mb-2"><label asp-for="TileProviderSustainedRequestsPerSecond">Contacts/sec</label><input asp-for="TileProviderSustainedRequestsPerSecond" class="form-control" min="1" max="20" /></div>
+    <div class="col-md-3 mb-2"><label asp-for="TileProviderBurstCapacity">Contact burst</label><input asp-for="TileProviderBurstCapacity" class="form-control" min="1" max="50" /></div>
     <div class="col-md-3 mb-2"><label asp-for="TileProviderMaxConcurrency">Concurrency</label><input asp-for="TileProviderMaxConcurrency" class="form-control" min="1" max="16" /></div>
+    <div class="col-md-3 mb-2"><label asp-for="TileOutboundBudgetPerIpPerMinute">Series/client/min</label><input asp-for="TileOutboundBudgetPerIpPerMinute" class="form-control" min="0" max="1000" /><small class="text-muted">0 disables this allowance.</small></div>
     <div class="col-md-3 mb-2"><label asp-for="TileProviderMaxAttempts">Attempts</label><input asp-for="TileProviderMaxAttempts" class="form-control" min="1" max="3" /></div>
-    <div class="col-md-3 mb-2"><label asp-for="TileProviderFallbackBaseDelayMs">Base delay (ms)</label><input asp-for="TileProviderFallbackBaseDelayMs" class="form-control" min="250" max="5000" /></div>
-    <div class="col-md-3 mb-2"><label asp-for="TileProviderFallbackDelayCapSeconds">Delay cap (sec)</label><input asp-for="TileProviderFallbackDelayCapSeconds" class="form-control" min="1" max="30" /></div>
-    <div class="col-md-3 mb-2"><label asp-for="TileProviderMaxIndividualWaitSeconds">Max wait (sec)</label><input asp-for="TileProviderMaxIndividualWaitSeconds" class="form-control" min="1" max="120" /></div>
-    <div class="col-md-3 mb-2"><label asp-for="TileProviderTotalRetryCeilingSeconds">Total ceiling (sec)</label><input asp-for="TileProviderTotalRetryCeilingSeconds" class="form-control" min="5" max="180" /></div>
+    <div class="col-md-3 mb-2"><label asp-for="TileProviderFallbackBaseDelayMs">Fallback base (ms)</label><input asp-for="TileProviderFallbackBaseDelayMs" class="form-control" min="250" max="5000" /></div>
+    <div class="col-md-3 mb-2"><label asp-for="TileProviderFallbackDelayCapSeconds">Fallback cap (sec)</label><input asp-for="TileProviderFallbackDelayCapSeconds" class="form-control" min="1" max="30" /></div>
+    <div class="col-md-3 mb-2"><label asp-for="TileProviderMaxIndividualWaitSeconds">Provider wait cap (sec)</label><input asp-for="TileProviderMaxIndividualWaitSeconds" class="form-control" min="1" max="120" /></div>
+    <div class="col-md-3 mb-2"><label asp-for="TileProviderTotalRetryCeilingSeconds">Retry ceiling (sec)</label><input asp-for="TileProviderTotalRetryCeilingSeconds" class="form-control" min="5" max="180" /></div>
 </div>
-<div class="col-12">
-    <small class="text-muted">
-        OSM Standard is best-effort with no SLA and permits no prefetch or offline cache warming.
-        Cached tiles and provider migration continue automatically; rate-policy changes never require clearing the cache.
-    </small>
-</div>
+<div class="col-12"><small class="text-muted">These are administrator-managed Wayfarer safeguards, not provider-published allowances. Mode changes do not change cache identity and never require a purge.</small></div>

--- a/Areas/Admin/Views/Settings/_TileProviderPolicySettings.cshtml
+++ b/Areas/Admin/Views/Settings/_TileProviderPolicySettings.cshtml
@@ -33,11 +33,17 @@
 
 <div class="col-md-6 mb-3">
     <div class="alert alert-info mb-0">
-        <strong>Effective active controls:</strong><br />
-        Rate: @(policy.UsesRateTokens ? $"{policy.SustainedRequestsPerSecond} actual contacts/sec" : "inactive")<br />
-        Burst: @(policy.UsesRateTokens ? $"{policy.BurstCapacity} contact tokens" : "inactive")<br />
-        Concurrency: @policy.MaxConcurrency simultaneous contacts (local resource protection)<br />
-        Client allowance: @(policy.ClientSeriesPerMinute > 0 ? $"{policy.ClientSeriesPerMinute} admitted series/client/min" : "inactive")
+        <strong>Complete effective traffic policy:</strong><br />
+        Mode: @policy.TrafficMode<br />
+        Rate: @(policy.IsRateActive ? $"{policy.SustainedRequestsPerSecond} actual contacts/sec (active)" : "inactive")<br />
+        Burst: @(policy.IsBurstActive ? $"{policy.BurstCapacity} contact tokens (active)" : "inactive")<br />
+        Concurrency: @(policy.IsConcurrencyActive ? $"{policy.MaxConcurrency} simultaneous contacts (active; local resource protection, not provider permission)" : "inactive")<br />
+        Client allowance: @(policy.IsClientSeriesAllowanceActive ? $"{policy.ClientSeriesPerMinute} admitted series/client/min (active)" : "inactive")<br />
+        Maximum attempts: @(compatible ? $"{policy.MaxAttempts}" : "inactive")<br />
+        Fallback base delay: @(compatible ? $"{policy.FallbackBaseDelay.TotalMilliseconds:0} ms" : "inactive")<br />
+        Fallback delay cap: @(compatible ? $"{policy.FallbackDelayCap.TotalSeconds:0} sec" : "inactive")<br />
+        Maximum provider/individual wait: @(compatible ? $"{policy.MaxIndividualWait.TotalSeconds:0} sec" : "inactive")<br />
+        Total retry ceiling: @(compatible ? $"{policy.TotalRetryCeiling.TotalSeconds:0} sec" : "inactive")
     </div>
 </div>
 

--- a/Areas/Public/Controllers/TilesController.cs
+++ b/Areas/Public/Controllers/TilesController.cs
@@ -153,6 +153,12 @@ public class TilesController : Controller
         }
         var preset = TileProviderCatalog.FindPreset(settings.TileProviderKey);
         var template = preset?.UrlTemplate ?? settings.TileProviderUrlTemplate;
+        var policy = TileProviderPolicyResolver.Resolve(settings, _logger);
+        if (!policy.CanContactProvider)
+        {
+            _logger.LogWarning("Tile provider compatibility blocks the active configuration.");
+            return StatusCode(503, "Tile provider configuration requires administrator attention.");
+        }
         var providerIdentity = TileProviderCatalog.CreateCacheIdentity(
             settings.TileProviderKey, template);
         var apiKey = TileProviderCatalog.RequiresApiKey(template) ? settings.TileProviderApiKey : null;

--- a/Migrations/20260726085113_AddTileTrafficMode.Designer.cs
+++ b/Migrations/20260726085113_AddTileTrafficMode.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Wayfarer.Models;
 namespace Wayfarer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726085113_AddTileTrafficMode")]
+    partial class AddTileTrafficMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260726085113_AddTileTrafficMode.cs
+++ b/Migrations/20260726085113_AddTileTrafficMode.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wayfarer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTileTrafficMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TileTrafficMode",
+                table: "ApplicationSettings",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            // The single settings row migrates deterministically without consulting dormant numeric values.
+            migrationBuilder.Sql("""
+                UPDATE "ApplicationSettings"
+                SET "TileTrafficMode" = 2
+                WHERE lower("TileProviderKey") = 'custom'
+                  AND "TileProviderAdvancedLimitsEnabled" = TRUE;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TileTrafficMode",
+                table: "ApplicationSettings");
+        }
+    }
+}

--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -83,6 +83,10 @@ public class ApplicationSettings
     [MaxLength(200)]
     public string? TileProviderApiKey { get; set; }
 
+    /// <summary>Explicit traffic behavior for compatible tile providers.</summary>
+    public Wayfarer.Services.TileTrafficMode TileTrafficMode { get; set; } =
+        Wayfarer.Services.TileTrafficMode.Interactive;
+
     /// <summary>Whether bounded custom-provider transport limits are administrator-managed.</summary>
     public bool TileProviderAdvancedLimitsEnabled { get; set; }
 

--- a/Services/ApplicationSettingsService.cs
+++ b/Services/ApplicationSettingsService.cs
@@ -63,17 +63,6 @@ namespace Wayfarer.Parsers
                 settings.UploadSizeLimitMB = ApplicationSettings.DefaultUploadSizeLimitMB;
             }
 
-            // Resolve tile provider defaults when fields are missing.
-            if (string.IsNullOrWhiteSpace(settings.TileProviderKey))
-            {
-                settings.TileProviderKey = ApplicationSettings.DefaultTileProviderKey;
-            }
-
-            if (string.IsNullOrWhiteSpace(settings.TileProviderUrlTemplate))
-            {
-                settings.TileProviderUrlTemplate = ApplicationSettings.DefaultTileProviderUrlTemplate;
-            }
-
             // Only a recognized preset can safely supply missing legacy attribution.
             // Unknown and custom providers must never be mislabeled as OpenStreetMap.
             if (string.IsNullOrWhiteSpace(settings.TileProviderAttribution) &&

--- a/Services/TileCacheService.cs
+++ b/Services/TileCacheService.cs
@@ -323,42 +323,9 @@ public partial class TileCacheService
             _logger.LogWarning("Tile provider compatibility rejected upstream traffic before contact.");
             return TileRequestSendResult.Rejected(TileRequestRejection.InvalidProviderResponse);
         }
-        // Two-phase per-IP outbound budget: peek first (fast-fail without incrementing),
-        // then record the hit only after the global budget is acquired. This prevents
-        // budget-exhausted requests from inflating the per-IP counter, which previously
-        // caused cascading 503 rejections: on cold-cache loads with ~35 tiles, every
-        // request (including those rejected by the global budget) incremented the per-IP
-        // counter, so retries found the counter already past the limit and failed immediately.
-        // The initiating request charges this allowance once; retries do not charge it again.
-        // clientIp may be passed explicitly by callers (e.g., coalesced revalidation) where
-        // HttpContext is no longer available; falls back to HttpContext if not provided.
-        string? resolvedIpForBudget = null;
-        if (chargeClientAllowance)
-        {
-            var perIpLimit = providerPolicy.ClientSeriesPerMinute;
-            if (perIpLimit > 0)
-            {
-                resolvedIpForBudget = clientIp;
-                if (resolvedIpForBudget == null && allowHttpContext)
-                {
-                    var ctx = _httpContextAccessor.HttpContext;
-                    if (ctx != null)
-                    {
-                        resolvedIpForBudget = ResolveSchedulerClientKey(
-                            ctx, RateLimitHelper.GetClientIpAddress(ctx));
-                    }
-                }
-
-                if (resolvedIpForBudget != null && RateLimitHelper.WouldExceedRateLimit(
-                        TilesController.OutboundBudgetCache, resolvedIpForBudget, perIpLimit))
-                {
-                    TileCacheDiagnostics.ClientBudgetRejected(_logger, "outbound-client");
-                    _logger.LogWarning(
-                        "Per-client outbound tile allowance exceeded; upstream request rejected.");
-                    return TileRequestSendResult.Rejected(TileRequestRejection.ClientBudget);
-                }
-            }
-        }
+        if (!TryPrepareClientSeriesAllowance(providerPolicy, chargeClientAllowance,
+                clientIp, allowHttpContext, out var resolvedIpForBudget))
+            return TileRequestSendResult.Rejected(TileRequestRejection.ClientBudget);
 
         const int maxRedirects = 3;
         var initialUri = new Uri(tileUrl);

--- a/Services/TileCacheService.cs
+++ b/Services/TileCacheService.cs
@@ -318,6 +318,11 @@ public partial class TileCacheService
         CancellationToken cancellationToken = default)
     {
         providerPolicy ??= TileProviderPolicyResolver.Resolve(_applicationSettings.GetSettings(), _logger);
+        if (!providerPolicy.CanContactProvider)
+        {
+            _logger.LogWarning("Tile provider compatibility rejected upstream traffic before contact.");
+            return TileRequestSendResult.Rejected(TileRequestRejection.InvalidProviderResponse);
+        }
         // Two-phase per-IP outbound budget: peek first (fast-fail without incrementing),
         // then record the hit only after the global budget is acquired. This prevents
         // budget-exhausted requests from inflating the per-IP counter, which previously
@@ -330,7 +335,7 @@ public partial class TileCacheService
         string? resolvedIpForBudget = null;
         if (chargeClientAllowance)
         {
-            var perIpLimit = _applicationSettings.GetSettings().TileOutboundBudgetPerIpPerMinute;
+            var perIpLimit = providerPolicy.ClientSeriesPerMinute;
             if (perIpLimit > 0)
             {
                 resolvedIpForBudget = clientIp;
@@ -339,7 +344,8 @@ public partial class TileCacheService
                     var ctx = _httpContextAccessor.HttpContext;
                     if (ctx != null)
                     {
-                        resolvedIpForBudget = RateLimitHelper.GetClientIpAddress(ctx);
+                        resolvedIpForBudget = ResolveSchedulerClientKey(
+                            ctx, RateLimitHelper.GetClientIpAddress(ctx));
                     }
                 }
 
@@ -363,6 +369,13 @@ public partial class TileCacheService
 
         for (var redirectCount = 0; redirectCount <= maxRedirects; redirectCount++)
         {
+            // Compatibility is checked immediately before every possible transport contact.
+            if (TileProviderCatalog.IsBlockedContactHost(currentUri.IdnHost))
+            {
+                _logger.LogWarning("Blocked tile provider contact rejected before transport.");
+                return TileRequestSendResult.Rejected(TileRequestRejection.InvalidProviderResponse);
+            }
+
             if (contactState.IsExhausted)
             {
                 return TileRequestSendResult.Rejected(TileRequestRejection.ContactLimit);
@@ -533,6 +546,13 @@ public partial class TileCacheService
                 }
 
                 var nextUri = location.IsAbsoluteUri ? location : new Uri(currentUri, location);
+
+                if (TileProviderCatalog.IsBlockedContactHost(nextUri.IdnHost))
+                {
+                    _logger.LogWarning("Blocked tile provider redirect rejected before transport.");
+                    response.Dispose();
+                    return TileRequestSendResult.Rejected(TileRequestRejection.InvalidProviderResponse);
+                }
 
                 if (!string.Equals(nextUri.Host, initialUri.Host, StringComparison.OrdinalIgnoreCase))
                 {
@@ -1220,7 +1240,7 @@ public partial class TileCacheService
                 {
                     ScheduleBackgroundRefresh(
                         tileUrl, tileFilePath, tileKey, activeProvider.Fingerprint, zoomLvl, xVal, yVal,
-                        etag, lastModified, clientIp, publicOrigin);
+                        etag, lastModified, schedulerClientKey, publicOrigin);
                 }
 
                 // Graceful degradation: serve stale cached tile even when budget is exhausted
@@ -1271,7 +1291,7 @@ public partial class TileCacheService
                     schedulerClientKey,
                     sharedCancellation => RetrieveColdTileInFreshScopeAsync(
                         tileUrl, zoomLevel, xCoordinate, yCoordinate,
-                        activeProvider.Fingerprint, scopedTilePath, providerPolicy, clientIp, publicOrigin,
+                        activeProvider.Fingerprint, scopedTilePath, providerPolicy, schedulerClientKey, publicOrigin,
                         sharedCancellation),
                     cancellationToken);
             }

--- a/Services/TileClientSeriesAllowance.cs
+++ b/Services/TileClientSeriesAllowance.cs
@@ -1,0 +1,35 @@
+using Wayfarer.Areas.Public.Controllers;
+using Wayfarer.Parsers;
+using Wayfarer.Services;
+
+public partial class TileCacheService
+{
+    /// <summary>
+    /// Resolves and peeks the captured policy's opaque client-series allowance without charging it.
+    /// The caller records the charge only immediately before the first admitted transport contact.
+    /// </summary>
+    private bool TryPrepareClientSeriesAllowance(
+        Wayfarer.Services.TileProviderPolicy policy,
+        bool shouldCharge,
+        string? capturedOpaqueClientKey,
+        bool allowHttpContext,
+        out string? allowanceKey)
+    {
+        allowanceKey = null;
+        if (!shouldCharge || policy.ClientSeriesPerMinute <= 0)
+            return true;
+
+        allowanceKey = capturedOpaqueClientKey;
+        var context = allowHttpContext ? _httpContextAccessor.HttpContext : null;
+        if (allowanceKey == null && context != null)
+            allowanceKey = ResolveSchedulerClientKey(context, RateLimitHelper.GetClientIpAddress(context));
+
+        if (allowanceKey == null || !RateLimitHelper.WouldExceedRateLimit(
+                TilesController.OutboundBudgetCache, allowanceKey, policy.ClientSeriesPerMinute))
+            return true;
+
+        TileCacheDiagnostics.ClientBudgetRejected(_logger, "outbound-client");
+        _logger.LogWarning("Per-client outbound tile allowance exceeded; upstream request rejected.");
+        return false;
+    }
+}

--- a/Services/TileOutboundBudget.cs
+++ b/Services/TileOutboundBudget.cs
@@ -138,7 +138,7 @@ public partial class TileCacheService
             var stopwatch = Stopwatch.StartNew();
             var stateKey = string.Create(
                 System.Globalization.CultureInfo.InvariantCulture,
-                $"{profile.Identity}|{profile.SustainedRequestsPerSecond}|{profile.BurstCapacity}|{profile.MaxConcurrency}");
+                $"{profile.Identity}|{profile.UsesRateTokens}|{profile.SustainedRequestsPerSecond}|{profile.BurstCapacity}|{profile.MaxConcurrency}");
             var beforeProviderStateLock = _beforeProviderStateLock;
             if (beforeProviderStateLock != null)
             {
@@ -161,7 +161,8 @@ public partial class TileCacheService
                     await beforeCapacityWait(stateKey, cancellationToken).ConfigureAwait(false);
                 }
 
-                if (!await state.AcquireRateAsync(priority, cancellationToken).ConfigureAwait(false) ||
+                if ((profile.UsesRateTokens &&
+                     !await state.AcquireRateAsync(priority, cancellationToken).ConfigureAwait(false)) ||
                     !await state.AcquireConcurrencyAsync(priority, cancellationToken).ConfigureAwait(false))
                 {
                     stopwatch.Stop();
@@ -449,11 +450,19 @@ public partial class TileCacheService
             internal ProviderBudgetState(string stateKey, TileProviderPolicy profile)
             {
                 _stateKey = stateKey;
-                _tokens = new SemaphoreSlim(profile.BurstCapacity, profile.BurstCapacity);
+                var tokenCapacity = profile.UsesRateTokens ? profile.BurstCapacity : 1;
+                _tokens = new SemaphoreSlim(tokenCapacity, tokenCapacity);
                 _concurrency = new SemaphoreSlim(profile.MaxConcurrency, profile.MaxConcurrency);
-                var interval = TimeSpan.FromSeconds(1d / profile.SustainedRequestsPerSecond);
-                Interlocked.Increment(ref _providerReplenisherStarts);
-                _replenisher = Task.Run(() => ReplenishAsync(interval, profile.BurstCapacity));
+                if (profile.UsesRateTokens)
+                {
+                    var interval = TimeSpan.FromSeconds(1d / profile.SustainedRequestsPerSecond);
+                    Interlocked.Increment(ref _providerReplenisherStarts);
+                    _replenisher = Task.Run(() => ReplenishAsync(interval, profile.BurstCapacity));
+                }
+                else
+                {
+                    _replenisher = Task.CompletedTask;
+                }
             }
 
             internal DateTime LastUsedUtc { get; private set; } = DateTime.UtcNow;

--- a/Services/TileProviderPolicy.cs
+++ b/Services/TileProviderPolicy.cs
@@ -1,75 +1,109 @@
-using Wayfarer.Util;
 using Microsoft.Extensions.Logging;
+using Wayfarer.Util;
 
 namespace Wayfarer.Services;
 
+/// <summary>Administrator-selected outbound tile traffic behavior.</summary>
+public enum TileTrafficMode
+{
+    Interactive = 0,
+    Conservative = 1,
+    Custom = 2
+}
+
+/// <summary>Whether the persisted provider and endpoint may use Wayfarer's proxy/cache architecture.</summary>
+public enum TileProviderCompatibility
+{
+    Supported = 0,
+    Blocked = 1,
+    InvalidOrUnsupported = 2
+}
+
+/// <summary>Non-secret compatibility result captured with an upstream work series.</summary>
+internal sealed record TileProviderCompatibilityDecision(
+    TileProviderCompatibility Status,
+    string Source,
+    string Message);
+
 /// <summary>
-/// Immutable, non-secret transport and retry policy captured for one upstream work series.
+/// Immutable, non-secret compatibility, admission, transport, and retry policy captured for one work series.
 /// </summary>
 internal sealed record TileProviderPolicy(
     string Identity,
+    TileTrafficMode TrafficMode,
+    TileProviderCompatibilityDecision Compatibility,
+    bool UsesRateTokens,
     int SustainedRequestsPerSecond,
     int BurstCapacity,
     int MaxConcurrency,
+    int ClientSeriesPerMinute,
     int MaxAttempts,
     TimeSpan FallbackBaseDelay,
     TimeSpan FallbackDelayCap,
     TimeSpan MaxIndividualWait,
     TimeSpan TotalRetryCeiling,
-    bool PrefetchEnabled);
+    bool PrefetchEnabled)
+{
+    /// <summary>True only when the complete captured compatibility and scalar policy is eligible.</summary>
+    internal bool CanContactProvider => Compatibility.Status == TileProviderCompatibility.Supported;
+}
 
-/// <summary>
-/// Resolves administrator settings to an immutable provider policy without including credentials.
-/// </summary>
+/// <summary>Resolves persisted settings into one deterministic, fail-closed work-series policy.</summary>
 internal static class TileProviderPolicyResolver
 {
-    private static readonly TileProviderPolicyDefaults Defaults = new(
-        6, 20, 6, 3, 500, 4, 30, 45);
+    private const string WayfarerSafeguardsSource = "Wayfarer safeguards";
+    private static readonly TileProviderCompatibilityDecision Supported = new(
+        TileProviderCompatibility.Supported,
+        "Provider policy and Wayfarer compatibility rules",
+        "Compatible with Wayfarer's tile cache/proxy architecture.");
 
-    /// <summary>Resolves the active preset or bounded custom-provider policy.</summary>
+    /// <summary>Resolves compatibility before selecting an active traffic mode.</summary>
     internal static TileProviderPolicy Resolve(ApplicationSettings settings, ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(settings);
-        var canonicalOsm = TileProviderCatalog.IsCanonicalOsmTemplate(settings.TileProviderUrlTemplate);
-        var preset = canonicalOsm
-            ? TileProviderCatalog.FindPreset(ApplicationSettings.DefaultTileProviderKey)
-            : TileProviderCatalog.FindPreset(settings.TileProviderKey);
-
-        if (preset != null)
+        var compatibility = TileProviderCatalog.ResolveCompatibility(
+            settings.TileProviderKey, settings.TileProviderUrlTemplate);
+        if (compatibility.Status != TileProviderCompatibility.Supported)
         {
-            return Create($"builtin:{preset.Key.ToLowerInvariant()}", Defaults);
+            return Disabled(settings, compatibility);
         }
 
-        if (!settings.TileProviderAdvancedLimitsEnabled)
-        {
-            return Create("custom:default", Defaults);
-        }
+        var preset = TileProviderCatalog.FindPreset(settings.TileProviderKey);
+        var mode = preset == null && settings.TileProviderAdvancedLimitsEnabled
+            ? TileTrafficMode.Custom
+            : settings.TileTrafficMode == TileTrafficMode.Conservative
+                ? TileTrafficMode.Conservative
+                : TileTrafficMode.Interactive;
 
-        var errors = GetCustomValidationErrors(settings);
-        if (errors.Count > 0)
+        if (mode == TileTrafficMode.Custom)
         {
-            if (Interlocked.Exchange(ref _invalidProfileDiagnosticEmitted, 1) == 0)
+            var errors = GetCustomValidationErrors(settings);
+            if (errors.Count > 0)
             {
-                logger?.LogWarning(
-                    "Invalid persisted custom tile-provider limits were replaced with safe defaults.");
+                logger?.LogWarning("Invalid persisted custom tile-provider limits prevent upstream traffic.");
+                return Disabled(settings, new TileProviderCompatibilityDecision(
+                    TileProviderCompatibility.InvalidOrUnsupported,
+                    WayfarerSafeguardsSource,
+                    "Custom traffic values are invalid and must be corrected before activation."));
             }
-            return Create("custom:default", Defaults);
+
+            return Create(settings, mode, Supported, true,
+                settings.TileProviderSustainedRequestsPerSecond,
+                settings.TileProviderBurstCapacity,
+                settings.TileProviderMaxConcurrency,
+                settings.TileOutboundBudgetPerIpPerMinute);
         }
 
-        return new TileProviderPolicy(
-            "custom:advanced",
-            settings.TileProviderSustainedRequestsPerSecond,
-            settings.TileProviderBurstCapacity,
-            settings.TileProviderMaxConcurrency,
-            settings.TileProviderMaxAttempts,
-            TimeSpan.FromMilliseconds(settings.TileProviderFallbackBaseDelayMs),
-            TimeSpan.FromSeconds(settings.TileProviderFallbackDelayCapSeconds),
-            TimeSpan.FromSeconds(settings.TileProviderMaxIndividualWaitSeconds),
-            TimeSpan.FromSeconds(settings.TileProviderTotalRetryCeilingSeconds),
-            PrefetchEnabled: false);
+        if (mode == TileTrafficMode.Conservative)
+        {
+            return Create(settings, mode, Supported, true, 12, 40, 8, 480);
+        }
+
+        // Interactive deliberately has no proactive rate, burst, global-token, or client-series admission.
+        return Create(settings, mode, Supported, false, 0, 0, 6, 0);
     }
 
-    /// <summary>Validates cross-field invariants not expressible through range attributes.</summary>
+    /// <summary>Validates all Custom scalars and cross-field invariants.</summary>
     internal static IReadOnlyDictionary<string, string> ValidateCustom(ApplicationSettings settings)
     {
         var errors = GetCustomValidationErrors(settings);
@@ -81,70 +115,54 @@ internal static class TileProviderPolicyResolver
         return errors;
     }
 
-    private static int _invalidProfileDiagnosticEmitted;
+    private static TileProviderPolicy Create(
+        ApplicationSettings settings,
+        TileTrafficMode mode,
+        TileProviderCompatibilityDecision compatibility,
+        bool usesRateTokens,
+        int rate,
+        int burst,
+        int concurrency,
+        int allowance) =>
+        new($"{settings.TileProviderKey?.Trim().ToLowerInvariant()}:{mode.ToString().ToLowerInvariant()}",
+            mode, compatibility, usesRateTokens, rate, burst, concurrency, allowance,
+            settings.TileProviderMaxAttempts,
+            TimeSpan.FromMilliseconds(settings.TileProviderFallbackBaseDelayMs),
+            TimeSpan.FromSeconds(settings.TileProviderFallbackDelayCapSeconds),
+            TimeSpan.FromSeconds(settings.TileProviderMaxIndividualWaitSeconds),
+            TimeSpan.FromSeconds(settings.TileProviderTotalRetryCeilingSeconds), false);
+
+    private static TileProviderPolicy Disabled(
+        ApplicationSettings settings,
+        TileProviderCompatibilityDecision compatibility) =>
+        Create(settings, settings.TileTrafficMode, compatibility, false, 0, 0, 1, 0);
 
     private static Dictionary<string, string> GetCustomValidationErrors(ApplicationSettings settings)
     {
         var errors = new Dictionary<string, string>();
-        AddRangeError(errors, nameof(settings.TileProviderSustainedRequestsPerSecond),
-            settings.TileProviderSustainedRequestsPerSecond, 1, 20);
-        AddRangeError(errors, nameof(settings.TileProviderBurstCapacity),
-            settings.TileProviderBurstCapacity, 1, 50);
-        AddRangeError(errors, nameof(settings.TileProviderMaxConcurrency),
-            settings.TileProviderMaxConcurrency, 1, 16);
-        AddRangeError(errors, nameof(settings.TileProviderMaxAttempts),
-            settings.TileProviderMaxAttempts, 1, 3);
-        AddRangeError(errors, nameof(settings.TileProviderFallbackBaseDelayMs),
-            settings.TileProviderFallbackBaseDelayMs, 250, 5000);
-        AddRangeError(errors, nameof(settings.TileProviderFallbackDelayCapSeconds),
-            settings.TileProviderFallbackDelayCapSeconds, 1, 30);
-        AddRangeError(errors, nameof(settings.TileProviderMaxIndividualWaitSeconds),
-            settings.TileProviderMaxIndividualWaitSeconds, 1, 120);
-        AddRangeError(errors, nameof(settings.TileProviderTotalRetryCeilingSeconds),
-            settings.TileProviderTotalRetryCeilingSeconds, 5, 180);
+        AddRangeError(errors, nameof(settings.TileProviderSustainedRequestsPerSecond), settings.TileProviderSustainedRequestsPerSecond, 1, 20);
+        AddRangeError(errors, nameof(settings.TileProviderBurstCapacity), settings.TileProviderBurstCapacity, 1, 50);
+        AddRangeError(errors, nameof(settings.TileProviderMaxConcurrency), settings.TileProviderMaxConcurrency, 1, 16);
+        AddRangeError(errors, nameof(settings.TileOutboundBudgetPerIpPerMinute), settings.TileOutboundBudgetPerIpPerMinute, 0, 1000);
+        AddRangeError(errors, nameof(settings.TileProviderMaxAttempts), settings.TileProviderMaxAttempts, 1, 3);
+        AddRangeError(errors, nameof(settings.TileProviderFallbackBaseDelayMs), settings.TileProviderFallbackBaseDelayMs, 250, 5000);
+        AddRangeError(errors, nameof(settings.TileProviderFallbackDelayCapSeconds), settings.TileProviderFallbackDelayCapSeconds, 1, 30);
+        AddRangeError(errors, nameof(settings.TileProviderMaxIndividualWaitSeconds), settings.TileProviderMaxIndividualWaitSeconds, 1, 120);
+        AddRangeError(errors, nameof(settings.TileProviderTotalRetryCeilingSeconds), settings.TileProviderTotalRetryCeilingSeconds, 5, 180);
 
         if (settings.TileProviderBurstCapacity < settings.TileProviderMaxConcurrency)
-        {
-            errors[nameof(settings.TileProviderBurstCapacity)] =
-                "Burst capacity must be at least maximum concurrency.";
-        }
-
-        if (TimeSpan.FromSeconds(settings.TileProviderFallbackDelayCapSeconds) <
-            TimeSpan.FromMilliseconds(settings.TileProviderFallbackBaseDelayMs))
-        {
-            errors[nameof(settings.TileProviderFallbackDelayCapSeconds)] =
-                "Fallback delay cap must not be below the base delay.";
-        }
-
-        if (settings.TileProviderTotalRetryCeilingSeconds <
-            settings.TileProviderMaxIndividualWaitSeconds)
-        {
-            errors[nameof(settings.TileProviderTotalRetryCeilingSeconds)] =
-                "Total retry ceiling must not be below maximum individual wait.";
-        }
+            errors[nameof(settings.TileProviderBurstCapacity)] = "Burst capacity must be at least maximum concurrency.";
+        if (TimeSpan.FromSeconds(settings.TileProviderFallbackDelayCapSeconds) < TimeSpan.FromMilliseconds(settings.TileProviderFallbackBaseDelayMs))
+            errors[nameof(settings.TileProviderFallbackDelayCapSeconds)] = "Fallback delay cap must not be below the base delay.";
+        if (settings.TileProviderTotalRetryCeilingSeconds < settings.TileProviderMaxIndividualWaitSeconds)
+            errors[nameof(settings.TileProviderTotalRetryCeilingSeconds)] = "Total retry ceiling must not be below maximum individual wait.";
 
         return errors;
     }
 
-    private static void AddRangeError(
-        IDictionary<string, string> errors,
-        string field,
-        int value,
-        int minimum,
-        int maximum)
+    private static void AddRangeError(IDictionary<string, string> errors, string field, int value, int minimum, int maximum)
     {
         if (value < minimum || value > maximum)
-        {
             errors[field] = $"{field} must be between {minimum} and {maximum}.";
-        }
     }
-
-    private static TileProviderPolicy Create(string identity, TileProviderPolicyDefaults values) =>
-        new(identity, values.Rate, values.Burst, values.Concurrency, values.Attempts,
-            TimeSpan.FromMilliseconds(values.BaseDelayMs), TimeSpan.FromSeconds(values.DelayCapSeconds),
-            TimeSpan.FromSeconds(values.MaxWaitSeconds), TimeSpan.FromSeconds(values.TotalSeconds), false);
-
-    private sealed record TileProviderPolicyDefaults(
-        int Rate, int Burst, int Concurrency, int Attempts, int BaseDelayMs,
-        int DelayCapSeconds, int MaxWaitSeconds, int TotalSeconds);
 }

--- a/Services/TileProviderPolicy.cs
+++ b/Services/TileProviderPolicy.cs
@@ -23,6 +23,7 @@ public enum TileProviderCompatibility
 internal sealed record TileProviderCompatibilityDecision(
     TileProviderCompatibility Status,
     string Source,
+    string AuditSource,
     string Message);
 
 /// <summary>
@@ -46,6 +47,18 @@ internal sealed record TileProviderPolicy(
 {
     /// <summary>True only when the complete captured compatibility and scalar policy is eligible.</summary>
     internal bool CanContactProvider => Compatibility.Status == TileProviderCompatibility.Supported;
+
+    /// <summary>Whether sustained-rate admission is effective for this policy.</summary>
+    internal bool IsRateActive => CanContactProvider && UsesRateTokens;
+
+    /// <summary>Whether burst-token admission is effective for this policy.</summary>
+    internal bool IsBurstActive => CanContactProvider && UsesRateTokens;
+
+    /// <summary>Whether provider-contact concurrency is effective for this policy.</summary>
+    internal bool IsConcurrencyActive => CanContactProvider;
+
+    /// <summary>Whether the per-client admitted-series allowance is effective.</summary>
+    internal bool IsClientSeriesAllowanceActive => CanContactProvider && ClientSeriesPerMinute > 0;
 }
 
 /// <summary>Resolves persisted settings into one deterministic, fail-closed work-series policy.</summary>
@@ -78,6 +91,7 @@ internal static class TileProviderPolicyResolver
                 logger?.LogWarning("Invalid persisted custom tile-provider limits prevent upstream traffic.");
                 return Disabled(settings, new TileProviderCompatibilityDecision(
                     TileProviderCompatibility.InvalidOrUnsupported,
+                    WayfarerSafeguardsSource,
                     WayfarerSafeguardsSource,
                     "Custom traffic values are invalid and must be corrected before activation."));
             }

--- a/Services/TileProviderPolicy.cs
+++ b/Services/TileProviderPolicy.cs
@@ -95,7 +95,15 @@ internal static class TileProviderPolicyResolver
         }
 
         // Interactive deliberately has no proactive rate, burst, global-token, or client-series admission.
-        return Create(settings, mode, compatibility, false, 0, 0, 6, 0);
+        return Create(
+            settings,
+            mode,
+            compatibility,
+            false,
+            0,
+            0,
+            TileWorkScheduler.ForegroundConcurrency,
+            0);
     }
 
     /// <summary>Validates all Custom scalars and cross-field invariants.</summary>

--- a/Services/TileProviderPolicy.cs
+++ b/Services/TileProviderPolicy.cs
@@ -52,11 +52,6 @@ internal sealed record TileProviderPolicy(
 internal static class TileProviderPolicyResolver
 {
     private const string WayfarerSafeguardsSource = "Wayfarer safeguards";
-    private static readonly TileProviderCompatibilityDecision Supported = new(
-        TileProviderCompatibility.Supported,
-        "Provider policy and Wayfarer compatibility rules",
-        "Compatible with Wayfarer's tile cache/proxy architecture.");
-
     /// <summary>Resolves compatibility before selecting an active traffic mode.</summary>
     internal static TileProviderPolicy Resolve(ApplicationSettings settings, ILogger? logger = null)
     {
@@ -87,7 +82,7 @@ internal static class TileProviderPolicyResolver
                     "Custom traffic values are invalid and must be corrected before activation."));
             }
 
-            return Create(settings, mode, Supported, true,
+            return Create(settings, mode, compatibility, true,
                 settings.TileProviderSustainedRequestsPerSecond,
                 settings.TileProviderBurstCapacity,
                 settings.TileProviderMaxConcurrency,
@@ -96,11 +91,11 @@ internal static class TileProviderPolicyResolver
 
         if (mode == TileTrafficMode.Conservative)
         {
-            return Create(settings, mode, Supported, true, 12, 40, 8, 480);
+            return Create(settings, mode, compatibility, true, 12, 40, 8, 480);
         }
 
         // Interactive deliberately has no proactive rate, burst, global-token, or client-series admission.
-        return Create(settings, mode, Supported, false, 0, 0, 6, 0);
+        return Create(settings, mode, compatibility, false, 0, 0, 6, 0);
     }
 
     /// <summary>Validates all Custom scalars and cross-field invariants.</summary>

--- a/Util/TileProviderCatalog.cs
+++ b/Util/TileProviderCatalog.cs
@@ -83,7 +83,13 @@ public static class TileProviderCatalog
             "opentopomap" => "https://services.opentopomap.org/about",
             _ => "Administrator-managed provider agreement"
         };
-        return new(TileProviderCompatibility.Supported, source, "Supported.");
+        var auditSource = normalizedKey switch
+        {
+            ApplicationSettings.DefaultTileProviderKey => "OSM tile policy",
+            "opentopomap" => "OpenTopoMap usage policy",
+            _ => "Administrator-managed provider agreement"
+        };
+        return new(TileProviderCompatibility.Supported, source, auditSource, "Supported.");
     }
 
     /// <summary>Returns true for an exact maintained host or one of its DNS subdomains.</summary>
@@ -94,10 +100,20 @@ public static class TileProviderCatalog
     }
 
     private static TileProviderCompatibilityDecision Blocked(string source, string message) =>
-        new(TileProviderCompatibility.Blocked, source, message);
+        new(
+            TileProviderCompatibility.Blocked,
+            source,
+            source.Contains("thunderforest", StringComparison.OrdinalIgnoreCase)
+                ? "Thunderforest terms"
+                : "CARTO basemap policy",
+            message);
 
     private static TileProviderCompatibilityDecision Invalid(string message) =>
-        new(TileProviderCompatibility.InvalidOrUnsupported, "Wayfarer compatibility validation", message);
+        new(
+            TileProviderCompatibility.InvalidOrUnsupported,
+            "Wayfarer compatibility validation",
+            "Wayfarer compatibility validation",
+            message);
 
     private static string NormalizeHost(string? host) => (host ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
 

--- a/Util/TileProviderCatalog.cs
+++ b/Util/TileProviderCatalog.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using Wayfarer.Models;
+using Wayfarer.Services;
 
 namespace Wayfarer.Util;
 
@@ -28,30 +29,74 @@ public static class TileProviderCatalog
             ApplicationSettings.DefaultTileProviderAttribution,
             requiresApiKey: false),
         new TileProviderDefinition(
-            "carto-positron",
-            "CARTO Positron (Light)",
-            "https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png",
-            "&copy; OpenStreetMap contributors &copy; CARTO",
-            requiresApiKey: false),
-        new TileProviderDefinition(
-            "carto-dark",
-            "CARTO Dark Matter",
-            "https://cartodb-basemaps-a.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png",
-            "&copy; OpenStreetMap contributors &copy; CARTO",
-            requiresApiKey: false),
-        new TileProviderDefinition(
             "opentopomap",
             "OpenTopoMap",
             "https://a.tile.opentopomap.org/{z}/{x}/{y}.png",
-            "&copy; OpenStreetMap contributors, SRTM | &copy; OpenTopoMap",
-            requiresApiKey: false),
-        new TileProviderDefinition(
-            "thunderforest-cycle",
-            "Thunderforest Cycle (API key required)",
-            "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey={apiKey}",
-            "&copy; OpenStreetMap contributors &copy; Thunderforest",
-            requiresApiKey: true)
+            "Map data: &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors, SRTM | Map style: &copy; <a href=\"https://opentopomap.org\">OpenTopoMap</a> (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a>)",
+            requiresApiKey: false)
     };
+
+    private static readonly string[] ThunderforestKeys = ["thunderforest-cycle"];
+    private static readonly string[] CartoKeys = ["carto-positron", "carto-dark"];
+    private static readonly string[] ThunderforestHosts = ["tile.thunderforest.com", "api.thunderforest.com"];
+    private static readonly string[] CartoHosts =
+    [
+        "cartodb-basemaps-a.global.ssl.fastly.net",
+        "cartodb-basemaps-b.global.ssl.fastly.net",
+        "cartodb-basemaps-c.global.ssl.fastly.net",
+        "cartodb-basemaps-d.global.ssl.fastly.net",
+        "basemaps.cartocdn.com"
+    ];
+
+    /// <summary>Resolves provider compatibility from both persisted key and normalized endpoint.</summary>
+    internal static TileProviderCompatibilityDecision ResolveCompatibility(string? key, string? template)
+    {
+        var normalizedKey = key?.Trim().ToLowerInvariant() ?? string.Empty;
+        if (ThunderforestKeys.Contains(normalizedKey, StringComparer.Ordinal))
+            return Blocked("Thunderforest terms", "This removed Thunderforest provider is incompatible with Wayfarer's cache/proxy architecture.");
+        if (CartoKeys.Contains(normalizedKey, StringComparer.Ordinal))
+            return Blocked("CARTO licensing", "This removed CARTO provider is not available through Wayfarer's cache/proxy architecture.");
+
+        if (!TryCreateTemplateUri(template?.Trim() ?? string.Empty, out var uri, out _))
+            return Invalid("The provider endpoint is blank or malformed.");
+
+        var host = NormalizeHost(uri.IdnHost);
+        if (MatchesHostSet(host, ThunderforestHosts))
+            return Blocked("Thunderforest terms", "The endpoint is blocked for compatibility.");
+        if (MatchesHostSet(host, CartoHosts))
+            return Blocked("CARTO licensing", "The endpoint is blocked for compatibility.");
+
+        var preset = FindPreset(normalizedKey);
+        if (preset != null)
+        {
+            if (!string.Equals(NormalizeTemplate(template!), NormalizeTemplate(preset.UrlTemplate), StringComparison.Ordinal))
+                return Invalid("The selected built-in provider endpoint does not match its maintained preset.");
+        }
+        else if (!string.Equals(normalizedKey, CustomProviderKey, StringComparison.Ordinal))
+        {
+            return Invalid("The provider selection is removed or unknown.");
+        }
+
+        return new(TileProviderCompatibility.Supported, "Provider policy and Wayfarer compatibility rules", "Supported.");
+    }
+
+    /// <summary>Returns true for an exact maintained host or one of its DNS subdomains.</summary>
+    internal static bool IsBlockedContactHost(string? host)
+    {
+        var normalized = NormalizeHost(host);
+        return MatchesHostSet(normalized, ThunderforestHosts) || MatchesHostSet(normalized, CartoHosts);
+    }
+
+    private static TileProviderCompatibilityDecision Blocked(string source, string message) =>
+        new(TileProviderCompatibility.Blocked, source, message);
+
+    private static TileProviderCompatibilityDecision Invalid(string message) =>
+        new(TileProviderCompatibility.InvalidOrUnsupported, "Wayfarer compatibility validation", message);
+
+    private static string NormalizeHost(string? host) => (host ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+
+    private static bool MatchesHostSet(string host, IEnumerable<string> blockedHosts) =>
+        blockedHosts.Any(blocked => host.Equals(blocked, StringComparison.Ordinal) || host.EndsWith($".{blocked}", StringComparison.Ordinal));
 
     /// <summary>
     /// Attempts to resolve a preset provider by key.

--- a/Util/TileProviderCatalog.cs
+++ b/Util/TileProviderCatalog.cs
@@ -53,18 +53,18 @@ public static class TileProviderCatalog
     {
         var normalizedKey = key?.Trim().ToLowerInvariant() ?? string.Empty;
         if (ThunderforestKeys.Contains(normalizedKey, StringComparer.Ordinal))
-            return Blocked("Thunderforest terms", "This removed Thunderforest provider is incompatible with Wayfarer's cache/proxy architecture.");
+            return Blocked("https://www.thunderforest.com/terms/", "This removed Thunderforest provider is incompatible with Wayfarer's cache/proxy architecture.");
         if (CartoKeys.Contains(normalizedKey, StringComparer.Ordinal))
-            return Blocked("CARTO licensing", "This removed CARTO provider is not available through Wayfarer's cache/proxy architecture.");
+            return Blocked("https://docs.carto.com/faqs/carto-basemaps", "This removed CARTO provider is not available through Wayfarer's cache/proxy architecture.");
 
         if (!TryCreateTemplateUri(template?.Trim() ?? string.Empty, out var uri, out _))
             return Invalid("The provider endpoint is blank or malformed.");
 
         var host = NormalizeHost(uri.IdnHost);
         if (MatchesHostSet(host, ThunderforestHosts))
-            return Blocked("Thunderforest terms", "The endpoint is blocked for compatibility.");
+            return Blocked("https://www.thunderforest.com/terms/", "The endpoint is blocked for compatibility.");
         if (MatchesHostSet(host, CartoHosts))
-            return Blocked("CARTO licensing", "The endpoint is blocked for compatibility.");
+            return Blocked("https://docs.carto.com/faqs/carto-basemaps", "The endpoint is blocked for compatibility.");
 
         var preset = FindPreset(normalizedKey);
         if (preset != null)
@@ -77,7 +77,13 @@ public static class TileProviderCatalog
             return Invalid("The provider selection is removed or unknown.");
         }
 
-        return new(TileProviderCompatibility.Supported, "Provider policy and Wayfarer compatibility rules", "Supported.");
+        var source = normalizedKey switch
+        {
+            ApplicationSettings.DefaultTileProviderKey => "https://operations.osmfoundation.org/policies/tiles/",
+            "opentopomap" => "https://services.opentopomap.org/about",
+            _ => "Administrator-managed provider agreement"
+        };
+        return new(TileProviderCompatibility.Supported, source, "Supported.");
     }
 
     /// <summary>Returns true for an exact maintained host or one of its DNS subdomains.</summary>

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -278,11 +278,14 @@ If configuring manually, add these lines to `/etc/systemd/system/wayfarer.servic
 ```ini
 Environment="ConnectionStrings__DefaultConnection=Host=localhost;Database=wayfarer;Username=wayfarer_user;Password=YOUR_SECURE_PASSWORD"
 Environment=Application__ContactEmail=admin@your-domain.example
-Environment=AllowedHosts=wayfarer.example.com
+# One exact public hostname
+Environment="AllowedHosts=wayfarer.example.com"
+# Multiple exact public hostnames
+Environment="AllowedHosts=wayfarer.example.com;www.wayfarer.example.com"
 ```
 
 The `Application__ContactEmail` is included in the User-Agent header sent to tile providers (e.g. OpenStreetMap) for policy compliance.
-`AllowedHosts` authorizes the public Wayfarer hostname used for the origin-only provider Referer. Do not use wildcards: wildcard configuration deliberately omits the Referer and may recreate provider 403 responses. The installer preserves a valid existing hostname before considering `CERTBOT_DOMAIN`; otherwise it prompts or warns without guessing.
+`AllowedHosts` authorizes the public Wayfarer hostnames used for the origin-only provider Referer. Enter semicolon-separated exact public DNS hostnames. Do not include wildcards, IP literals, localhost/private names, ports, or URL schemes. The installer preserves a valid existing hostname list before considering `CERTBOT_DOMAIN`; otherwise it prompts or warns without guessing.
 
 Then reload: `sudo systemctl daemon-reload && sudo systemctl restart wayfarer`
 

--- a/deployment/install.sh
+++ b/deployment/install.sh
@@ -719,7 +719,8 @@ echo "========================================="
 echo " Configuring the public Wayfarer hostname"
 echo "========================================="
 echo ""
-echo "Wayfarer uses AllowedHosts to authorize the origin-only Referer sent to tile providers."
+echo "Wayfarer uses semicolon-separated exact public DNS names in AllowedHosts to authorize the origin-only Referer."
+echo "Do not enter wildcards, IP literals, localhost/private names, ports, or URL schemes."
 
 if is_valid_public_host_configuration "$ALLOWED_HOSTS"; then
   ALLOWED_HOSTS="$(normalize_public_host_configuration "$ALLOWED_HOSTS")"
@@ -731,7 +732,7 @@ elif is_valid_public_host_configuration "$CERTBOT_DOMAIN"; then
   ALLOWED_HOSTS="$(normalize_public_host_configuration "$CERTBOT_DOMAIN")"
   echo "Using the public domain already supplied for Certbot: $ALLOWED_HOSTS"
 elif [[ $NONINTERACTIVE -eq 0 ]]; then
-  read -rp "Public Wayfarer hostname (leave blank to configure manually): " ALLOWED_HOSTS
+  read -rp "Public Wayfarer hostname(s), separated by semicolons (leave blank to configure manually): " ALLOWED_HOSTS
   if is_valid_public_host_configuration "$ALLOWED_HOSTS"; then
     ALLOWED_HOSTS="$(normalize_public_host_configuration "$ALLOWED_HOSTS")"
   else
@@ -758,7 +759,8 @@ elif [[ -n "$ALLOWED_HOSTS" ]]; then
 else
   echo "⚠ No public hostname was supplied; existing AllowedHosts configuration was left unchanged."
   echo "  Configure the real public Wayfarer hostname before restart:"
-  echo "  Environment=AllowedHosts=wayfarer.example.com"
+  echo "  Environment=\"AllowedHosts=wayfarer.example.com\""
+  echo "  Environment=\"AllowedHosts=wayfarer.example.com;www.wayfarer.example.com\""
   echo "  A wildcard does not authorize an upstream Referer and may cause tile-provider 403 responses."
 fi
 

--- a/deployment/wayfarer.service
+++ b/deployment/wayfarer.service
@@ -66,7 +66,10 @@ Environment=HOME=/home/wayfarer
 # PUBLIC WAYFARER HOSTNAME
 # Required to send a trustworthy origin-only Referer to tile providers.
 # Use the public hostname only, without a scheme, port, path, or wildcard.
-# Environment=AllowedHosts=wayfarer.example.com
+# One exact public hostname:
+# Environment="AllowedHosts=wayfarer.example.com"
+# Multiple exact public hostnames:
+# Environment="AllowedHosts=wayfarer.example.com;www.wayfarer.example.com"
 
 # DATABASE CONNECTION STRING
 # This overrides the placeholder in appsettings.json - REQUIRED for production!

--- a/docs/02-Install-and-Dependencies.md
+++ b/docs/02-Install-and-Dependencies.md
@@ -151,7 +151,7 @@ Edit `appsettings.json`:
 
 - **`Logging:LogFilePath:Default`** - Where application logs are written (ensure directory exists and is writable)
 - **`CacheSettings:TileCacheDirectory`** - Where map tiles are cached locally
-- **`AllowedHosts`** - Configure for your domain in production
+- **`AllowedHosts`** - Configure semicolon-separated exact public DNS hostnames in production; do not use wildcards, IP literals, localhost/private names, or ports
 
 ### Environment-Specific Configuration
 

--- a/docs/03-Features.md
+++ b/docs/03-Features.md
@@ -10,7 +10,7 @@ Wayfarer is a comprehensive self-hosted travel companion with location tracking,
 
 - **Interactive maps** with configurable tile providers.
 - **Tile provider settings** (Admin > Settings):
-  - Built-in presets: OpenStreetMap Standard, CARTO Light/Dark, OpenTopoMap, and Thunderforest Cycle.
+  - Built-in presets: OpenStreetMap Standard and OpenTopoMap. Removed Thunderforest/CARTO configurations are preserved for recovery but blocked before contact.
   - Custom tile URL templates with API key placeholders.
   - Optional bounded custom-provider rate, burst, concurrency, and retry limits.
   - Dynamic map attribution from active provider.

--- a/docs/09-Troubleshooting.md
+++ b/docs/09-Troubleshooting.md
@@ -7,7 +7,7 @@ Sign‑In Issues
 Maps Not Loading
 - Check connectivity.
 - Ask your admin if tile cache path is configured and accessible.
-- **403 "Referrer is required"**: The tile provider (e.g. OpenStreetMap) is blocking requests. Configure `AllowedHosts` with Wayfarer's real public hostname so the application can derive a trustworthy origin-only Referer. Also configure `Application:ContactEmail` for the User-Agent contact identity; it does not configure Referer.
+- **403 "Referrer is required"**: Configure `AllowedHosts=wayfarer.example.com` for one hostname or `AllowedHosts=wayfarer.example.com;www.wayfarer.example.com` for several. Entries are semicolon-separated exact public DNS hostnames; wildcards, IP literals, localhost/private names, ports, and URL schemes are invalid. Also configure `Application:ContactEmail` for the User-Agent contact identity; it does not configure Referer.
 
 Imports Fail or Hang
 - Verify file format/size and required fields.

--- a/docs/16-Configuration.md
+++ b/docs/16-Configuration.md
@@ -23,7 +23,7 @@ Logging
 
 Application
 - `Application:ContactEmail` — contact email included in the User-Agent header sent to tile providers (e.g. OpenStreetMap). OSM's tile usage policy requires an honest User-Agent identifying the application. Set this to a monitored email address. Default: `noreply@wayfarer.app`. In production, configure via systemd environment variable: `Application__ContactEmail=admin@your-domain.example`.
-- `AllowedHosts` — semicolon-separated public hostnames allowed to address Wayfarer and supply its origin-only tile-provider Referer. Production must configure the real public hostname through `AllowedHosts=wayfarer.example.com`; `*`, IP literals, localhost, and private names are not trusted for the provider Referer. Ports received through trusted forwarded headers are preserved after hostname authorization.
+- `AllowedHosts` — semicolon-separated exact public DNS hostnames allowed to address Wayfarer and supply its origin-only tile-provider Referer. Use `AllowedHosts=wayfarer.example.com` for one hostname or `AllowedHosts=wayfarer.example.com;www.wayfarer.example.com` for several. Do not include wildcards, IP literals, localhost/private names, ports, or URL schemes. Ports received separately through trusted forwarded headers are preserved after hostname authorization.
 
 CacheSettings
 - `CacheSettings:TileCacheDirectory` — local directory for map tile cache.
@@ -32,7 +32,7 @@ CacheSettings
 Tile Provider Settings (Admin UI)
 - **Tile Provider** — select from presets (OpenStreetMap, Carto Light/Dark, ESRI Satellite) or configure a custom URL template.
 - **Custom URL Template** — use `{z}`, `{x}`, `{y}` placeholders; optionally `{apikey}` for providers requiring authentication.
-- **API Key** — stored securely for tile providers that require it (e.g., Mapbox, Thunderforest).
+- **API Key** — stored securely for compatible Custom providers that require it.
 - **Attribution** — HTML attribution text displayed on maps; auto-filled for presets.
 - Provider changes trigger automatic cache purge to avoid tile mixing.
 

--- a/docs/17-Services.md
+++ b/docs/17-Services.md
@@ -145,7 +145,9 @@ This document covers the key services, file parsers, and background jobs in the 
 ### TileCacheService
 - Manages provider-isolated map tile caching and bounded foreground/background scheduling.
 - Built-in profiles use Wayfarer operational defaults of 6 upstream contacts/second,
-  burst 20, and concurrency 6. These values are not provider-published guarantees or allowances.
+  Interactive bypasses proactive contact-rate, burst, and client-series admission while retaining concurrency 6.
+  Conservative uses Wayfarer safeguards of 12 actual contacts/second, burst 40, concurrency 8, and 480 admitted series/client/minute.
+  These values are not provider-published guarantees or allowances.
 - OSM Standard is best-effort with no SLA; prefetch, offline download, adjacent-zoom warming,
   and other cache-warming traffic are not permitted.
 - Custom-provider administrators are responsible for configuring advanced limits according to

--- a/docs/20-Deployment.md
+++ b/docs/20-Deployment.md
@@ -370,14 +370,16 @@ Environment=ASPNETCORE_ENVIRONMENT=Production
 Environment=HOME=/home/wayfarer
 # Contact email for tile provider User-Agent (OSM compliance)
 Environment=Application__ContactEmail=admin@your-domain.example
-# Public hostname authorized for the origin-only tile provider Referer
-Environment=AllowedHosts=wayfarer.example.com
+# One exact public hostname authorized for the origin-only tile provider Referer
+Environment="AllowedHosts=wayfarer.example.com"
+# Multiple exact public hostnames
+Environment="AllowedHosts=wayfarer.example.com;www.wayfarer.example.com"
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-Replace `wayfarer.example.com` with the real public hostname. Do not leave `AllowedHosts` as `*` in production: Wayfarer will omit the upstream Referer because a wildcard cannot establish a trustworthy deployment origin, and providers such as OSM may respond with 403.
+Replace the examples with semicolon-separated exact public DNS hostnames. Do not include wildcards, IP literals, localhost/private names, ports, or URL schemes. A wildcard cannot establish a trustworthy deployment origin, so Wayfarer omits the upstream Referer and providers may respond with 403.
 
 ```bash
 sudo systemctl daemon-reload

--- a/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
@@ -294,7 +294,9 @@ public class AdminSettingsControllerTests : TestBase
         };
         db.ApplicationSettings.Add(existing);
         await db.SaveChangesAsync();
-        var originalIdentity = TileProviderCatalog.CreateCacheIdentity(providerKey, template);
+        TileProviderCacheIdentity? originalIdentity = Uri.TryCreate(template, UriKind.Absolute, out _)
+            ? TileProviderCatalog.CreateCacheIdentity(providerKey, template)
+            : null;
         var (controller, _, _) = BuildController(db);
 
         var result = await controller.Update(new ApplicationSettings
@@ -319,8 +321,11 @@ public class AdminSettingsControllerTests : TestBase
         Assert.Equal(7, stored.TileProviderFallbackDelayCapSeconds);
         Assert.Equal(44, stored.TileProviderMaxIndividualWaitSeconds);
         Assert.Equal(88, stored.TileProviderTotalRetryCeilingSeconds);
-        Assert.Equal(originalIdentity, TileProviderCatalog.CreateCacheIdentity(
-            stored.TileProviderKey, stored.TileProviderUrlTemplate));
+        if (originalIdentity != null)
+        {
+            Assert.Equal(originalIdentity, TileProviderCatalog.CreateCacheIdentity(
+                stored.TileProviderKey, stored.TileProviderUrlTemplate));
+        }
     }
 
     /// <summary>A successful policy save emits one complete bounded non-secret transition.</summary>

--- a/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
@@ -21,7 +21,7 @@ namespace Wayfarer.Tests.Controllers;
 /// <summary>
 /// Admin settings controller basics.
 /// </summary>
-public class AdminSettingsControllerTests : TestBase
+public partial class AdminSettingsControllerTests : TestBase
 {
     [Fact]
     public async Task Index_ReturnsView_WithSettings()
@@ -259,105 +259,6 @@ public class AdminSettingsControllerTests : TestBase
         Assert.Equal(ApplicationSettings.DefaultTileProviderUrlTemplate, stored.TileProviderUrlTemplate);
         Assert.Contains("OpenStreetMap contributors", stored.TileProviderAttribution);
         Assert.DoesNotContain("Wrong provider", stored.TileProviderAttribution);
-    }
-
-    /// <summary>Unsupported persisted provider state survives an unrelated normal form save.</summary>
-    [Theory]
-    [InlineData("thunderforest-cycle", "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")]
-    [InlineData("carto-dark", "https://cartodb-basemaps-a.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png")]
-    [InlineData("retired-provider", "https://tiles.retired.example/{z}/{x}/{y}.png")]
-    [InlineData("", "")]
-    [InlineData("custom", "malformed endpoint")]
-    public async Task Update_UnrelatedSavePreservesUnsupportedProviderRecoveryState(
-        string providerKey, string template)
-    {
-        const string attribution = "Recovery attribution";
-        const string apiKey = "recovery-secret";
-        var db = CreateDbContext();
-        var existing = new ApplicationSettings
-        {
-            Id = 1,
-            TileProviderKey = providerKey,
-            TileProviderUrlTemplate = template,
-            TileProviderAttribution = attribution,
-            TileProviderApiKey = apiKey,
-            TileProviderSustainedRequestsPerSecond = 17,
-            TileProviderBurstCapacity = 41,
-            TileProviderMaxConcurrency = 9,
-            TileOutboundBudgetPerIpPerMinute = 321,
-            TileProviderMaxAttempts = 2,
-            TileProviderFallbackBaseDelayMs = 750,
-            TileProviderFallbackDelayCapSeconds = 7,
-            TileProviderMaxIndividualWaitSeconds = 44,
-            TileProviderTotalRetryCeilingSeconds = 88,
-            IsRegistrationOpen = false
-        };
-        db.ApplicationSettings.Add(existing);
-        await db.SaveChangesAsync();
-        TileProviderCacheIdentity? originalIdentity = Uri.TryCreate(template, UriKind.Absolute, out _)
-            ? TileProviderCatalog.CreateCacheIdentity(providerKey, template)
-            : null;
-        var (controller, _, _) = BuildController(db);
-
-        var result = await controller.Update(new ApplicationSettings
-        {
-            Id = 1,
-            IsRegistrationOpen = true,
-            TileProviderKey = providerKey
-        });
-
-        Assert.IsType<RedirectToActionResult>(result);
-        var stored = Assert.IsType<ApplicationSettings>(await db.ApplicationSettings.FindAsync(1));
-        Assert.Equal(providerKey, stored.TileProviderKey);
-        Assert.Equal(template, stored.TileProviderUrlTemplate);
-        Assert.Equal(attribution, stored.TileProviderAttribution);
-        Assert.Equal(apiKey, stored.TileProviderApiKey);
-        Assert.Equal(17, stored.TileProviderSustainedRequestsPerSecond);
-        Assert.Equal(41, stored.TileProviderBurstCapacity);
-        Assert.Equal(9, stored.TileProviderMaxConcurrency);
-        Assert.Equal(321, stored.TileOutboundBudgetPerIpPerMinute);
-        Assert.Equal(2, stored.TileProviderMaxAttempts);
-        Assert.Equal(750, stored.TileProviderFallbackBaseDelayMs);
-        Assert.Equal(7, stored.TileProviderFallbackDelayCapSeconds);
-        Assert.Equal(44, stored.TileProviderMaxIndividualWaitSeconds);
-        Assert.Equal(88, stored.TileProviderTotalRetryCeilingSeconds);
-        if (originalIdentity != null)
-        {
-            Assert.Equal(originalIdentity, TileProviderCatalog.CreateCacheIdentity(
-                stored.TileProviderKey, stored.TileProviderUrlTemplate));
-        }
-    }
-
-    /// <summary>A successful policy save emits one complete bounded non-secret transition.</summary>
-    [Fact]
-    public async Task Update_TrafficModeAuditsCompleteEffectivePolicyOnce()
-    {
-        var db = CreateDbContext();
-        db.ApplicationSettings.Add(new ApplicationSettings { Id = 1 });
-        await db.SaveChangesAsync();
-        var (controller, _, _) = BuildController(db);
-        var updated = new ApplicationSettings
-        {
-            Id = 1,
-            TileProviderKey = ApplicationSettings.DefaultTileProviderKey,
-            TileProviderUrlTemplate = ApplicationSettings.DefaultTileProviderUrlTemplate,
-            TileProviderAttribution = ApplicationSettings.DefaultTileProviderAttribution,
-            TileTrafficMode = TileTrafficMode.Conservative
-        };
-
-        await controller.Update(updated);
-
-        var audit = Assert.Single(db.AuditLogs, entry => entry.Action == "SettingsUpdate");
-        Assert.Contains("TileEffectiveRateActive", audit.Details);
-        Assert.Contains("TileEffectiveBurstActive", audit.Details);
-        Assert.Contains("TileEffectiveConcurrencyActive", audit.Details);
-        Assert.Contains("TileEffectiveClientAllowanceActive", audit.Details);
-        Assert.Contains("TileEffectiveMaxAttempts", audit.Details);
-        Assert.Contains("TileEffectiveFallbackBaseDelayMs", audit.Details);
-        Assert.Contains("TileEffectiveFallbackDelayCapSeconds", audit.Details);
-        Assert.Contains("TileEffectiveMaxIndividualWaitSeconds", audit.Details);
-        Assert.Contains("TileEffectiveTotalRetryCeilingSeconds", audit.Details);
-        Assert.DoesNotContain(updated.TileProviderUrlTemplate, audit.Details, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
@@ -266,6 +266,8 @@ public class AdminSettingsControllerTests : TestBase
     [InlineData("thunderforest-cycle", "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")]
     [InlineData("carto-dark", "https://cartodb-basemaps-a.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png")]
     [InlineData("retired-provider", "https://tiles.retired.example/{z}/{x}/{y}.png")]
+    [InlineData("", "")]
+    [InlineData("custom", "malformed endpoint")]
     public async Task Update_UnrelatedSavePreservesUnsupportedProviderRecoveryState(
         string providerKey, string template)
     {
@@ -283,6 +285,11 @@ public class AdminSettingsControllerTests : TestBase
             TileProviderBurstCapacity = 41,
             TileProviderMaxConcurrency = 9,
             TileOutboundBudgetPerIpPerMinute = 321,
+            TileProviderMaxAttempts = 2,
+            TileProviderFallbackBaseDelayMs = 750,
+            TileProviderFallbackDelayCapSeconds = 7,
+            TileProviderMaxIndividualWaitSeconds = 44,
+            TileProviderTotalRetryCeilingSeconds = 88,
             IsRegistrationOpen = false
         };
         db.ApplicationSettings.Add(existing);
@@ -294,7 +301,7 @@ public class AdminSettingsControllerTests : TestBase
         {
             Id = 1,
             IsRegistrationOpen = true,
-            TileProviderKey = string.Empty
+            TileProviderKey = providerKey
         });
 
         Assert.IsType<RedirectToActionResult>(result);
@@ -307,6 +314,11 @@ public class AdminSettingsControllerTests : TestBase
         Assert.Equal(41, stored.TileProviderBurstCapacity);
         Assert.Equal(9, stored.TileProviderMaxConcurrency);
         Assert.Equal(321, stored.TileOutboundBudgetPerIpPerMinute);
+        Assert.Equal(2, stored.TileProviderMaxAttempts);
+        Assert.Equal(750, stored.TileProviderFallbackBaseDelayMs);
+        Assert.Equal(7, stored.TileProviderFallbackDelayCapSeconds);
+        Assert.Equal(44, stored.TileProviderMaxIndividualWaitSeconds);
+        Assert.Equal(88, stored.TileProviderTotalRetryCeilingSeconds);
         Assert.Equal(originalIdentity, TileProviderCatalog.CreateCacheIdentity(
             stored.TileProviderKey, stored.TileProviderUrlTemplate));
     }

--- a/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
@@ -220,6 +220,7 @@ public class AdminSettingsControllerTests : TestBase
         {
             Id = 1,
             TileProviderKey = TileProviderCatalog.CustomProviderKey,
+            TileTrafficMode = TileTrafficMode.Custom,
             TileProviderUrlTemplate = "https://tiles.example.test/{z}/{x}/{y}.png",
             TileProviderAttribution = "Example",
             TileProviderAdvancedLimitsEnabled = true,

--- a/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
+++ b/tests/Wayfarer.Tests/Controllers/AdminSettingsControllerTests.cs
@@ -261,6 +261,88 @@ public class AdminSettingsControllerTests : TestBase
         Assert.DoesNotContain("Wrong provider", stored.TileProviderAttribution);
     }
 
+    /// <summary>Unsupported persisted provider state survives an unrelated normal form save.</summary>
+    [Theory]
+    [InlineData("thunderforest-cycle", "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")]
+    [InlineData("carto-dark", "https://cartodb-basemaps-a.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png")]
+    [InlineData("retired-provider", "https://tiles.retired.example/{z}/{x}/{y}.png")]
+    public async Task Update_UnrelatedSavePreservesUnsupportedProviderRecoveryState(
+        string providerKey, string template)
+    {
+        const string attribution = "Recovery attribution";
+        const string apiKey = "recovery-secret";
+        var db = CreateDbContext();
+        var existing = new ApplicationSettings
+        {
+            Id = 1,
+            TileProviderKey = providerKey,
+            TileProviderUrlTemplate = template,
+            TileProviderAttribution = attribution,
+            TileProviderApiKey = apiKey,
+            TileProviderSustainedRequestsPerSecond = 17,
+            TileProviderBurstCapacity = 41,
+            TileProviderMaxConcurrency = 9,
+            TileOutboundBudgetPerIpPerMinute = 321,
+            IsRegistrationOpen = false
+        };
+        db.ApplicationSettings.Add(existing);
+        await db.SaveChangesAsync();
+        var originalIdentity = TileProviderCatalog.CreateCacheIdentity(providerKey, template);
+        var (controller, _, _) = BuildController(db);
+
+        var result = await controller.Update(new ApplicationSettings
+        {
+            Id = 1,
+            IsRegistrationOpen = true,
+            TileProviderKey = string.Empty
+        });
+
+        Assert.IsType<RedirectToActionResult>(result);
+        var stored = Assert.IsType<ApplicationSettings>(await db.ApplicationSettings.FindAsync(1));
+        Assert.Equal(providerKey, stored.TileProviderKey);
+        Assert.Equal(template, stored.TileProviderUrlTemplate);
+        Assert.Equal(attribution, stored.TileProviderAttribution);
+        Assert.Equal(apiKey, stored.TileProviderApiKey);
+        Assert.Equal(17, stored.TileProviderSustainedRequestsPerSecond);
+        Assert.Equal(41, stored.TileProviderBurstCapacity);
+        Assert.Equal(9, stored.TileProviderMaxConcurrency);
+        Assert.Equal(321, stored.TileOutboundBudgetPerIpPerMinute);
+        Assert.Equal(originalIdentity, TileProviderCatalog.CreateCacheIdentity(
+            stored.TileProviderKey, stored.TileProviderUrlTemplate));
+    }
+
+    /// <summary>A successful policy save emits one complete bounded non-secret transition.</summary>
+    [Fact]
+    public async Task Update_TrafficModeAuditsCompleteEffectivePolicyOnce()
+    {
+        var db = CreateDbContext();
+        db.ApplicationSettings.Add(new ApplicationSettings { Id = 1 });
+        await db.SaveChangesAsync();
+        var (controller, _, _) = BuildController(db);
+        var updated = new ApplicationSettings
+        {
+            Id = 1,
+            TileProviderKey = ApplicationSettings.DefaultTileProviderKey,
+            TileProviderUrlTemplate = ApplicationSettings.DefaultTileProviderUrlTemplate,
+            TileProviderAttribution = ApplicationSettings.DefaultTileProviderAttribution,
+            TileTrafficMode = TileTrafficMode.Conservative
+        };
+
+        await controller.Update(updated);
+
+        var audit = Assert.Single(db.AuditLogs, entry => entry.Action == "SettingsUpdate");
+        Assert.Contains("TileEffectiveRateActive", audit.Details);
+        Assert.Contains("TileEffectiveBurstActive", audit.Details);
+        Assert.Contains("TileEffectiveConcurrencyActive", audit.Details);
+        Assert.Contains("TileEffectiveClientAllowanceActive", audit.Details);
+        Assert.Contains("TileEffectiveMaxAttempts", audit.Details);
+        Assert.Contains("TileEffectiveFallbackBaseDelayMs", audit.Details);
+        Assert.Contains("TileEffectiveFallbackDelayCapSeconds", audit.Details);
+        Assert.Contains("TileEffectiveMaxIndividualWaitSeconds", audit.Details);
+        Assert.Contains("TileEffectiveTotalRetryCeilingSeconds", audit.Details);
+        Assert.DoesNotContain(updated.TileProviderUrlTemplate, audit.Details, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task Update_PreservesAndSanitizesCustomProviderAttribution()
     {

--- a/tests/Wayfarer.Tests/Controllers/AdminSettingsIssue396Tests.cs
+++ b/tests/Wayfarer.Tests/Controllers/AdminSettingsIssue396Tests.cs
@@ -1,0 +1,109 @@
+using Microsoft.AspNetCore.Mvc;
+using Wayfarer.Services;
+using Wayfarer.Util;
+using Xunit;
+
+namespace Wayfarer.Tests.Controllers;
+
+/// <summary>Contains focused Admin regressions for issue #396 provider recovery and audit behavior.</summary>
+public partial class AdminSettingsControllerTests
+{
+    /// <summary>Unsupported persisted provider state survives an unrelated normal form save.</summary>
+    [Theory]
+    [InlineData("thunderforest-cycle", "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")]
+    [InlineData("carto-dark", "https://cartodb-basemaps-a.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png")]
+    [InlineData("retired-provider", "https://tiles.retired.example/{z}/{x}/{y}.png")]
+    [InlineData("", "")]
+    [InlineData("custom", "malformed endpoint")]
+    public async Task Update_UnrelatedSavePreservesUnsupportedProviderRecoveryState(
+        string providerKey, string template)
+    {
+        const string attribution = "Recovery attribution";
+        const string apiKey = "recovery-secret";
+        var db = CreateDbContext();
+        var existing = new ApplicationSettings
+        {
+            Id = 1,
+            TileProviderKey = providerKey,
+            TileProviderUrlTemplate = template,
+            TileProviderAttribution = attribution,
+            TileProviderApiKey = apiKey,
+            TileProviderSustainedRequestsPerSecond = 17,
+            TileProviderBurstCapacity = 41,
+            TileProviderMaxConcurrency = 9,
+            TileOutboundBudgetPerIpPerMinute = 321,
+            TileProviderMaxAttempts = 2,
+            TileProviderFallbackBaseDelayMs = 750,
+            TileProviderFallbackDelayCapSeconds = 7,
+            TileProviderMaxIndividualWaitSeconds = 44,
+            TileProviderTotalRetryCeilingSeconds = 88,
+            IsRegistrationOpen = false
+        };
+        db.ApplicationSettings.Add(existing);
+        await db.SaveChangesAsync();
+        TileProviderCacheIdentity? originalIdentity = Uri.TryCreate(template, UriKind.Absolute, out _)
+            ? TileProviderCatalog.CreateCacheIdentity(providerKey, template)
+            : null;
+        var (controller, _, _) = BuildController(db);
+
+        var result = await controller.Update(new ApplicationSettings
+        {
+            Id = 1,
+            IsRegistrationOpen = true,
+            TileProviderKey = providerKey
+        });
+
+        Assert.IsType<RedirectToActionResult>(result);
+        var stored = Assert.IsType<ApplicationSettings>(await db.ApplicationSettings.FindAsync(1));
+        Assert.Equal(providerKey, stored.TileProviderKey);
+        Assert.Equal(template, stored.TileProviderUrlTemplate);
+        Assert.Equal(attribution, stored.TileProviderAttribution);
+        Assert.Equal(apiKey, stored.TileProviderApiKey);
+        Assert.Equal(17, stored.TileProviderSustainedRequestsPerSecond);
+        Assert.Equal(41, stored.TileProviderBurstCapacity);
+        Assert.Equal(9, stored.TileProviderMaxConcurrency);
+        Assert.Equal(321, stored.TileOutboundBudgetPerIpPerMinute);
+        Assert.Equal(2, stored.TileProviderMaxAttempts);
+        Assert.Equal(750, stored.TileProviderFallbackBaseDelayMs);
+        Assert.Equal(7, stored.TileProviderFallbackDelayCapSeconds);
+        Assert.Equal(44, stored.TileProviderMaxIndividualWaitSeconds);
+        Assert.Equal(88, stored.TileProviderTotalRetryCeilingSeconds);
+        if (originalIdentity != null)
+        {
+            Assert.Equal(originalIdentity, TileProviderCatalog.CreateCacheIdentity(
+                stored.TileProviderKey, stored.TileProviderUrlTemplate));
+        }
+    }
+
+    /// <summary>A successful policy save emits one complete bounded non-secret transition.</summary>
+    [Fact]
+    public async Task Update_TrafficModeAuditsCompleteEffectivePolicyOnce()
+    {
+        var db = CreateDbContext();
+        db.ApplicationSettings.Add(new ApplicationSettings { Id = 1 });
+        await db.SaveChangesAsync();
+        var (controller, _, _) = BuildController(db);
+        var updated = new ApplicationSettings
+        {
+            Id = 1,
+            TileProviderKey = ApplicationSettings.DefaultTileProviderKey,
+            TileProviderUrlTemplate = ApplicationSettings.DefaultTileProviderUrlTemplate,
+            TileProviderAttribution = ApplicationSettings.DefaultTileProviderAttribution,
+            TileTrafficMode = TileTrafficMode.Conservative
+        };
+
+        await controller.Update(updated);
+
+        var audit = Assert.Single(db.AuditLogs, entry => entry.Action == "SettingsUpdate");
+        Assert.Contains("TileEffectiveRateActive", audit.Details);
+        Assert.Contains("TileEffectiveBurstActive", audit.Details);
+        Assert.Contains("TileEffectiveConcurrencyActive", audit.Details);
+        Assert.Contains("TileEffectiveClientAllowanceActive", audit.Details);
+        Assert.Contains("TileEffectiveMaxAttempts", audit.Details);
+        Assert.Contains("TileEffectiveFallbackBaseDelayMs", audit.Details);
+        Assert.Contains("TileEffectiveFallbackDelayCapSeconds", audit.Details);
+        Assert.Contains("TileEffectiveMaxIndividualWaitSeconds", audit.Details);
+        Assert.Contains("TileEffectiveTotalRetryCeilingSeconds", audit.Details);
+        Assert.DoesNotContain(updated.TileProviderUrlTemplate, audit.Details, StringComparison.Ordinal);
+    }
+}

--- a/tests/Wayfarer.Tests/Controllers/AdminSettingsIssue396Tests.cs
+++ b/tests/Wayfarer.Tests/Controllers/AdminSettingsIssue396Tests.cs
@@ -93,7 +93,7 @@ public partial class AdminSettingsControllerTests
         Assert.Contains("Compatibility=Blocked", audit.Details);
         Assert.Contains("TileRetryControlsActive=False", audit.Details);
         AssertPreservedRetryValuesAreBoundedAndNotEffective(audit.Details);
-        AssertSafeFocusedAudit(audit.Details, existing);
+        AssertSafeFocusedAudit(audit.Details);
         AssertStoredRetryValuesUnchanged(await db.ApplicationSettings.FindAsync(1));
     }
 
@@ -118,10 +118,8 @@ public partial class AdminSettingsControllerTests
         Assert.Contains("TileRetryControlsActive=False", audit.Details);
         Assert.Contains("TileRetryMaxAttempts=4", audit.Details);
         Assert.DoesNotContain("TileEffectiveMaxAttempts=4", audit.Details);
-        AssertSafeFocusedAudit(audit.Details, existing);
-        var stored = Assert.IsType<ApplicationSettings>(await db.ApplicationSettings.FindAsync(1));
-        Assert.Equal(4, stored.TileProviderMaxAttempts);
-        AssertStoredRetryValuesUnchanged(stored);
+        AssertSafeFocusedAudit(audit.Details);
+        AssertStoredRetryValuesUnchanged(await db.ApplicationSettings.FindAsync(1));
     }
 
     /// <summary>An active Conservative policy reports its bounded retry controls as active and accurate.</summary>
@@ -146,7 +144,7 @@ public partial class AdminSettingsControllerTests
         Assert.Contains("TileRetryFallbackDelayCapSeconds=7", audit.Details);
         Assert.Contains("TileRetryMaxIndividualWaitSeconds=44", audit.Details);
         Assert.Contains("TileRetryTotalCeilingSeconds=88", audit.Details);
-        AssertSafeFocusedAudit(audit.Details, existing);
+        AssertSafeFocusedAudit(audit.Details);
         AssertStoredRetryValuesUnchanged(await db.ApplicationSettings.FindAsync(1));
     }
 
@@ -197,11 +195,11 @@ public partial class AdminSettingsControllerTests
     }
 
     /// <summary>Asserts the audit excludes provider secrets, identity data, and settings snapshots.</summary>
-    private static void AssertSafeFocusedAudit(string details, ApplicationSettings original)
+    private static void AssertSafeFocusedAudit(string details)
     {
-        Assert.DoesNotContain(original.TileProviderUrlTemplate, details, StringComparison.Ordinal);
-        Assert.DoesNotContain(original.TileProviderAttribution, details, StringComparison.Ordinal);
-        Assert.DoesNotContain(original.TileProviderApiKey!, details, StringComparison.Ordinal);
+        Assert.DoesNotContain("http", details, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("audit-attribution-marker", details, StringComparison.Ordinal);
+        Assert.DoesNotContain("audit-api-key-marker", details, StringComparison.Ordinal);
         Assert.DoesNotContain("TileProviderUrlTemplate", details);
         Assert.DoesNotContain("TileProviderApiKey", details);
         Assert.DoesNotContain("Credential", details, StringComparison.OrdinalIgnoreCase);

--- a/tests/Wayfarer.Tests/Controllers/AdminSettingsIssue396Tests.cs
+++ b/tests/Wayfarer.Tests/Controllers/AdminSettingsIssue396Tests.cs
@@ -75,35 +75,149 @@ public partial class AdminSettingsControllerTests
         }
     }
 
-    /// <summary>A successful policy save emits one complete bounded non-secret transition.</summary>
+    /// <summary>A blocked provider marks preserved retry controls inactive in one safe audit transition.</summary>
     [Fact]
-    public async Task Update_TrafficModeAuditsCompleteEffectivePolicyOnce()
+    public async Task Update_BlockedProviderAuditsPreservedRetryControlsAsInactive()
     {
         var db = CreateDbContext();
-        db.ApplicationSettings.Add(new ApplicationSettings { Id = 1 });
+        var existing = CreateAuditSettings(
+            "thunderforest-cycle",
+            "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png");
+        db.ApplicationSettings.Add(existing);
         await db.SaveChangesAsync();
         var (controller, _, _) = BuildController(db);
-        var updated = new ApplicationSettings
-        {
-            Id = 1,
-            TileProviderKey = ApplicationSettings.DefaultTileProviderKey,
-            TileProviderUrlTemplate = ApplicationSettings.DefaultTileProviderUrlTemplate,
-            TileProviderAttribution = ApplicationSettings.DefaultTileProviderAttribution,
-            TileTrafficMode = TileTrafficMode.Conservative
-        };
 
-        await controller.Update(updated);
+        await controller.Update(CreateSupportedAuditUpdate(TileTrafficMode.Conservative));
 
         var audit = Assert.Single(db.AuditLogs, entry => entry.Action == "SettingsUpdate");
-        Assert.Contains("TileEffectiveRateActive", audit.Details);
-        Assert.Contains("TileEffectiveBurstActive", audit.Details);
-        Assert.Contains("TileEffectiveConcurrencyActive", audit.Details);
-        Assert.Contains("TileEffectiveClientAllowanceActive", audit.Details);
-        Assert.Contains("TileEffectiveMaxAttempts", audit.Details);
-        Assert.Contains("TileEffectiveFallbackBaseDelayMs", audit.Details);
-        Assert.Contains("TileEffectiveFallbackDelayCapSeconds", audit.Details);
-        Assert.Contains("TileEffectiveMaxIndividualWaitSeconds", audit.Details);
-        Assert.Contains("TileEffectiveTotalRetryCeilingSeconds", audit.Details);
-        Assert.DoesNotContain(updated.TileProviderUrlTemplate, audit.Details, StringComparison.Ordinal);
+        Assert.Contains("Compatibility=Blocked", audit.Details);
+        Assert.Contains("TileRetryControlsActive=False", audit.Details);
+        AssertPreservedRetryValuesAreBoundedAndNotEffective(audit.Details);
+        AssertSafeFocusedAudit(audit.Details, existing);
+        AssertStoredRetryValuesUnchanged(await db.ApplicationSettings.FindAsync(1));
+    }
+
+    /// <summary>An invalid Custom profile preserves correction values while marking retry controls inactive.</summary>
+    [Fact]
+    public async Task Update_InvalidCustomProviderAuditsPreservedRetryControlsAsInactive()
+    {
+        var db = CreateDbContext();
+        var existing = CreateAuditSettings(
+            TileProviderCatalog.CustomProviderKey,
+            "https://tiles.example.test/{z}/{x}/{y}.png");
+        existing.TileProviderAdvancedLimitsEnabled = true;
+        existing.TileProviderMaxAttempts = 4;
+        db.ApplicationSettings.Add(existing);
+        await db.SaveChangesAsync();
+        var (controller, _, _) = BuildController(db);
+
+        await controller.Update(CreateSupportedAuditUpdate(TileTrafficMode.Interactive));
+
+        var audit = Assert.Single(db.AuditLogs, entry => entry.Action == "SettingsUpdate");
+        Assert.Contains("Compatibility=InvalidOrUnsupported", audit.Details);
+        Assert.Contains("TileRetryControlsActive=False", audit.Details);
+        Assert.Contains("TileRetryMaxAttempts=4", audit.Details);
+        Assert.DoesNotContain("TileEffectiveMaxAttempts=4", audit.Details);
+        AssertSafeFocusedAudit(audit.Details, existing);
+        var stored = Assert.IsType<ApplicationSettings>(await db.ApplicationSettings.FindAsync(1));
+        Assert.Equal(4, stored.TileProviderMaxAttempts);
+        AssertStoredRetryValuesUnchanged(stored);
+    }
+
+    /// <summary>An active Conservative policy reports its bounded retry controls as active and accurate.</summary>
+    [Fact]
+    public async Task Update_ActivePolicyAuditsEffectiveRetryControlsAsActive()
+    {
+        var db = CreateDbContext();
+        var existing = CreateAuditSettings(
+            ApplicationSettings.DefaultTileProviderKey,
+            ApplicationSettings.DefaultTileProviderUrlTemplate);
+        db.ApplicationSettings.Add(existing);
+        await db.SaveChangesAsync();
+        var (controller, _, _) = BuildController(db);
+
+        await controller.Update(CreateSupportedAuditUpdate(TileTrafficMode.Conservative));
+
+        var audit = Assert.Single(db.AuditLogs, entry => entry.Action == "SettingsUpdate");
+        Assert.Contains("Compatibility=Supported", audit.Details);
+        Assert.Contains("TileRetryControlsActive=True", audit.Details);
+        Assert.Contains("TileRetryMaxAttempts=2", audit.Details);
+        Assert.Contains("TileRetryFallbackBaseDelayMs=750", audit.Details);
+        Assert.Contains("TileRetryFallbackDelayCapSeconds=7", audit.Details);
+        Assert.Contains("TileRetryMaxIndividualWaitSeconds=44", audit.Details);
+        Assert.Contains("TileRetryTotalCeilingSeconds=88", audit.Details);
+        AssertSafeFocusedAudit(audit.Details, existing);
+        AssertStoredRetryValuesUnchanged(await db.ApplicationSettings.FindAsync(1));
+    }
+
+    /// <summary>Creates settings with distinctive bounded retry values for audit assertions.</summary>
+    private static ApplicationSettings CreateAuditSettings(string providerKey, string template) => new()
+    {
+        Id = 1,
+        TileProviderKey = providerKey,
+        TileProviderUrlTemplate = template,
+        TileProviderAttribution = "audit-attribution-marker",
+        TileProviderApiKey = "audit-api-key-marker",
+        TileTrafficMode = TileTrafficMode.Interactive,
+        TileProviderMaxAttempts = 2,
+        TileProviderFallbackBaseDelayMs = 750,
+        TileProviderFallbackDelayCapSeconds = 7,
+        TileProviderMaxIndividualWaitSeconds = 44,
+        TileProviderTotalRetryCeilingSeconds = 88
+    };
+
+    /// <summary>Creates the explicitly submitted supported-provider transition.</summary>
+    private static ApplicationSettings CreateSupportedAuditUpdate(TileTrafficMode mode) => new()
+    {
+        Id = 1,
+        TileProviderKey = ApplicationSettings.DefaultTileProviderKey,
+        TileProviderUrlTemplate = ApplicationSettings.DefaultTileProviderUrlTemplate,
+        TileProviderAttribution = ApplicationSettings.DefaultTileProviderAttribution,
+        TileTrafficMode = mode,
+        TileProviderMaxAttempts = 2,
+        TileProviderFallbackBaseDelayMs = 750,
+        TileProviderFallbackDelayCapSeconds = 7,
+        TileProviderMaxIndividualWaitSeconds = 44,
+        TileProviderTotalRetryCeilingSeconds = 88
+    };
+
+    /// <summary>Asserts inactive retry values remain bounded without effective labels.</summary>
+    private static void AssertPreservedRetryValuesAreBoundedAndNotEffective(string details)
+    {
+        Assert.Contains("TileRetryMaxAttempts=2", details);
+        Assert.Contains("TileRetryFallbackBaseDelayMs=750", details);
+        Assert.Contains("TileRetryFallbackDelayCapSeconds=7", details);
+        Assert.Contains("TileRetryMaxIndividualWaitSeconds=44", details);
+        Assert.Contains("TileRetryTotalCeilingSeconds=88", details);
+        Assert.DoesNotContain("TileEffectiveMaxAttempts", details);
+        Assert.DoesNotContain("TileEffectiveFallbackBaseDelayMs", details);
+        Assert.DoesNotContain("TileEffectiveFallbackDelayCapSeconds", details);
+        Assert.DoesNotContain("TileEffectiveMaxIndividualWaitSeconds", details);
+        Assert.DoesNotContain("TileEffectiveTotalRetryCeilingSeconds", details);
+    }
+
+    /// <summary>Asserts the audit excludes provider secrets, identity data, and settings snapshots.</summary>
+    private static void AssertSafeFocusedAudit(string details, ApplicationSettings original)
+    {
+        Assert.DoesNotContain(original.TileProviderUrlTemplate, details, StringComparison.Ordinal);
+        Assert.DoesNotContain(original.TileProviderAttribution, details, StringComparison.Ordinal);
+        Assert.DoesNotContain(original.TileProviderApiKey!, details, StringComparison.Ordinal);
+        Assert.DoesNotContain("TileProviderUrlTemplate", details);
+        Assert.DoesNotContain("TileProviderApiKey", details);
+        Assert.DoesNotContain("Credential", details, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("UserId", details, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("IpAddress", details, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ApplicationSettings", details);
+    }
+
+    /// <summary>Asserts persistence did not mutate the submitted retry values.</summary>
+    private static void AssertStoredRetryValuesUnchanged(ApplicationSettings? stored)
+    {
+        var settings = Assert.IsType<ApplicationSettings>(stored);
+        Assert.Equal(2, settings.TileProviderMaxAttempts);
+        Assert.Equal(750, settings.TileProviderFallbackBaseDelayMs);
+        Assert.Equal(7, settings.TileProviderFallbackDelayCapSeconds);
+        Assert.Equal(44, settings.TileProviderMaxIndividualWaitSeconds);
+        Assert.Equal(88, settings.TileProviderTotalRetryCeilingSeconds);
     }
 }

--- a/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheCancellationAndPrivacyTests.cs
@@ -11,6 +11,7 @@ using Wayfarer.Models;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
+using Wayfarer.Util;
 using Xunit;
 
 namespace Wayfarer.Tests.Services;
@@ -251,6 +252,10 @@ public sealed class TileCacheCancellationAndPrivacyTests
     public async Task OutboundClientThrottle_Retains503AndReportsBoundedScope()
     {
         using var harness = new TileCacheTestHarness();
+        harness.Settings.TileProviderKey = TileProviderCatalog.CustomProviderKey;
+        harness.Settings.TileProviderUrlTemplate = "https://tiles.example.test/{z}/{x}/{y}.png";
+        harness.Settings.TileTrafficMode = TileTrafficMode.Custom;
+        harness.Settings.TileProviderAdvancedLimitsEnabled = true;
         harness.Settings.TileOutboundBudgetPerIpPerMinute = 1;
         using var scope = harness.CreateScope();
         var context = TileCacheTestHarness.CreateHttpContext();

--- a/tests/Wayfarer.Tests/Services/TileCacheColdCacheBaselineTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheColdCacheBaselineTests.cs
@@ -70,7 +70,7 @@ public sealed class TileCacheColdCacheBaselineTests
     /// Broadly characterizes real production-budget progress with actual fake latency and no public network.
     /// </summary>
     [Fact]
-    public async Task RealOutboundBudget_SpreadsStartsAndContinuesAfterInitialBurst()
+    public async Task InteractiveBudget_UsesConcurrencyWithoutRateTokenDelay()
     {
         const int productionPathTileCount = 24;
         var stopwatch = Stopwatch.StartNew();
@@ -90,18 +90,10 @@ public sealed class TileCacheColdCacheBaselineTests
             .Select(request => request.StartTime)
             .OrderBy(start => start)
             .ToArray();
-        var initialBurstStarts = starts.Take(TileCacheService.OutboundBudget.BurstCapacity).ToArray();
-        var laterStarts = starts.Skip(TileCacheService.OutboundBudget.BurstCapacity).ToArray();
-
         Assert.Equal(productionPathTileCount, outcomes.Length);
-        Assert.Equal(TileCacheService.OutboundBudget.BurstCapacity, initialBurstStarts.Length);
-        Assert.True(initialBurstStarts.Max() < TimeSpan.FromSeconds(1));
-        Assert.NotEmpty(laterStarts);
-        Assert.True(laterStarts.Max() - laterStarts.Min() >= TimeSpan.FromMilliseconds(300));
-        Assert.Contains(outcomes, outcome => outcome.StatusCode == StatusCodes.Status200OK);
-        Assert.True(
-            laterStarts.Any(start => start >= TimeSpan.FromMilliseconds(250)) ||
-            outcomes.Any(outcome => outcome.StatusCode == StatusCodes.Status503ServiceUnavailable));
+        Assert.All(outcomes, outcome => Assert.Equal(StatusCodes.Status200OK, outcome.StatusCode));
+        Assert.Equal(productionPathTileCount, starts.Length);
+        Assert.All(starts, start => Assert.True(start < TimeSpan.FromSeconds(1)));
     }
 
     /// <summary>Runs one isolated controller request and captures its local status and Retry-After.</summary>

--- a/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheDiagnosticsAndPolicyTests.cs
@@ -7,6 +7,7 @@ using Wayfarer.Areas.Public.Controllers;
 using Wayfarer.Models;
 using Wayfarer.Services;
 using Wayfarer.Tests.Infrastructure;
+using Wayfarer.Util;
 using Xunit;
 
 namespace Wayfarer.Tests.Services;
@@ -174,6 +175,10 @@ public sealed class TileCacheDiagnosticsAndPolicyTests
     public async Task PerClientBudgetRejection_IsDistinctFromGlobalRejection()
     {
         using var harness = new TileCacheTestHarness();
+        harness.Settings.TileProviderKey = TileProviderCatalog.CustomProviderKey;
+        harness.Settings.TileProviderUrlTemplate = "https://tiles.example.test/{z}/{x}/{y}.png";
+        harness.Settings.TileTrafficMode = TileTrafficMode.Custom;
+        harness.Settings.TileProviderAdvancedLimitsEnabled = true;
         harness.Settings.TileOutboundBudgetPerIpPerMinute = 1;
 
         using (var firstScope = harness.CreateScope())

--- a/tests/Wayfarer.Tests/Services/TileCachePhase2AProductionReviewTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCachePhase2AProductionReviewTests.cs
@@ -75,7 +75,7 @@ public sealed partial class TileCacheRetryStatusTests
             });
         });
         using var harness = new TileCacheTestHarness(upstream);
-        harness.Settings.TileOutboundBudgetPerIpPerMinute = 10;
+        harness.Settings.TileTrafficMode = TileTrafficMode.Conservative;
         SeedExpiredLowZoomTile(harness.CacheDirectory, 5, 23, 1, [9, 8, 7]);
         TileCacheService.SetRefreshRetryDelayForTesting(_ => TimeSpan.Zero);
         var acquisitions = 0;

--- a/tests/Wayfarer.Tests/Services/TileCachePhase3ProductionReviewTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCachePhase3ProductionReviewTests.cs
@@ -398,14 +398,12 @@ public sealed class TileCachePhase3ProductionReviewTests
         var secondUserRequest = RequestTileAsync(harness, 5, 7, 1, userB);
         try
         {
-            await Task.Delay(100);
-            Assert.False(secondUserStarted.Task.IsCompleted);
+            await secondUserStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         }
         finally
         {
             release.TrySetResult();
         }
-        await secondUserStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
         Assert.All(
             await Task.WhenAll(firstUserRequests.Append(secondUserRequest)),

--- a/tests/Wayfarer.Tests/Services/TileCachePhase3Tests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCachePhase3Tests.cs
@@ -283,7 +283,7 @@ public sealed class TileCachePhase3Tests
         Assert.NotEqual(osm.Bytes, custom.Bytes);
     }
 
-    /// <summary>A 24-tile cold viewport completes progressively under the unchanged 12/2s budget.</summary>
+    /// <summary>A 24-tile Interactive viewport completes through concurrency without local rate delay.</summary>
     [Fact]
     public async Task ControlledColdViewport_CompletesProgressivelyWithinDerivedCeiling()
     {
@@ -308,11 +308,10 @@ public sealed class TileCachePhase3Tests
 
         Assert.All(outcomes, outcome => Assert.Equal(StatusCodes.Status200OK, outcome.StatusCode));
         Assert.Equal(tileCount, starts.Length);
-        Assert.Equal(20, TileCacheService.OutboundBudget.BurstCapacity);
-        Assert.Contains(starts, start => start >= TimeSpan.FromMilliseconds(500));
+        Assert.All(starts, start => Assert.True(start < TimeSpan.FromSeconds(1)));
         Assert.True(stopwatch.Elapsed <= derivedCeiling + TimeSpan.FromSeconds(2));
         _output.WriteLine(
-            "N={0}, B={1}, R=6/s, L={2}ms, queue={3}, ceiling={4:F1}s, actual={5:F3}s",
+            "N={0}, mode=Interactive, concurrency=6, L={2}ms, queue={3}, ceiling={4:F1}s, actual={5:F3}s",
             tileCount,
             TileCacheService.OutboundBudget.BurstCapacity,
             latency.TotalMilliseconds,

--- a/tests/Wayfarer.Tests/Services/TileCacheRetryStatusTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheRetryStatusTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Wayfarer.Areas.Public.Controllers;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
+using Wayfarer.Util;
 using Xunit;
 
 namespace Wayfarer.Tests.Services;
@@ -17,6 +18,63 @@ namespace Wayfarer.Tests.Services;
 [Collection("OutboundBudget")]
 public sealed partial class TileCacheRetryStatusTests
 {
+    /// <summary>Blocked provider targets are rejected before the fake transport sees an initial contact.</summary>
+    [Theory]
+    [InlineData("thunderforest-cycle", "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")]
+    [InlineData("carto-dark", "https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png")]
+    [InlineData("unknown-provider", "https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png")]
+    public async Task BlockedInitialProviderTarget_IsRejectedBeforeTransport(string key, string template)
+    {
+        using var harness = new TileCacheTestHarness();
+        harness.Settings.TileProviderKey = key;
+        harness.Settings.TileProviderUrlTemplate = template;
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        await controller.GetTile(5, 18, 1);
+
+        Assert.Empty(harness.Upstream.Requests);
+    }
+
+    /// <summary>Redirects to each blocked provider family stop before the target contact.</summary>
+    [Theory]
+    [InlineData("https://tile.thunderforest.com/cycle/5/91/1.png")]
+    [InlineData("https://basemaps.cartocdn.com/dark_all/5/91/1.png")]
+    public async Task BlockedRedirectTarget_IsRejectedBeforeTargetTransport(string target)
+    {
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Redirect);
+            response.Headers.Location = new Uri(target);
+            return Task.FromResult(response);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        await controller.GetTile(5, 19, 1);
+
+        var contact = Assert.Single(harness.Upstream.Requests);
+        Assert.Equal("tile.openstreetmap.org", contact.RequestUri?.Host);
+    }
+
+    /// <summary>A DNS-boundary lookalike remains eligible and reaches only the fake transport.</summary>
+    [Fact]
+    public async Task SafeBlockedProviderLookalike_IsNotFalselyRejected()
+    {
+        using var harness = new TileCacheTestHarness();
+        harness.Settings.TileProviderKey = TileProviderCatalog.CustomProviderKey;
+        harness.Settings.TileProviderUrlTemplate =
+            "https://tile.thunderforest.com.example.test/{z}/{x}/{y}.png";
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        await controller.GetTile(5, 20, 1);
+
+        var contact = Assert.Single(harness.Upstream.Requests);
+        Assert.Equal("tile.thunderforest.com.example.test", contact.RequestUri?.Host);
+    }
+
     /// <summary>Proves a confirmed upstream absence is not retried and remains a local 404.</summary>
     [Fact]
     public async Task Upstream404_ReturnsLocal404AfterOneAttempt()

--- a/tests/Wayfarer.Tests/Services/TileCacheRetryStatusTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheRetryStatusTests.cs
@@ -18,63 +18,6 @@ namespace Wayfarer.Tests.Services;
 [Collection("OutboundBudget")]
 public sealed partial class TileCacheRetryStatusTests
 {
-    /// <summary>Blocked provider targets are rejected before the fake transport sees an initial contact.</summary>
-    [Theory]
-    [InlineData("thunderforest-cycle", "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")]
-    [InlineData("carto-dark", "https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png")]
-    [InlineData("unknown-provider", "https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png")]
-    public async Task BlockedInitialProviderTarget_IsRejectedBeforeTransport(string key, string template)
-    {
-        using var harness = new TileCacheTestHarness();
-        harness.Settings.TileProviderKey = key;
-        harness.Settings.TileProviderUrlTemplate = template;
-        using var scope = harness.CreateScope();
-        var controller = CreateController(scope);
-
-        await controller.GetTile(5, 18, 1);
-
-        Assert.Empty(harness.Upstream.Requests);
-    }
-
-    /// <summary>Redirects to each blocked provider family stop before the target contact.</summary>
-    [Theory]
-    [InlineData("https://tile.thunderforest.com/cycle/5/91/1.png")]
-    [InlineData("https://basemaps.cartocdn.com/dark_all/5/91/1.png")]
-    public async Task BlockedRedirectTarget_IsRejectedBeforeTargetTransport(string target)
-    {
-        var upstream = new RecordingTileHandler((_, _) =>
-        {
-            var response = new HttpResponseMessage(HttpStatusCode.Redirect);
-            response.Headers.Location = new Uri(target);
-            return Task.FromResult(response);
-        });
-        using var harness = new TileCacheTestHarness(upstream);
-        using var scope = harness.CreateScope();
-        var controller = CreateController(scope);
-
-        await controller.GetTile(5, 19, 1);
-
-        var contact = Assert.Single(harness.Upstream.Requests);
-        Assert.Equal("tile.openstreetmap.org", contact.RequestUri?.Host);
-    }
-
-    /// <summary>A DNS-boundary lookalike remains eligible and reaches only the fake transport.</summary>
-    [Fact]
-    public async Task SafeBlockedProviderLookalike_IsNotFalselyRejected()
-    {
-        using var harness = new TileCacheTestHarness();
-        harness.Settings.TileProviderKey = TileProviderCatalog.CustomProviderKey;
-        harness.Settings.TileProviderUrlTemplate =
-            "https://tile.thunderforest.com.example.test/{z}/{x}/{y}.png";
-        using var scope = harness.CreateScope();
-        var controller = CreateController(scope);
-
-        await controller.GetTile(5, 20, 1);
-
-        var contact = Assert.Single(harness.Upstream.Requests);
-        Assert.Equal("tile.thunderforest.com.example.test", contact.RequestUri?.Host);
-    }
-
     /// <summary>Proves a confirmed upstream absence is not retried and remains a local 404.</summary>
     [Fact]
     public async Task Upstream404_ReturnsLocal404AfterOneAttempt()

--- a/tests/Wayfarer.Tests/Services/TileCacheTestHarness.cs
+++ b/tests/Wayfarer.Tests/Services/TileCacheTestHarness.cs
@@ -95,7 +95,7 @@ internal sealed class TileCacheTestHarness : IDisposable, IAsyncDisposable
     /// <summary>Cancels tracked refreshes before synchronously completing bounded test cleanup.</summary>
     public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
 
-    /// <summary>Awaits tracked refresh completion before disposing services and deleting temporary data.</summary>
+    /// <summary>Awaits tracked refresh and scheduler completion before deleting temporary data.</summary>
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
@@ -111,6 +111,7 @@ internal sealed class TileCacheTestHarness : IDisposable, IAsyncDisposable
             throw new TimeoutException("Tracked stale-tile refresh work exceeded the test cleanup timeout.");
         }
 
+        await TileWorkScheduler.StopAndDrainAsync();
         TileCacheService.ResetStaticStateForTesting();
         await _rootProvider.DisposeAsync();
 

--- a/tests/Wayfarer.Tests/Services/TileInteractiveConcurrencyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileInteractiveConcurrencyTests.cs
@@ -1,0 +1,60 @@
+using Wayfarer.Services;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>Contains the issue #396 provider-wide Interactive concurrency regression.</summary>
+public sealed partial class TileProviderStateAdmissionTests
+{
+    /// <summary>Interactive permits the scheduler's full two-client foreground width.</summary>
+    [Fact]
+    public async Task Interactive_TwoClientsStartTwelveContacts_WithSixPerClient()
+    {
+        TileCacheService.OutboundBudget.ResetForTesting();
+        TileWorkScheduler.ResetForTesting();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var startedCount = 0;
+        var profile = TileProviderPolicyResolver.Resolve(new ApplicationSettings());
+
+        async Task<TileRetrievalResult> ContactAsync(string clientKey, CancellationToken token)
+        {
+            var acquisition = await TileCacheService.OutboundBudget.AcquireProviderContactAsync(
+                profile, TileWorkPriority.Foreground, token);
+            using var lease = Assert.IsType<TileCacheService.OutboundBudget.ProviderContactLease>(acquisition.Lease);
+            lock (counts)
+            {
+                counts[clientKey] = counts.GetValueOrDefault(clientKey) + 1;
+                if (++startedCount == TileWorkScheduler.ForegroundConcurrency)
+                    started.TrySetResult();
+            }
+            await release.Task.WaitAsync(token);
+            return TileRetrievalResult.Success([1]);
+        }
+
+        try
+        {
+            var work = new[] { "client-a", "client-b" }
+                .SelectMany(client => Enumerable.Range(0, TileWorkScheduler.PerClientConcurrency)
+                    .Select(index => TileWorkScheduler.ExecuteForegroundAsync(
+                        $"{client}:{index}", client,
+                        token => ContactAsync(client, token), CancellationToken.None)))
+                .ToArray();
+
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(12, startedCount);
+            Assert.Equal(6, counts["client-a"]);
+            Assert.Equal(6, counts["client-b"]);
+            Assert.Equal(0, TileCacheService.OutboundBudget.ProviderReplenisherStartCountForTesting);
+            release.TrySetResult();
+            await Task.WhenAll(work);
+        }
+        finally
+        {
+            release.TrySetResult();
+            TileWorkScheduler.ResetForTesting();
+            TileCacheService.OutboundBudget.ResetForTesting();
+        }
+    }
+}

--- a/tests/Wayfarer.Tests/Services/TileProviderBlockingTransportTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileProviderBlockingTransportTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using Wayfarer.Util;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>Contains the compact issue #396 blocked-provider pre-contact transport matrix.</summary>
+public sealed partial class TileCacheRetryStatusTests
+{
+    /// <summary>Blocked provider targets are rejected before the fake transport sees an initial contact.</summary>
+    [Theory]
+    [InlineData("thunderforest-cycle", "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")]
+    [InlineData("carto-dark", "https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png")]
+    [InlineData("unknown-provider", "https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png")]
+    public async Task BlockedInitialProviderTarget_IsRejectedBeforeTransport(string key, string template)
+    {
+        using var harness = new TileCacheTestHarness();
+        harness.Settings.TileProviderKey = key;
+        harness.Settings.TileProviderUrlTemplate = template;
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        await controller.GetTile(5, 18, 1);
+
+        Assert.Empty(harness.Upstream.Requests);
+    }
+
+    /// <summary>Redirects to each blocked provider family stop before the target contact.</summary>
+    [Theory]
+    [InlineData("https://tile.thunderforest.com/cycle/5/91/1.png")]
+    [InlineData("https://basemaps.cartocdn.com/dark_all/5/91/1.png")]
+    public async Task BlockedRedirectTarget_IsRejectedBeforeTargetTransport(string target)
+    {
+        var upstream = new RecordingTileHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Redirect);
+            response.Headers.Location = new Uri(target);
+            return Task.FromResult(response);
+        });
+        using var harness = new TileCacheTestHarness(upstream);
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        await controller.GetTile(5, 19, 1);
+
+        var contact = Assert.Single(harness.Upstream.Requests);
+        Assert.Equal("tile.openstreetmap.org", contact.RequestUri?.Host);
+    }
+
+    /// <summary>A DNS-boundary lookalike remains eligible and reaches only the fake transport.</summary>
+    [Fact]
+    public async Task SafeBlockedProviderLookalike_IsNotFalselyRejected()
+    {
+        using var harness = new TileCacheTestHarness();
+        harness.Settings.TileProviderKey = TileProviderCatalog.CustomProviderKey;
+        harness.Settings.TileProviderUrlTemplate =
+            "https://tile.thunderforest.com.example.test/{z}/{x}/{y}.png";
+        using var scope = harness.CreateScope();
+        var controller = CreateController(scope);
+
+        await controller.GetTile(5, 20, 1);
+
+        var contact = Assert.Single(harness.Upstream.Requests);
+        Assert.Equal("tile.thunderforest.com.example.test", contact.RequestUri?.Host);
+    }
+}

--- a/tests/Wayfarer.Tests/Services/TileProviderPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileProviderPolicyTests.cs
@@ -137,7 +137,8 @@ public sealed class TileProviderPolicyTests
         {
             Assert.Equal(TileTrafficMode.Interactive, profile.TrafficMode);
             Assert.False(profile.UsesRateTokens);
-            Assert.Equal(6, profile.MaxConcurrency);
+            Assert.Equal(TileWorkScheduler.ForegroundConcurrency, profile.MaxConcurrency);
+            Assert.Equal(0, profile.ClientSeriesPerMinute);
         });
     }
 
@@ -260,6 +261,58 @@ public sealed class TileProviderStateAdmissionTests
         }
         finally
         {
+            TileCacheService.OutboundBudget.ResetForTesting();
+        }
+    }
+
+    /// <summary>Interactive permits the scheduler's full two-client foreground width.</summary>
+    [Fact]
+    public async Task Interactive_TwoClientsStartTwelveContacts_WithSixPerClient()
+    {
+        TileCacheService.OutboundBudget.ResetForTesting();
+        TileWorkScheduler.ResetForTesting();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var startedCount = 0;
+        var profile = TileProviderPolicyResolver.Resolve(new ApplicationSettings());
+
+        async Task<TileRetrievalResult> ContactAsync(string clientKey, CancellationToken token)
+        {
+            var acquisition = await TileCacheService.OutboundBudget.AcquireProviderContactAsync(
+                profile, TileWorkPriority.Foreground, token);
+            using var lease = Assert.IsType<TileCacheService.OutboundBudget.ProviderContactLease>(acquisition.Lease);
+            lock (counts)
+            {
+                counts[clientKey] = counts.GetValueOrDefault(clientKey) + 1;
+                if (++startedCount == TileWorkScheduler.ForegroundConcurrency)
+                    started.TrySetResult();
+            }
+            await release.Task.WaitAsync(token);
+            return TileRetrievalResult.Success([1]);
+        }
+
+        try
+        {
+            var work = new[] { "client-a", "client-b" }
+                .SelectMany(client => Enumerable.Range(0, TileWorkScheduler.PerClientConcurrency)
+                    .Select(index => TileWorkScheduler.ExecuteForegroundAsync(
+                        $"{client}:{index}", client,
+                        token => ContactAsync(client, token), CancellationToken.None)))
+                .ToArray();
+
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(12, startedCount);
+            Assert.Equal(6, counts["client-a"]);
+            Assert.Equal(6, counts["client-b"]);
+            Assert.Equal(0, TileCacheService.OutboundBudget.ProviderReplenisherStartCountForTesting);
+            release.TrySetResult();
+            await Task.WhenAll(work);
+        }
+        finally
+        {
+            release.TrySetResult();
+            TileWorkScheduler.ResetForTesting();
             TileCacheService.OutboundBudget.ResetForTesting();
         }
     }

--- a/tests/Wayfarer.Tests/Services/TileProviderPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileProviderPolicyTests.cs
@@ -239,7 +239,7 @@ public sealed class TileProviderPolicyTests
 
 /// <summary>Proves the provider-state table enforces its hard admission boundary.</summary>
 [Collection("OutboundBudget")]
-public sealed class TileProviderStateAdmissionTests
+public sealed partial class TileProviderStateAdmissionTests
 {
     /// <summary>Interactive has no token ceiling while every contact still acquires concurrency.</summary>
     [Fact]
@@ -261,58 +261,6 @@ public sealed class TileProviderStateAdmissionTests
         }
         finally
         {
-            TileCacheService.OutboundBudget.ResetForTesting();
-        }
-    }
-
-    /// <summary>Interactive permits the scheduler's full two-client foreground width.</summary>
-    [Fact]
-    public async Task Interactive_TwoClientsStartTwelveContacts_WithSixPerClient()
-    {
-        TileCacheService.OutboundBudget.ResetForTesting();
-        TileWorkScheduler.ResetForTesting();
-        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
-        var startedCount = 0;
-        var profile = TileProviderPolicyResolver.Resolve(new ApplicationSettings());
-
-        async Task<TileRetrievalResult> ContactAsync(string clientKey, CancellationToken token)
-        {
-            var acquisition = await TileCacheService.OutboundBudget.AcquireProviderContactAsync(
-                profile, TileWorkPriority.Foreground, token);
-            using var lease = Assert.IsType<TileCacheService.OutboundBudget.ProviderContactLease>(acquisition.Lease);
-            lock (counts)
-            {
-                counts[clientKey] = counts.GetValueOrDefault(clientKey) + 1;
-                if (++startedCount == TileWorkScheduler.ForegroundConcurrency)
-                    started.TrySetResult();
-            }
-            await release.Task.WaitAsync(token);
-            return TileRetrievalResult.Success([1]);
-        }
-
-        try
-        {
-            var work = new[] { "client-a", "client-b" }
-                .SelectMany(client => Enumerable.Range(0, TileWorkScheduler.PerClientConcurrency)
-                    .Select(index => TileWorkScheduler.ExecuteForegroundAsync(
-                        $"{client}:{index}", client,
-                        token => ContactAsync(client, token), CancellationToken.None)))
-                .ToArray();
-
-            await started.Task.WaitAsync(TimeSpan.FromSeconds(2));
-            Assert.Equal(12, startedCount);
-            Assert.Equal(6, counts["client-a"]);
-            Assert.Equal(6, counts["client-b"]);
-            Assert.Equal(0, TileCacheService.OutboundBudget.ProviderReplenisherStartCountForTesting);
-            release.TrySetResult();
-            await Task.WhenAll(work);
-        }
-        finally
-        {
-            release.TrySetResult();
-            TileWorkScheduler.ResetForTesting();
             TileCacheService.OutboundBudget.ResetForTesting();
         }
     }

--- a/tests/Wayfarer.Tests/Services/TileProviderPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileProviderPolicyTests.cs
@@ -103,7 +103,7 @@ public sealed class TileProviderPolicyTests
         settings => settings.TileProviderTotalRetryCeilingSeconds = 29
     };
 
-    /// <summary>Invalid persisted values fail safely to the approved custom defaults.</summary>
+    /// <summary>Invalid persisted values remain recoverable and prevent activation.</summary>
     [Theory]
     [MemberData(nameof(InvalidPersistedProfiles))]
     public void Resolve_InvalidPersistedCustomProfile_ReturnsSafeDefaults(
@@ -114,8 +114,8 @@ public sealed class TileProviderPolicyTests
 
         var profile = TileProviderPolicyResolver.Resolve(settings);
 
-        Assert.Equal("custom:default", profile.Identity);
-        AssertApprovedDefaults(profile);
+        Assert.Equal(TileProviderCompatibility.InvalidOrUnsupported, profile.Compatibility.Status);
+        Assert.False(profile.CanContactProvider);
     }
 
     /// <summary>
@@ -133,7 +133,12 @@ public sealed class TileProviderPolicyTests
             .ToArray();
 
         Assert.Equal(profiles.Length, profiles.Select(profile => profile.Identity).Distinct().Count());
-        Assert.All(profiles, AssertApprovedDefaults);
+        Assert.All(profiles, profile =>
+        {
+            Assert.Equal(TileTrafficMode.Interactive, profile.TrafficMode);
+            Assert.False(profile.UsesRateTokens);
+            Assert.Equal(6, profile.MaxConcurrency);
+        });
     }
 
     /// <summary>
@@ -152,8 +157,7 @@ public sealed class TileProviderPolicyTests
             TileProviderMaxConcurrency = 16
         });
 
-        Assert.Equal("builtin:osm", profile.Identity);
-        AssertApprovedDefaults(profile);
+        Assert.Equal(TileTrafficMode.Custom, profile.TrafficMode);
         Assert.False(profile.PrefetchEnabled);
     }
 
@@ -236,6 +240,30 @@ public sealed class TileProviderPolicyTests
 [Collection("OutboundBudget")]
 public sealed class TileProviderStateAdmissionTests
 {
+    /// <summary>Interactive has no token ceiling while every contact still acquires concurrency.</summary>
+    [Fact]
+    public async Task AcquireProviderContactAsync_Interactive_AllowsMoreThanHistoricalBurst()
+    {
+        TileCacheService.OutboundBudget.ResetForTesting();
+        var profile = TileProviderPolicyResolver.Resolve(new ApplicationSettings());
+        try
+        {
+            for (var index = 0; index < 81; index++)
+            {
+                var acquisition = await TileCacheService.OutboundBudget.AcquireProviderContactAsync(
+                    profile, TileWorkPriority.Foreground, CancellationToken.None);
+                Assert.NotNull(acquisition.Lease);
+                acquisition.Lease.Dispose();
+            }
+
+            Assert.Equal(0, TileCacheService.OutboundBudget.ProviderReplenisherStartCountForTesting);
+        }
+        finally
+        {
+            TileCacheService.OutboundBudget.ResetForTesting();
+        }
+    }
+
     /// <summary>Shutdown closes provider-state admission before a request can enter the state table.</summary>
     [Fact]
     public async Task AcquireProviderContactAsync_PausedBeforeStateLock_IsRejectedAfterStop()
@@ -385,7 +413,9 @@ public sealed class TileProviderStateAdmissionTests
     }
 
     private static TileProviderPolicy Profile(int index) => new(
-        $"custom:test-{index}", 20, 50, 16, 3,
+        $"custom:test-{index}", TileTrafficMode.Custom,
+        new(TileProviderCompatibility.Supported, "test", "test"), true,
+        20, 50, 16, 0, 3,
         TimeSpan.FromMilliseconds(250), TimeSpan.FromSeconds(1),
         TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5), false);
 }

--- a/tests/Wayfarer.Tests/Services/TileProviderPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileProviderPolicyTests.cs
@@ -10,6 +10,75 @@ namespace Wayfarer.Tests.Services;
 /// </summary>
 public sealed class TileProviderPolicyTests
 {
+    /// <summary>Supported built-ins migrate to Interactive without consulting dormant values.</summary>
+    [Fact]
+    public void Resolve_SupportedBuiltInWithDormantValues_IsInteractive()
+    {
+        var profile = TileProviderPolicyResolver.Resolve(new ApplicationSettings
+        {
+            TileProviderKey = "opentopomap",
+            TileProviderUrlTemplate = "https://a.tile.opentopomap.org/{z}/{x}/{y}.png",
+            TileProviderAdvancedLimitsEnabled = true,
+            TileOutboundBudgetPerIpPerMinute = 30
+        });
+
+        Assert.Equal(TileTrafficMode.Interactive, profile.TrafficMode);
+        Assert.False(profile.UsesRateTokens);
+        Assert.Equal(0, profile.ClientSeriesPerMinute);
+        Assert.Equal(TileProviderCompatibility.Supported, profile.Compatibility.Status);
+    }
+
+    /// <summary>Blocked hosts win over a Custom label and advanced traffic controls.</summary>
+    [Theory]
+    [InlineData("custom", "https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png")]
+    [InlineData("unknown", "https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png")]
+    public void Resolve_BlockedEndpoint_PrecedesTrafficMode(string key, string template)
+    {
+        var profile = TileProviderPolicyResolver.Resolve(new ApplicationSettings
+        {
+            TileProviderKey = key,
+            TileProviderUrlTemplate = template,
+            TileProviderAdvancedLimitsEnabled = true
+        });
+
+        Assert.Equal(TileProviderCompatibility.Blocked, profile.Compatibility.Status);
+        Assert.False(profile.CanContactProvider);
+    }
+
+    /// <summary>Blank and unknown provider states remain recoverable but fail closed.</summary>
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("removed", "https://tiles.example.test/{z}/{x}/{y}.png")]
+    public void Resolve_UnknownOrBlankProvider_FailsClosed(string key, string template)
+    {
+        var profile = TileProviderPolicyResolver.Resolve(new ApplicationSettings
+        {
+            TileProviderKey = key,
+            TileProviderUrlTemplate = template
+        });
+
+        Assert.Equal(TileProviderCompatibility.InvalidOrUnsupported, profile.Compatibility.Status);
+        Assert.False(profile.CanContactProvider);
+    }
+
+    /// <summary>Conservative mode has exact Wayfarer contact and series safeguards.</summary>
+    [Fact]
+    public void Resolve_Conservative_UsesDocumentedSafeguards()
+    {
+        var profile = TileProviderPolicyResolver.Resolve(new ApplicationSettings
+        {
+            TileProviderKey = ApplicationSettings.DefaultTileProviderKey,
+            TileProviderUrlTemplate = ApplicationSettings.DefaultTileProviderUrlTemplate,
+            TileTrafficMode = TileTrafficMode.Conservative
+        });
+
+        Assert.Equal(12, profile.SustainedRequestsPerSecond);
+        Assert.Equal(40, profile.BurstCapacity);
+        Assert.Equal(8, profile.MaxConcurrency);
+        Assert.Equal(480, profile.ClientSeriesPerMinute);
+        Assert.True(profile.UsesRateTokens);
+    }
+
     /// <summary>Supplies persisted scalar and relationship violations that runtime resolution must contain.</summary>
     public static TheoryData<Action<ApplicationSettings>> InvalidPersistedProfiles => new()
     {

--- a/tests/Wayfarer.Tests/Services/TileProviderPolicyTests.cs
+++ b/tests/Wayfarer.Tests/Services/TileProviderPolicyTests.cs
@@ -467,7 +467,7 @@ public sealed class TileProviderStateAdmissionTests
 
     private static TileProviderPolicy Profile(int index) => new(
         $"custom:test-{index}", TileTrafficMode.Custom,
-        new(TileProviderCompatibility.Supported, "test", "test"), true,
+        new(TileProviderCompatibility.Supported, "test", "test", "test"), true,
         20, 50, 16, 0, 3,
         TimeSpan.FromMilliseconds(250), TimeSpan.FromSeconds(1),
         TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5), false);

--- a/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
+++ b/tests/Wayfarer.Tests/Util/TileProviderAttributionTests.cs
@@ -104,9 +104,7 @@ public class TileProviderAttributionTests
     }
 
     [Theory]
-    [InlineData("carto-dark", "CARTO", null)]
     [InlineData("opentopomap", "SRTM", "OpenTopoMap")]
-    [InlineData("thunderforest-cycle", "Thunderforest", null)]
     public void Resolve_PreservesEveryPartyInBuiltInPresetAttribution(
         string providerKey,
         string expectedParty,

--- a/tests/Wayfarer.Tests/Util/TileProviderCatalogTests.cs
+++ b/tests/Wayfarer.Tests/Util/TileProviderCatalogTests.cs
@@ -9,6 +9,25 @@ namespace Wayfarer.Tests.Util;
 /// </summary>
 public class TileProviderCatalogTests
 {
+    /// <summary>Removed providers cannot be selected as built-in presets.</summary>
+    [Theory]
+    [InlineData("thunderforest-cycle")]
+    [InlineData("carto-positron")]
+    [InlineData("carto-dark")]
+    public void FindPreset_RemovedProvider_ReturnsNull(string key) =>
+        Assert.Null(TileProviderCatalog.FindPreset(key));
+
+    /// <summary>Blocked-host matching is exact or DNS-subdomain based, never substring based.</summary>
+    [Theory]
+    [InlineData("tile.thunderforest.com", true)]
+    [InlineData("a.tile.thunderforest.com", true)]
+    [InlineData("basemaps.cartocdn.com", true)]
+    [InlineData("tiles.basemaps.cartocdn.com", true)]
+    [InlineData("tile.thunderforest.com.example.test", false)]
+    [InlineData("notcartocdn.com", false)]
+    public void IsBlockedContactHost_UsesDnsBoundary(string host, bool expected) =>
+        Assert.Equal(expected, TileProviderCatalog.IsBlockedContactHost(host));
+
     [Fact]
     public void FindPreset_IgnoresCase()
     {

--- a/wwwroot/js/Areas/Admin/Settings/Index.js
+++ b/wwwroot/js/Areas/Admin/Settings/Index.js
@@ -75,9 +75,9 @@ document.addEventListener('DOMContentLoaded', () => {
             attribution: tileProviderAttribution.value
         };
 
-        const setApiKeyVisibility = (requiresApiKey) => {
+        const setApiKeyVisibility = (requiresApiKey, clearValue) => {
             tileProviderApiKeyRow.classList.toggle('d-none', !requiresApiKey);
-            if (!requiresApiKey) {
+            if (!requiresApiKey && clearValue) {
                 tileProviderApiKey.value = '';
             }
         };
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const requiresApiKey = isCustom
                 ? tileProviderTemplate.value.includes('{apiKey}')
                 : presetRequiresKey;
-            setApiKeyVisibility(requiresApiKey);
+            setApiKeyVisibility(requiresApiKey, true);
         };
 
         tileProviderKey.addEventListener('change', applyTileProviderSelection);
@@ -119,7 +119,16 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
 
-        applyTileProviderSelection();
+        // Initialization is display-only: persisted recovery fields must not be rewritten.
+        const selectedOption = tileProviderKey.options[tileProviderKey.selectedIndex];
+        const isCustom = selectedOption?.value === customKey;
+        const isPreserved = selectedOption?.dataset.preserved === 'true';
+        tileProviderTemplate.readOnly = !isCustom;
+        tileProviderAttribution.readOnly = !isCustom;
+        setApiKeyVisibility(
+            isPreserved || tileProviderTemplate.value.includes('{apiKey}') ||
+            selectedOption?.dataset.requiresKey === 'true',
+            false);
     }
 
     // On page load, check if a cache purge is already in progress and reconnect SSE.

--- a/wwwroot/js/Areas/Admin/Settings/Index.js
+++ b/wwwroot/js/Areas/Admin/Settings/Index.js
@@ -67,9 +67,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const tileProviderAttribution = document.getElementById('TileProviderAttribution');
     const tileProviderApiKeyRow = document.getElementById('tileProviderApiKeyRow');
     const tileProviderApiKey = document.getElementById('TileProviderApiKey');
-    const tileProviderAdvancedRow = document.getElementById('tileProviderAdvancedRow');
-    const tileProviderAdvancedToggle = document.getElementById('TileProviderAdvancedLimitsEnabled');
-    const tileProviderAdvancedFields = document.getElementById('tileProviderAdvancedFields');
 
     if (tileProviderKey && tileProviderTemplate && tileProviderAttribution && tileProviderApiKeyRow && tileProviderApiKey) {
         const customKey = tileProviderKey.dataset.customKey || 'custom';
@@ -91,11 +88,6 @@ document.addEventListener('DOMContentLoaded', () => {
             const presetTemplate = selectedOption?.dataset.template || '';
             const presetAttribution = selectedOption?.dataset.attribution || '';
             const presetRequiresKey = selectedOption?.dataset.requiresKey === 'true';
-            tileProviderAdvancedRow?.classList.toggle('d-none', !isCustom);
-            tileProviderAdvancedFields?.classList.toggle(
-                'd-none',
-                !isCustom || !tileProviderAdvancedToggle?.checked);
-
             if (isCustom) {
                 tileProviderTemplate.readOnly = false;
                 tileProviderAttribution.readOnly = false;
@@ -115,7 +107,6 @@ document.addEventListener('DOMContentLoaded', () => {
         };
 
         tileProviderKey.addEventListener('change', applyTileProviderSelection);
-        tileProviderAdvancedToggle?.addEventListener('change', applyTileProviderSelection);
         tileProviderTemplate.addEventListener('input', () => {
             if (tileProviderKey.value === customKey) {
                 customState.template = tileProviderTemplate.value;


### PR DESCRIPTION
## Summary

- add explicit Interactive, Conservative, and Custom / Provider Agreement tile traffic modes
- make Interactive bypass Wayfarer rate/burst and historical per-client throttles while retaining 12-global/6-client concurrency, caching, coalescing, retries, and provider-directed safety gates
- remove and fail closed for incompatible Thunderforest and CARTO providers across preset, Custom, initial-contact, and redirect paths
- preserve unsupported/invalid provider configuration and provider-scoped cache for recovery without silent OSM substitution
- correct OpenTopoMap attribution and document single/multiple `AllowedHosts` systemd configuration
- expose and audit complete effective/inactive traffic-policy state without secrets or client identities

## Why

The v1.7.0 numeric limits were Wayfarer safeguards rather than provider-published allowances and remained too restrictive for ordinary interactive navigation. This redesign restores responsive human-driven map use while preserving upstream compliance, bounded local resource use, provider `Retry-After`, cache behavior, and no-prefetch rules.

Thunderforest explicitly prohibits Wayfarer’s caching-proxy architecture, and CARTO’s legacy unauthenticated raster endpoints lack a confirmed general-use licensing basis. Both are removed rather than adding ongoing legal/licensing integration burden.

Closes #396

## User and administrator impact

- supported built-in providers migrate to Interactive without restart
- existing `30`, `80`, `0`, and customized values are preserved but inactive where the selected mode does not use them
- Custom providers with advanced limits retain Custom mode and validated values
- existing cache identity and tile files remain unchanged; no cache purge is required
- removed, blocked, unknown, or malformed providers fail closed while preserving recoverable settings and cache
- Admin shows active mode, compatibility status/source, effective and inactive values, units, and blocking warnings

## Migration notes

Adds the persisted tile traffic-mode column. Migration classification is deterministic and compatibility is resolved before mode. It performs no cache scan, provider substitution, endpoint rewrite, or cache deletion.

## Validation

- focused changed-seam tests: 170 passed during implementation
- broad non-browser suite: 1,855 passed, 9 environment-gated tests skipped, 0 failed
- remediation review suites: 101 passed, followed by 12 focused audit tests
- independent final audit review: 6 passed
- `dotnet build Wayfarer.csproj --no-restore`: passed
- LOC checker: passed with no #396 file warnings at final remediation
- `git diff --check`: passed
- tracked-artifact and credential-shaped diff scans: clean
- no public tile provider contacted

Browser/PDF/mobile validation was intentionally out of scope because #396 does not change those runtime paths. Existing AngleSharp and SQLitePCLRaw advisories are unchanged and unrelated.