### PR TITLE
Fix Trip Editor manual place marker workflow

### DIFF
--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -7,18 +7,10 @@ import MapWorkToolbar from './components/MapWorkToolbar.vue';
 import TripSidebar from './components/TripSidebar.vue';
 import { disposeConfirmDialogHost, setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
 import { useEditorSurface } from './composables/useEditorSurface';
-import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type AreaPolygonWorkOptions, type CoordinatePickOptions, type FocusActiveEntityResult, type SegmentRouteWorkOptions } from './map/leafletAdapter';
+import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type AreaPolygonWorkOptions, type CoordinatePickOptions, type FocusActiveEntityResult, type PlaceDraftMarkerPreview, type SegmentRouteWorkOptions, type TripEditorMapView } from './map/leafletAdapter';
 import type { BootstrapConfig, EditorCoordinate, EditorGeocodeSearchResult, EditorMutationResult, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from './types';
 
 const props = defineProps<{ config: BootstrapConfig }>();
-
-type PlaceDraftPreview = {
-  coordinate: EditorCoordinate | null;
-  iconName: string;
-  label: string;
-  markerColor: string;
-  placeId: Guid | null;
-};
 
 const state = ref<EditorTripState | null>(null);
 const error = ref<string | null>(null);
@@ -30,14 +22,14 @@ const mobileDrawerActive = ref(false);
 const navigationStatus = ref<string | null>(null);
 const hiddenSegmentIds = ref<Set<string>>(new Set());
 const selectedPlaceId = ref<Guid | null>(null);
-const activePlaceDraftPreview = ref<PlaceDraftPreview | null>(null);
+const activePlaceDraftPreview = ref<PlaceDraftMarkerPreview | null>(null);
 const pendingSearchAdd = ref<{ result: EditorGeocodeSearchResult; regionId: Guid; requestId: number } | null>(null);
 const completedSearchAddRequestId = ref<number | null>(null);
 const editorSurface = useEditorSurface();
 let mapAdapter: ReturnType<typeof createTripEditorMap> | null = null;
 let mobileDrawerQuery: MediaQueryList | null = null;
 const coordinatePicker = {
-  applyPlaceDraftCoordinate: (placeId: Guid, coordinate: EditorCoordinate): void => mapAdapter?.applyPlaceDraftCoordinate(placeId, coordinate),
+  getMapView: (): TripEditorMapView | null => mapAdapter?.getMapView() ?? null,
   startCoordinatePick: (options: CoordinatePickOptions): (() => void) => mapAdapter?.startCoordinatePick(options) ?? (() => undefined)
 };
 const polygonEditor = {
@@ -107,7 +99,7 @@ watch(
     mapAdapter?.clearSearchPreview();
     const target = editorSurface.activeTarget.value;
     if (target?.kind === 'place' && target.mode === 'edit' && target.entityId && state.value?.placesById[target.entityId]) {
-      void selectPlace(target.entityId, { focusMap: true });
+      void selectPlace(target.entityId, { focusMap: false });
     }
   }
 );
@@ -320,32 +312,14 @@ const setRegionDraftChanges = (isDirty: boolean): void => {
 };
 
 /// Applies active place draft icon/color to the selected marker preview without saving it.
-const applyPlaceDraftPreview = (preview: PlaceDraftPreview | null): void => {
+const applyPlaceDraftPreview = (preview: PlaceDraftMarkerPreview | null): void => {
   if (!state.value) {
     activePlaceDraftPreview.value = preview;
     return;
   }
 
-  const previous = activePlaceDraftPreview.value;
-  if (previous?.placeId && previous.placeId !== preview?.placeId) {
-    mapAdapter?.applyPlaceDraftMarker(state.value, previous.placeId, null);
-  }
-  if (previous && previous.placeId === null && preview?.placeId !== null) {
-    mapAdapter?.clearPlaceDraftPreview();
-  }
-
   activePlaceDraftPreview.value = preview;
-  if (preview?.placeId) {
-    mapAdapter?.applyPlaceDraftMarker(state.value, preview.placeId, preview);
-    mapAdapter?.clearPlaceDraftPreview();
-  } else if (preview?.coordinate) {
-    mapAdapter?.showPlaceDraftPreview(preview.coordinate, preview.label, preview);
-  } else if (previous) {
-    if (previous.placeId) {
-      mapAdapter?.applyPlaceDraftMarker(state.value, previous.placeId, null);
-    }
-    mapAdapter?.clearPlaceDraftPreview();
-  }
+  mapAdapter?.setPlaceDraftPreview(state.value, preview);
 };
 
 /// Applies mutation affected slices and authoritative deleted IDs to normalized editor state.
@@ -432,13 +406,6 @@ const applyMutation = (result: EditorMutationResult<unknown>): void => {
 
   state.value = next;
   mapAdapter?.render(next, hiddenSegmentIds.value, selectedPlaceId.value);
-  if (activePlaceDraftPreview.value) {
-    if (activePlaceDraftPreview.value.placeId) {
-      mapAdapter?.applyPlaceDraftMarker(next, activePlaceDraftPreview.value.placeId, activePlaceDraftPreview.value);
-    } else if (activePlaceDraftPreview.value.coordinate) {
-      mapAdapter?.showPlaceDraftPreview(activePlaceDraftPreview.value.coordinate, activePlaceDraftPreview.value.label, activePlaceDraftPreview.value);
-    }
-  }
 };
 
 /// Updates client-session-only segment visibility without touching the API contract.

--- a/ClientApps/trip-editor/src/components/PlaceEditorForm.vue
+++ b/ClientApps/trip-editor/src/components/PlaceEditorForm.vue
@@ -6,6 +6,7 @@ import RichNotesEditor from './RichNotesEditor.vue';
 
 const props = defineProps<{
   activePlace: EditorPlace | null;
+  coordinateReadOnly: boolean;
   draft: EditorPlaceDraft;
   fieldErrors: (key: string) => string[];
   formId: string;
@@ -55,12 +56,12 @@ const markerColorOptions = computed(() => orderedMarkerColors.filter(color => pr
     <div class="trip-editor-grid">
       <label class="trip-editor-field">
         <span>Latitude</span>
-        <input v-model="props.draft.latitude" type="number" step="any" />
+        <input v-model="props.draft.latitude" type="number" step="any" :readonly="props.coordinateReadOnly" />
         <small v-for="message in props.fieldErrors('location.latitude')" :key="message">{{ message }}</small>
       </label>
       <label class="trip-editor-field">
         <span>Longitude</span>
-        <input v-model="props.draft.longitude" type="number" step="any" />
+        <input v-model="props.draft.longitude" type="number" step="any" :readonly="props.coordinateReadOnly" />
         <small v-for="message in props.fieldErrors('location.longitude')" :key="message">{{ message }}</small>
       </label>
     </div>

--- a/ClientApps/trip-editor/src/components/PlaceEditorSurface.vue
+++ b/ClientApps/trip-editor/src/components/PlaceEditorSurface.vue
@@ -41,6 +41,7 @@ defineEmits<{
         :form-id="formId"
         :form-summary-errors="formSummaryErrors"
         :is-saving="isSaving"
+        :coordinate-read-only="isMapWorkActive"
         :normal-regions="normalRegions"
         :state="state"
         @save="$emit('save')"
@@ -60,7 +61,7 @@ defineEmits<{
         @click="$emit('pickCoordinate')"
       >
         Pick on map
-        <span :id="`${formId}-pick-help`" class="visually-hidden">Use the map to choose this place's latitude and longitude.</span>
+        <span :id="`${formId}-pick-help`" class="visually-hidden">Click the map or drag the marker. Done updates the draft; Save Place persists it.</span>
       </button>
       <button type="button" class="btn btn-outline-light btn-sm" :disabled="isSaving || isMapWorkActive" @click="$emit('cancel')">Cancel</button>
       <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="isSaving || isMapWorkActive || !isDirty" @click="$emit('reset')">Reset</button>

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -62,6 +62,7 @@ const isSaving = ref(false);
 const isOrdering = ref(false);
 const regionCreateBaselineRequest = ref<EditorRegionSaveRequest | null>(null);
 const placeCreateBaselineRequest = ref<EditorPlaceSaveRequest | null>(null);
+const placeCreateBaselineDraft = ref<EditorPlaceDraft | null>(null);
 const placeEditBaselineRequest = ref<EditorPlaceSaveRequest | null>(null);
 const areaCreateBaselineRequest = ref<EditorAreaSaveRequest | null>(null);
 let unregisterRegionHandler: (() => void) | null = null;
@@ -257,6 +258,7 @@ const { cancelPlaceDraft, deleteDraftPlace, openPlaceCreate, openPlaceCreateFrom
   isSaving,
   markSaved,
   placeCoordinateMapWork,
+  placeCreateBaselineDraft,
   placeCreateBaselineRequest,
   placeEditBaselineRequest,
   placeFormId,
@@ -393,6 +395,7 @@ function clearRegionPlaceDrafts(): void {
 function clearRegionPlaceBaselines(): void {
   regionCreateBaselineRequest.value = null;
   placeCreateBaselineRequest.value = null;
+  placeCreateBaselineDraft.value = null;
   placeEditBaselineRequest.value = null;
 }
 
@@ -415,9 +418,18 @@ function pushUnique(record: Record<Guid, Guid[]>, regionId: Guid, id: Guid): voi
 }
 
 function parseDraftCoordinate(): { latitude: number; longitude: number } | null {
-  const latitude = Number(String(placeDraft.latitude ?? '').trim());
-  const longitude = Number(String(placeDraft.longitude ?? '').trim());
-  return Number.isFinite(latitude) && Number.isFinite(longitude) ? { latitude, longitude } : null;
+  const latitudeText = String(placeDraft.latitude ?? '').trim();
+  const longitudeText = String(placeDraft.longitude ?? '').trim();
+  if (!latitudeText || !longitudeText) {
+    return null;
+  }
+
+  const latitude = Number(latitudeText);
+  const longitude = Number(longitudeText);
+  return Number.isFinite(latitude) && latitude >= -90 && latitude <= 90 &&
+    Number.isFinite(longitude) && longitude >= -180 && longitude <= 180
+    ? { latitude, longitude }
+    : null;
 }
 
 function confirmDiscard(message = 'Discard unsaved changes?'): Promise<boolean> {
@@ -452,6 +464,7 @@ function discardRegionDraft(): void {
 function discardPlaceDraft(): void {
   Object.assign(placeDraft, emptyPlaceDraft());
   placeCreateBaselineRequest.value = null;
+  placeCreateBaselineDraft.value = null;
   placeEditBaselineRequest.value = null;
   resetFeedback();
 }

--- a/ClientApps/trip-editor/src/components/RegionManager.vue
+++ b/ClientApps/trip-editor/src/components/RegionManager.vue
@@ -143,9 +143,14 @@ const renderedAreaIdsByRegionId = computed(() => {
   return result;
 });
 const placePreview = computed<PlaceDraftPreview | null>(() => {
+  // Pick owns the pending coordinate until Done or Cancel; form fields continue to own draft styling.
+  const coordinate = props.editorSurface.mapWork.value?.modeName === 'Pick place location'
+    && props.editorSurface.mapWork.value.target.identity === activePlaceTarget.value.identity
+    ? placeCoordinateMapWork.coordinate
+    : parseDraftCoordinate();
   if (placeDraft.id && activePlace.value && isPlaceEditOpen(activePlace.value)) {
     return {
-      coordinate: parseDraftCoordinate(),
+      coordinate,
       placeId: placeDraft.id,
       label: placeDraft.name || activePlace.value.name,
       iconName: placeDraft.iconName || activePlace.value.iconName,
@@ -155,7 +160,7 @@ const placePreview = computed<PlaceDraftPreview | null>(() => {
 
   if (!placeDraft.id && placeDraft.regionId && props.editorSurface.isTargetActive(activePlaceTarget.value)) {
     return {
-      coordinate: parseDraftCoordinate(),
+      coordinate,
       placeId: null,
       label: placeDraft.name || 'New place',
       iconName: placeDraft.iconName || 'marker',

--- a/ClientApps/trip-editor/src/components/placeCoordinateMapWork.ts
+++ b/ClientApps/trip-editor/src/components/placeCoordinateMapWork.ts
@@ -1,9 +1,9 @@
 import type { EditorSurfaceController } from '../composables/useEditorSurface';
-import type { CoordinatePickOptions } from '../map/leafletAdapter';
-import type { EditorCoordinate, EditorPlaceDraft, Guid } from '../types';
+import type { CoordinatePickOptions, TripEditorMapView } from '../map/leafletAdapter';
+import type { EditorCoordinate, EditorPlaceDraft } from '../types';
 
 export type PlaceCoordinatePicker = {
-  applyPlaceDraftCoordinate?: (placeId: Guid, coordinate: EditorCoordinate) => void;
+  getMapView: () => TripEditorMapView | null;
   startCoordinatePick: (options: CoordinatePickOptions) => () => void;
 };
 
@@ -36,7 +36,7 @@ export function beginPlaceCoordinateMapWork(
 
   const entered = editorSurface.enterMapWork({
     modeName: 'Pick place location',
-    instruction: 'Click the map to choose this place location.',
+    instruction: 'Click the map or drag the marker. Done updates the draft; Save Place persists it.',
     statusText: () => placeCoordinatePickStatus(state.coordinate),
     canFinish: () => isValidCoordinate(state.coordinate),
     isDirty: () => !sameCoordinate(state.coordinate, coordinateFromSnapshot(coordinateSnapshot)),
@@ -48,9 +48,6 @@ export function beginPlaceCoordinateMapWork(
       if (isValidCoordinate(state.coordinate)) {
         draft.latitude = state.coordinate.latitude;
         draft.longitude = state.coordinate.longitude;
-        if (draft.id) {
-          coordinatePicker.applyPlaceDraftCoordinate?.(draft.id, state.coordinate);
-        }
       }
       stopPlaceCoordinatePick(state);
     },

--- a/ClientApps/trip-editor/src/components/placeEditorActions.ts
+++ b/ClientApps/trip-editor/src/components/placeEditorActions.ts
@@ -17,6 +17,8 @@ export function usePlaceEditorActions(context: any) {
   };
 
   const openPlaceCreateDraft = async (region: EditorRegion, result: EditorGeocodeSearchResult | null): Promise<boolean> => {
+    // Manual creation owns the map center that exists at invocation time, before target activation can render or wait.
+    const manualCenter = result ? null : context.props.coordinatePicker.getMapView()?.center ?? null;
     const target = buildPlaceCreateTarget(region);
     const isAlreadyActive = context.props.editorSurface.isTargetActive(target);
     if (!(await context.props.editorSurface.activateTarget(target)) || (isAlreadyActive && !result)) {
@@ -32,13 +34,14 @@ export function usePlaceEditorActions(context: any) {
     Object.assign(context.areaDraft, emptyAreaDraft());
     context.placeDraft.name = result ? searchResultName(result) : 'New Place';
     context.placeDraft.address = result?.address || result?.displayName || '';
-    context.placeDraft.latitude = result?.latitude ?? '';
-    context.placeDraft.longitude = result?.longitude ?? '';
+    context.placeDraft.latitude = result?.latitude ?? manualCenter?.latitude ?? '';
+    context.placeDraft.longitude = result?.longitude ?? manualCenter?.longitude ?? '';
     context.placeDraft.iconName = defaultPlaceIconName;
     context.placeDraft.markerColor = defaultPlaceMarkerColor;
     context.placeDraft.reverseGeocode = false;
     context.regionCreateBaselineRequest.value = null;
     context.placeCreateBaselineRequest.value = buildPlaceRequest(context.placeDraft);
+    context.placeCreateBaselineDraft.value = { ...context.placeDraft };
     context.placeEditBaselineRequest.value = null;
     context.areaCreateBaselineRequest.value = null;
     context.resetFeedback();
@@ -59,6 +62,7 @@ export function usePlaceEditorActions(context: any) {
     Object.assign(context.areaDraft, emptyAreaDraft());
     context.regionCreateBaselineRequest.value = null;
     context.placeCreateBaselineRequest.value = null;
+    context.placeCreateBaselineDraft.value = null;
     context.placeEditBaselineRequest.value = buildPlaceRequest(context.placeDraft);
     context.areaCreateBaselineRequest.value = null;
     // Quill can normalize legacy persisted notes after render; keep that hydration out of dirty-state prompts.
@@ -73,11 +77,7 @@ export function usePlaceEditorActions(context: any) {
 
   const resetPlaceDraft = (): void => {
     if (!context.placeDraft.id) {
-      const regionId = context.placeDraft.regionId;
-      Object.assign(context.placeDraft, emptyPlaceDraft(regionId));
-      context.placeDraft.name = 'New Place';
-      context.placeDraft.iconName = defaultPlaceIconName;
-      context.placeDraft.markerColor = defaultPlaceMarkerColor;
+      Object.assign(context.placeDraft, context.placeCreateBaselineDraft.value ?? emptyPlaceDraft(context.placeDraft.regionId));
     } else {
       Object.assign(context.placeDraft, toPlaceDraft(context.activePlace.value, context.placeDraft.regionId));
       context.placeEditBaselineRequest.value = buildPlaceRequest(context.placeDraft);
@@ -109,6 +109,7 @@ export function usePlaceEditorActions(context: any) {
       context.emit('mutationApplied', result as EditorMutationResult<unknown>);
       Object.assign(context.placeDraft, toPlaceDraft(result.data, result.data.regionId));
       context.placeCreateBaselineRequest.value = null;
+      context.placeCreateBaselineDraft.value = null;
       context.placeEditBaselineRequest.value = buildPlaceRequest(context.placeDraft);
       context.props.editorSurface.replaceActiveTarget(context.activePlaceTarget.value);
       context.markSaved(result.warnings.map((warning: { message: string }) => warning.message), 'Place saved');
@@ -153,6 +154,7 @@ export function usePlaceEditorActions(context: any) {
       Object.assign(context.placeDraft, emptyPlaceDraft());
       Object.assign(context.areaDraft, emptyAreaDraft());
       context.placeCreateBaselineRequest.value = null;
+      context.placeCreateBaselineDraft.value = null;
       context.placeEditBaselineRequest.value = null;
       context.areaCreateBaselineRequest.value = null;
       context.props.editorSurface.clearActiveTarget(deletedTarget);

--- a/ClientApps/trip-editor/src/map.css
+++ b/ClientApps/trip-editor/src/map.css
@@ -327,6 +327,8 @@
     min-height: 0;
     position: absolute;
     width: 100%;
+    /* Contain Leaflet's pane z-indexes beneath sibling editor chrome. */
+    z-index: 0;
   }
 
   .trip-editor-toolbar {

--- a/ClientApps/trip-editor/src/map.css
+++ b/ClientApps/trip-editor/src/map.css
@@ -343,7 +343,8 @@
     padding: 0.5rem;
     position: absolute;
     right: 0.75rem;
-    top: 0.75rem;
+    /* Clear Leaflet's top-right utilities while retaining the full toolbar width. */
+    top: 4rem;
     z-index: 12;
   }
 

--- a/ClientApps/trip-editor/src/map.css
+++ b/ClientApps/trip-editor/src/map.css
@@ -344,7 +344,7 @@
     position: absolute;
     right: 0.75rem;
     /* Clear Leaflet's top-right utilities while retaining the full toolbar width. */
-    top: 4rem;
+    top: 4.5rem;
     z-index: 12;
   }
 

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -211,7 +211,7 @@ const renderPlace = (
   place: EditorPlace,
   state: EditorTripState,
   layers: LayerGroup,
-  coordinatePick: ReturnType<typeof createCoordinatePickLayer>,
+  coordinatePick: ReturnType<typeof createPlaceCoordinatePickLayer>,
   placeMarkers: Map<Guid, L.Marker>,
   onSelected: () => boolean | Promise<boolean>
 ): void => {

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -2,15 +2,16 @@ import L, { type LayerGroup, type LeafletMouseEvent, type Map as LeafletMap } fr
 import 'leaflet/dist/leaflet.css';
 import type { EditorTarget } from '../composables/useEditorSurface';
 import type { EditorArea, EditorCoordinate, EditorPlace, EditorRegion, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from '../types';
-import { createAreaPolygonWorkLayer } from './areaPolygonWorkLayer';
+import { createAreaPolygonWorkLayer, type AreaPolygonWorkOptions } from './areaPolygonWorkLayer';
 import { createMapUtilitiesControl } from './mapUtilitiesControl';
-import { createPlaceDraftPreviewLayer } from './placeDraftPreviewLayer';
-import { placeMarkerIcon, previewMarkerIcon, regionMarkerIcon } from './markerRendering';
+import { createPlaceCoordinatePickLayer, createPlaceDraftPreviewLayer, type CoordinatePickOptions } from './placeDraftPreviewLayer';
+import { placeMarkerIcon, regionMarkerIcon } from './markerRendering';
 import { placePopupHtml } from './placePopupRendering';
 import { createSearchPreviewLayer } from './searchPreviewLayer';
-import { createSegmentRouteWorkLayer } from './segmentRouteWorkLayer';
+import { createSegmentRouteWorkLayer, type SegmentRouteWorkOptions } from './segmentRouteWorkLayer';
 import { createTripEditorTileLayer } from './tileRetryLayer';
 export type { AreaPolygonWorkOptions } from './areaPolygonWorkLayer';
+export type { CoordinatePickOptions } from './placeDraftPreviewLayer';
 export type { SegmentRouteWorkOptions } from './segmentRouteWorkLayer';
 
 export type FitAllGeometryResult = 'moved' | 'no-geometry';
@@ -20,11 +21,10 @@ export type InitialMapViewSource = 'url' | 'saved' | 'fit-bounds' | 'fallback';
 
 interface TripEditorMapAdapter {
   render: (state: EditorTripState, hiddenSegmentIds?: ReadonlySet<Guid>, selectedPlaceId?: Guid | null) => void;
-  applyPlaceDraftCoordinate: (placeId: Guid, coordinate: EditorCoordinate) => void;
-  applyPlaceDraftMarker: (state: EditorTripState, placeId: Guid, preview: Pick<EditorPlace, 'iconName' | 'markerColor'> | null) => void;
-  clearPlaceDraftPreview: () => void;
   clearSearchPreview: () => void;
+  getMapView: () => TripEditorMapView;
   selectPlace: (state: EditorTripState, placeId: Guid | null, options?: SelectPlaceOptions) => void;
+  setPlaceDraftPreview: (state: EditorTripState, preview: PlaceDraftMarkerPreview | null) => void;
   startCoordinatePick: (options: CoordinatePickOptions) => () => void;
   startAreaPolygonWork: (options: AreaPolygonWorkOptions) => () => void;
   startSegmentRouteWork: (options: SegmentRouteWorkOptions) => () => void;
@@ -32,9 +32,19 @@ interface TripEditorMapAdapter {
   fitAllGeometry: (state: EditorTripState) => FitAllGeometryResult;
   focusSavedTripView: (metadata: EditorTripMetadata) => FocusSavedTripViewResult;
   focusActiveEntity: (state: EditorTripState, target: EditorTarget | null) => FocusActiveEntityResult;
-  showPlaceDraftPreview: (coordinate: EditorCoordinate, label: string, preview: Pick<EditorPlace, 'iconName' | 'markerColor'>) => void;
   showSearchPreview: (coordinate: EditorCoordinate, label: string) => void;
   dispose: () => void;
+}
+
+export interface TripEditorMapView {
+  center: EditorCoordinate;
+  zoom: number;
+}
+
+export interface PlaceDraftMarkerPreview extends Pick<EditorPlace, 'iconName' | 'markerColor'> {
+  coordinate: EditorCoordinate | null;
+  label: string;
+  placeId: Guid | null;
 }
 
 export interface TripEditorMapOptions {
@@ -51,11 +61,12 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
   const layers = L.layerGroup().addTo(map);
   const searchPreview = createSearchPreviewLayer(map);
   const placeDraftPreview = createPlaceDraftPreviewLayer(map);
-  const coordinatePick = createCoordinatePickLayer(map);
+  const coordinatePick = createPlaceCoordinatePickLayer(map, placeDraftPreview);
   const areaPolygonWork = createAreaPolygonWorkLayer(map);
   const segmentRouteWork = createSegmentRouteWorkLayer(map);
   const mapUtilities = createMapUtilitiesControl(element).addTo(map);
   const placeMarkers = new Map<Guid, L.Marker>();
+  let activePlaceDraftPreview: PlaceDraftMarkerPreview | null = null;
   const updateMapViewDataset = (): void => {
     const center = map.getCenter();
     element.dataset.tripEditorMapLat = center.lat.toFixed(6);
@@ -64,7 +75,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
   };
   let selectedPlaceId: Guid | null = null;
   let initialViewApplied = false;
-  const prepareMapWork = (): void => { searchPreview.clear(); placeDraftPreview.clear(); mapUtilities.cancelMeasure(); };
+  const prepareMapWork = (): void => { searchPreview.clear(); mapUtilities.cancelMeasure(); };
 
   map.on('moveend zoomend', updateMapViewDataset);
 
@@ -108,32 +119,48 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
     }
     updateMapViewDataset();
     applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
+    applyActivePlaceDraftPreview(state);
+  };
+
+  const applyActivePlaceDraftPreview = (state: EditorTripState): void => {
+    placeDraftPreview.clear();
+    const preview = activePlaceDraftPreview;
+    if (!preview) {
+      return;
+    }
+
+    if (preview.placeId) {
+      placeMarkers.get(preview.placeId)?.remove();
+    }
+    placeDraftPreview.show(preview.coordinate, preview.label, preview);
+  };
+
+  const setPlaceDraftPreview = (state: EditorTripState, preview: PlaceDraftMarkerPreview | null): void => {
+    const previousPlaceId = activePlaceDraftPreview?.placeId;
+    if (previousPlaceId) {
+      const marker = placeMarkers.get(previousPlaceId);
+      const place = state.placesById[previousPlaceId];
+      if (marker && place?.location) {
+        marker.setLatLng([place.location.latitude, place.location.longitude]);
+        marker.setIcon(placeMarkerIcon(place));
+        marker.addTo(layers);
+      }
+    }
+
+    // Partial or invalid direct input cannot take coordinate ownership from the last complete pair.
+    activePlaceDraftPreview = preview && !preview.coordinate && activePlaceDraftPreview?.coordinate && preview.placeId === previousPlaceId
+      ? { ...preview, coordinate: activePlaceDraftPreview.coordinate }
+      : preview;
+    applyActivePlaceDraftPreview(state);
   };
 
   return {
     render,
-    applyPlaceDraftCoordinate: (placeId, coordinate) => {
-      const marker = placeMarkers.get(placeId);
-      if (!marker) {
-        return;
-      }
-
-      marker.setLatLng([coordinate.latitude, coordinate.longitude]);
-      applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
-      updateMapViewDataset();
-    },
-    applyPlaceDraftMarker: (state, placeId, preview) => {
-      const marker = placeMarkers.get(placeId);
-      const place = state.placesById[placeId];
-      if (!marker || !place) {
-        return;
-      }
-
-      marker.setIcon(placeMarkerIcon(preview ? { ...place, ...preview } : place));
-      applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
-    },
-    clearPlaceDraftPreview: placeDraftPreview.clear,
     clearSearchPreview: searchPreview.clear,
+    getMapView: () => {
+      const center = map.getCenter();
+      return { center: { latitude: center.lat, longitude: center.lng }, zoom: map.getZoom() };
+    },
     selectPlace: (state, placeId, selectOptions = {}) => {
       selectedPlaceId = placeId && state.placesById[placeId] ? placeId : null;
       applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
@@ -144,6 +171,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
         focusSelectedPlace(map, state, placeMarkers, selectedPlaceId, selectOptions);
       }
     },
+    setPlaceDraftPreview,
     startCoordinatePick: options => (prepareMapWork(), coordinatePick.start(options)),
     startAreaPolygonWork: options => (prepareMapWork(), areaPolygonWork.start(options)),
     startSegmentRouteWork: options => (prepareMapWork(), segmentRouteWork.start(options)),
@@ -151,7 +179,6 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
     fitAllGeometry: state => fitAllGeometry(map, state),
     focusSavedTripView: metadata => focusSavedTripView(map, metadata),
     focusActiveEntity: (state, target) => focusActiveEntity(map, state, target),
-    showPlaceDraftPreview: placeDraftPreview.show,
     showSearchPreview: searchPreview.show,
     dispose: () => {
       searchPreview.dispose();
@@ -163,125 +190,6 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
       map.off('moveend zoomend', updateMapViewDataset);
       map.remove();
     }
-  };
-};
-
-export interface CoordinatePickOptions {
-  initialCoordinate: EditorCoordinate | null;
-  onPicked: (coordinate: EditorCoordinate) => void;
-}
-
-const createCoordinatePickLayer = (map: LeafletMap): {
-  clearRegisteredMarkers: () => void;
-  dispose: () => void;
-  isActive: () => boolean;
-  pick: (coordinate: EditorCoordinate) => void;
-  registerMarker: (marker: L.Marker, coordinate: EditorCoordinate) => void;
-  start: (options: CoordinatePickOptions) => () => void;
-  stop: () => void;
-} => {
-  const layer = L.layerGroup().addTo(map);
-  let clickHandler: ((event: LeafletMouseEvent) => void) | null = null;
-  let onPicked: ((coordinate: EditorCoordinate) => void) | null = null;
-  let previousCursor: string | null = null;
-  const markers: Array<{ marker: L.Marker; coordinate: EditorCoordinate }> = [];
-  const markerListeners: Array<() => void> = [];
-
-  const setPreview = (coordinate: EditorCoordinate): void => {
-    layer.clearLayers();
-    L.marker([coordinate.latitude, coordinate.longitude], {
-      icon: previewMarkerIcon('coordinate', 'Selected place location preview'),
-      interactive: false,
-      keyboard: false,
-      title: 'Selected place location preview',
-      alt: 'Selected place location preview'
-    }).addTo(layer);
-  };
-
-  const pick = (coordinate: EditorCoordinate): void => {
-    setPreview(coordinate);
-    onPicked?.(coordinate);
-  };
-
-  const stop = (): void => {
-    if (clickHandler) {
-      map.off('click', clickHandler);
-      clickHandler = null;
-    }
-
-    onPicked = null;
-    if (previousCursor !== null) {
-      map.getContainer().style.cursor = previousCursor;
-      previousCursor = null;
-    }
-    detachMarkerListeners();
-    layer.clearLayers();
-  };
-
-  const attachMarkerListener = (marker: L.Marker, coordinate: EditorCoordinate): void => {
-    const handler = (event: LeafletMouseEvent): void => {
-      if (event.originalEvent) {
-        L.DomEvent.stop(event.originalEvent);
-      }
-
-      marker.closePopup();
-      pick(coordinate);
-    };
-    marker.on('click', handler);
-    markerListeners.push(() => marker.off('click', handler));
-  };
-
-  const attachMarkerListeners = (): void => {
-    detachMarkerListeners();
-    markers.forEach(({ marker, coordinate }) => attachMarkerListener(marker, coordinate));
-  };
-
-  const detachMarkerListeners = (): void => {
-    markerListeners.splice(0).forEach(detach => detach());
-  };
-
-  const registerMarker = (marker: L.Marker, coordinate: EditorCoordinate): void => {
-    markers.push({ marker, coordinate });
-    if (clickHandler) {
-      attachMarkerListener(marker, coordinate);
-    }
-  };
-
-  const clearRegisteredMarkers = (): void => {
-    detachMarkerListeners();
-    markers.splice(0);
-  };
-
-  const start = (options: CoordinatePickOptions): (() => void) => {
-    stop();
-    onPicked = options.onPicked;
-    previousCursor = map.getContainer().style.cursor;
-    map.getContainer().style.cursor = 'default';
-    attachMarkerListeners();
-
-    if (options.initialCoordinate) {
-      setPreview(options.initialCoordinate);
-    }
-
-    clickHandler = event => {
-      const coordinate = { latitude: event.latlng.lat, longitude: event.latlng.lng };
-      pick(coordinate);
-    };
-    map.on('click', clickHandler);
-    return stop;
-  };
-
-  return {
-    clearRegisteredMarkers,
-    dispose: () => {
-      stop();
-      clearRegisteredMarkers();
-    },
-    isActive: () => clickHandler !== null,
-    pick,
-    registerMarker,
-    start,
-    stop
   };
 };
 

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -123,15 +123,16 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
   };
 
   const applyActivePlaceDraftPreview = (state: EditorTripState): void => {
-    placeDraftPreview.clear();
     const preview = activePlaceDraftPreview;
     if (!preview) {
+      placeDraftPreview.clear();
       return;
     }
 
     if (preview.placeId) {
       placeMarkers.get(preview.placeId)?.remove();
     }
+    // Preserve the authoritative marker instance and Pick listeners while draft styling rerenders.
     placeDraftPreview.show(preview.coordinate, preview.label, preview);
   };
 

--- a/ClientApps/trip-editor/src/map/placeDraftPreviewLayer.ts
+++ b/ClientApps/trip-editor/src/map/placeDraftPreviewLayer.ts
@@ -1,35 +1,209 @@
-import L, { type Map as LeafletMap } from 'leaflet';
+import L, { type LeafletMouseEvent, type Map as LeafletMap } from 'leaflet';
 import type { EditorCoordinate, EditorPlace } from '../types';
 import { previewMarkerIcon } from './markerRendering';
+
+export interface CoordinatePickOptions {
+  initialCoordinate: EditorCoordinate | null;
+  onPicked: (coordinate: EditorCoordinate) => void;
+}
 
 /// Renders the unsaved add-place location that must be visible before Save Place persists it.
 export const createPlaceDraftPreviewLayer = (map: LeafletMap): {
   clear: () => void;
   dispose: () => void;
-  show: (coordinate: EditorCoordinate, label: string, preview: Pick<EditorPlace, 'iconName' | 'markerColor'>) => void;
+  setCoordinate: (coordinate: EditorCoordinate) => void;
+  setPickMode: (active: boolean, onDragged?: (coordinate: EditorCoordinate) => void) => void;
+  show: (coordinate: EditorCoordinate | null, label: string, preview: Pick<EditorPlace, 'iconName' | 'markerColor'>) => void;
 } => {
   const layer = L.layerGroup().addTo(map);
+  let marker: L.Marker | null = null;
+  let dragHandler: (() => void) | null = null;
+  let pickActive = false;
+  let onMarkerDragged: ((coordinate: EditorCoordinate) => void) | undefined;
+  let markerLabel = 'New place';
+  let markerPreview: Pick<EditorPlace, 'iconName' | 'markerColor'> = { iconName: 'marker', markerColor: 'bg-blue' };
 
   const clear = (): void => {
+    dragHandler?.();
+    dragHandler = null;
+    marker = null;
     layer.clearLayers();
   };
 
-  const show = (coordinate: EditorCoordinate, label: string, preview: Pick<EditorPlace, 'iconName' | 'markerColor'>): void => {
-    const title = `Pending place location: ${label}`;
-    clear();
-    L.marker([coordinate.latitude, coordinate.longitude], {
-      icon: previewMarkerIcon('place-draft', title, preview),
-      interactive: false,
-      keyboard: false,
+  const setCoordinate = (coordinate: EditorCoordinate): void => {
+    if (!marker) {
+      renderMarker(coordinate);
+      return;
+    }
+
+    marker.setLatLng([coordinate.latitude, coordinate.longitude]);
+    exposeCoordinate(coordinate);
+  };
+
+  const setPickMode = (active: boolean, onDragged?: (coordinate: EditorCoordinate) => void): void => {
+    dragHandler?.();
+    dragHandler = null;
+    pickActive = active;
+    onMarkerDragged = active ? onDragged : undefined;
+    if (!marker) return;
+
+    if (!active) {
+      marker.dragging?.disable();
+      return;
+    }
+
+    marker.dragging?.enable();
+    const handleDragEnd = (): void => {
+      const coordinate = marker!.getLatLng();
+      onMarkerDragged?.({ latitude: coordinate.lat, longitude: coordinate.lng });
+    };
+    const stopMarkerClick = (event: LeafletMouseEvent): void => {
+      if (event.originalEvent) L.DomEvent.stop(event.originalEvent);
+    };
+    marker.on('dragend', handleDragEnd);
+    marker.on('click', stopMarkerClick);
+    dragHandler = () => {
+      marker?.off('dragend', handleDragEnd);
+      marker?.off('click', stopMarkerClick);
+    };
+  };
+
+  const renderMarker = (coordinate: EditorCoordinate): void => {
+    const title = `Pending place location: ${markerLabel}`;
+    marker = L.marker([coordinate.latitude, coordinate.longitude], {
+      icon: previewMarkerIcon('place-draft', title, markerPreview),
+      draggable: pickActive,
+      interactive: true,
+      keyboard: true,
       title,
       alt: title
     }).addTo(layer);
-    map.setView([coordinate.latitude, coordinate.longitude], Math.max(map.getZoom(), 13));
+    exposeCoordinate(coordinate);
+    if (pickActive) {
+      setPickMode(true, onMarkerDragged);
+    }
+  };
+
+  const show = (coordinate: EditorCoordinate | null, label: string, preview: Pick<EditorPlace, 'iconName' | 'markerColor'>): void => {
+    markerLabel = label;
+    markerPreview = preview;
+    if (!coordinate) {
+      return;
+    }
+    if (!marker) {
+      renderMarker(coordinate);
+      return;
+    }
+
+    marker.setLatLng([coordinate.latitude, coordinate.longitude]);
+    marker.setIcon(previewMarkerIcon('place-draft', `Pending place location: ${label}`, preview));
+    exposeCoordinate(coordinate);
+  };
+
+  const exposeCoordinate = (coordinate: EditorCoordinate): void => {
+    const element = marker?.getElement();
+    if (element) {
+      element.dataset.placeDraftLatitude = String(coordinate.latitude);
+      element.dataset.placeDraftLongitude = String(coordinate.longitude);
+    }
   };
 
   return {
     clear,
-    dispose: clear,
+    dispose: () => {
+      setPickMode(false);
+      clear();
+    },
+    setCoordinate,
+    setPickMode,
     show
+  };
+};
+
+/// Coordinates map clicks, persisted-marker clicks, and draft-marker drags through one pending coordinate owner.
+export const createPlaceCoordinatePickLayer = (
+  map: LeafletMap,
+  draftPreview: ReturnType<typeof createPlaceDraftPreviewLayer>
+): {
+  clearRegisteredMarkers: () => void;
+  dispose: () => void;
+  isActive: () => boolean;
+  pick: (coordinate: EditorCoordinate) => void;
+  registerMarker: (marker: L.Marker, coordinate: EditorCoordinate) => void;
+  start: (options: CoordinatePickOptions) => () => void;
+  stop: () => void;
+} => {
+  let clickHandler: ((event: LeafletMouseEvent) => void) | null = null;
+  let onPicked: ((coordinate: EditorCoordinate) => void) | null = null;
+  let previousCursor: string | null = null;
+  const markers: Array<{ marker: L.Marker; coordinate: EditorCoordinate }> = [];
+  const markerListeners: Array<() => void> = [];
+
+  const setPreview = (coordinate: EditorCoordinate): void => draftPreview.setCoordinate(coordinate);
+  const pick = (coordinate: EditorCoordinate): void => {
+    setPreview(coordinate);
+    onPicked?.(coordinate);
+  };
+  const detachMarkerListeners = (): void => {
+    markerListeners.splice(0).forEach(detach => detach());
+  };
+  const stop = (): void => {
+    if (clickHandler) {
+      map.off('click', clickHandler);
+      clickHandler = null;
+    }
+    onPicked = null;
+    if (previousCursor !== null) {
+      map.getContainer().style.cursor = previousCursor;
+      previousCursor = null;
+    }
+    detachMarkerListeners();
+    draftPreview.setPickMode(false);
+  };
+  const attachMarkerListener = (marker: L.Marker, coordinate: EditorCoordinate): void => {
+    const handler = (event: LeafletMouseEvent): void => {
+      if (event.originalEvent) L.DomEvent.stop(event.originalEvent);
+      marker.closePopup();
+      pick(coordinate);
+    };
+    marker.on('click', handler);
+    markerListeners.push(() => marker.off('click', handler));
+  };
+  const attachMarkerListeners = (): void => {
+    detachMarkerListeners();
+    markers.forEach(({ marker, coordinate }) => attachMarkerListener(marker, coordinate));
+  };
+  const registerMarker = (marker: L.Marker, coordinate: EditorCoordinate): void => {
+    markers.push({ marker, coordinate });
+    if (clickHandler) attachMarkerListener(marker, coordinate);
+  };
+  const clearRegisteredMarkers = (): void => {
+    detachMarkerListeners();
+    markers.splice(0);
+  };
+  const start = (options: CoordinatePickOptions): (() => void) => {
+    stop();
+    onPicked = options.onPicked;
+    previousCursor = map.getContainer().style.cursor;
+    map.getContainer().style.cursor = 'default';
+    attachMarkerListeners();
+    draftPreview.setPickMode(true, pick);
+    if (options.initialCoordinate) setPreview(options.initialCoordinate);
+    clickHandler = event => pick({ latitude: event.latlng.lat, longitude: event.latlng.lng });
+    map.on('click', clickHandler);
+    return stop;
+  };
+
+  return {
+    clearRegisteredMarkers,
+    dispose: () => {
+      stop();
+      clearRegisteredMarkers();
+    },
+    isActive: () => clickHandler !== null,
+    pick,
+    registerMarker,
+    start,
+    stop
   };
 };

--- a/ClientApps/trip-editor/src/surfaces.css
+++ b/ClientApps/trip-editor/src/surfaces.css
@@ -275,7 +275,8 @@
     padding: 0.55rem;
     position: absolute;
     right: 0.75rem;
-    top: 0.75rem;
+    /* Match the normal mobile toolbar clearance below Leaflet utilities. */
+    top: 4rem;
     z-index: 14;
   }
 

--- a/ClientApps/trip-editor/src/surfaces.css
+++ b/ClientApps/trip-editor/src/surfaces.css
@@ -280,14 +280,14 @@
   }
 
   .trip-editor-map-work-toolbar__actions {
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    overflow-x: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(5rem, 1fr));
     width: 100%;
   }
 
   .trip-editor-map-work-toolbar__actions .btn {
-    flex: 0 0 auto;
+    min-width: 0;
+    width: 100%;
   }
 
   .trip-editor-sidebar--mobile-drawer .trip-editor-surface {

--- a/ClientApps/trip-editor/src/surfaces.css
+++ b/ClientApps/trip-editor/src/surfaces.css
@@ -276,7 +276,7 @@
     position: absolute;
     right: 0.75rem;
     /* Match the normal mobile toolbar clearance below Leaflet utilities. */
-    top: 4rem;
+    top: 4.5rem;
     z-index: 14;
   }
 

--- a/tests/e2e/trip-editor/tripEditorIconSelector.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorIconSelector.spec.ts
@@ -32,6 +32,76 @@ const iconNames = [
 const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:/.*)?$`, 'i');
 
 test.describe('Trip Editor icon selector', () => {
+  test('Pick styling preserves the pending coordinate across Done and coordinate-only Cancel', async ({ page }) => {
+    await signIn(page);
+    const requests: Record<string, any>[] = [];
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await loadWorkspaceWithIconFixture(page, requests);
+    await openPlace(page);
+    const form = page.locator('#trip-editor-place-form');
+    const baseline = await draftCoordinates(form);
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await clickMap(page, { xRatio: 0.62, yRatio: 0.39 });
+    const pending = await markerCoordinate(page);
+    expect(pending).not.toEqual(baseline);
+    await openIconSelector(page);
+    await page.locator('[data-selector-kind="icon"] [data-icon-selector-option]').nth(1).click();
+    await openColorSelector(page);
+    await page.locator('[data-selector-kind="color"] [data-icon-selector-option]').nth(1).click();
+    await expect.poll(() => markerCoordinate(page)).toEqual(pending);
+    await expect(draftMarkers(page)).toHaveCount(1);
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+    await expect.poll(() => draftCoordinates(form)).toEqual(pending);
+    const selectedIcon = await selectedStyle(page, 'icon');
+    const selectedColor = await selectedStyle(page, 'color');
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await clickMap(page, { xRatio: 0.35, yRatio: 0.64 });
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+    await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await expect.poll(() => draftCoordinates(form)).toEqual(pending);
+    await expect.poll(() => markerCoordinate(page)).toEqual(pending);
+    expect(await selectedStyle(page, 'icon')).toBe(selectedIcon);
+    expect(await selectedStyle(page, 'color')).toBe(selectedColor);
+    expect(requests).toEqual([]);
+  });
+
+  test('phone Pick actions remain visible, contained, non-overlapping, and operable', async ({ page }) => {
+    await signIn(page);
+    const requests: Record<string, any>[] = [];
+    await loadWorkspaceWithIconFixture(page, requests);
+    await openPlace(page);
+    for (const width of [390, 430]) {
+      await page.setViewportSize({ width, height: 844 });
+      await page.getByRole('button', { name: 'Pick on map' }).click();
+      const mapWork = page.getByRole('region', { name: 'Map work' });
+      const done = mapWork.getByRole('button', { name: 'Done' });
+      const cancel = mapWork.getByRole('button', { name: 'Cancel' });
+      await expect(done).toBeInViewport();
+      await expect(cancel).toBeInViewport();
+      const layout = await page.evaluate(() => {
+        const drawer = document.querySelector<HTMLElement>('.trip-editor-sidebar--mobile-drawer');
+        const actions = document.querySelector<HTMLElement>('.trip-editor-map-work-toolbar__actions');
+        const buttons = Array.from(actions?.querySelectorAll<HTMLElement>('button') ?? []).map(button => button.getBoundingClientRect());
+        return {
+          actionsContained: Boolean(actions && actions.scrollWidth <= actions.clientWidth),
+          drawerContained: Boolean(drawer && drawer.scrollWidth <= drawer.clientWidth),
+          overlap: buttons.length >= 2 && buttons[0].right > buttons[buttons.length - 1].left
+        };
+      });
+      expect(layout.actionsContained).toBe(true);
+      expect(layout.drawerContained).toBe(true);
+      expect(layout.overlap).toBe(false);
+      await done.click();
+      await expect(mapWork).toHaveCount(0);
+      await page.getByRole('button', { name: 'Pick on map' }).click();
+      await cancel.click();
+      await expect(mapWork).toHaveCount(0);
+    }
+    expect(requests).toEqual([]);
+  });
+
   test('filters, selects, sends a mocked place save, and stays contained across responsive themes', async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await signIn(page);
@@ -357,6 +427,31 @@ function sidebarPlaceIcon(page: Page): Locator {
 
 function mapMarkerIcon(page: Page): Locator {
   return page.locator(`[data-place-marker-icon="${placeId}"]`);
+}
+
+function draftMarkers(page: Page): Locator {
+  return page.locator('[data-place-draft-preview-marker], [data-coordinate-preview-marker]');
+}
+
+async function clickMap(page: Page, position: { xRatio: number; yRatio: number }): Promise<void> {
+  await page.getByLabel('Read-only trip map').evaluate((element, point) => {
+    const box = element.getBoundingClientRect();
+    const clientX = box.left + box.width * point.xRatio;
+    const clientY = box.top + box.height * point.yRatio;
+    for (const type of ['mousedown', 'mouseup', 'click']) element.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, view: window }));
+  }, position);
+}
+
+async function markerCoordinate(page: Page): Promise<{ latitude: string; longitude: string }> {
+  return draftMarkers(page).evaluate(element => ({ latitude: (element as HTMLElement).dataset.placeDraftLatitude ?? '', longitude: (element as HTMLElement).dataset.placeDraftLongitude ?? '' }));
+}
+
+async function draftCoordinates(form: Locator): Promise<{ latitude: string; longitude: string }> {
+  return { latitude: await form.getByLabel('Latitude').inputValue(), longitude: await form.getByLabel('Longitude').inputValue() };
+}
+
+async function selectedStyle(page: Page, kind: 'icon' | 'color'): Promise<string> {
+  return (await page.locator(`[data-selector-kind="${kind}"] [data-icon-selector-selected-name]`).textContent())?.trim() ?? '';
 }
 
 async function expectLoadedImages(images: Locator): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorMobileDrawer.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMobileDrawer.spec.ts
@@ -181,8 +181,17 @@ test.describe.serial('Trip Editor mobile bottom drawer', () => {
     await expect(mapWorkEditor.getByRole('status')).toContainText('Saved');
     await expect(page.getByRole('region', { name: 'Map search' })).toHaveCount(0);
     await expectMapFirstPhoneLayout(page);
+    await expectMapWorkToolbarHitTesting(page);
     await capture(page, testInfo, 'phone-place-coordinate-map-work');
     await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByRole('region', { name: 'Map work' })).toHaveCount(0);
+
+    await page.setViewportSize({ width: 430, height: 844 });
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await expectDrawerState(page, 'peek');
+    await expectMapWorkToolbarHitTesting(page);
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+    await expect(page.getByRole('region', { name: 'Map work' })).toHaveCount(0);
   });
 
   test('dirty metadata tab switch keeps editing on cancel and discards before switching', async ({ page }) => {
@@ -513,6 +522,42 @@ async function expectOpaqueStickyChrome(page: Page): Promise<void> {
     expect(item.backgroundColor.length).toBeGreaterThan(0);
     expect(item.isOpaque).toBe(true);
   }
+}
+
+// Proves the map-work actions are the topmost focusable targets without covering the Peek drawer.
+async function expectMapWorkToolbarHitTesting(page: Page): Promise<void> {
+  const toolbar = page.getByRole('region', { name: 'Map work' });
+  const done = toolbar.getByRole('button', { name: 'Done' });
+  const cancel = toolbar.getByRole('button', { name: 'Cancel' });
+  await expect(done).toBeVisible();
+  await expect(cancel).toBeVisible();
+
+  for (const button of [done, cancel]) {
+    await button.focus();
+    await expect(button).toBeFocused();
+    const hitTargetIsButton = await button.evaluate(element => {
+      const rect = element.getBoundingClientRect();
+      const hitTarget = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+      return hitTarget === element || element.contains(hitTarget);
+    });
+    expect(hitTargetIsButton).toBe(true);
+  }
+
+  const geometry = await page.evaluate(() => {
+    const map = document.querySelector<HTMLElement>('.trip-editor-map')?.getBoundingClientRect();
+    const mapWork = document.querySelector<HTMLElement>('.trip-editor-map-work-toolbar')?.getBoundingClientRect();
+    const drawer = document.querySelector<HTMLElement>('.trip-editor-sidebar--mobile-drawer')?.getBoundingClientRect();
+    return {
+      mapTop: map?.top ?? 0,
+      mapBottom: map?.bottom ?? 0,
+      toolbarTop: mapWork?.top ?? 0,
+      toolbarBottom: mapWork?.bottom ?? 0,
+      drawerTop: drawer?.top ?? 0
+    };
+  });
+  expect(geometry.toolbarTop).toBeGreaterThanOrEqual(geometry.mapTop);
+  expect(geometry.toolbarBottom).toBeLessThanOrEqual(geometry.mapBottom);
+  expect(geometry.toolbarBottom).toBeLessThanOrEqual(geometry.drawerTop);
 }
 
 async function expectDirtyTabSwitchGuard(

--- a/tests/e2e/trip-editor/tripEditorMobileDrawer.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorMobileDrawer.spec.ts
@@ -187,6 +187,7 @@ test.describe.serial('Trip Editor mobile bottom drawer', () => {
     await expect(page.getByRole('region', { name: 'Map work' })).toHaveCount(0);
 
     await page.setViewportSize({ width: 430, height: 844 });
+    await expectMapFirstPhoneLayout(page);
     await page.getByRole('button', { name: 'Pick on map' }).click();
     await expectDrawerState(page, 'peek');
     await expectMapWorkToolbarHitTesting(page);
@@ -476,9 +477,7 @@ async function expectDrawerState(page: Page, state: string): Promise<void> {
   await expect(page.locator('.trip-editor-sidebar--mobile-drawer')).toHaveAttribute('data-mobile-drawer-state', state);
 }
 
-async function drawerHeight(page: Page): Promise<number> {
-  return page.locator('.trip-editor-sidebar--mobile-drawer').evaluate(element => element.getBoundingClientRect().height);
-}
+const drawerHeight = (page: Page) => page.locator('.trip-editor-sidebar--mobile-drawer').evaluate(element => element.getBoundingClientRect().height);
 
 async function expectDrawerHeight(page: Page, expected: { min: number; max: number }): Promise<void> {
   const height = await drawerHeight(page);
@@ -547,17 +546,20 @@ async function expectMapWorkToolbarHitTesting(page: Page): Promise<void> {
     const map = document.querySelector<HTMLElement>('.trip-editor-map')?.getBoundingClientRect();
     const mapWork = document.querySelector<HTMLElement>('.trip-editor-map-work-toolbar')?.getBoundingClientRect();
     const drawer = document.querySelector<HTMLElement>('.trip-editor-sidebar--mobile-drawer')?.getBoundingClientRect();
+    const utilities = document.querySelector<HTMLElement>('.trip-editor-map-utilities')?.getBoundingClientRect();
     return {
       mapTop: map?.top ?? 0,
       mapBottom: map?.bottom ?? 0,
       toolbarTop: mapWork?.top ?? 0,
       toolbarBottom: mapWork?.bottom ?? 0,
-      drawerTop: drawer?.top ?? 0
+      drawerTop: drawer?.top ?? 0,
+      utilitiesBottom: utilities?.bottom ?? 0
     };
   });
   expect(geometry.toolbarTop).toBeGreaterThanOrEqual(geometry.mapTop);
   expect(geometry.toolbarBottom).toBeLessThanOrEqual(geometry.mapBottom);
   expect(geometry.toolbarBottom).toBeLessThanOrEqual(geometry.drawerTop);
+  expect(geometry.toolbarTop).toBeGreaterThanOrEqual(geometry.utilitiesBottom);
 }
 
 async function expectDirtyTabSwitchGuard(
@@ -591,9 +593,7 @@ async function expectDirtyTabSwitchGuard(
   await expect(page.getByRole('heading', { name: options.activeHeading })).toHaveCount(0);
 }
 
-function drawerTab(page: Page, name: string) {
-  return page.getByRole('navigation', { name: 'Trip editor sections' }).getByRole('button', { name, exact: true });
-}
+const drawerTab = (page: Page, name: string) => page.getByRole('navigation', { name: 'Trip editor sections' }).getByRole('button', { name, exact: true });
 
 async function tapFirstSavedPlaceMarker(page: Page): Promise<void> {
   const marker = page.locator('[data-place-marker-icon]').first();
@@ -603,9 +603,7 @@ async function tapFirstSavedPlaceMarker(page: Page): Promise<void> {
   });
 }
 
-async function expectSelectedMarkerCount(page: Page, count: number): Promise<void> {
-  await expect(page.locator('.trip-editor-map-marker--selected [data-place-marker-icon]')).toHaveCount(count);
-}
+const expectSelectedMarkerCount = async (page: Page, count: number) => expect(page.locator('.trip-editor-map-marker--selected [data-place-marker-icon]')).toHaveCount(count);
 
 async function expectMapFirstPhoneLayout(page: Page): Promise<void> {
   await expectInitializedTripMap(page);
@@ -613,6 +611,8 @@ async function expectMapFirstPhoneLayout(page: Page): Promise<void> {
     const workspace = document.querySelector<HTMLElement>('.trip-editor-workspace')?.getBoundingClientRect();
     const map = document.querySelector<HTMLElement>('.trip-editor-map')?.getBoundingClientRect();
     const drawer = document.querySelector<HTMLElement>('.trip-editor-sidebar--mobile-drawer')?.getBoundingClientRect();
+    const toolbar = document.querySelector<HTMLElement>('.trip-editor-toolbar, .trip-editor-map-work-toolbar')?.getBoundingClientRect();
+    const utilities = document.querySelector<HTMLElement>('.trip-editor-map-utilities')?.getBoundingClientRect();
     return {
       bodyWidth: document.body.scrollWidth,
       clientWidth: document.documentElement.clientWidth,
@@ -621,6 +621,8 @@ async function expectMapFirstPhoneLayout(page: Page): Promise<void> {
       mapBottom: map?.bottom ?? 0,
       mapHeight: map?.height ?? 0,
       mapTop: map?.top ?? 0,
+      toolbarTop: toolbar?.top ?? 0,
+      utilitiesBottom: utilities?.bottom ?? 0,
       viewportHeight: window.innerHeight,
       workspaceHeight: workspace?.height ?? 0,
       workspaceTop: workspace?.top ?? 0
@@ -634,6 +636,7 @@ async function expectMapFirstPhoneLayout(page: Page): Promise<void> {
   expect(metrics.mapHeight, 'Map should remain the primary phone workspace.').toBeGreaterThan(metrics.viewportHeight * 0.72);
   expect(metrics.drawerTop, 'Drawer should sit over the lower part of the map.').toBeGreaterThan(metrics.viewportHeight * 0.45);
   expect(metrics.mapBottom, 'Map should continue behind the drawer instead of being pushed below it.').toBeGreaterThan(metrics.drawerTop);
+  expect(metrics.toolbarTop, 'Editor toolbar should start below the top-right map utilities.').toBeGreaterThanOrEqual(metrics.utilitiesBottom);
 }
 
 async function expectContainedSearch(page: Page): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -78,6 +78,74 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     expect(forbidden(), 'Coordinate picking must not call geocode/search providers.').toEqual([]);
   });
 
+  test('Pick styling preserves the pending coordinate across Done and coordinate-only Cancel', async ({ page }) => {
+    await useMapWorkViewport(page);
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+    await firstEditableRegion(page).getByRole('button', { name: 'Add Place' }).click();
+    const baseline = await draftCoordinates(page);
+    const view = await mapView(page);
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await clickMap(page, { xRatio: 0.62, yRatio: 0.39 });
+    const pending = await markerCoordinate(page);
+    expect(pending).not.toEqual(baseline);
+    await selectDraftStyle(page, 'icon');
+    await selectDraftStyle(page, 'color');
+    await expectMarkerCoordinate(page, pending);
+    await expect(activeDraftMarkers(page)).toHaveCount(1);
+    await expect.poll(() => mapView(page)).toEqual(view);
+
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+    await expectDraftCoordinates(page, pending);
+    const selectedIcon = await selectedDraftStyle(page, 'icon');
+    const selectedColor = await selectedDraftStyle(page, 'color');
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await clickMap(page, { xRatio: 0.35, yRatio: 0.64 });
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+    await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await expectDraftCoordinates(page, pending);
+    await expectMarkerCoordinate(page, pending);
+    expect(await selectedDraftStyle(page, 'icon')).toBe(selectedIcon);
+    expect(await selectedDraftStyle(page, 'color')).toBe(selectedColor);
+    await expect(activeDraftMarkers(page)).toHaveCount(1);
+    await expect.poll(() => mapView(page)).toEqual(view);
+  });
+
+  test('phone Pick actions remain visible, contained, non-overlapping, and operable', async ({ page }) => {
+    await signIn(page);
+    for (const width of [390, 430]) {
+      await page.setViewportSize({ width, height: 844 });
+      await loadWorkspaceWithCoordinateFixture(page);
+      await firstEditableRegion(page).getByRole('button', { name: 'Add Place' }).click();
+      await page.getByRole('button', { name: 'Pick on map' }).click();
+      const mapWork = page.getByRole('region', { name: 'Map work' });
+      const done = mapWork.getByRole('button', { name: 'Done' });
+      const cancel = mapWork.getByRole('button', { name: 'Cancel' });
+      await expect(done).toBeInViewport();
+      await expect(cancel).toBeInViewport();
+      const layout = await page.evaluate(() => {
+        const drawer = document.querySelector<HTMLElement>('.trip-editor-sidebar--mobile-drawer');
+        const actions = document.querySelector<HTMLElement>('.trip-editor-map-work-toolbar__actions');
+        const buttons = Array.from(actions?.querySelectorAll<HTMLElement>('button') ?? []).map(button => button.getBoundingClientRect());
+        return {
+          actionsContained: Boolean(actions && actions.scrollWidth <= actions.clientWidth),
+          drawerContained: Boolean(drawer && drawer.scrollWidth <= drawer.clientWidth),
+          overlap: buttons.length >= 2 && buttons[0].right > buttons[buttons.length - 1].left
+        };
+      });
+      expect(layout.actionsContained, `${width}px Pick actions should not scroll horizontally.`).toBe(true);
+      expect(layout.drawerContained, `${width}px drawer should not overflow horizontally.`).toBe(true);
+      expect(layout.overlap, `${width}px Done and Cancel should not overlap.`).toBe(false);
+      await done.click();
+      await expect(mapWork).toHaveCount(0);
+      await page.getByRole('button', { name: 'Pick on map' }).click();
+      await cancel.click();
+      await expect(mapWork).toHaveCount(0);
+    }
+  });
+
   test('Pick on map cancels active distance measurement before handling map clicks', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithCoordinateFixture(page);
@@ -548,6 +616,19 @@ async function expectDraftCoordinates(page: Page, values: { latitude: string; lo
   const form = page.locator('#trip-editor-place-form');
   await expect(form.getByLabel('Latitude')).toHaveValue(values.latitude);
   await expect(form.getByLabel('Longitude')).toHaveValue(values.longitude);
+}
+
+// Selects a non-default draft style through the same controls used by the place form.
+async function selectDraftStyle(page: Page, kind: 'icon' | 'color'): Promise<void> {
+  const selector = page.locator(`[data-selector-kind="${kind}"]`);
+  await selector.locator('[data-icon-selector-trigger]').click();
+  const options = selector.locator('[data-icon-selector-option]');
+  await expect(options.nth(1)).toBeVisible();
+  await options.nth(1).click();
+}
+
+async function selectedDraftStyle(page: Page, kind: 'icon' | 'color'): Promise<string> {
+  return (await page.locator(`[data-selector-kind="${kind}"] [data-icon-selector-selected-name]`).textContent())?.trim() ?? '';
 }
 
 async function markerAnchor(locator: Locator): Promise<{ x: number; y: number }> {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -95,7 +95,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     const mapWork = page.getByRole('region', { name: 'Map work' });
     await expect(mapWork).toContainText('Selected');
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
-    await expect(page.getByTitle('Selected place location preview')).toHaveCount(1);
+    await expect(activeDraftMarkers(page)).toHaveCount(1);
     await expect(page.locator('.trip-editor-map-distance-label')).toHaveCount(0);
   });
 
@@ -161,20 +161,19 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
 
     await openEditablePlace(page);
     await expectDraftCoordinates(page, { latitude: '10', longitude: '20' });
-    const originalAnchor = await markerAnchor(page.getByTitle(editablePlaceName));
+    const originalAnchor = await markerAnchor(activeDraftMarkers(page));
 
     await page.getByRole('button', { name: 'Pick on map' }).click();
     await clickMap(page, { xRatio: 0.58, yRatio: 0.44 });
-    const previewAnchor = await markerAnchor(page.getByTitle('Selected place location preview'));
+    const previewAnchor = await markerAnchor(activeDraftMarkers(page));
 
     await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
     const form = page.locator('#trip-editor-place-form');
     await expect(form.getByLabel('Latitude')).not.toHaveValue('10');
     await expect(form.getByLabel('Longitude')).not.toHaveValue('20');
-    await expect(page.getByTitle('Selected place location preview')).toHaveCount(0);
-    await expect(page.locator(`.trip-editor-map-marker--selected[title="${editablePlaceName}"]`)).toBeVisible();
+    await expect(activeDraftMarkers(page)).toHaveCount(1);
 
-    const selectedAnchor = await markerAnchor(page.getByTitle(editablePlaceName));
+    const selectedAnchor = await markerAnchor(activeDraftMarkers(page));
     expect(Math.hypot(selectedAnchor.x - originalAnchor.x, selectedAnchor.y - originalAnchor.y), 'Selected marker should move away from the saved coordinate.').toBeGreaterThan(20);
     expect(Math.abs(selectedAnchor.x - previewAnchor.x), 'Selected marker should move to the picked preview x-position.').toBeLessThanOrEqual(3);
     expect(Math.abs(selectedAnchor.y - previewAnchor.y), 'Selected marker should move to the picked preview y-position.').toBeLessThanOrEqual(16);
@@ -255,11 +254,117 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await expect(page.locator('#trip-editor-place-form').getByLabel('Name')).toHaveValue('Unsaved switch name');
   });
 
+  test('new-place map Cancel, Reset, and form Cancel restore their distinct baselines', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+    await firstEditableRegion(page).getByRole('button', { name: 'Add Place' }).click();
+    const form = page.locator('#trip-editor-place-form');
+    const initialDraft = await draftCoordinates(page);
+    const initialView = await mapView(page);
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await clickMap(page, { xRatio: 0.35, yRatio: 0.35 });
+    await clickMap(page, { xRatio: 0.65, yRatio: 0.55 });
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
+    await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await expectDraftCoordinates(page, initialDraft);
+    await expectMarkerCoordinate(page, initialDraft);
+
+    await form.getByLabel('Name').fill('Changed draft name');
+    await form.getByLabel('Latitude').fill('12.5');
+    await form.getByLabel('Longitude').fill('44.25');
+    await expectMarkerCoordinate(page, { latitude: '12.5', longitude: '44.25' });
+    await page.getByRole('button', { name: 'Reset' }).click();
+    await expectDraftCoordinates(page, initialDraft);
+    await expectMarkerCoordinate(page, initialDraft);
+    await expect.poll(() => mapView(page)).toEqual(initialView);
+
+    await form.getByLabel('Name').fill('Discard this draft');
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await page.getByRole('dialog', { name: 'Discard changes?' }).getByRole('button', { name: 'Discard' }).click();
+    await expect(form).toHaveCount(0);
+    await expect(activeDraftMarkers(page)).toHaveCount(0);
+    await expect.poll(() => mapView(page)).toEqual(initialView);
+  });
+
+  test('direct coordinate pairs preserve zero and ignore blank, partial, and out-of-range input', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+    await openEditablePlace(page);
+    const form = page.locator('#trip-editor-place-form');
+    const initialMarker = await markerCoordinate(page);
+    const initialView = await mapView(page);
+
+    await form.getByLabel('Latitude').fill('');
+    await form.getByLabel('Longitude').fill('0');
+    await expectMarkerCoordinate(page, initialMarker);
+    await form.getByLabel('Latitude').fill('0');
+    await expectMarkerCoordinate(page, { latitude: '0', longitude: '0' });
+    await form.getByLabel('Latitude').fill('91');
+    await expectMarkerCoordinate(page, { latitude: '0', longitude: '0' });
+    await form.getByLabel('Latitude').fill('10');
+    await form.getByLabel('Longitude').fill('181');
+    await expectMarkerCoordinate(page, { latitude: '0', longitude: '0' });
+    await expect.poll(() => mapView(page)).toEqual(initialView);
+  });
+
+  test('dragging the one Pick marker changes pending state only until Done', async ({ page }) => {
+    await useMapWorkViewport(page);
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+    await openEditablePlace(page);
+    const before = await draftCoordinates(page);
+    const marker = activeDraftMarkers(page);
+
+    await page.getByRole('button', { name: 'Pick on map' }).click();
+    await expect(marker).toHaveClass(/leaflet-marker-draggable/);
+    const box = await marker.boundingBox();
+    expect(box).not.toBeNull();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width / 2 + 80, box!.y + box!.height / 2 + 45, { steps: 8 });
+    await page.mouse.up();
+
+    await expectDraftCoordinates(page, before);
+    expect(await markerCoordinate(page)).not.toEqual(before);
+    await expect(activeDraftMarkers(page)).toHaveCount(1);
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+    expect(await draftCoordinates(page)).not.toEqual(before);
+    await expect(activeDraftMarkers(page)).toHaveCount(1);
+  });
+
+  test('failed Save retains the complete retryable draft marker and viewport', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+    await page.route(editorApiMatcher, async route => {
+      if (route.request().method() === 'GET') {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ title: 'Injected save failure' }) });
+    });
+    await openEditablePlace(page);
+    const form = page.locator('#trip-editor-place-form');
+    await form.getByLabel('Name').fill('Retryable name');
+    await form.getByLabel('Latitude').fill('12.25');
+    await form.getByLabel('Longitude').fill('22.75');
+    const beforeView = await mapView(page);
+
+    await page.getByRole('button', { name: 'Save Place' }).click();
+    await expect(page.getByText(/Place save failed|Injected save failure/).first()).toBeVisible();
+    await expect(form.getByLabel('Name')).toHaveValue('Retryable name');
+    await expectDraftCoordinates(page, { latitude: '12.25', longitude: '22.75' });
+    await expectMarkerCoordinate(page, { latitude: '12.25', longitude: '22.75' });
+    await expect(page.getByRole('button', { name: 'Reset' })).toBeEnabled();
+    await expect.poll(() => mapView(page)).toEqual(beforeView);
+  });
+
   test('Save after Done sends the picked coordinate to a mocked existing place endpoint', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithCoordinateFixture(page);
     const forbidden = watchForbiddenPickRequests(page);
     const savedRequests: Array<Record<string, any>> = [];
+    const serverCoordinate = { latitude: 12.125, longitude: 22.875 };
     await page.route(editorApiMatcher, async route => {
       const request = route.request();
       if (request.method() === 'GET') {
@@ -277,7 +382,7 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(editorMutationResult({ ...body, id: editablePlaceId }))
+        body: JSON.stringify(editorMutationResult({ ...body, id: editablePlaceId, location: serverCoordinate }))
       });
     });
 
@@ -292,11 +397,14 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await expect.poll(() => savedRequests.length).toBe(1);
     expect(String(savedRequests[0].location.latitude)).toBe(picked.latitude);
     expect(String(savedRequests[0].location.longitude)).toBe(picked.longitude);
+    await expectDraftCoordinates(page, { latitude: String(serverCoordinate.latitude), longitude: String(serverCoordinate.longitude) });
+    await expectMarkerCoordinate(page, { latitude: String(serverCoordinate.latitude), longitude: String(serverCoordinate.longitude) });
     expect(forbidden(), 'Saving a picked coordinate must not call geocode/search providers.').toEqual([]);
   });
 });
 
 async function loadWorkspaceWithCoordinateFixture(page: Page): Promise<void> {
+  await blockTileRequests(page);
   await page.unroute(editorApiMatcher).catch(() => undefined);
   const state = await loadEditorStateFixture(page) as MutableEditorState;
   prepareCoordinateState(state);
@@ -386,6 +494,10 @@ async function mapCursor(page: Page): Promise<string> {
   return page.getByLabel('Read-only trip map').evaluate(element => getComputedStyle(element).cursor);
 }
 
+async function blockTileRequests(page: Page): Promise<void> {
+  await page.route(/\/map\/tiles\//i, route => route.fulfill({ status: 204, body: '' }));
+}
+
 function activeDraftMarkers(page: Page): Locator {
   return page.locator('[data-place-draft-preview-marker], [data-coordinate-preview-marker]');
 }
@@ -396,6 +508,17 @@ async function mapView(page: Page): Promise<{ latitude: number; longitude: numbe
     longitude: Number((element as HTMLElement).dataset.tripEditorMapLng),
     zoom: Number((element as HTMLElement).dataset.tripEditorMapZoom)
   }));
+}
+
+async function markerCoordinate(page: Page): Promise<{ latitude: string; longitude: string }> {
+  return await activeDraftMarkers(page).evaluate(element => ({
+    latitude: (element as HTMLElement).dataset.placeDraftLatitude ?? '',
+    longitude: (element as HTMLElement).dataset.placeDraftLongitude ?? ''
+  }));
+}
+
+async function expectMarkerCoordinate(page: Page, coordinate: { latitude: string; longitude: string }): Promise<void> {
+  await expect.poll(() => markerCoordinate(page)).toEqual(coordinate);
 }
 
 function utilityButton(page: Page, name: string): Locator {
@@ -446,7 +569,7 @@ async function expectPickOnMapHelp(page: Page): Promise<void> {
   await expect(pickButton).toHaveAttribute('title', "Pick this place's latitude and longitude on the map");
   const describedBy = await pickButton.getAttribute('aria-describedby');
   expect(describedBy, 'Pick on map should expose an accessible help description.').toBeTruthy();
-  await expect(page.locator(`#${describedBy}`)).toContainText("Use the map to choose this place's latitude and longitude.");
+  await expect(page.locator(`#${describedBy}`)).toContainText('Click the map or drag the marker. Done updates the draft; Save Place persists it.');
 }
 
 async function captureEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -78,74 +78,6 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     expect(forbidden(), 'Coordinate picking must not call geocode/search providers.').toEqual([]);
   });
 
-  test('Pick styling preserves the pending coordinate across Done and coordinate-only Cancel', async ({ page }) => {
-    await useMapWorkViewport(page);
-    await signIn(page);
-    await loadWorkspaceWithCoordinateFixture(page);
-    await firstEditableRegion(page).getByRole('button', { name: 'Add Place' }).click();
-    const baseline = await draftCoordinates(page);
-    const view = await mapView(page);
-
-    await page.getByRole('button', { name: 'Pick on map' }).click();
-    await clickMap(page, { xRatio: 0.62, yRatio: 0.39 });
-    const pending = await markerCoordinate(page);
-    expect(pending).not.toEqual(baseline);
-    await selectDraftStyle(page, 'icon');
-    await selectDraftStyle(page, 'color');
-    await expectMarkerCoordinate(page, pending);
-    await expect(activeDraftMarkers(page)).toHaveCount(1);
-    await expect.poll(() => mapView(page)).toEqual(view);
-
-    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
-    await expectDraftCoordinates(page, pending);
-    const selectedIcon = await selectedDraftStyle(page, 'icon');
-    const selectedColor = await selectedDraftStyle(page, 'color');
-
-    await page.getByRole('button', { name: 'Pick on map' }).click();
-    await clickMap(page, { xRatio: 0.35, yRatio: 0.64 });
-    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
-    await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
-    await expectDraftCoordinates(page, pending);
-    await expectMarkerCoordinate(page, pending);
-    expect(await selectedDraftStyle(page, 'icon')).toBe(selectedIcon);
-    expect(await selectedDraftStyle(page, 'color')).toBe(selectedColor);
-    await expect(activeDraftMarkers(page)).toHaveCount(1);
-    await expect.poll(() => mapView(page)).toEqual(view);
-  });
-
-  test('phone Pick actions remain visible, contained, non-overlapping, and operable', async ({ page }) => {
-    await signIn(page);
-    for (const width of [390, 430]) {
-      await page.setViewportSize({ width, height: 844 });
-      await loadWorkspaceWithCoordinateFixture(page);
-      await firstEditableRegion(page).getByRole('button', { name: 'Add Place' }).click();
-      await page.getByRole('button', { name: 'Pick on map' }).click();
-      const mapWork = page.getByRole('region', { name: 'Map work' });
-      const done = mapWork.getByRole('button', { name: 'Done' });
-      const cancel = mapWork.getByRole('button', { name: 'Cancel' });
-      await expect(done).toBeInViewport();
-      await expect(cancel).toBeInViewport();
-      const layout = await page.evaluate(() => {
-        const drawer = document.querySelector<HTMLElement>('.trip-editor-sidebar--mobile-drawer');
-        const actions = document.querySelector<HTMLElement>('.trip-editor-map-work-toolbar__actions');
-        const buttons = Array.from(actions?.querySelectorAll<HTMLElement>('button') ?? []).map(button => button.getBoundingClientRect());
-        return {
-          actionsContained: Boolean(actions && actions.scrollWidth <= actions.clientWidth),
-          drawerContained: Boolean(drawer && drawer.scrollWidth <= drawer.clientWidth),
-          overlap: buttons.length >= 2 && buttons[0].right > buttons[buttons.length - 1].left
-        };
-      });
-      expect(layout.actionsContained, `${width}px Pick actions should not scroll horizontally.`).toBe(true);
-      expect(layout.drawerContained, `${width}px drawer should not overflow horizontally.`).toBe(true);
-      expect(layout.overlap, `${width}px Done and Cancel should not overlap.`).toBe(false);
-      await done.click();
-      await expect(mapWork).toHaveCount(0);
-      await page.getByRole('button', { name: 'Pick on map' }).click();
-      await cancel.click();
-      await expect(mapWork).toHaveCount(0);
-    }
-  });
-
   test('Pick on map cancels active distance measurement before handling map clicks', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithCoordinateFixture(page);
@@ -616,19 +548,6 @@ async function expectDraftCoordinates(page: Page, values: { latitude: string; lo
   const form = page.locator('#trip-editor-place-form');
   await expect(form.getByLabel('Latitude')).toHaveValue(values.latitude);
   await expect(form.getByLabel('Longitude')).toHaveValue(values.longitude);
-}
-
-// Selects a non-default draft style through the same controls used by the place form.
-async function selectDraftStyle(page: Page, kind: 'icon' | 'color'): Promise<void> {
-  const selector = page.locator(`[data-selector-kind="${kind}"]`);
-  await selector.locator('[data-icon-selector-trigger]').click();
-  const options = selector.locator('[data-icon-selector-option]');
-  await expect(options.nth(1)).toBeVisible();
-  await options.nth(1).click();
-}
-
-async function selectedDraftStyle(page: Page, kind: 'icon' | 'color'): Promise<string> {
-  return (await page.locator(`[data-selector-kind="${kind}"] [data-icon-selector-selected-name]`).textContent())?.trim() ?? '';
 }
 
 async function markerAnchor(locator: Locator): Promise<{ x: number; y: number }> {

--- a/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorPlaceCoordinateMapWork.spec.ts
@@ -20,7 +20,25 @@ const editorApiMatcher = new RegExp(`${editorApiPath.replace(/[.*+?^${}()|[\]\\]
 const forbiddenPickRequest = /nominatim|geocode|geosearch|search-add|searchadd|\/search(?:[/?#]|$)/i;
 
 test.describe.serial('Trip Editor place coordinate map-work', () => {
-  test('add-place picks a temporary coordinate and Done updates only the draft', async ({ page }, testInfo) => {
+  test('manual Add Place preserves the viewport and seeds one marker at the captured center', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithCoordinateFixture(page);
+    const forbidden = watchForbiddenPickRequests(page);
+
+    await page.goto(absoluteUrl(`${editorPath}?lat=37.9715321&lng=23.7257498&zoom=16`));
+    await expectMountedWorkspace(page);
+    const before = await mapView(page);
+    await firstEditableRegion(page).getByRole('button', { name: 'Add Place' }).click();
+    const form = page.locator('#trip-editor-place-form');
+    await expect(page.getByRole('heading', { name: 'Add Place' })).toBeVisible();
+    await expect.poll(() => mapView(page)).toEqual(before);
+    await expect.poll(async () => Number(await form.getByLabel('Latitude').inputValue())).toBeCloseTo(before.latitude, 6);
+    await expect.poll(async () => Number(await form.getByLabel('Longitude').inputValue())).toBeCloseTo(before.longitude, 6);
+    await expect(activeDraftMarkers(page)).toHaveCount(1);
+    expect(forbidden(), 'Opening a manual draft must not contact search providers.').toEqual([]);
+  });
+
+  test('add-place reuses one marker through Pick and Done without persisting', async ({ page }, testInfo) => {
     await signIn(page);
     await loadWorkspaceWithCoordinateFixture(page);
     const mutations = watchEditorMutations(page);
@@ -28,26 +46,24 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
 
     await firstEditableRegion(page).getByRole('button', { name: 'Add Place' }).click();
     const form = page.locator('#trip-editor-place-form');
-    await expect(page.getByRole('heading', { name: 'Add Place' })).toBeVisible();
-    await clickMap(page, { xRatio: 0.28, yRatio: 0.62 });
-    await expect(form.getByLabel('Latitude')).toHaveValue('');
-    await expect(form.getByLabel('Longitude')).toHaveValue('');
+    const initial = await draftCoordinates(page);
 
     await expectPickOnMapHelp(page);
     const normalCursor = await mapCursor(page);
     await page.getByRole('button', { name: 'Pick on map' }).click();
     const mapWork = page.getByRole('region', { name: 'Map work' });
     await expect(mapWork).toContainText('Pick place location');
-    await expect(mapWork).toContainText('No coordinate selected');
-    await expect(mapWork.getByRole('button', { name: 'Done' })).toBeDisabled();
+    await expect(mapWork).toContainText('Selected');
+    await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
+    await expect(form.getByLabel('Latitude')).toBeReadOnly();
+    await expect(form.getByLabel('Longitude')).toBeReadOnly();
     await expectNoSearchAddUi(page);
     await expect.poll(() => mapCursor(page)).toBe('default');
 
     await clickMap(page, { xRatio: 0.38, yRatio: 0.46 });
     await expect(mapWork).toContainText('Selected');
-    await expect(page.getByTitle('Selected place location preview')).toHaveCount(1);
-    await expectLoadedImages(page.locator('[data-coordinate-preview-marker]'));
-    await expect(page.locator('[data-coordinate-preview-marker]')).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-blue\/marker\.png$/);
+    await expect(activeDraftMarkers(page)).toHaveCount(1);
+    await expectLoadedImages(activeDraftMarkers(page));
     await captureEvidence(page, testInfo, 'pick-on-map-preview-marker');
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
     expect(mutations(), 'Done has not been clicked and no mutation should have run.').toEqual([]);
@@ -55,7 +71,8 @@ test.describe.serial('Trip Editor place coordinate map-work', () => {
     await mapWork.getByRole('button', { name: 'Done' }).click();
     await expect(form.getByLabel('Latitude')).not.toHaveValue('');
     await expect(form.getByLabel('Longitude')).not.toHaveValue('');
-    await expect(page.getByTitle('Selected place location preview')).toHaveCount(0);
+    await expect(activeDraftMarkers(page)).toHaveCount(1);
+    expect(await draftCoordinates(page)).not.toEqual(initial);
     await expect.poll(() => mapCursor(page)).toBe(normalCursor);
     expect(mutations(), 'Done must not call create/update/order/delete endpoints.').toEqual([]);
     expect(forbidden(), 'Coordinate picking must not call geocode/search providers.').toEqual([]);
@@ -367,6 +384,18 @@ async function clickMap(page: Page, position: { xRatio: number; yRatio: number }
 
 async function mapCursor(page: Page): Promise<string> {
   return page.getByLabel('Read-only trip map').evaluate(element => getComputedStyle(element).cursor);
+}
+
+function activeDraftMarkers(page: Page): Locator {
+  return page.locator('[data-place-draft-preview-marker], [data-coordinate-preview-marker]');
+}
+
+async function mapView(page: Page): Promise<{ latitude: number; longitude: number; zoom: number }> {
+  return await page.getByLabel('Read-only trip map').evaluate(element => ({
+    latitude: Number((element as HTMLElement).dataset.tripEditorMapLat),
+    longitude: Number((element as HTMLElement).dataset.tripEditorMapLng),
+    zoom: Number((element as HTMLElement).dataset.tripEditorMapZoom)
+  }));
 }
 
 function utilityButton(page: Page, name: string): Locator {

--- a/tests/e2e/trip-editor/tripEditorSearchAddPersistence.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSearchAddPersistence.spec.ts
@@ -30,10 +30,14 @@ test.describe.serial('Trip Editor search-add real place persistence contracts', 
       await runSearch(page, placeName);
       await selectSearchResult(page, placeName);
       await expect(page.getByLabel('Target region')).toHaveValue(targets.unassigned.id);
+      const resultView = await mapView(page);
 
       await page.getByRole('button', { name: 'Add as place' }).click();
       await expectSearchResultsCollapsed(page, placeName);
       await expectSearchAddDraft(page, placeName, targets.unassigned.id);
+      await expect(page.locator('[data-search-preview-marker]')).toHaveCount(0);
+      await expect(page.locator('[data-place-draft-preview-marker]')).toHaveCount(1);
+      await expect.poll(() => mapView(page)).toEqual(resultView);
 
       const createdPlaceId = await savePlaceThroughRealEndpoint(page, targets.unassigned.id);
       await expectSaved(page);
@@ -90,6 +94,7 @@ test.describe.serial('Trip Editor search-add real place persistence contracts', 
 });
 
 async function openEditor(page: Page): Promise<void> {
+  await page.route(/\/map\/tiles\//i, route => route.fulfill({ status: 204, body: '' }));
   await signIn(page);
   await page.goto(absoluteUrl(editorPath));
   await expectMountedWorkspace(page);
@@ -154,6 +159,14 @@ async function expectSearchAddDraft(page: Page, name: string, regionId: string):
   await expect(form.locator('[data-selector-kind="color"] [data-icon-selector-selected-name]')).toHaveText('Blue');
   await expect(page.locator(`img[alt="Pending place location: ${name}"]`)).toBeVisible();
   await expect(page.locator('[data-place-draft-preview-marker]')).toHaveAttribute('src', /\/icons\/wayfarer-map-icons\/dist\/png\/marker\/bg-blue\/marker\.png$/);
+}
+
+async function mapView(page: Page): Promise<{ latitude: number; longitude: number; zoom: number }> {
+  return await page.getByLabel('Read-only trip map').evaluate(element => ({
+    latitude: Number((element as HTMLElement).dataset.tripEditorMapLat),
+    longitude: Number((element as HTMLElement).dataset.tripEditorMapLng),
+    zoom: Number((element as HTMLElement).dataset.tripEditorMapZoom)
+  }));
 }
 
 async function savePlaceThroughRealEndpoint(page: Page, regionId: string): Promise<string> {


### PR DESCRIPTION
## Summary

- preserve the current map center and zoom when manually adding a place
- maintain one authoritative draft/Pick marker across click, drag, styling, Done, Cancel, Reset, Save, rerender, and teardown
- preserve geocoder-selected coordinates and prevent implicit draft-preview navigation
- keep mobile Pick-mode Done/Cancel visible and operable above Leaflet while the drawer exposes the map

## Root cause

Blank coordinate fields were converted through `Number('')`, producing an unintended valid `0,0` preview, and draft rendering navigated the map to that coordinate. Persisted, draft, and Pick layers also had competing ownership paths. On phone layouts, Leaflet's internal pane/control z-indexes escaped the absolute map layer and painted above the map-work toolbar.

## User impact

Manual Add Place now starts at the location the user is already viewing without losing the viewport. A single marker moves through the Pick workflow, styling no longer resets its pending coordinate, and phone users can complete or cancel map work.

## Validation

- frontend production build passed (809 modules)
- LOC checker passed with warnings only; the focused lifecycle specs remain cohesive and no file exceeds the 600-line hard cap
- `git diff --check origin/main...HEAD` passed
- manual desktop workflow passed
- manual narrow-phone Pick workflow passed after the final stacking correction, including visible and operable Done/Cancel actions
- automated provider traffic did not contact public tile or geocoding services

The focused Playwright specs compile/discover successfully; execution remains unavailable against the stale configured local fixture. Manual rendered validation covers the affected interaction seam.

## Database/API/mobile

- no database migration
- no API or persistence-schema change
- no WayfarerMobile change
- no provider/geocoder behavior change

Fixes #386
