### PR TITLE
Keep edited segment routes visible before save

### DIFF
--- a/ClientApps/trip-editor/src/App.vue
+++ b/ClientApps/trip-editor/src/App.vue
@@ -7,7 +7,7 @@ import MapWorkToolbar from './components/MapWorkToolbar.vue';
 import TripSidebar from './components/TripSidebar.vue';
 import { disposeConfirmDialogHost, setConfirmDialogFocusFallback } from './composables/useConfirmDialog';
 import { useEditorSurface } from './composables/useEditorSurface';
-import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type AreaPolygonWorkOptions, type CoordinatePickOptions, type FocusActiveEntityResult, type PlaceDraftMarkerPreview, type SegmentRouteWorkOptions, type TripEditorMapView } from './map/leafletAdapter';
+import { canFocusActiveEntity, createTripEditorMap, hasAnyGeometry, hasSavedTripView, type AreaPolygonWorkOptions, type CoordinatePickOptions, type FocusActiveEntityResult, type PlaceDraftMarkerPreview, type SegmentDraftRoutePreview, type SegmentRouteWorkOptions, type TripEditorMapView } from './map/leafletAdapter';
 import type { BootstrapConfig, EditorCoordinate, EditorGeocodeSearchResult, EditorMutationResult, EditorSegment, EditorTripMetadata, EditorTripState, Guid } from './types';
 
 const props = defineProps<{ config: BootstrapConfig }>();
@@ -322,6 +322,13 @@ const applyPlaceDraftPreview = (preview: PlaceDraftMarkerPreview | null): void =
   mapAdapter?.setPlaceDraftPreview(state.value, preview);
 };
 
+/// Applies segment form ownership through the segment-specific map preview contract.
+const applySegmentRouteDraftPreview = (preview: SegmentDraftRoutePreview | null): void => {
+  if (state.value) {
+    mapAdapter?.setSegmentDraftPreview(state.value, preview);
+  }
+};
+
 /// Applies mutation affected slices and authoritative deleted IDs to normalized editor state.
 const applyMutation = (result: EditorMutationResult<unknown>): void => {
   if (!state.value) {
@@ -491,6 +498,7 @@ function focusStatusText(result: FocusActiveEntityResult, target: { kind: string
         @mutation-applied="applyMutation"
         @region-draft-dirty-changed="setRegionDraftChanges"
         @place-draft-preview-changed="applyPlaceDraftPreview"
+        @segment-route-draft-preview-changed="applySegmentRouteDraftPreview"
         @hidden-segment-ids-changed="updateHiddenSegmentIds"
         :select-place="placeId => selectPlace(placeId, { focusMap: true })"
         :clear-selected-place="clearSelectedPlace"

--- a/ClientApps/trip-editor/src/components/SegmentEditorForm.vue
+++ b/ClientApps/trip-editor/src/components/SegmentEditorForm.vue
@@ -9,6 +9,7 @@ const props = defineProps<{
   fieldErrors: (key: string) => string[];
   formId: string;
   formSummaryErrors: string[];
+  isDirty: boolean;
   state: EditorTripState;
 }>();
 
@@ -19,10 +20,12 @@ defineEmits<{
 const normalRegions = computed(() => props.state.regionOrder.map(id => props.state.regionsById[id]).filter(region => region && !region.isShadow) as EditorRegion[]);
 const routeSummary = computed(() => {
   if (props.draft.route) {
-    return `${props.draft.route.coordinates.length} custom route points`;
+    return `${props.isDirty ? 'Unsaved' : 'Saved'} route · ${props.draft.route.coordinates.length} custom route points`;
   }
 
-  return fallbackRoute(props.draft, props.state) ? 'Endpoint fallback available until saved' : 'No route';
+  return fallbackRoute(props.draft, props.state)
+    ? `Endpoint fallback available until saved${props.isDirty ? ' · unsaved' : ''}`
+    : 'No route';
 });
 
 function orderedPlaceIds(regionId: Guid): Guid[] {

--- a/ClientApps/trip-editor/src/components/SegmentEditorSurface.vue
+++ b/ClientApps/trip-editor/src/components/SegmentEditorSurface.vue
@@ -36,6 +36,7 @@ defineEmits<{
         :field-errors="fieldErrors"
         :form-id="formId"
         :form-summary-errors="formSummaryErrors"
+        :is-dirty="isDirty"
         :state="state"
         @save="$emit('save')"
       />

--- a/ClientApps/trip-editor/src/components/SegmentManager.vue
+++ b/ClientApps/trip-editor/src/components/SegmentManager.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from
 import { createSegment, deleteSegment, orderSegments, updateSegment } from '../api/tripEditorApi';
 import { confirm } from '../composables/useConfirmDialog';
 import type { EditorSurfaceController, EditorTarget } from '../composables/useEditorSurface';
+import type { SegmentDraftRoutePreview } from '../map/leafletAdapter';
 import type { EditorMutationResult, EditorSegment, EditorSegmentDraft, EditorSegmentSaveRequest, EditorTripState, Guid } from '../types';
 import { buildSegmentCreateTarget, buildSegmentEditTarget, segmentDraftKey } from './regionPlaceEditorTargets';
 import { buildSegmentRequest, emptySegmentDraft, toSegmentDraft } from './regionPlaceDrafts';
@@ -33,6 +34,7 @@ const emit = defineEmits<{
   dirtyStateChanged: [isDirty: boolean];
   hiddenSegmentIdsChanged: [ids: Set<Guid>];
   mutationApplied: [result: EditorMutationResult<unknown>];
+  routeDraftPreviewChanged: [preview: SegmentDraftRoutePreview | null];
 }>();
 
 const segmentFields = ['fromPlaceId', 'toPlaceId', 'mode', 'estimatedDistanceKm', 'estimatedDurationMinutes', 'notesHtml', 'route', 'route.coordinates'];
@@ -63,6 +65,11 @@ const activeSegmentTarget = computed<EditorTarget>(() => draft.id && activeSegme
   : buildSegmentCreateTarget());
 
 watch(isDirty, value => emit('dirtyStateChanged', value), { immediate: true });
+watch(
+  () => [draft.id, draft.fromPlaceId, draft.toPlaceId, JSON.stringify(draft.route), props.hiddenSegmentIds.has(draft.id ?? '')],
+  syncRouteDraftPreview,
+  { flush: 'sync' }
+);
 watch(() => [props.segments.length, props.searchActive, segmentListKey.value], () => nextTick(attachSortable), { immediate: true });
 
 onMounted(() => {
@@ -76,6 +83,7 @@ onUnmounted(() => {
   unregisterHandler?.();
   destroySortable();
   stopSegmentRouteEdit(routeMapWork);
+  emit('routeDraftPreviewChanged', null);
   emit('dirtyStateChanged', false);
 });
 
@@ -89,6 +97,7 @@ async function openCreate(): Promise<void> {
   Object.assign(draft, emptySegmentDraft());
   createBaselineRequest.value = buildSegmentRequest(draft);
   resetFeedback();
+  syncRouteDraftPreview();
 }
 
 async function openEdit(segment: EditorSegment): Promise<boolean> {
@@ -109,12 +118,14 @@ async function openEdit(segment: EditorSegment): Promise<boolean> {
   Object.assign(draft, toSegmentDraft(segment));
   createBaselineRequest.value = null;
   resetFeedback();
+  syncRouteDraftPreview();
   return true;
 }
 
 function resetDraft(): void {
   Object.assign(draft, draft.id ? toSegmentDraft(activeSegment.value) : emptySegmentDraft());
   resetFeedback();
+  syncRouteDraftPreview();
 }
 
 async function cancelDraft(): Promise<void> {
@@ -126,13 +137,18 @@ async function saveDraft(): Promise<void> {
   resetFeedback();
   try {
     const request = buildSegmentRequest(draft);
+    const wasCreate = draft.id === null;
     const result = draft.id
       ? await updateSegment(props.editorEndpoint, draft.id, props.antiforgeryToken, request)
       : await createSegment(props.editorEndpoint, props.antiforgeryToken, request);
+    if (wasCreate) {
+      emit('routeDraftPreviewChanged', buildRouteDraftPreview(result.data.id));
+    }
     emit('mutationApplied', result as EditorMutationResult<unknown>);
     Object.assign(draft, toSegmentDraft(result.data));
     createBaselineRequest.value = null;
     props.editorSurface.replaceActiveTarget(activeSegmentTarget.value);
+    emit('routeDraftPreviewChanged', null);
     markSaved();
   } catch (error) {
     applyError(error, 'Segment save failed.');
@@ -199,6 +215,7 @@ async function deleteSegmentWithConfirmation(segment: EditorSegment, deletedTarg
     hidden.delete(segment.id);
     emit('hiddenSegmentIdsChanged', hidden);
     Object.assign(draft, emptySegmentDraft());
+    emit('routeDraftPreviewChanged', null);
     createBaselineRequest.value = null;
     props.editorSurface.clearActiveTarget(deletedTarget);
     markSaved();
@@ -210,7 +227,7 @@ async function deleteSegmentWithConfirmation(segment: EditorSegment, deletedTarg
 }
 
 function drawRoute(): void {
-  beginSegmentRouteMapWork(draft, props.editorSurface, props.routeEditor, routeMapWork, props.state);
+  beginSegmentRouteMapWork(routePreviewIdentity(), draft, props.editorSurface, props.routeEditor, routeMapWork, props.state);
 }
 
 function clearRoute(): void {
@@ -318,9 +335,34 @@ function restoreSegmentOrder(_previousIds: Guid[]): void {
 }
 
 function discardDraft(): void {
+  stopSegmentRouteEdit(routeMapWork);
   Object.assign(draft, emptySegmentDraft());
   createBaselineRequest.value = null;
   resetFeedback();
+  emit('routeDraftPreviewChanged', null);
+}
+
+/// Publishes the active segment form route without exposing form state to Leaflet internals.
+function syncRouteDraftPreview(): void {
+  if (!props.editorSurface.isTargetActive(activeSegmentTarget.value)) {
+    return;
+  }
+
+  emit('routeDraftPreviewChanged', buildRouteDraftPreview());
+}
+
+function buildRouteDraftPreview(segmentId: Guid | null = draft.id): SegmentDraftRoutePreview {
+  return {
+    fromPlaceId: draft.fromPlaceId,
+    identity: routePreviewIdentity(),
+    route: draft.route ? JSON.parse(JSON.stringify(draft.route)) : null,
+    segmentId,
+    toPlaceId: draft.toPlaceId
+  };
+}
+
+function routePreviewIdentity(): string {
+  return draft.id ?? activeSegmentTarget.value.identity;
 }
 
 function confirmDiscard(message: string): Promise<boolean> {

--- a/ClientApps/trip-editor/src/components/TripSidebar.vue
+++ b/ClientApps/trip-editor/src/components/TripSidebar.vue
@@ -7,7 +7,7 @@ import MapSearchControl from './MapSearchControl.vue';
 import RegionManager from './RegionManager.vue';
 import SegmentManager from './SegmentManager.vue';
 import VisitProgressSurface from './VisitProgressSurface.vue';
-import type { AreaPolygonWorkOptions, CoordinatePickOptions, SegmentRouteWorkOptions } from '../map/leafletAdapter';
+import type { AreaPolygonWorkOptions, CoordinatePickOptions, SegmentDraftRoutePreview, SegmentRouteWorkOptions } from '../map/leafletAdapter';
 
 type SidebarSearchResult = {
   hasMatches: boolean;
@@ -51,6 +51,7 @@ const emit = defineEmits<{
   regionDraftDirtyChanged: [isDirty: boolean];
   hiddenSegmentIdsChanged: [ids: Set<Guid>];
   placeDraftPreviewChanged: [preview: PlaceDraftPreview | null];
+  segmentRouteDraftPreviewChanged: [preview: SegmentDraftRoutePreview | null];
   searchAddOpened: [requestId: number];
   searchAddPlace: [request: { result: EditorGeocodeSearchResult; regionId: Guid; requestId: number }];
   searchClearPreview: [];
@@ -401,6 +402,7 @@ function normalize(value: string): string {
             @dirty-state-changed="isDirty => { segmentDraftDirty = isDirty; emit('regionDraftDirtyChanged', hasAnyDraftChanges); }"
             @hidden-segment-ids-changed="ids => emit('hiddenSegmentIdsChanged', ids)"
             @mutation-applied="result => emit('mutationApplied', result)"
+            @route-draft-preview-changed="preview => emit('segmentRouteDraftPreviewChanged', preview)"
           />
         </section>
       </div>

--- a/ClientApps/trip-editor/src/components/segmentRouteMapWork.ts
+++ b/ClientApps/trip-editor/src/components/segmentRouteMapWork.ts
@@ -9,6 +9,7 @@ export type SegmentRouteEditor = {
 
 type SegmentRouteSnapshot = {
   route: GeoJsonLineString | null;
+  workBaseline: GeoJsonLineString | null;
 };
 
 export type SegmentRouteMapWorkState = {
@@ -18,17 +19,20 @@ export type SegmentRouteMapWorkState = {
 
 /// Starts route-only map-work for the active segment draft.
 export function beginSegmentRouteMapWork(
+  identity: string,
   draft: EditorSegmentDraft,
   editorSurface: EditorSurfaceController,
   routeEditor: SegmentRouteEditor,
   state: SegmentRouteMapWorkState,
   editorState: EditorTripState
 ): void {
-  const snapshot = snapshotSegmentRoute(draft);
-  state.route = cloneGeometry(draft.route ?? fallbackRoute(draft, editorState));
+  const snapshot = snapshotSegmentRoute(draft, editorState);
+  state.route = cloneGeometry(snapshot.workBaseline);
   stopSegmentRouteEdit(state);
   state.stopEdit = routeEditor.startSegmentRouteWork({
+    identity,
     initialRoute: state.route,
+    initialRouteKind: draft.route === null ? 'fallback' : 'custom',
     onChanged: route => {
       state.route = cloneGeometry(route);
     }
@@ -39,18 +43,19 @@ export function beginSegmentRouteMapWork(
     instruction: 'Draw or edit one route polyline.',
     statusText: () => segmentRouteStatus(state.route),
     canFinish: () => hasValidRoute(state.route),
-    isDirty: () => !sameGeometry(state.route, snapshot.route),
+    isDirty: () => !sameGeometry(state.route, snapshot.workBaseline),
     snapshot: () => snapshot,
     rollback: rollbackSnapshot => {
       restoreSegmentRoute(draft, state, rollbackSnapshot as SegmentRouteSnapshot);
     },
     clear: () => {
       state.route = null;
-      draft.route = null;
       routeEditor.setSegmentRouteWorkRoute(null);
     },
     done: () => {
-      draft.route = cloneGeometry(state.route);
+      draft.route = sameGeometry(state.route, snapshot.workBaseline)
+        ? cloneGeometry(snapshot.route)
+        : cloneGeometry(state.route);
       stopSegmentRouteEdit(state);
     },
     cancel: () => {
@@ -74,8 +79,11 @@ export function fallbackRoute(draft: Pick<EditorSegmentDraft, 'fromPlaceId' | 't
   return from && to ? { type: 'LineString', coordinates: [[from.longitude, from.latitude], [to.longitude, to.latitude]] } : null;
 }
 
-function snapshotSegmentRoute(draft: EditorSegmentDraft): SegmentRouteSnapshot {
-  return { route: cloneGeometry(draft.route) };
+function snapshotSegmentRoute(draft: EditorSegmentDraft, state: EditorTripState): SegmentRouteSnapshot {
+  return {
+    route: cloneGeometry(draft.route),
+    workBaseline: cloneGeometry(draft.route ?? fallbackRoute(draft, state))
+  };
 }
 
 function restoreSegmentRoute(draft: EditorSegmentDraft, state: SegmentRouteMapWorkState, snapshot: SegmentRouteSnapshot): void {
@@ -84,7 +92,13 @@ function restoreSegmentRoute(draft: EditorSegmentDraft, state: SegmentRouteMapWo
 }
 
 function hasValidRoute(route: GeoJsonLineString | null): boolean {
-  return Boolean(route?.coordinates && route.coordinates.length >= 2);
+  return Boolean(route?.type === 'LineString' && route.coordinates.length >= 2 && route.coordinates.every(([longitude, latitude]) =>
+    Number.isFinite(longitude) &&
+    Number.isFinite(latitude) &&
+    longitude >= -180 &&
+    longitude <= 180 &&
+    latitude >= -90 &&
+    latitude <= 90));
 }
 
 function sameGeometry(left: GeoJsonLineString | null, right: GeoJsonLineString | null): boolean {

--- a/ClientApps/trip-editor/src/components/segmentRouteMapWork.ts
+++ b/ClientApps/trip-editor/src/components/segmentRouteMapWork.ts
@@ -107,7 +107,7 @@ function sameGeometry(left: GeoJsonLineString | null, right: GeoJsonLineString |
 
 function segmentRouteStatus(route: GeoJsonLineString | null): string {
   const points = route?.coordinates.length ?? 0;
-  return points >= 2 ? `${points} route points ready` : 'No route ready';
+  return points >= 2 ? `Editing route · ${points} route points ready` : 'Editing route · no route ready';
 }
 
 function cloneGeometry<T>(geometry: T): T {

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -25,6 +25,7 @@ interface TripEditorMapAdapter {
   getMapView: () => TripEditorMapView;
   selectPlace: (state: EditorTripState, placeId: Guid | null, options?: SelectPlaceOptions) => void;
   setPlaceDraftPreview: (state: EditorTripState, preview: PlaceDraftMarkerPreview | null) => void;
+  setSegmentDraftPreview: (state: EditorTripState, preview: SegmentDraftRoutePreview | null) => void;
   startCoordinatePick: (options: CoordinatePickOptions) => () => void;
   startAreaPolygonWork: (options: AreaPolygonWorkOptions) => () => void;
   startSegmentRouteWork: (options: SegmentRouteWorkOptions) => () => void;
@@ -47,6 +48,14 @@ export interface PlaceDraftMarkerPreview extends Pick<EditorPlace, 'iconName' | 
   placeId: Guid | null;
 }
 
+export interface SegmentDraftRoutePreview {
+  fromPlaceId: Guid | null;
+  identity: string;
+  route: EditorSegment['route'];
+  segmentId: Guid | null;
+  toPlaceId: Guid | null;
+}
+
 export interface TripEditorMapOptions {
   onPlaceSelected?: (placeId: Guid) => boolean | Promise<boolean>;
 }
@@ -64,9 +73,13 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
   const coordinatePick = createPlaceCoordinatePickLayer(map, placeDraftPreview);
   const areaPolygonWork = createAreaPolygonWorkLayer(map);
   const segmentRouteWork = createSegmentRouteWorkLayer(map);
+  const segmentDraftLayers = L.layerGroup().addTo(map);
   const mapUtilities = createMapUtilitiesControl(element).addTo(map);
   const placeMarkers = new Map<Guid, L.Marker>();
   let activePlaceDraftPreview: PlaceDraftMarkerPreview | null = null;
+  let activeSegmentDraftPreview: SegmentDraftRoutePreview | null = null;
+  let lastRenderedState: EditorTripState | null = null;
+  let lastHiddenSegmentIds: ReadonlySet<Guid> = new Set();
   const updateMapViewDataset = (): void => {
     const center = map.getCenter();
     element.dataset.tripEditorMapLat = center.lat.toFixed(6);
@@ -89,11 +102,12 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
   map.attributionControl.getContainer()?.setAttribute('title', 'Map attribution');
 
   const render = (state: EditorTripState, hiddenSegmentIds: ReadonlySet<Guid> = new Set(), nextSelectedPlaceId: Guid | null = selectedPlaceId): void => {
+    lastRenderedState = state;
+    lastHiddenSegmentIds = hiddenSegmentIds;
     searchPreview.clear();
     placeDraftPreview.clear();
     coordinatePick.clearRegisteredMarkers();
     areaPolygonWork.stop();
-    segmentRouteWork.stop();
     layers.clearLayers();
     placeMarkers.clear();
     selectedPlaceId = nextSelectedPlaceId && state.placesById[nextSelectedPlaceId] ? nextSelectedPlaceId : null;
@@ -108,7 +122,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
       return options.onPlaceSelected?.(place.id) ?? true;
     }));
     Object.values(state.segmentsById).forEach(segment => {
-      if (!hiddenSegmentIds.has(segment.id)) {
+      if (!hiddenSegmentIds.has(segment.id) && segment.id !== activeSegmentDraftPreview?.segmentId) {
         renderSegment(segment, state, layers);
       }
     });
@@ -120,6 +134,39 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
     updateMapViewDataset();
     applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
     applyActivePlaceDraftPreview(state);
+    applyActiveSegmentDraftPreview(state);
+  };
+
+  const applyActiveSegmentDraftPreview = (state: EditorTripState): void => {
+    segmentDraftLayers.clearLayers();
+    const preview = activeSegmentDraftPreview;
+    if (!preview || (preview.segmentId !== null && lastHiddenSegmentIds.has(preview.segmentId)) || segmentRouteWork.isActive()) {
+      return;
+    }
+
+    const coordinates = preview.route?.coordinates ?? fallbackSegmentPreviewCoordinates(preview, state);
+    if (!coordinates || coordinates.length < 2) {
+      return;
+    }
+
+    const polyline = L.polyline(coordinates.map(([longitude, latitude]) => [latitude, longitude]), {
+      color: '#38bdf8',
+      dashArray: '8 6',
+      opacity: 0.9,
+      weight: 4
+    }).addTo(segmentDraftLayers);
+    const element = polyline.getElement();
+    if (element) {
+      element.dataset.segmentId = preview.identity;
+      element.dataset.routeOwner = 'draft';
+      element.dataset.routeKind = preview.route === null ? 'fallback' : 'custom';
+    }
+  };
+
+  const setSegmentDraftPreview = (state: EditorTripState, preview: SegmentDraftRoutePreview | null): void => {
+    activeSegmentDraftPreview = preview;
+    // Reconcile the normal layer and preview in one synchronous adapter render.
+    render(state, lastHiddenSegmentIds, selectedPlaceId);
   };
 
   const applyActivePlaceDraftPreview = (state: EditorTripState): void => {
@@ -173,9 +220,20 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
       }
     },
     setPlaceDraftPreview,
+    setSegmentDraftPreview,
     startCoordinatePick: options => (prepareMapWork(), coordinatePick.start(options)),
     startAreaPolygonWork: options => (prepareMapWork(), areaPolygonWork.start(options)),
-    startSegmentRouteWork: options => (prepareMapWork(), segmentRouteWork.start(options)),
+    startSegmentRouteWork: options => {
+      prepareMapWork();
+      segmentDraftLayers.clearLayers();
+      const stop = segmentRouteWork.start(options);
+      return () => {
+        stop();
+        if (lastRenderedState) {
+          applyActiveSegmentDraftPreview(lastRenderedState);
+        }
+      };
+    },
     setSegmentRouteWorkRoute: route => segmentRouteWork.setRoute(route),
     fitAllGeometry: state => fitAllGeometry(map, state),
     focusSavedTripView: metadata => focusSavedTripView(map, metadata),
@@ -187,11 +245,18 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
       coordinatePick.dispose();
       areaPolygonWork.dispose();
       segmentRouteWork.dispose();
+      segmentDraftLayers.clearLayers();
       mapUtilities.remove();
       map.off('moveend zoomend', updateMapViewDataset);
       map.remove();
     }
   };
+};
+
+const fallbackSegmentPreviewCoordinates = (preview: SegmentDraftRoutePreview, state: EditorTripState): Array<[number, number]> | null => {
+  const from = preview.fromPlaceId ? state.placesById[preview.fromPlaceId]?.location : null;
+  const to = preview.toPlaceId ? state.placesById[preview.toPlaceId]?.location : null;
+  return from && to ? [[from.longitude, from.latitude], [to.longitude, to.latitude]] : null;
 };
 
 const renderRegion = (region: EditorRegion, layers: LayerGroup): void => {
@@ -288,11 +353,17 @@ const renderSegment = (segment: EditorSegment, state: EditorTripState, layers: L
   }
 
   const latLngs = coordinates.map(([longitude, latitude]) => [latitude, longitude] as [number, number]);
-  L.polyline(latLngs, {
+  const polyline = L.polyline(latLngs, {
     color: '#0ea5e9',
     weight: 3,
     opacity: 0.8
   }).bindTooltip(escapeHtml(segmentLabel(segment, state))).addTo(layers);
+  const element = polyline.getElement();
+  if (element) {
+    element.dataset.segmentId = segment.id;
+    element.dataset.routeOwner = 'saved';
+    element.dataset.routeKind = segment.route === null ? 'fallback' : 'custom';
+  }
 };
 
 const fallbackSegmentCoordinates = (segment: EditorSegment, state: EditorTripState): Array<[number, number]> | null => {

--- a/ClientApps/trip-editor/src/map/leafletAdapter.ts
+++ b/ClientApps/trip-editor/src/map/leafletAdapter.ts
@@ -8,11 +8,13 @@ import { createPlaceCoordinatePickLayer, createPlaceDraftPreviewLayer, type Coor
 import { placeMarkerIcon, regionMarkerIcon } from './markerRendering';
 import { placePopupHtml } from './placePopupRendering';
 import { createSearchPreviewLayer } from './searchPreviewLayer';
+import { createSegmentRouteDraftPreviewLayer, type SegmentDraftRoutePreview } from './segmentRouteDraftPreviewLayer';
 import { createSegmentRouteWorkLayer, type SegmentRouteWorkOptions } from './segmentRouteWorkLayer';
 import { createTripEditorTileLayer } from './tileRetryLayer';
 export type { AreaPolygonWorkOptions } from './areaPolygonWorkLayer';
 export type { CoordinatePickOptions } from './placeDraftPreviewLayer';
 export type { SegmentRouteWorkOptions } from './segmentRouteWorkLayer';
+export type { SegmentDraftRoutePreview } from './segmentRouteDraftPreviewLayer';
 
 export type FitAllGeometryResult = 'moved' | 'no-geometry';
 export type FocusSavedTripViewResult = 'moved' | 'missing-view';
@@ -48,14 +50,6 @@ export interface PlaceDraftMarkerPreview extends Pick<EditorPlace, 'iconName' | 
   placeId: Guid | null;
 }
 
-export interface SegmentDraftRoutePreview {
-  fromPlaceId: Guid | null;
-  identity: string;
-  route: EditorSegment['route'];
-  segmentId: Guid | null;
-  toPlaceId: Guid | null;
-}
-
 export interface TripEditorMapOptions {
   onPlaceSelected?: (placeId: Guid) => boolean | Promise<boolean>;
 }
@@ -73,11 +67,10 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
   const coordinatePick = createPlaceCoordinatePickLayer(map, placeDraftPreview);
   const areaPolygonWork = createAreaPolygonWorkLayer(map);
   const segmentRouteWork = createSegmentRouteWorkLayer(map);
-  const segmentDraftLayers = L.layerGroup().addTo(map);
+  const segmentDraftPreview = createSegmentRouteDraftPreviewLayer(map);
   const mapUtilities = createMapUtilitiesControl(element).addTo(map);
   const placeMarkers = new Map<Guid, L.Marker>();
   let activePlaceDraftPreview: PlaceDraftMarkerPreview | null = null;
-  let activeSegmentDraftPreview: SegmentDraftRoutePreview | null = null;
   let lastRenderedState: EditorTripState | null = null;
   let lastHiddenSegmentIds: ReadonlySet<Guid> = new Set();
   const updateMapViewDataset = (): void => {
@@ -122,7 +115,7 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
       return options.onPlaceSelected?.(place.id) ?? true;
     }));
     Object.values(state.segmentsById).forEach(segment => {
-      if (!hiddenSegmentIds.has(segment.id) && segment.id !== activeSegmentDraftPreview?.segmentId) {
+      if (!hiddenSegmentIds.has(segment.id) && segment.id !== segmentDraftPreview.segmentId()) {
         renderSegment(segment, state, layers);
       }
     });
@@ -134,37 +127,11 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
     updateMapViewDataset();
     applySelectedPlaceMarker(placeMarkers, selectedPlaceId);
     applyActivePlaceDraftPreview(state);
-    applyActiveSegmentDraftPreview(state);
-  };
-
-  const applyActiveSegmentDraftPreview = (state: EditorTripState): void => {
-    segmentDraftLayers.clearLayers();
-    const preview = activeSegmentDraftPreview;
-    if (!preview || (preview.segmentId !== null && lastHiddenSegmentIds.has(preview.segmentId)) || segmentRouteWork.isActive()) {
-      return;
-    }
-
-    const coordinates = preview.route?.coordinates ?? fallbackSegmentPreviewCoordinates(preview, state);
-    if (!coordinates || coordinates.length < 2) {
-      return;
-    }
-
-    const polyline = L.polyline(coordinates.map(([longitude, latitude]) => [latitude, longitude]), {
-      color: '#38bdf8',
-      dashArray: '8 6',
-      opacity: 0.9,
-      weight: 4
-    }).addTo(segmentDraftLayers);
-    const element = polyline.getElement();
-    if (element) {
-      element.dataset.segmentId = preview.identity;
-      element.dataset.routeOwner = 'draft';
-      element.dataset.routeKind = preview.route === null ? 'fallback' : 'custom';
-    }
+    segmentDraftPreview.render(state, hiddenSegmentIds, segmentRouteWork.isActive());
   };
 
   const setSegmentDraftPreview = (state: EditorTripState, preview: SegmentDraftRoutePreview | null): void => {
-    activeSegmentDraftPreview = preview;
+    segmentDraftPreview.set(preview);
     // Reconcile the normal layer and preview in one synchronous adapter render.
     render(state, lastHiddenSegmentIds, selectedPlaceId);
   };
@@ -225,12 +192,14 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
     startAreaPolygonWork: options => (prepareMapWork(), areaPolygonWork.start(options)),
     startSegmentRouteWork: options => {
       prepareMapWork();
-      segmentDraftLayers.clearLayers();
+      if (lastRenderedState) {
+        segmentDraftPreview.render(lastRenderedState, lastHiddenSegmentIds, true);
+      }
       const stop = segmentRouteWork.start(options);
       return () => {
         stop();
         if (lastRenderedState) {
-          applyActiveSegmentDraftPreview(lastRenderedState);
+          segmentDraftPreview.render(lastRenderedState, lastHiddenSegmentIds, false);
         }
       };
     },
@@ -245,18 +214,12 @@ export const createTripEditorMap = (element: HTMLElement, tilesUrl: string, opti
       coordinatePick.dispose();
       areaPolygonWork.dispose();
       segmentRouteWork.dispose();
-      segmentDraftLayers.clearLayers();
+      segmentDraftPreview.dispose();
       mapUtilities.remove();
       map.off('moveend zoomend', updateMapViewDataset);
       map.remove();
     }
   };
-};
-
-const fallbackSegmentPreviewCoordinates = (preview: SegmentDraftRoutePreview, state: EditorTripState): Array<[number, number]> | null => {
-  const from = preview.fromPlaceId ? state.placesById[preview.fromPlaceId]?.location : null;
-  const to = preview.toPlaceId ? state.placesById[preview.toPlaceId]?.location : null;
-  return from && to ? [[from.longitude, from.latitude], [to.longitude, to.latitude]] : null;
 };
 
 const renderRegion = (region: EditorRegion, layers: LayerGroup): void => {

--- a/ClientApps/trip-editor/src/map/segmentRouteDraftPreviewLayer.ts
+++ b/ClientApps/trip-editor/src/map/segmentRouteDraftPreviewLayer.ts
@@ -1,0 +1,60 @@
+import L, { type Map as LeafletMap } from 'leaflet';
+import type { EditorSegment, EditorTripState, Guid } from '../types';
+
+export interface SegmentDraftRoutePreview {
+  fromPlaceId: Guid | null;
+  identity: string;
+  route: EditorSegment['route'];
+  segmentId: Guid | null;
+  toPlaceId: Guid | null;
+}
+
+/// Owns the single non-editable segment draft route rendered outside map-work.
+export const createSegmentRouteDraftPreviewLayer = (map: LeafletMap): {
+  dispose: () => void;
+  render: (state: EditorTripState, hiddenSegmentIds: ReadonlySet<Guid>, workActive: boolean) => void;
+  segmentId: () => Guid | null;
+  set: (preview: SegmentDraftRoutePreview | null) => void;
+} => {
+  const layers = L.layerGroup().addTo(map);
+  let activePreview: SegmentDraftRoutePreview | null = null;
+
+  const render = (state: EditorTripState, hiddenSegmentIds: ReadonlySet<Guid>, workActive: boolean): void => {
+    layers.clearLayers();
+    const preview = activePreview;
+    if (!preview || workActive || (preview.segmentId !== null && hiddenSegmentIds.has(preview.segmentId))) {
+      return;
+    }
+
+    const coordinates = preview.route?.coordinates ?? fallbackCoordinates(preview, state);
+    if (!coordinates || coordinates.length < 2) {
+      return;
+    }
+
+    const polyline = L.polyline(coordinates.map(([longitude, latitude]) => [latitude, longitude]), {
+      color: '#38bdf8',
+      dashArray: '8 6',
+      opacity: 0.9,
+      weight: 4
+    }).addTo(layers);
+    const element = polyline.getElement();
+    if (element) {
+      element.dataset.segmentId = preview.identity;
+      element.dataset.routeOwner = 'draft';
+      element.dataset.routeKind = preview.route === null ? 'fallback' : 'custom';
+    }
+  };
+
+  return {
+    dispose: () => layers.clearLayers(),
+    render,
+    segmentId: () => activePreview?.segmentId ?? null,
+    set: preview => { activePreview = preview; }
+  };
+};
+
+const fallbackCoordinates = (preview: SegmentDraftRoutePreview, state: EditorTripState): Array<[number, number]> | null => {
+  const from = preview.fromPlaceId ? state.placesById[preview.fromPlaceId]?.location : null;
+  const to = preview.toPlaceId ? state.placesById[preview.toPlaceId]?.location : null;
+  return from && to ? [[from.longitude, from.latitude], [to.longitude, to.latitude]] : null;
+};

--- a/ClientApps/trip-editor/src/map/segmentRouteWorkLayer.ts
+++ b/ClientApps/trip-editor/src/map/segmentRouteWorkLayer.ts
@@ -3,7 +3,9 @@ import { ensureLeafletDraw } from './leafletDrawPlugin';
 import type { GeoJsonLineString } from '../types';
 
 export interface SegmentRouteWorkOptions {
+  identity: string;
   initialRoute: GeoJsonLineString | null;
+  initialRouteKind: 'custom' | 'fallback';
   onChanged: (route: GeoJsonLineString | null) => void;
 }
 
@@ -14,6 +16,7 @@ type LatLngRoute = L.LatLng[];
 /// Owns the single temporary Leaflet.Draw polyline used by Trip Editor segment route map-work.
 export const createSegmentRouteWorkLayer = (map: LeafletMap): {
   dispose: () => void;
+  isActive: () => boolean;
   setRoute: (route: GeoJsonLineString | null) => void;
   start: (options: SegmentRouteWorkOptions) => () => void;
   stop: () => void;
@@ -27,6 +30,17 @@ export const createSegmentRouteWorkLayer = (map: LeafletMap): {
 
   const publish = (): void => {
     options?.onChanged(polyline ? latLngsToLineString(routeLatLngs(polyline)) : null);
+  };
+
+  const applyIdentity = (kind: 'custom' | 'fallback'): void => {
+    const element = polyline?.getElement();
+    if (!element || !options) {
+      return;
+    }
+
+    element.dataset.segmentId = options.identity;
+    element.dataset.routeOwner = 'work';
+    element.dataset.routeKind = kind;
   };
 
   const stopHandlers = (): void => {
@@ -46,11 +60,12 @@ export const createSegmentRouteWorkLayer = (map: LeafletMap): {
     options = null;
   };
 
-  const setRoute = (route: GeoJsonLineString | null): void => {
+  const setRoute = (route: GeoJsonLineString | null, kind: 'custom' | 'fallback' = 'custom'): void => {
     featureGroup.clearLayers();
     polyline = routeToLatLngs(route).length >= 2 ? createPolyline(routeToLatLngs(route)) : null;
     if (polyline) {
       featureGroup.addLayer(polyline);
+      applyIdentity(kind);
       startEditMode();
     } else {
       startDrawMode();
@@ -62,7 +77,7 @@ export const createSegmentRouteWorkLayer = (map: LeafletMap): {
   const start = (workOptions: SegmentRouteWorkOptions): (() => void) => {
     stop();
     options = workOptions;
-    setRoute(workOptions.initialRoute);
+    setRoute(workOptions.initialRoute, workOptions.initialRouteKind);
     if (polyline?.getBounds().isValid()) {
       map.fitBounds(polyline.getBounds(), { padding: [32, 32], maxZoom: 14 });
     }
@@ -100,12 +115,14 @@ export const createSegmentRouteWorkLayer = (map: LeafletMap): {
     polyline = event.layer;
     polyline.setStyle(routeStyle());
     featureGroup.addLayer(polyline);
+    applyIdentity('custom');
     startEditMode();
     publish();
   }
 
   return {
     dispose: stop,
+    isActive: () => options !== null,
     setRoute,
     start,
     stop
@@ -114,6 +131,7 @@ export const createSegmentRouteWorkLayer = (map: LeafletMap): {
 
 const routeStyle = (): L.PathOptions => ({
   color: '#f97316',
+  dashArray: '2 7',
   opacity: 0.9,
   weight: 4
 });

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -422,6 +422,16 @@ body {
   overflow-wrap: anywhere;
 }
 
+.trip-editor-segments .trip-editor-segment-row > .trip-editor-list-button {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+
+.trip-editor-segments .trip-editor-segment-row > .trip-editor-list-button > * {
+  display: block;
+}
+
 .trip-editor-place-row,
 .trip-editor-area-row {
   align-items: center;

--- a/ClientApps/trip-editor/src/styles.css
+++ b/ClientApps/trip-editor/src/styles.css
@@ -406,9 +406,20 @@ body {
   grid-template-columns: auto auto minmax(0, 1fr) auto;
 }
 
-.trip-editor-segments .trip-editor-segment-row > .trip-editor-surface {
+.trip-editor-segments .trip-editor-segment-row > .trip-editor-surface,
+.trip-editor-segments .trip-editor-segment-row > .trip-editor-surface-context {
   grid-column: 1 / -1;
   min-width: 0;
+}
+
+.trip-editor-segments .trip-editor-segment-row > .trip-editor-surface-context > div {
+  min-width: 0;
+}
+
+.trip-editor-segments .trip-editor-segment-row > .trip-editor-surface-context strong,
+.trip-editor-segments .trip-editor-segment-row > .trip-editor-surface-context small {
+  display: block;
+  overflow-wrap: anywhere;
 }
 
 .trip-editor-place-row,

--- a/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
@@ -35,6 +35,44 @@ test.describe.serial('Trip Editor segment editing', () => {
     await expect(page.locator('#trip-editor-segment-form')).toHaveCount(1);
   });
 
+  test('open segment draft owns one test-observable route representation', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithSegmentFixture(page);
+
+    await openEditableSegment(page);
+
+    const activeRoute = page.locator(`[data-segment-id="${segmentId}"][data-route-owner="draft"]`);
+    await expect(activeRoute).toHaveCount(1);
+    await expect(activeRoute).toHaveAttribute('data-route-kind', 'custom');
+    await expect(page.locator(`[data-segment-id="${segmentId}"][data-route-owner="saved"]`)).toHaveCount(0);
+  });
+
+  test('docked segment map-work context spans and stays contained in its row', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithSegmentFixture(page);
+
+    await openEditableSegment(page);
+    await page.getByRole('button', { name: 'Draw/Edit Route' }).click();
+
+    const row = segmentRow(page, segmentId);
+    const context = row.locator('.trip-editor-surface-context');
+    await expect(context).toBeVisible();
+    const layout = await row.evaluate(element => {
+      const contextElement = element.querySelector<HTMLElement>('.trip-editor-surface-context');
+      if (!contextElement) {
+        throw new Error('Expected active segment map-work context.');
+      }
+
+      const rowBounds = element.getBoundingClientRect();
+      const contextBounds = contextElement.getBoundingClientRect();
+      return {
+        contained: element.scrollWidth <= element.clientWidth && contextElement.scrollWidth <= contextElement.clientWidth,
+        spansRow: Math.abs(contextBounds.left - rowBounds.left) <= 1 && Math.abs(contextBounds.right - rowBounds.right) <= 1
+      };
+    });
+    expect(layout).toEqual({ contained: true, spansRow: true });
+  });
+
   test('route map-work from docked and expanded sends a mocked route save only after Save', async ({ page }) => {
     await signIn(page);
     const state = await loadWorkspaceWithSegmentFixture(page);

--- a/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
@@ -57,20 +57,23 @@ test.describe.serial('Trip Editor segment editing', () => {
     const row = segmentRow(page, segmentId);
     const context = row.locator('.trip-editor-surface-context');
     await expect(context).toBeVisible();
-    const layout = await row.evaluate(element => {
-      const contextElement = element.querySelector<HTMLElement>('.trip-editor-surface-context');
-      if (!contextElement) {
-        throw new Error('Expected active segment map-work context.');
-      }
+    for (const viewport of [{ width: 1280, height: 800 }, { width: 430, height: 800 }, { width: 390, height: 800 }]) {
+      await page.setViewportSize(viewport);
+      const layout = await row.evaluate(element => {
+        const contextElement = element.querySelector<HTMLElement>('.trip-editor-surface-context');
+        if (!contextElement) {
+          throw new Error('Expected active segment map-work context.');
+        }
 
-      const rowBounds = element.getBoundingClientRect();
-      const contextBounds = contextElement.getBoundingClientRect();
-      return {
-        contained: element.scrollWidth <= element.clientWidth && contextElement.scrollWidth <= contextElement.clientWidth,
-        spansRow: Math.abs(contextBounds.left - rowBounds.left) <= 1 && Math.abs(contextBounds.right - rowBounds.right) <= 1
-      };
-    });
-    expect(layout).toEqual({ contained: true, spansRow: true });
+        const rowBounds = element.getBoundingClientRect();
+        const contextBounds = contextElement.getBoundingClientRect();
+        return {
+          contained: element.scrollWidth <= element.clientWidth && contextElement.scrollWidth <= contextElement.clientWidth,
+          spansRow: Math.abs(contextBounds.left - rowBounds.left) <= 1 && Math.abs(contextBounds.right - rowBounds.right) <= 1
+        };
+      });
+      expect(layout).toEqual({ contained: true, spansRow: true });
+    }
   });
 
   test('route map-work from docked and expanded sends a mocked route save only after Save', async ({ page }) => {
@@ -99,28 +102,60 @@ test.describe.serial('Trip Editor segment editing', () => {
     const mapWork = page.getByRole('region', { name: 'Map work' });
     await expect(mapWork).toContainText('Draw segment route');
     await expect(mapWork.getByRole('button', { name: 'Done' })).toBeEnabled();
+    const workRoute = page.locator(`[data-segment-id="${segmentId}"][data-route-owner="work"]`);
+    await expect(workRoute).toHaveAttribute('data-route-kind', 'custom');
     await expect(page.locator('.trip-editor-toolbar').getByRole('button', { name: 'Fit All' })).toHaveCount(0);
     await expectNoLegacyEditorAction(page);
     await expect(page.getByRole('button', { name: /pick on map|draw\/edit area|geocode|search.?add|marker drag/i })).toHaveCount(0);
     await expectNoSearchAddUi(page);
 
+    const editHandle = page.locator('.leaflet-editing-icon').last();
+    const handleBox = await editHandle.boundingBox();
+    if (!handleBox) {
+      throw new Error('Expected an editable segment route vertex.');
+    }
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(handleBox.x + handleBox.width / 2 + 40, handleBox.y + handleBox.height / 2 - 30);
+    await page.mouse.up();
+    const workPath = await workRoute.getAttribute('d');
+
     await mapWork.getByRole('button', { name: 'Done' }).click();
     await expectNoLegacyEditorAction(page);
     expect(savedRequests, 'Done must not call the segment save endpoint.').toEqual([]);
     await expect(page.locator('#trip-editor-segment-form')).toContainText('2 custom route points');
-
-    await page.getByRole('button', { name: 'Clear Route' }).click();
-    expect(savedRequests, 'Clear Route must not call the segment save endpoint.').toEqual([]);
-    await expect(page.locator('#trip-editor-segment-form')).toContainText('Endpoint fallback available until saved');
+    const draftRoute = page.locator(`[data-segment-id="${segmentId}"][data-route-owner="draft"]`);
+    await expect(draftRoute).toHaveAttribute('d', workPath ?? '');
+    await expect(page.locator(`[data-segment-id="${segmentId}"][data-route-owner="saved"]`)).toHaveCount(0);
 
     await page.getByRole('button', { name: 'Save Segment' }).click();
     await expect.poll(() => savedRequests.length).toBe(1);
-    expect(savedRequests[0].route).toBeNull();
+    expect(savedRequests[0].route?.type).toBe('LineString');
+    expect(savedRequests[0].route?.coordinates).toHaveLength(2);
+    await expect(page.locator(`[data-segment-id="${segmentId}"][data-route-owner="saved"]`)).toHaveCount(1);
+    await expect(draftRoute).toHaveCount(0);
 
     await openEditableSegment(page);
     await page.getByRole('button', { name: 'Expand Editor' }).click();
     await page.getByRole('dialog', { name: /Edit Segment -/ }).getByRole('button', { name: 'Draw/Edit Route' }).click();
     await expect(page.getByRole('region', { name: 'Map work' })).toContainText('Draw segment route');
+  });
+
+  test('no-op Done preserves a nullable draft route and its endpoint fallback', async ({ page }) => {
+    await signIn(page);
+    await loadWorkspaceWithSegmentFixture(page);
+
+    await segmentRow(page, secondSegmentId).locator('.trip-editor-list-button').click();
+    const form = page.locator('#trip-editor-segment-form');
+    await expect(form).toContainText('Endpoint fallback available until saved');
+    await page.getByRole('button', { name: 'Draw/Edit Route' }).click();
+    await expect(page.locator(`[data-segment-id="${secondSegmentId}"][data-route-owner="work"]`)).toHaveAttribute('data-route-kind', 'fallback');
+    await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Done' }).click();
+
+    await expect(form).toContainText('Endpoint fallback available until saved');
+    await expect(form).not.toContainText('custom route points');
+    await expect(page.getByRole('button', { name: 'Clear Route' })).toBeDisabled();
+    await expect(page.locator(`[data-segment-id="${secondSegmentId}"][data-route-owner="draft"][data-route-kind="fallback"]`)).toHaveCount(1);
   });
 
   test('Cancel route map-work rolls back only route and delete confirms dirty discard first', async ({ page }) => {
@@ -135,6 +170,17 @@ test.describe.serial('Trip Editor segment editing', () => {
     await page.getByRole('region', { name: 'Map work' }).getByRole('button', { name: 'Cancel' }).click();
     await page.getByRole('dialog', { name: 'Discard map editing changes?' }).getByRole('button', { name: 'Discard' }).click();
     await expect(form.getByLabel('Estimated distance km')).toHaveValue('99');
+    await expect(form).toContainText('2 custom route points');
+    await expect(page.locator(`[data-segment-id="${segmentId}"][data-route-owner="draft"][data-route-kind="custom"]`)).toHaveCount(1);
+
+    await page.getByRole('button', { name: 'Clear Route' }).click();
+    await expect(form).toContainText('Endpoint fallback available until saved');
+    await expect(page.locator(`[data-segment-id="${segmentId}"][data-route-owner="draft"][data-route-kind="fallback"]`)).toHaveCount(1);
+
+    await page.getByRole('button', { name: 'Reset' }).click();
+    await expect(form).toContainText('2 custom route points');
+    await expect(form.getByLabel('Estimated distance km')).toHaveValue('2');
+    await form.getByLabel('Estimated distance km').fill('99');
 
     await page.getByRole('button', { name: 'Delete', exact: true }).click();
     await expect(page.getByRole('dialog', { name: 'Discard changes?' })).toBeVisible();
@@ -159,6 +205,8 @@ test.describe.serial('Trip Editor segment editing', () => {
     await expect(segmentRow(page, secondSegmentId)).toBeVisible();
     await expect(form.getByLabel('Estimated distance km')).toHaveValue('99');
     await expect(segmentRow(page, segmentId).locator('#trip-editor-segment-form')).toHaveCount(1);
+    await expect(page.locator(`[data-segment-id="${segmentId}"][data-route-owner="draft"]`)).toHaveCount(1);
+    await expect(page.locator(`[data-segment-id="${secondSegmentId}"][data-route-owner="saved"]`)).toHaveCount(1);
   });
 
   test('client-session visibility hides map route without changing API or reload defaults', async ({ page }) => {

--- a/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
+++ b/tests/e2e/trip-editor/tripEditorSegmentEditing.spec.ts
@@ -49,7 +49,11 @@ test.describe.serial('Trip Editor segment editing', () => {
 
   test('docked segment map-work context spans and stays contained in its row', async ({ page }) => {
     await signIn(page);
-    await loadWorkspaceWithSegmentFixture(page);
+    await loadWorkspaceWithSegmentFixture(page, state => {
+      const [first, second] = Object.values(state.placesById) as Array<Record<string, any>>;
+      first.name = 'A very long departure station name that must wrap inside the segment row';
+      second.name = 'An equally long arrival station name that must remain contained';
+    });
 
     await openEditableSegment(page);
     await page.getByRole('button', { name: 'Draw/Edit Route' }).click();
@@ -158,6 +162,36 @@ test.describe.serial('Trip Editor segment editing', () => {
     await expect(page.locator(`[data-segment-id="${secondSegmentId}"][data-route-owner="draft"][data-route-kind="fallback"]`)).toHaveCount(1);
   });
 
+  test('failed Save retains the complete visible retryable draft and viewport', async ({ page }) => {
+    await signIn(page);
+    const state = await loadWorkspaceWithSegmentFixture(page);
+    await page.unroute(editorApiMatcher);
+    await page.route(editorApiMatcher, async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state) });
+        return;
+      }
+
+      await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ title: 'Forced segment save failure' }) });
+    });
+
+    await openEditableSegment(page);
+    const form = page.locator('#trip-editor-segment-form');
+    const draftRoute = page.locator(`[data-segment-id="${segmentId}"][data-route-owner="draft"]`);
+    const routePath = await draftRoute.getAttribute('d');
+    const map = page.locator('.trip-editor-map');
+    const viewport = await map.evaluate(element => ({ lat: element.dataset.tripEditorMapLat, lng: element.dataset.tripEditorMapLng, zoom: element.dataset.tripEditorMapZoom }));
+    await form.getByLabel('Estimated distance km').fill('99');
+    await page.getByRole('button', { name: 'Save Segment' }).click();
+
+    await expect(page.getByRole('status').filter({ hasText: 'Save failed' })).toBeVisible();
+    await expect(form.getByLabel('Estimated distance km')).toHaveValue('99');
+    await expect(draftRoute).toHaveAttribute('d', routePath ?? '');
+    await expect(map).toHaveAttribute('data-trip-editor-map-lat', viewport.lat ?? '');
+    await expect(map).toHaveAttribute('data-trip-editor-map-lng', viewport.lng ?? '');
+    await expect(map).toHaveAttribute('data-trip-editor-map-zoom', viewport.zoom ?? '');
+  });
+
   test('Cancel route map-work rolls back only route and delete confirms dirty discard first', async ({ page }) => {
     await signIn(page);
     await loadWorkspaceWithSegmentFixture(page);
@@ -251,10 +285,11 @@ test.describe.serial('Trip Editor segment editing', () => {
   });
 });
 
-async function loadWorkspaceWithSegmentFixture(page: Page): Promise<MutableEditorState> {
+async function loadWorkspaceWithSegmentFixture(page: Page, customize?: (state: MutableEditorState) => void): Promise<MutableEditorState> {
   await page.unroute(editorApiMatcher).catch(() => undefined);
   const state = await loadEditorStateFixture(page) as MutableEditorState;
   prepareSegmentState(state);
+  customize?.(state);
   await page.route(editorApiMatcher, async route => routeEditorReadOnly(route, state));
   await page.goto(absoluteUrl(editorPath));
   await expectMountedWorkspace(page);


### PR DESCRIPTION
## Summary

- retain edited segment geometry after map-work Done and before Save
- establish deterministic persisted/draft/work route ownership and cleanup
- preserve nullable custom-route semantics across Done, Clear, Cancel, Reset, Save, rerender, and switching
- add stable saved/draft/work route identity with accessible non-color visual distinctions
- correct docked and responsive segment context containment for long endpoint names

## Root cause

Done copied the edited GeoJSON into the form draft, but stopping map-work removed the temporary route layer while normal map rendering still sourced the persisted segment. The map therefore reverted visually to stale or endpoint-fallback geometry until Save, despite the draft retaining the custom route. The docked map-work context also did not span the segment-row grid, allowing long labels and actions to become compressed or escape their container.

## User impact

Users now continue seeing the exact route they edited after Done, can distinguish saved, unsaved, fallback, and active-work routes, and can safely Save, retry, Cancel, Reset, Clear, or switch without stale or competing route layers. Segment editing remains contained on desktop and phone layouts.

## Validation

- focused segment controller/validation tests: 18 passed
- frontend production build passed (810 modules; existing chunk-size advisory only)
- .NET build passed with existing dependency advisories only
- focused Playwright specifications compile and discover successfully
- `git diff --check` passed
- LOC checker passed with warnings only; the route-preview layer was split from adapter orchestration along a cohesive ownership boundary
- manual rendered validation passed for temporary map-work geometry, post-Done draft geometry, saved custom geometry, and narrow-layout containment/actions
- no public routing, tile, or geocoding provider was contacted

## Database/API/mobile

- no database migration or schema change
- no segment API or GeoJSON serialization change
- no WayfarerMobile change; mobile #237 remains separate
- no multipoint #388 or route-label #389 expansion

Fixes #387
