### PR TITLE
Release Wayfarer v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## [1.8.0] - 2026-07-26
+
+### Added
+- Added explicit Interactive, Conservative, and Custom/Provider Agreement tile traffic modes. Interactive removes Wayfarer-originated rate-token and per-client cold-series throttling for ordinary human-driven map use while retaining bounded concurrency, queues, caching, coalescing, retries, and provider-directed safety gates (#396, #397).
+
+### Changed
+- Increased Interactive map responsiveness to the existing 12-request global and six-request per-client scheduler bounds, while Conservative mode provides explicit 12-contact/second, burst-40, concurrency-eight, and 480-series/client/minute safeguards (#396, #397).
+- Removed the incompatible Thunderforest and CARTO presets and fail closed for their known endpoints without deleting preserved configuration or provider-scoped cache data. Corrected the OpenTopoMap preset attribution and documented exact single- and multi-host `AllowedHosts` deployment configuration (#396, #397).
+- Existing supported built-ins migrate deterministically to Interactive mode and compatible Custom settings remain preserved. Traffic-mode changes do not change cache identity and require no cache purge (#396, #397).
+
+### Fixed
+- Corrected manual Trip Editor place positioning so Add Place preserves the current high-zoom viewport, initializes one authoritative marker at the map center, and retains click, drag, styling, Done, Cancel, Reset, Save, and responsive mobile behavior without duplicate markers (#386, #398).
+- Kept edited segment routes visible after map-work Done and before Save, with deterministic persisted/draft/work ownership, failure-safe lifecycle handling, distinguishable route states, and contained docked/mobile segment controls (#387, #399).
+
 ## [1.7.0] - 2026-07-25
 
 ### Added

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <WayfarerVersion>1.7.0</WayfarerVersion>
+    <WayfarerVersion>1.8.0</WayfarerVersion>
     <Version>$(WayfarerVersion)</Version>
     <PackageVersion>$(WayfarerVersion)</PackageVersion>
     <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>

--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -5,7 +5,7 @@ file contains the manually edited `WayfarerVersion` value and maps the standard
 MSBuild metadata directly from it:
 
 ```xml
-<WayfarerVersion>1.6.0</WayfarerVersion>
+<WayfarerVersion>1.8.0</WayfarerVersion>
 <Version>$(WayfarerVersion)</Version>
 <PackageVersion>$(WayfarerVersion)</PackageVersion>
 <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
@@ -19,7 +19,7 @@ assembly through `IAppVersionProvider`. Runtime surfaces such as
 separate constants.
 
 Use `dotnet run --no-launch-profile -- version` when validating exact CLI
-output. The app writes exactly `Wayfarer 1.6.0`; `--no-launch-profile` avoids
+output. The app writes exactly `Wayfarer 1.8.0`; `--no-launch-profile` avoids
 .NET SDK launch-profile messages so validation stays focused on app output.
 
 ## Release helper

--- a/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
@@ -13,7 +13,7 @@ public class AppVersionProviderTests
     {
         var provider = new AppVersionProvider();
 
-        provider.Version.Should().Be("1.7.0");
+        provider.Version.Should().Be("1.8.0");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Prepare Wayfarer v1.8.0 for publication.

### Highlights

- adds Interactive, Conservative, and Custom/Provider Agreement tile traffic modes
- removes incompatible CARTO and Thunderforest presets while preserving recoverable configuration/cache data
- corrects OpenTopoMap attribution and documents single/multiple `AllowedHosts`
- fixes manual Trip Editor place positioning and authoritative draft-marker behavior
- keeps edited segment routes visible between Done and Save with responsive segment controls

## Upgrade impact

- existing supported built-in providers migrate deterministically to Interactive mode
- compatible Custom settings and inactive numeric values remain preserved
- existing provider-scoped tile cache remains usable; no cache purge is required
- incompatible/unknown providers fail closed without silent OSM substitution or cache deletion
- WayfarerMobile changes are not required for this release

## Database migration

Includes the already-reviewed `20260726085113_AddTileTrafficMode` migration from #397. It adds persisted traffic-mode state without rewriting provider endpoints or deleting cache data.

## Release metadata

- updates `Version.props` to `1.8.0`
- adds the dated v1.8.0 changelog section
- aligns versioning documentation and compiled-version test expectations

## Validation

- release helper metadata check passed
- runtime output: `Wayfarer 1.8.0`
- version-focused tests: 21 passed
- non-browser .NET suite: 1,870 passed, 9 environment-gated PostgreSQL tests skipped
- frontend production build passed (810 modules)
- solution build passed with existing AngleSharp/SQLitePCLRaw advisories only
- LOC checker passed with existing warnings only
- `git diff --check` passed

The browser-tagged PDF attribution test requires its pinned Playwright Chromium executable and was excluded from the authoritative non-browser suite; this is unchanged environment-dependent validation, not a v1.8.0 regression.

## Included work

- #396 / #397
- #386 / #398
- #387 / #399
