### PR TITLE
fix: preserve trip thumbnail generation with restricted hosts

### DIFF
--- a/Services/TileCacheService.cs
+++ b/Services/TileCacheService.cs
@@ -14,6 +14,10 @@ using Wayfarer.Util;
 
 public partial class TileCacheService
 {
+    /// <summary>Returns the first configured hostname accepted by the shared public-host policy.</summary>
+    internal static string? GetFirstAuthorizedPublicHost(IConfiguration configuration) =>
+        GetAuthorizedHosts(configuration).FirstOrDefault();
+
     private readonly ILogger<TileCacheService> _logger;
 
     /// <summary>

--- a/Services/TripMapThumbnailGenerator.Resources.cs
+++ b/Services/TripMapThumbnailGenerator.Resources.cs
@@ -1,0 +1,138 @@
+using System.Runtime.InteropServices;
+using Microsoft.Playwright;
+
+namespace Wayfarer.Services;
+
+/// <summary>
+/// Owns temporary-file publication and browser-resource cleanup for thumbnail generation.
+/// </summary>
+public sealed partial class TripMapThumbnailGenerator
+{
+    private static Action<string, string> _replaceThumbnailFile = ReplaceThumbnailFileAtomicallyCore;
+
+    /// <summary>Writes and timestamps a complete same-directory file before atomically publishing it.</summary>
+    private static async Task PersistThumbnailAsync(
+        string filePath,
+        byte[] thumbnailBytes,
+        DateTime updatedAt,
+        CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(filePath) ?? ".";
+        var tempFilePath = Path.Combine(
+            directory,
+            $"{Path.GetFileName(filePath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            await File.WriteAllBytesAsync(tempFilePath, thumbnailBytes, cancellationToken);
+            File.SetLastWriteTimeUtc(tempFilePath, updatedAt);
+            _replaceThumbnailFile(tempFilePath, filePath);
+        }
+        finally
+        {
+            TryDeleteTemporaryThumbnail(tempFilePath);
+        }
+    }
+
+    /// <summary>Atomically replaces an existing thumbnail or publishes the first thumbnail.</summary>
+    private static void ReplaceThumbnailFileAtomicallyCore(string tempFilePath, string filePath)
+    {
+        if (File.Exists(filePath))
+        {
+            File.Replace(tempFilePath, filePath, null);
+            return;
+        }
+
+        File.Move(tempFilePath, filePath);
+    }
+
+    /// <summary>Removes an unpublished temporary thumbnail without masking the original failure.</summary>
+    private static void TryDeleteTemporaryThumbnail(string tempFilePath)
+    {
+        try
+        {
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
+        }
+        catch
+        {
+            // Cleanup is best-effort so the original persistence failure remains authoritative.
+        }
+    }
+
+    /// <summary>Overrides thumbnail replacement for deterministic atomic-persistence tests.</summary>
+    internal static void SetThumbnailFileReplacerForTesting(Action<string, string>? replacer)
+    {
+        _replaceThumbnailFile = replacer ?? ReplaceThumbnailFileAtomicallyCore;
+    }
+
+    /// <summary>Builds the Chromium launch arguments required for loopback thumbnail capture.</summary>
+    private static List<string> CreateLaunchArguments(string hostResolverRule)
+    {
+        var launchArgs = new List<string>
+        {
+            "--ignore-certificate-errors",
+            "--disable-web-security",
+            $"--host-resolver-rules={hostResolverRule}"
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+            RuntimeInformation.OSArchitecture == Architecture.Arm64)
+        {
+            launchArgs.AddRange(new[]
+            {
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+                "--disable-gpu"
+            });
+        }
+
+        return launchArgs;
+    }
+
+    /// <summary>Closes every created capture resource once and returns the first cleanup failure.</summary>
+    private static async Task<Exception?> DisposeCaptureResourcesAsync(
+        IPage? page,
+        IBrowser? browser,
+        IPlaywright? playwright)
+    {
+        Exception? firstException = null;
+
+        try
+        {
+            if (page != null)
+            {
+                await page.CloseAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            firstException = ex;
+        }
+
+        try
+        {
+            if (browser != null)
+            {
+                await browser.CloseAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            firstException ??= ex;
+        }
+
+        try
+        {
+            playwright?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            firstException ??= ex;
+        }
+
+        return firstException;
+    }
+}

--- a/Services/TripMapThumbnailGenerator.cs
+++ b/Services/TripMapThumbnailGenerator.cs
@@ -1,5 +1,5 @@
 using System.Globalization;
-using System.Runtime.InteropServices;
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Playwright;
@@ -10,7 +10,7 @@ namespace Wayfarer.Services;
 /// Service for generating trip map thumbnails using Playwright screenshots.
 /// Screenshots the public embed view of trips to create thumbnails that use the app's local tile cache.
 /// </summary>
-public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
+public sealed partial class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
 {
     // Static semaphore to prevent concurrent browser installations across all instances
     private static readonly SemaphoreSlim _installLock = new(1, 1);
@@ -153,11 +153,7 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
 
             if (thumbnailBytes != null && thumbnailBytes.Length > 0)
             {
-                // Save to disk
-                await File.WriteAllBytesAsync(filePath, thumbnailBytes, cancellationToken);
-
-                // Set file timestamp to match trip's UpdatedAt for cache validation
-                File.SetLastWriteTimeUtc(filePath, updatedAt);
+                await PersistThumbnailAsync(filePath, thumbnailBytes, updatedAt, cancellationToken);
 
                 _logger.LogInformation("Generated thumbnail for trip {TripId}: {Width}x{Height}, saved to: {FilePath}",
                     tripId, width, height, filePath);
@@ -166,6 +162,10 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
                 var timestamp = updatedAt.Ticks;
                 return $"/thumbs/trips/{filename}?v={timestamp}";
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -249,14 +249,15 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
     /// <summary>
     /// Captures a screenshot of the trip embed view using Playwright.
     /// </summary>
-    private async Task<byte[]?> CaptureEmbedViewAsync(
+    internal async Task<byte[]?> CaptureEmbedViewAsync(
         Guid tripId,
         double lat,
         double lon,
         int zoom,
         int width,
         int height,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Func<Task<IPlaywright>>? playwrightFactory = null)
     {
         var captureSettings = BuildCaptureSettings(tripId, lat, lon, zoom);
         if (captureSettings == null)
@@ -269,57 +270,43 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
 
         _logger.LogDebug("Capturing thumbnail for trip {TripId} through the loopback endpoint", tripId);
 
-        var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var launchArgs = new List<string>
-        {
-            "--ignore-certificate-errors",
-            "--disable-web-security",
-            $"--host-resolver-rules={captureSettings.Value.HostResolverRule}"
-        };
-
-        // ARM64 Linux specific flags
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-            RuntimeInformation.OSArchitecture == Architecture.Arm64)
-        {
-            launchArgs.AddRange(new[]
-            {
-                "--no-sandbox",
-                "--disable-dev-shm-usage",
-                "--disable-gpu"
-            });
-        }
-
-        var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
-        {
-            Headless = true,
-            Args = launchArgs
-        });
-        cancellationToken.ThrowIfCancellationRequested();
-
+        IPlaywright? playwright = null;
+        IBrowser? browser = null;
+        IPage? page = null;
+        Exception? captureException = null;
         try
         {
-            var page = await browser.NewPageAsync(new BrowserNewPageOptions
+            playwright = await (playwrightFactory?.Invoke() ?? Microsoft.Playwright.Playwright.CreateAsync());
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var launchArgs = CreateLaunchArguments(captureSettings.Value.HostResolverRule);
+            browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true,
+                Args = launchArgs
+            });
+            cancellationToken.ThrowIfCancellationRequested();
+
+            page = await browser.NewPageAsync(new BrowserNewPageOptions
             {
                 ViewportSize = new ViewportSize { Width = width, Height = height }
             });
             cancellationToken.ThrowIfCancellationRequested();
 
-            try
-            {
-                return await CapturePageAsync(
-                    page, captureSettings.Value.EmbedUrl, cancellationToken);
-            }
-            finally
-            {
-                await page.CloseAsync();
-            }
+            return await CapturePageAsync(page, captureSettings.Value.EmbedUrl, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            captureException = ex;
+            throw;
         }
         finally
         {
-            await browser.CloseAsync();
-            playwright.Dispose();
+            var cleanupException = await DisposeCaptureResourcesAsync(page, browser, playwright);
+            if (captureException == null && cleanupException != null)
+            {
+                ExceptionDispatchInfo.Capture(cleanupException).Throw();
+            }
         }
     }
 

--- a/Services/TripMapThumbnailGenerator.cs
+++ b/Services/TripMapThumbnailGenerator.cs
@@ -21,6 +21,7 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
     private readonly IConfiguration _configuration;
     private readonly string _thumbsDirectory;
     private readonly string _chromeCachePath;
+    private readonly Func<CancellationToken, Task<byte[]?>>? _captureOverride;
 
     /// <summary>
     /// Initializes the thumbnail generator.
@@ -48,6 +49,17 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
         Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", playwrightPath);
 
         _logger.LogInformation("Thumbnail generator - Chrome cache: {ChromePath}", _chromeCachePath);
+    }
+
+    /// <summary>Creates a generator with a controllable capture seam for focused tests.</summary>
+    internal TripMapThumbnailGenerator(
+        ILogger<TripMapThumbnailGenerator> logger,
+        IWebHostEnvironment env,
+        IConfiguration configuration,
+        Func<CancellationToken, Task<byte[]?>> captureOverride)
+        : this(logger, env, configuration)
+    {
+        _captureOverride = captureOverride;
     }
 
     /// <summary>
@@ -127,10 +139,17 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
         // Generate new thumbnail by screenshotting the embed view
         try
         {
-            await EnsureBrowsersInstalledAsync(cancellationToken);
-
-            var thumbnailBytes = await CaptureEmbedViewAsync(
-                tripId, centerLat, centerLon, zoom, width, height, cancellationToken);
+            byte[]? thumbnailBytes;
+            if (_captureOverride != null)
+            {
+                thumbnailBytes = await _captureOverride(cancellationToken);
+            }
+            else
+            {
+                await EnsureBrowsersInstalledAsync(cancellationToken);
+                thumbnailBytes = await CaptureEmbedViewAsync(
+                    tripId, centerLat, centerLon, zoom, width, height, cancellationToken);
+            }
 
             if (thumbnailBytes != null && thumbnailBytes.Length > 0)
             {
@@ -205,6 +224,29 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
     }
 
     /// <summary>
+    /// Builds an authorized request authority whose DNS resolution is pinned to loopback.
+    /// </summary>
+    internal (string EmbedUrl, string HostResolverRule)? BuildCaptureSettings(
+        Guid tripId,
+        double lat,
+        double lon,
+        int zoom)
+    {
+        var authorizedHost = TileCacheService.GetFirstAuthorizedPublicHost(_configuration);
+        if (authorizedHost == null)
+        {
+            return null;
+        }
+
+        var localUri = new Uri(GetLocalBaseUrl());
+        var thumbnailZoom = Math.Max(1, zoom - 1);
+        var embedUrl = $"http://{authorizedHost}:{localUri.Port}/Public/Trips/{tripId}" +
+            $"?embed=true&lat={lat.ToString("F6", CultureInfo.InvariantCulture)}" +
+            $"&lon={lon.ToString("F6", CultureInfo.InvariantCulture)}&zoom={thumbnailZoom}";
+        return (embedUrl, $"MAP {authorizedHost} 127.0.0.1");
+    }
+
+    /// <summary>
     /// Captures a screenshot of the trip embed view using Playwright.
     /// </summary>
     private async Task<byte[]?> CaptureEmbedViewAsync(
@@ -216,16 +258,16 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
         int height,
         CancellationToken cancellationToken)
     {
-        // Build embed URL using localhost HTTP endpoint (secure since it's loopback only)
-        // Playwright runs on same server, so we use http://127.0.0.1:{port} for performance and simplicity
-        var baseUrl = GetLocalBaseUrl();
+        var captureSettings = BuildCaptureSettings(tripId, lat, lon, zoom);
+        if (captureSettings == null)
+        {
+            _logger.LogWarning(
+                "Thumbnail capture skipped for trip {TripId}: no authorized public hostname is configured",
+                tripId);
+            return null;
+        }
 
-        // Zoom out by 1 level for better thumbnail overview (lower zoom = more area visible)
-        var thumbnailZoom = Math.Max(1, zoom - 1);
-
-        var embedUrl = $"{baseUrl}/Public/Trips/{tripId}?embed=true&lat={lat.ToString("F6", CultureInfo.InvariantCulture)}&lon={lon.ToString("F6", CultureInfo.InvariantCulture)}&zoom={thumbnailZoom}";
-
-        _logger.LogDebug("Capturing thumbnail from: {Url}", embedUrl);
+        _logger.LogDebug("Capturing thumbnail for trip {TripId} through the loopback endpoint", tripId);
 
         var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
         cancellationToken.ThrowIfCancellationRequested();
@@ -233,7 +275,8 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
         var launchArgs = new List<string>
         {
             "--ignore-certificate-errors",
-            "--disable-web-security"
+            "--disable-web-security",
+            $"--host-resolver-rules={captureSettings.Value.HostResolverRule}"
         };
 
         // ARM64 Linux specific flags
@@ -265,23 +308,8 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
 
             try
             {
-                // Navigate to embed view and wait for map to load
-                await page.GotoAsync(embedUrl, new PageGotoOptions
-                {
-                    WaitUntil = WaitUntilState.NetworkIdle,
-                    Timeout = 30000
-                });
-                cancellationToken.ThrowIfCancellationRequested();
-
-                // Take screenshot
-                var screenshot = await page.ScreenshotAsync(new PageScreenshotOptions
-                {
-                    Type = ScreenshotType.Jpeg,
-                    Quality = 85,
-                    FullPage = false
-                });
-
-                return screenshot;
+                return await CapturePageAsync(
+                    page, captureSettings.Value.EmbedUrl, cancellationToken);
             }
             finally
             {
@@ -293,6 +321,33 @@ public sealed class TripMapThumbnailGenerator : ITripMapThumbnailGenerator
             await browser.CloseAsync();
             playwright.Dispose();
         }
+    }
+
+    /// <summary>Captures only after Playwright confirms a successful main-document response.</summary>
+    internal static async Task<byte[]?> CapturePageAsync(
+        IPage page,
+        string embedUrl,
+        CancellationToken cancellationToken)
+    {
+        var response = await page.GotoAsync(embedUrl, new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle,
+            Timeout = 30000
+        });
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (response?.Ok != true ||
+            !string.Equals(response.Url, embedUrl, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Type = ScreenshotType.Jpeg,
+            Quality = 85,
+            FullPage = false
+        });
     }
 
     /// <summary>

--- a/tests/Wayfarer.Tests/Services/TripMapThumbnailGeneratorTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripMapThumbnailGeneratorTests.cs
@@ -106,18 +106,56 @@ public class TripMapThumbnailGeneratorTests : IDisposable
     }
 
     [Fact]
+    public async Task CapturePageAsync_ReturnsNull_WhenNavigationRedirectsToAnotherPage()
+    {
+        const string embedUrl = "http://wayfarer.example.com:5500/Public/Trips/example";
+        var page = new Mock<IPage>();
+        var response = new Mock<IResponse>();
+        response.SetupGet(item => item.Ok).Returns(true);
+        response.SetupGet(item => item.Url).Returns("http://wayfarer.example.com:5500/Identity/Account/Login");
+        page.Setup(item => item.GotoAsync(embedUrl, It.IsAny<PageGotoOptions>()))
+            .ReturnsAsync(response.Object);
+
+        var result = await TripMapThumbnailGenerator.CapturePageAsync(
+            page.Object, embedUrl, CancellationToken.None);
+
+        Assert.Null(result);
+        page.Verify(item => item.ScreenshotAsync(It.IsAny<PageScreenshotOptions>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CapturePageAsync_ScreenshotsSuccessfulEmbedResponse()
+    {
+        const string embedUrl = "http://wayfarer.example.com:5500/Public/Trips/example";
+        var expected = new byte[] { 1, 2, 3 };
+        var page = new Mock<IPage>();
+        var response = new Mock<IResponse>();
+        response.SetupGet(item => item.Ok).Returns(true);
+        response.SetupGet(item => item.Url).Returns(embedUrl);
+        page.Setup(item => item.GotoAsync(embedUrl, It.IsAny<PageGotoOptions>()))
+            .ReturnsAsync(response.Object);
+        page.Setup(item => item.ScreenshotAsync(It.IsAny<PageScreenshotOptions>()))
+            .ReturnsAsync(expected);
+
+        var result = await TripMapThumbnailGenerator.CapturePageAsync(
+            page.Object, embedUrl, CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
     public async Task GetOrGenerateThumbnailAsync_PreservesExistingFile_WhenCaptureFails()
     {
         var tripId = Guid.NewGuid();
-        var path = Path.Combine(_root, "thumbs", "trips", $"{tripId}-800x450.jpg");
-        var original = new byte[] { 1, 2, 3 };
-        File.WriteAllBytes(path, original);
-        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddDays(-1));
         var generator = new TripMapThumbnailGenerator(
             _logger.Object,
             _env.Object,
             _config,
             _ => Task.FromResult<byte[]?>(null));
+        var path = Path.Combine(_root, "thumbs", "trips", $"{tripId}-800x450.jpg");
+        var original = new byte[] { 1, 2, 3 };
+        File.WriteAllBytes(path, original);
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddDays(-1));
 
         var result = await generator.GetOrGenerateThumbnailAsync(
             tripId, 10, 20, 5, 800, 450, DateTime.UtcNow);

--- a/tests/Wayfarer.Tests/Services/TripMapThumbnailGeneratorTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripMapThumbnailGeneratorTests.cs
@@ -165,6 +165,77 @@ public class TripMapThumbnailGeneratorTests : IDisposable
     }
 
     [Fact]
+    public async Task GetOrGenerateThumbnailAsync_PreservesExistingFile_WhenAtomicPublishFails()
+    {
+        var tripId = Guid.NewGuid();
+        var replacement = new byte[] { 9, 8, 7 };
+        var generator = new TripMapThumbnailGenerator(
+            _logger.Object,
+            _env.Object,
+            _config,
+            _ => Task.FromResult<byte[]?>(replacement));
+        var directory = Path.Combine(_root, "thumbs", "trips");
+        var path = Path.Combine(directory, $"{tripId}-800x450.jpg");
+        var original = new byte[] { 1, 2, 3 };
+        File.WriteAllBytes(path, original);
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddDays(-1));
+        var originalTimestamp = File.GetLastWriteTimeUtc(path);
+
+        TripMapThumbnailGenerator.SetThumbnailFileReplacerForTesting(
+            (_, _) => throw new IOException("publish failed"));
+        try
+        {
+            var result = await generator.GetOrGenerateThumbnailAsync(
+                tripId, 10, 20, 5, 800, 450, DateTime.UtcNow);
+
+            Assert.Null(result);
+            Assert.Equal(original, File.ReadAllBytes(path));
+            Assert.Equal(originalTimestamp, File.GetLastWriteTimeUtc(path));
+            Assert.Empty(Directory.GetFiles(directory, "*.tmp"));
+            Assert.Empty(Directory.GetFiles(directory, "*.bak"));
+        }
+        finally
+        {
+            TripMapThumbnailGenerator.SetThumbnailFileReplacerForTesting(null);
+        }
+    }
+
+    [Fact]
+    public async Task CaptureEmbedViewAsync_DisposesCreatedResourcesOnce_WhenCancelledAfterPageCreation()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AllowedHosts"] = "wayfarer.example.com",
+                ["Kestrel:Endpoints:Http:Url"] = "http://*:5500"
+            })
+            .Build();
+        var generator = new TripMapThumbnailGenerator(_logger.Object, _env.Object, config);
+        var playwright = new Mock<IPlaywright>();
+        var browserType = new Mock<IBrowserType>();
+        var browser = new Mock<IBrowser>();
+        var page = new Mock<IPage>();
+        using var cancellation = new CancellationTokenSource();
+        playwright.SetupGet(item => item.Chromium).Returns(browserType.Object);
+        browserType.Setup(item => item.LaunchAsync(It.IsAny<BrowserTypeLaunchOptions>()))
+            .ReturnsAsync(browser.Object);
+        browser.Setup(item => item.NewPageAsync(It.IsAny<BrowserNewPageOptions>()))
+            .ReturnsAsync(() =>
+            {
+                cancellation.Cancel();
+                return page.Object;
+            });
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => generator.CaptureEmbedViewAsync(
+            Guid.NewGuid(), 10, 20, 5, 800, 450, cancellation.Token,
+            () => Task.FromResult(playwright.Object)));
+
+        page.Verify(item => item.CloseAsync(It.IsAny<PageCloseOptions>()), Times.Once);
+        browser.Verify(item => item.CloseAsync(It.IsAny<BrowserCloseOptions>()), Times.Once);
+        playwright.Verify(item => item.Dispose(), Times.Once);
+    }
+
+    [Fact]
     public void DeleteThumbnails_RemovesFilesForTrip()
     {
         var tripId = Guid.NewGuid();

--- a/tests/Wayfarer.Tests/Services/TripMapThumbnailGeneratorTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripMapThumbnailGeneratorTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
 using Moq;
 using Wayfarer.Services;
 using Xunit;
@@ -34,6 +35,95 @@ public class TripMapThumbnailGeneratorTests : IDisposable
             Guid.NewGuid(), 200, 10, 5, 200, 200, DateTime.UtcNow);
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void BuildCaptureSettings_UsesAuthorizedHostWithLoopbackResolver()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AllowedHosts"] = "invalid host;wayfarer.example.com;other.example.com",
+                ["Kestrel:Endpoints:Http:Url"] = "http://*:5500"
+            })
+            .Build();
+        var generator = new TripMapThumbnailGenerator(_logger.Object, _env.Object, config);
+
+        var settings = generator.BuildCaptureSettings(Guid.Empty, 1, 2, 3);
+
+        Assert.NotNull(settings);
+        Assert.StartsWith("http://wayfarer.example.com:5500/Public/Trips/", settings.Value.EmbedUrl);
+        Assert.Equal("MAP wayfarer.example.com 127.0.0.1", settings.Value.HostResolverRule);
+        Assert.DoesNotContain("other.example.com", settings.Value.EmbedUrl);
+    }
+
+    [Fact]
+    public void BuildCaptureSettings_ReturnsNull_WhenAllowedHostIsNotPublic()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AllowedHosts"] = "wayfarer.test",
+                ["Kestrel:Endpoints:Http:Url"] = "http://*:5500"
+            })
+            .Build();
+        var generator = new TripMapThumbnailGenerator(_logger.Object, _env.Object, config);
+
+        var settings = generator.BuildCaptureSettings(Guid.Empty, 1, 2, 3);
+
+        Assert.Null(settings);
+    }
+
+    [Fact]
+    public async Task CapturePageAsync_ReturnsNull_WhenNavigationIsNonSuccess()
+    {
+        var page = new Mock<IPage>();
+        var response = new Mock<IResponse>();
+        response.SetupGet(item => item.Status).Returns(400);
+        response.SetupGet(item => item.Ok).Returns(false);
+        page.Setup(item => item.GotoAsync(It.IsAny<string>(), It.IsAny<PageGotoOptions>()))
+            .ReturnsAsync(response.Object);
+
+        var result = await TripMapThumbnailGenerator.CapturePageAsync(
+            page.Object, "http://wayfarer.example.com:5500/Public/Trips/example", CancellationToken.None);
+
+        Assert.Null(result);
+        page.Verify(item => item.ScreenshotAsync(It.IsAny<PageScreenshotOptions>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CapturePageAsync_ReturnsNull_WhenNavigationResponseIsNull()
+    {
+        var page = new Mock<IPage>();
+        page.Setup(item => item.GotoAsync(It.IsAny<string>(), It.IsAny<PageGotoOptions>()))
+            .ReturnsAsync((IResponse?)null);
+
+        var result = await TripMapThumbnailGenerator.CapturePageAsync(
+            page.Object, "http://wayfarer.example.com:5500/Public/Trips/example", CancellationToken.None);
+
+        Assert.Null(result);
+        page.Verify(item => item.ScreenshotAsync(It.IsAny<PageScreenshotOptions>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetOrGenerateThumbnailAsync_PreservesExistingFile_WhenCaptureFails()
+    {
+        var tripId = Guid.NewGuid();
+        var path = Path.Combine(_root, "thumbs", "trips", $"{tripId}-800x450.jpg");
+        var original = new byte[] { 1, 2, 3 };
+        File.WriteAllBytes(path, original);
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddDays(-1));
+        var generator = new TripMapThumbnailGenerator(
+            _logger.Object,
+            _env.Object,
+            _config,
+            _ => Task.FromResult<byte[]?>(null));
+
+        var result = await generator.GetOrGenerateThumbnailAsync(
+            tripId, 10, 20, 5, 800, 450, DateTime.UtcNow);
+
+        Assert.Null(result);
+        Assert.Equal(original, File.ReadAllBytes(path));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- keep Playwright thumbnail capture on loopback while presenting a validated public Host authority
- reject failed or redirected embed navigation before screenshot persistence
- publish thumbnails atomically and dispose browser resources deterministically
- preserve normal save-driven thumbnail invalidation and regeneration

## Production evidence
Restrictive production `AllowedHosts` rejected the generator's `127.0.0.1` Host with HTTP 400, after which the error page was saved as a JPEG. The correction maps the validated public hostname directly to loopback inside Chromium and validates navigation before capture.

## Validation
- `TripMapThumbnailGeneratorTests`: 19 passed
- focused successful-save invalidation test: passed
- `dotnet build Wayfarer.csproj --no-restore`: passed
- LOC checker: passed
- complete-range `git diff --check`: passed

## Scope
No API, schema, tile-provider, Referer, proxy, PDF, frontend, or mobile changes.

## Migration notes
No database migration. Existing bad thumbnails regenerate after the affected trip is saved, or after the cached thumbnail is otherwise invalidated.