### PR TITLE
chore: release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [1.8.1] - 2026-07-26
+
+### Fixed
+- Restored generated trip map thumbnails on deployments using restrictive public `AllowedHosts` by keeping browser capture on loopback with an authorized Host, rejecting failed navigation, and publishing completed JPEGs atomically (#401).
+
 ## [1.8.0] - 2026-07-26
 
 ### Added

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <WayfarerVersion>1.8.0</WayfarerVersion>
+    <WayfarerVersion>1.8.1</WayfarerVersion>
     <Version>$(WayfarerVersion)</Version>
     <PackageVersion>$(WayfarerVersion)</PackageVersion>
     <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>

--- a/docs/23-Versioning.md
+++ b/docs/23-Versioning.md
@@ -5,7 +5,7 @@ file contains the manually edited `WayfarerVersion` value and maps the standard
 MSBuild metadata directly from it:
 
 ```xml
-<WayfarerVersion>1.8.0</WayfarerVersion>
+<WayfarerVersion>1.8.1</WayfarerVersion>
 <Version>$(WayfarerVersion)</Version>
 <PackageVersion>$(WayfarerVersion)</PackageVersion>
 <AssemblyInformationalVersion>$(WayfarerVersion)</AssemblyInformationalVersion>
@@ -19,7 +19,7 @@ assembly through `IAppVersionProvider`. Runtime surfaces such as
 separate constants.
 
 Use `dotnet run --no-launch-profile -- version` when validating exact CLI
-output. The app writes exactly `Wayfarer 1.8.0`; `--no-launch-profile` avoids
+output. The app writes exactly `Wayfarer 1.8.1`; `--no-launch-profile` avoids
 .NET SDK launch-profile messages so validation stays focused on app output.
 
 ## Release helper

--- a/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
+++ b/tests/Wayfarer.Tests/Versioning/AppVersionProviderTests.cs
@@ -13,7 +13,7 @@ public class AppVersionProviderTests
     {
         var provider = new AppVersionProvider();
 
-        provider.Version.Should().Be("1.8.0");
+        provider.Version.Should().Be("1.8.1");
     }
 
     [Fact]


### PR DESCRIPTION
## Wayfarer v1.8.1

Patch release for the trip-thumbnail host-filter regression corrected in #401.

### Fixed
- keep thumbnail browser capture on loopback while using an authorized public Host
- reject failed/redirected embed navigation instead of saving error pages
- publish completed thumbnails atomically and dispose Playwright resources deterministically

### Validation
- release helper metadata check: passed
- runtime CLI: `Wayfarer 1.8.1`
- versioning tests: 26 passed
- full non-browser suite: 1,877 passed, 9 environment-gated PostgreSQL tests skipped
- frontend production build: passed
- .NET build: passed
- LOC checker: passed
- `git diff --check`: passed

### Migration notes
No database migration. Previously generated bad thumbnails regenerate after an affected trip is saved or its thumbnail is otherwise invalidated.