### PR TITLE
test(playwright): provision deterministic .NET Chromium

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      MvcFrontendKitEnabled: 'false'
+      PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/wayfarer-dotnet-playwright
+      WAYFARER_TEST_ARTIFACT_DIRECTORY: ${{ runner.temp }}/wayfarer-test-artifacts
 
     steps:
       - uses: actions/checkout@v4
@@ -28,8 +32,19 @@ jobs:
       - name: Check file size limits
         run: dotnet run --project tools/Wayfarer.LocCheck -- --warn 400 --fail 600
 
-      - name: Build and Test
-        run: dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --configuration Release --verbosity normal --filter "Category!=RequiresSpatialite&Category!=RequiresPlaywright"
-        env:
-          # Disable frontend bundling in CI - we're testing C# code, not frontend assets
-          MvcFrontendKitEnabled: 'false'
+      - name: Build tests
+        run: dotnet build tests/Wayfarer.Tests/Wayfarer.Tests.csproj --configuration Release --no-restore
+
+      - name: Run ordinary tests
+        run: dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --configuration Release --no-build --verbosity normal --filter "Category!=RequiresSpatialite&Category!=RequiresPlaywright"
+
+      - name: Install .NET Playwright Chromium
+        run: pwsh tests/Wayfarer.Tests/bin/Release/net10.0/playwright.ps1 install --with-deps chromium
+
+      - name: Run .NET Playwright rendering tests
+        run: dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --configuration Release --no-build --verbosity normal --filter "Category=RequiresPlaywright"
+
+      - name: Verify .NET Playwright rendering artifacts
+        run: |
+          test -s "$WAYFARER_TEST_ARTIFACT_DIRECTORY/phase2b-map-attribution.pdf"
+          test -s "$WAYFARER_TEST_ARTIFACT_DIRECTORY/phase2b-map-attribution-print.png"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MvcFrontendKitEnabled: 'false'
-      PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/wayfarer-dotnet-playwright
-      WAYFARER_TEST_ARTIFACT_DIRECTORY: ${{ runner.temp }}/wayfarer-test-artifacts
 
     steps:
       - uses: actions/checkout@v4
@@ -40,11 +38,18 @@ jobs:
 
       - name: Install .NET Playwright Chromium
         run: pwsh tests/Wayfarer.Tests/bin/Release/net10.0/playwright.ps1 install --with-deps chromium
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/wayfarer-dotnet-playwright
 
       - name: Run .NET Playwright rendering tests
         run: dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj --configuration Release --no-build --verbosity normal --filter "Category=RequiresPlaywright"
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/wayfarer-dotnet-playwright
+          WAYFARER_TEST_ARTIFACT_DIRECTORY: ${{ runner.temp }}/wayfarer-test-artifacts
 
       - name: Verify .NET Playwright rendering artifacts
         run: |
           test -s "$WAYFARER_TEST_ARTIFACT_DIRECTORY/phase2b-map-attribution.pdf"
           test -s "$WAYFARER_TEST_ARTIFACT_DIRECTORY/phase2b-map-attribution-print.png"
+        env:
+          WAYFARER_TEST_ARTIFACT_DIRECTORY: ${{ runner.temp }}/wayfarer-test-artifacts

--- a/docs/22-Testing.md
+++ b/docs/22-Testing.md
@@ -8,6 +8,44 @@ Running Tests
 - `dotnet test`
 - Trip Editor E2E: `npm run test:e2e:trip-editor`
 
+.NET Playwright Rendering Test
+- The .NET rendering test owns a browser cache separate from JavaScript Playwright.
+- Restore and build first so Microsoft.Playwright generates its version-coupled installer.
+- The installer and test process must receive the same absolute `PLAYWRIGHT_BROWSERS_PATH`.
+
+```powershell
+dotnet restore
+$env:MvcFrontendKitEnabled = 'false'
+dotnet build tests/Wayfarer.Tests/Wayfarer.Tests.csproj --configuration Release --no-restore
+
+$dotnetBrowserCache = [IO.Path]::GetFullPath('.local/playwright/dotnet-browsers')
+$artifactDirectory = [IO.Path]::GetFullPath('.local/test-results/415')
+New-Item -ItemType Directory -Force $dotnetBrowserCache, $artifactDirectory | Out-Null
+$env:PLAYWRIGHT_BROWSERS_PATH = $dotnetBrowserCache
+$env:WAYFARER_TEST_ARTIFACT_DIRECTORY = $artifactDirectory
+
+pwsh tests/Wayfarer.Tests/bin/Release/net10.0/playwright.ps1 install chromium
+
+dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj `
+    --configuration Release `
+    --no-build `
+    --filter "Category=RequiresPlaywright"
+
+# Optional: run every discovered .NET test with the same browser cache.
+dotnet test tests/Wayfarer.Tests/Wayfarer.Tests.csproj `
+    --configuration Release `
+    --no-build
+```
+
+- Retained PDF and screenshot evidence is written only when `WAYFARER_TEST_ARTIFACT_DIRECTORY` is set.
+- Cleanup is limited to the issue-owned directories created above:
+
+```powershell
+Remove-Item -LiteralPath $dotnetBrowserCache -Recurse -Force
+Remove-Item -LiteralPath $artifactDirectory -Recurse -Force
+```
+- Do not delete global Playwright caches, production `ChromeCache`, browser profiles, JavaScript browser assets, or unrelated `.local` content.
+
 Trip Editor Asset-Mode Smoke
 - These smokes are explicit opt-in checks. They do not run as part of `npm run test:e2e:trip-editor`.
 - Development smoke proves ASP.NET Development + Vite dev-server integration only.

--- a/tests/Wayfarer.Tests/Infrastructure/PlaywrightEnvironmentTestCollection.cs
+++ b/tests/Wayfarer.Tests/Infrastructure/PlaywrightEnvironmentTestCollection.cs
@@ -1,0 +1,30 @@
+using Xunit;
+using Xunit.Sdk;
+
+namespace Wayfarer.Tests.Infrastructure;
+
+/// <summary>
+/// Serializes tests that read or mutate Playwright's process-wide browser discovery path.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class PlaywrightEnvironmentTestCollection
+{
+    /// <summary>Stable collection name for process-wide Playwright environment users.</summary>
+    public const string Name = "Playwright browser environment";
+}
+
+/// <summary>
+/// Restores one process-wide environment variable to its exact original state after a test.
+/// </summary>
+internal sealed class PlaywrightEnvironmentIsolationAttribute : BeforeAfterTestAttribute
+{
+    private string? _originalValue;
+
+    /// <summary>Snapshots the browser path before each affected test executes.</summary>
+    public override void Before(System.Reflection.MethodInfo methodUnderTest) =>
+        _originalValue = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+
+    /// <summary>Restores the exact original browser path after success or failure.</summary>
+    public override void After(System.Reflection.MethodInfo methodUnderTest) =>
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", _originalValue);
+}

--- a/tests/Wayfarer.Tests/Services/TripExportServiceTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripExportServiceTests.cs
@@ -18,6 +18,26 @@ namespace Wayfarer.Tests.Services;
 /// </summary>
 public class TripExportServiceTests : TestBase
 {
+    [Fact]
+    public void CreateService_RestoresOriginalPlaywrightBrowserPath()
+    {
+        const string originalPath = "issue-415-original-browser-path";
+        var previousPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalPath);
+            using var db = CreateDbContext();
+
+            _ = CreateService(db);
+
+            Assert.Equal(originalPath, Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", previousPath);
+        }
+    }
+
     /// <summary>
     /// Creates a TripExportService with minimal mocked dependencies for scoped export testing.
     /// </summary>

--- a/tests/Wayfarer.Tests/Services/TripExportServiceTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripExportServiceTests.cs
@@ -14,30 +14,10 @@ namespace Wayfarer.Tests.Services;
 
 /// <summary>
 /// Tests for <see cref="TripExportService"/> covering KML export operations.
-/// Note: Full PDF generation tests are skipped due to complex external dependencies (Playwright, HttpContext).
 /// </summary>
+[Collection(PlaywrightEnvironmentTestCollection.Name), PlaywrightEnvironmentIsolation]
 public class TripExportServiceTests : TestBase
 {
-    [Fact]
-    public void CreateService_RestoresOriginalPlaywrightBrowserPath()
-    {
-        const string originalPath = "issue-415-original-browser-path";
-        var previousPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
-        try
-        {
-            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalPath);
-            using var db = CreateDbContext();
-
-            _ = CreateService(db);
-
-            Assert.Equal(originalPath, Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH"));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", previousPath);
-        }
-    }
-
     /// <summary>
     /// Creates a TripExportService with minimal mocked dependencies for scoped export testing.
     /// </summary>

--- a/tests/Wayfarer.Tests/Services/TripMapThumbnailGeneratorTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripMapThumbnailGeneratorTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Playwright;
 using Moq;
 using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
 using Xunit;
 
 namespace Wayfarer.Tests.Services;
@@ -11,6 +12,8 @@ namespace Wayfarer.Tests.Services;
 /// <summary>
 /// File-system behaviors for the map thumbnail generator (Playwright-free paths).
 /// </summary>
+[Collection(PlaywrightEnvironmentTestCollection.Name)]
+[PlaywrightEnvironmentIsolation]
 public class TripMapThumbnailGeneratorTests : IDisposable
 {
     private readonly string _root;
@@ -24,24 +27,6 @@ public class TripMapThumbnailGeneratorTests : IDisposable
         Directory.CreateDirectory(_root);
         _env.SetupGet(e => e.WebRootPath).Returns(_root);
         _config = new ConfigurationBuilder().Build();
-    }
-
-    [Fact]
-    public void Constructor_PreservesUnsetPlaywrightBrowserPath()
-    {
-        var previousPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
-        try
-        {
-            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", null);
-
-            _ = new TripMapThumbnailGenerator(_logger.Object, _env.Object, _config);
-
-            Assert.Null(Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH"));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", previousPath);
-        }
     }
 
     [Fact]

--- a/tests/Wayfarer.Tests/Services/TripMapThumbnailGeneratorTests.cs
+++ b/tests/Wayfarer.Tests/Services/TripMapThumbnailGeneratorTests.cs
@@ -27,6 +27,24 @@ public class TripMapThumbnailGeneratorTests : IDisposable
     }
 
     [Fact]
+    public void Constructor_PreservesUnsetPlaywrightBrowserPath()
+    {
+        var previousPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", null);
+
+            _ = new TripMapThumbnailGenerator(_logger.Object, _env.Object, _config);
+
+            Assert.Null(Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", previousPath);
+        }
+    }
+
+    [Fact]
     public async Task GetOrGenerateThumbnailAsync_ReturnsNull_WhenCoordinatesInvalid()
     {
         var generator = new TripMapThumbnailGenerator(_logger.Object, _env.Object, _config);

--- a/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
+++ b/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
@@ -20,6 +20,7 @@ using Wayfarer.Models;
 using Wayfarer.Models.ViewModels;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
+using Wayfarer.Tests.Services;
 using Wayfarer.Util;
 using Xunit;
 
@@ -30,6 +31,28 @@ namespace Wayfarer.Tests.Views;
 /// </summary>
 public sealed class TileAttributionLayoutRenderingTests
 {
+    [Fact]
+    public void PlaywrightEnvironmentUsers_ShareTheNonParallelCollection()
+    {
+        const string expectedCollection = "Playwright browser environment";
+        var affectedTypes = new[]
+        {
+            typeof(TripExportServiceTests),
+            typeof(TripMapThumbnailGeneratorTests),
+            typeof(TileAttributionLayoutRenderingTests)
+        };
+
+        Assert.All(affectedTypes, type =>
+            Assert.Equal(
+                expectedCollection,
+                type.GetCustomAttributesData()
+                    .Where(attribute => attribute.AttributeType == typeof(CollectionAttribute))
+                    .Single()
+                    .ConstructorArguments
+                    .Single()
+                    .Value));
+    }
+
     [Fact]
     public async Task LayoutReflectsProviderChangesAndSanitizesStoredAttributionOnEveryRender()
     {

--- a/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
+++ b/tests/Wayfarer.Tests/Views/TileAttributionLayoutRenderingTests.cs
@@ -20,6 +20,7 @@ using Wayfarer.Models;
 using Wayfarer.Models.ViewModels;
 using Wayfarer.Parsers;
 using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
 using Wayfarer.Tests.Services;
 using Wayfarer.Util;
 using Xunit;
@@ -29,12 +30,14 @@ namespace Wayfarer.Tests.Views;
 /// <summary>
 /// Verifies that the compiled shared layout serializes only final provider-safe attribution.
 /// </summary>
+[Collection(PlaywrightEnvironmentTestCollection.Name)]
+[PlaywrightEnvironmentIsolation]
 public sealed class TileAttributionLayoutRenderingTests
 {
+    /// <summary>Verifies every process-wide Playwright environment user is serialized.</summary>
     [Fact]
     public void PlaywrightEnvironmentUsers_ShareTheNonParallelCollection()
     {
-        const string expectedCollection = "Playwright browser environment";
         var affectedTypes = new[]
         {
             typeof(TripExportServiceTests),
@@ -44,13 +47,60 @@ public sealed class TileAttributionLayoutRenderingTests
 
         Assert.All(affectedTypes, type =>
             Assert.Equal(
-                expectedCollection,
+                PlaywrightEnvironmentTestCollection.Name,
                 type.GetCustomAttributesData()
                     .Where(attribute => attribute.AttributeType == typeof(CollectionAttribute))
                     .Single()
                     .ConstructorArguments
                     .Single()
                     .Value));
+
+        var definition = typeof(PlaywrightEnvironmentTestCollection)
+            .GetCustomAttributes(typeof(CollectionDefinitionAttribute), inherit: false)
+            .Cast<CollectionDefinitionAttribute>()
+            .Single();
+        Assert.True(definition.DisableParallelization);
+    }
+
+    /// <summary>Verifies the isolation hook restores set and unset browser-path states.</summary>
+    [Fact]
+    public void EnvironmentIsolation_RestoresExactOriginalBrowserPath()
+    {
+        var previousPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        try
+        {
+            AssertEnvironmentRestoration("issue-415-original-path");
+            AssertEnvironmentRestoration(null);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", previousPath);
+        }
+    }
+
+    /// <summary>Exercises the same guaranteed after-test hook used when an assertion fails.</summary>
+    private static void AssertEnvironmentRestoration(string? originalPath)
+    {
+        var isolation = new PlaywrightEnvironmentIsolationAttribute();
+        var testMethod = typeof(TileAttributionLayoutRenderingTests)
+            .GetMethod(nameof(EnvironmentIsolation_RestoresExactOriginalBrowserPath))!;
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", originalPath);
+        isolation.Before(testMethod);
+        try
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", "mutated-by-production-service");
+            throw new InvalidOperationException("Simulated test failure.");
+        }
+        catch (InvalidOperationException)
+        {
+            // xUnit invokes the after-test hook while unwinding a failed test.
+        }
+        finally
+        {
+            isolation.After(testMethod);
+        }
+
+        Assert.Equal(originalPath, Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH"));
     }
 
     [Fact]
@@ -102,10 +152,15 @@ public sealed class TileAttributionLayoutRenderingTests
         }
     }
 
+    /// <summary>Proves compiled viewer and print output using real package-compatible Chromium.</summary>
     [Fact]
     [Trait("Category", "RequiresPlaywright")]
     public async Task SnapshotBackedViewerAndPrintOutputRenderResolvedProviderAttribution()
     {
+        var browserPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        Assert.False(string.IsNullOrWhiteSpace(browserPath));
+        Assert.True(Path.IsPathFullyQualified(browserPath));
+
         var webRoot = Path.Combine(Path.GetTempPath(), $"wayfarer-attribution-snapshot-{Guid.NewGuid():N}");
         Directory.CreateDirectory(webRoot);
         await File.WriteAllTextAsync(Path.Combine(webRoot, "frontend.manifest.json"), "{}");


### PR DESCRIPTION
## Summary

- isolate .NET Playwright browser discovery in an explicit test-owned cache
- serialize and restore tests that mutate process-wide `PLAYWRIGHT_BROWSERS_PATH`
- provision the package-compatible Chromium revision through generated `playwright.ps1`
- run the real `RequiresPlaywright` rendering test as a required GitHub Actions step
- verify non-empty PDF and screenshot evidence in CI
- document deterministic Windows setup and scoped cleanup

## Root cause

Tests constructing production Playwright-consuming services changed the process-wide `PLAYWRIGHT_BROWSERS_PATH` and did not restore it. Parallel or later rendering tests could therefore inherit an accidental output-local `TestCache` path. Chromium was also not provisioned deterministically for the .NET Playwright package.

The correction is test-infrastructure-only. Production Playwright services and cache behavior are unchanged.

## Validation

- strict review: `READY FOR PR`
- environment-related tests: 40 passed, 0 failed, 0 skipped
- clean-cache browser run: 1 passed, 0 failed, 0 skipped; PDF and screenshot produced
- compatible-cache repeat: 1 passed, 0 failed, 0 skipped
- full Release suite: 1,906 passed, 0 failed, 16 skipped
- all 16 skips: PostgreSQL opt-in tests with no connection supplied
- SpatiaLite: 2 passed, 0 failed, 0 skipped
- backend build: passed with 0 errors
- LOC policy: passed; cohesive rendering-test warning reviewed and accepted
- workflow YAML parse: passed
- diff hygiene: passed
- no hardcoded Chromium revision or JavaScript/.NET cache sharing

## CI merge gate

This PR must not merge until the updated Ubuntu workflow successfully:

1. builds the Release test project;
2. installs the package-compatible .NET Chromium with Linux dependencies;
3. executes `Category=RequiresPlaywright`;
4. verifies non-empty PDF and screenshot artifacts.

Closes #415