### PR TITLE
feat(trips): add ordered waypoint aggregate foundation

### DIFF
--- a/Migrations/20260802085255_AddSegmentWaypoints.Designer.cs
+++ b/Migrations/20260802085255_AddSegmentWaypoints.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Wayfarer.Models;
 namespace Wayfarer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802085255_AddSegmentWaypoints")]
+    partial class AddSegmentWaypoints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260802085255_AddSegmentWaypoints.cs
+++ b/Migrations/20260802085255_AddSegmentWaypoints.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wayfarer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSegmentWaypoints : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SegmentWaypoints",
+                columns: table => new
+                {
+                    SegmentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PlaceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Position = table.Column<int>(type: "integer", nullable: false),
+                    RouteVertexIndex = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SegmentWaypoints", x => new { x.SegmentId, x.PlaceId });
+                    table.CheckConstraint("CK_SegmentWaypoint_Position", "\"Position\" >= 0");
+                    table.CheckConstraint("CK_SegmentWaypoint_RouteVertexIndex", "\"RouteVertexIndex\" IS NULL OR \"RouteVertexIndex\" > 0");
+                    table.ForeignKey(
+                        name: "FK_SegmentWaypoints_Places_PlaceId",
+                        column: x => x.PlaceId,
+                        principalTable: "Places",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_SegmentWaypoints_Segments_SegmentId",
+                        column: x => x.SegmentId,
+                        principalTable: "Segments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SegmentWaypoints_PlaceId",
+                table: "SegmentWaypoints",
+                column: "PlaceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SegmentWaypoints_SegmentId_Position",
+                table: "SegmentWaypoints",
+                columns: new[] { "SegmentId", "Position" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SegmentWaypoints_SegmentId_RouteVertexIndex",
+                table: "SegmentWaypoints",
+                columns: new[] { "SegmentId", "RouteVertexIndex" },
+                unique: true,
+                filter: "\"RouteVertexIndex\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SegmentWaypoints");
+        }
+    }
+}

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -37,6 +37,7 @@ namespace Wayfarer.Models
         public DbSet<Region> Regions { get; set; }
         public DbSet<Place> Places { get; set; }
         public DbSet<Segment> Segments { get; set; }
+        public DbSet<SegmentWaypoint> SegmentWaypoints { get; set; }
         public DbSet<Tag> Tags { get; set; }
 
         public DbSet<Area> Areas { get; set; }
@@ -217,6 +218,7 @@ namespace Wayfarer.Models
 
             // Trip planning setup
             builder.ApplyConfiguration(new Configuration.TransportProfileConfiguration());
+            builder.ApplyConfiguration(new Configuration.SegmentWaypointConfiguration());
 
             // Trip ↔ ApplicationUser (cascade on delete)
             builder.Entity<Trip>()

--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -37,7 +37,6 @@ namespace Wayfarer.Models
         public DbSet<Region> Regions { get; set; }
         public DbSet<Place> Places { get; set; }
         public DbSet<Segment> Segments { get; set; }
-        public DbSet<SegmentWaypoint> SegmentWaypoints { get; set; }
         public DbSet<Tag> Tags { get; set; }
 
         public DbSet<Area> Areas { get; set; }
@@ -217,8 +216,7 @@ namespace Wayfarer.Models
                 .OnDelete(DeleteBehavior.Cascade);
 
             // Trip planning setup
-            builder.ApplyConfiguration(new Configuration.TransportProfileConfiguration());
-            builder.ApplyConfiguration(new Configuration.SegmentWaypointConfiguration());
+            builder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
 
             // Trip ↔ ApplicationUser (cascade on delete)
             builder.Entity<Trip>()

--- a/Models/Configuration/SegmentWaypointConfiguration.cs
+++ b/Models/Configuration/SegmentWaypointConfiguration.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Wayfarer.Models.Configuration;
+
+/// <summary>Configures ordered waypoint persistence and database-enforceable row invariants.</summary>
+public sealed class SegmentWaypointConfiguration : IEntityTypeConfiguration<SegmentWaypoint>
+{
+    /// <summary>Configures keys, relationships, checks, and deterministic lookup indexes.</summary>
+    public void Configure(EntityTypeBuilder<SegmentWaypoint> waypoint)
+    {
+        waypoint.ToTable("SegmentWaypoints", table =>
+        {
+            table.HasCheckConstraint("CK_SegmentWaypoint_Position", "\"Position\" >= 0");
+            table.HasCheckConstraint(
+                "CK_SegmentWaypoint_RouteVertexIndex",
+                "\"RouteVertexIndex\" IS NULL OR \"RouteVertexIndex\" > 0");
+        });
+
+        waypoint.HasKey(item => new { item.SegmentId, item.PlaceId });
+
+        waypoint.HasOne(item => item.Segment)
+            .WithMany(segment => segment.Waypoints)
+            .HasForeignKey(item => item.SegmentId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // A waypoint association cannot own or delete its canonical saved place.
+        waypoint.HasOne(item => item.Place)
+            .WithMany()
+            .HasForeignKey(item => item.PlaceId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        waypoint.HasIndex(item => new { item.SegmentId, item.Position })
+            .IsUnique()
+            .HasDatabaseName("IX_SegmentWaypoints_SegmentId_Position");
+
+        waypoint.HasIndex(item => new { item.SegmentId, item.RouteVertexIndex })
+            .IsUnique()
+            .HasFilter("\"RouteVertexIndex\" IS NOT NULL")
+            .HasDatabaseName("IX_SegmentWaypoints_SegmentId_RouteVertexIndex");
+    }
+}

--- a/Models/Segment.cs
+++ b/Models/Segment.cs
@@ -35,6 +35,10 @@ public class Segment
     [JsonIgnore]
     public Place? ToPlace { get; set; }
 
+    /// <summary>Ordered intermediate saved-place anchors owned by this segment.</summary>
+    [JsonIgnore]
+    public ICollection<SegmentWaypoint> Waypoints { get; set; } = new List<SegmentWaypoint>();
+
     /// <summary>Mode of transport (e.g., "walk", "bike").</summary>
     public string Mode { get; set; } = string.Empty;
 

--- a/Models/SegmentWaypoint.cs
+++ b/Models/SegmentWaypoint.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Wayfarer.Models;
+
+/// <summary>Associates an ordered intermediate saved place with one segment route.</summary>
+public sealed class SegmentWaypoint
+{
+    /// <summary>Foreign key to the owning segment.</summary>
+    public Guid SegmentId { get; set; }
+
+    /// <summary>Owning segment navigation.</summary>
+    [JsonIgnore]
+    public Segment Segment { get; set; } = null!;
+
+    /// <summary>Foreign key to the referenced saved place.</summary>
+    public Guid PlaceId { get; set; }
+
+    /// <summary>Referenced saved place navigation.</summary>
+    [JsonIgnore]
+    public Place Place { get; set; } = null!;
+
+    /// <summary>Zero-based contiguous position among the segment's intermediate places.</summary>
+    public int Position { get; set; }
+
+    /// <summary>Zero-based custom-route vertex index, or null when the segment uses fallback geometry.</summary>
+    public int? RouteVertexIndex { get; set; }
+}

--- a/Services/SegmentRouteReconciler.cs
+++ b/Services/SegmentRouteReconciler.cs
@@ -161,13 +161,22 @@ public static class SegmentRouteReconciler
                      .Where(entry => entry.Entity.SegmentId == segment.Id).ToArray())
             entry.State = EntityState.Detached;
         await dbContext.Entry(segment).ReloadAsync(cancellationToken);
-        segment.Waypoints = new List<SegmentWaypoint>();
-        await dbContext.Entry(segment).Reference(item => item.FromPlace).LoadAsync(cancellationToken);
-        await dbContext.Entry(segment).Reference(item => item.ToPlace).LoadAsync(cancellationToken);
-        await dbContext.Entry(segment).Collection(item => item.Waypoints).Query()
+        var endpointIds = new[] { segment.FromPlaceId, segment.ToPlaceId }
+            .Where(id => id.HasValue).Select(id => id!.Value).Distinct().ToArray();
+        var endpoints = await dbContext.Places.Include(item => item.Region)
+            .Where(item => endpointIds.Contains(item.Id))
+            .ToDictionaryAsync(item => item.Id, cancellationToken);
+        segment.FromPlace = segment.FromPlaceId.HasValue ? endpoints[segment.FromPlaceId.Value] : null;
+        segment.ToPlace = segment.ToPlaceId.HasValue ? endpoints[segment.ToPlaceId.Value] : null;
+        segment.Waypoints = await dbContext.Set<SegmentWaypoint>()
+            .Where(item => item.SegmentId == segment.Id)
             .Include(item => item.Place).ThenInclude(place => place.Region)
             .OrderBy(item => item.Position)
-            .LoadAsync(cancellationToken);
+            .ToListAsync(cancellationToken);
+        var trackedTrip = dbContext.ChangeTracker.Entries<Trip>()
+            .SingleOrDefault(entry => entry.Entity.Id == segment.TripId);
+        if (trackedTrip is { State: not EntityState.Unchanged })
+            await trackedTrip.ReloadAsync(cancellationToken);
     }
 
     private static List<string> Validate(

--- a/Services/SegmentRouteReconciler.cs
+++ b/Services/SegmentRouteReconciler.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Geometries;
 using Wayfarer.Models;
 
@@ -24,6 +25,18 @@ public static class SegmentRouteReconciler
     /// <summary>Maximum independent longitude or latitude difference accepted for an anchor vertex.</summary>
     public const double CoordinateToleranceDegrees = 0.0000001d;
 
+    /// <summary>Loads the complete tracked aggregate required for authoritative route reconciliation.</summary>
+    public static Task<Segment?> LoadAggregateAsync(
+        ApplicationDbContext dbContext,
+        Guid segmentId,
+        CancellationToken cancellationToken = default) =>
+        dbContext.Segments
+            .Include(segment => segment.FromPlace).ThenInclude(place => place!.Region)
+            .Include(segment => segment.ToPlace).ThenInclude(place => place!.Region)
+            .Include(segment => segment.Waypoints.OrderBy(waypoint => waypoint.Position))
+                .ThenInclude(waypoint => waypoint.Place).ThenInclude(place => place.Region)
+            .SingleOrDefaultAsync(segment => segment.Id == segmentId, cancellationToken);
+
     /// <summary>
     /// Validates a complete proposal before changing the tracked segment, so rejection cannot partially
     /// replace waypoint rows, endpoints, or geometry.
@@ -49,19 +62,27 @@ public static class SegmentRouteReconciler
         segment.ToPlaceId = to?.Id;
         segment.ToPlace = to;
         segment.RouteGeometry = routeGeometry;
-        segment.Waypoints.Clear();
+        var existingByPlaceId = segment.Waypoints.ToDictionary(waypoint => waypoint.PlaceId);
+        var reconciledWaypoints = new List<SegmentWaypoint>(waypoints.Count);
         foreach (var proposed in waypoints)
         {
-            segment.Waypoints.Add(new SegmentWaypoint
+            if (!existingByPlaceId.TryGetValue(proposed.Place.Id, out var waypoint))
             {
-                SegmentId = segment.Id,
-                Segment = segment,
-                PlaceId = proposed.Place.Id,
-                Place = proposed.Place,
-                Position = proposed.Position,
-                RouteVertexIndex = proposed.RouteVertexIndex
-            });
+                waypoint = new SegmentWaypoint
+                {
+                    SegmentId = segment.Id,
+                    Segment = segment,
+                    PlaceId = proposed.Place.Id
+                };
+            }
+
+            waypoint.Place = proposed.Place;
+            waypoint.Position = proposed.Position;
+            waypoint.RouteVertexIndex = proposed.RouteVertexIndex;
+            reconciledWaypoints.Add(waypoint);
         }
+
+        segment.Waypoints = reconciledWaypoints;
 
         return new(true, [], BuildAnchorChain(from, waypoints, to));
     }
@@ -82,10 +103,10 @@ public static class SegmentRouteReconciler
 
         if (from == null) errors.Add("From place is required when a segment has waypoints.");
         if (to == null) errors.Add("To place is required when a segment has waypoints.");
-        if (from?.Location == null) errors.Add("From place must have a location when a segment has waypoints.");
-        if (to?.Location == null) errors.Add("To place must have a location when a segment has waypoints.");
-        if (from != null && TripId(from) != tripId) errors.Add("From place must belong to the segment trip.");
-        if (to != null && TripId(to) != tripId) errors.Add("To place must belong to the segment trip.");
+        if (from != null && !HasValidLocation(from)) errors.Add("From place must have a valid SRID 4326 location when a segment has waypoints.");
+        if (to != null && !HasValidLocation(to)) errors.Add("To place must have a valid SRID 4326 location when a segment has waypoints.");
+        if (from != null && !BelongsToTrip(from, tripId)) errors.Add("From place must belong to the segment trip.");
+        if (to != null && !BelongsToTrip(to, tripId)) errors.Add("To place must belong to the segment trip.");
 
         var placeIds = new HashSet<Guid>();
         var positions = new HashSet<int>();
@@ -98,8 +119,8 @@ public static class SegmentRouteReconciler
                 errors.Add("Intermediate waypoint places must be unique within a segment.");
             if (waypoint.Place.Id == from?.Id) errors.Add("A waypoint cannot equal the From place.");
             if (waypoint.Place.Id == to?.Id) errors.Add("A waypoint cannot equal the To place.");
-            if (TripId(waypoint.Place) != tripId) errors.Add("Every waypoint place must belong to the segment trip.");
-            if (waypoint.Place.Location == null) errors.Add("Every waypoint place must have a location.");
+            if (!BelongsToTrip(waypoint.Place, tripId)) errors.Add("Every waypoint place must belong to the segment trip.");
+            if (!HasValidLocation(waypoint.Place)) errors.Add("Every waypoint place must have a valid SRID 4326 location.");
         }
 
         if (geometry == null)
@@ -170,7 +191,12 @@ public static class SegmentRouteReconciler
         return anchors;
     }
 
-    private static Guid TripId(Place place) => place.Region.TripId;
+    private static bool BelongsToTrip(Place place, Guid tripId) => place.Region != null && place.Region.TripId == tripId;
+
+    private static bool HasValidLocation(Place place) =>
+        place.Location is { IsEmpty: false, SRID: 4326 } location
+        && double.IsFinite(location.X)
+        && double.IsFinite(location.Y);
 
     private static bool CoordinatesMatch(Coordinate actual, Coordinate expected)
     {

--- a/Services/SegmentRouteReconciler.cs
+++ b/Services/SegmentRouteReconciler.cs
@@ -4,29 +4,105 @@ using Wayfarer.Models;
 
 namespace Wayfarer.Services;
 
-/// <summary>Describes one proposed intermediate saved-place anchor.</summary>
-/// <param name="Place">The canonical saved place.</param>
-/// <param name="Position">Its zero-based position in the submitted sequence.</param>
-/// <param name="RouteVertexIndex">Its custom-route vertex index, or null for fallback geometry.</param>
-public sealed record SegmentWaypointProposal(Place Place, int Position, int? RouteVertexIndex);
+/// <summary>Describes one proposed intermediate saved-place anchor by canonical identity.</summary>
+/// <param name="PlaceId">Canonical saved-place identity.</param>
+/// <param name="Position">Zero-based position in the submitted sequence.</param>
+/// <param name="RouteVertexIndex">Custom-route vertex index, or null for fallback geometry.</param>
+public sealed record SegmentWaypointProposal(Guid PlaceId, int Position, int? RouteVertexIndex);
 
-/// <summary>Reports whether a route proposal was applied and its effective saved-place anchor chain.</summary>
-/// <param name="Succeeded">Whether validation succeeded and the tracked aggregate was updated.</param>
+/// <summary>Describes a complete persisted Segment route aggregate proposal.</summary>
+/// <param name="SegmentId">Canonical Segment identity.</param>
+/// <param name="FromPlaceId">Proposed canonical origin identity.</param>
+/// <param name="ToPlaceId">Proposed canonical destination identity.</param>
+/// <param name="Waypoints">Ordered waypoint scalar proposals.</param>
+/// <param name="RouteGeometry">Proposed custom route, or null for fallback rendering.</param>
+public sealed record SegmentRouteProposal(
+    Guid SegmentId,
+    Guid? FromPlaceId,
+    Guid? ToPlaceId,
+    IReadOnlyList<SegmentWaypointProposal> Waypoints,
+    LineString? RouteGeometry);
+
+/// <summary>Reports whether a route proposal committed and its effective canonical anchor chain.</summary>
+/// <param name="Succeeded">Whether validation succeeded and the aggregate committed.</param>
 /// <param name="Errors">Deterministic aggregate validation errors.</param>
-/// <param name="EffectiveAnchorChain">The ordered saved-place anchors used by fallback rendering.</param>
+/// <param name="EffectiveAnchorChain">Canonical saved-place anchors used by fallback rendering.</param>
 public sealed record SegmentRouteReconciliationResult(
     bool Succeeded,
     IReadOnlyList<string> Errors,
     IReadOnlyList<Place> EffectiveAnchorChain);
 
-/// <summary>Validates and atomically applies endpoint, waypoint, and custom-route aggregate state.</summary>
+/// <summary>Loads, validates, and atomically persists canonical Segment route aggregate state.</summary>
 public static class SegmentRouteReconciler
 {
     /// <summary>Maximum independent longitude or latitude difference accepted for an anchor vertex.</summary>
     public const double CoordinateToleranceDegrees = 0.0000001d;
 
-    /// <summary>Loads the complete tracked aggregate required for authoritative route reconciliation.</summary>
-    public static Task<Segment?> LoadAggregateAsync(
+    /// <summary>
+    /// Owns the transaction and SaveChanges boundary required to replace ordered waypoint rows without
+    /// exposing an intermediate PostgreSQL uniqueness collision.
+    /// </summary>
+    public static async Task<SegmentRouteReconciliationResult> ReconcileAsync(
+        ApplicationDbContext dbContext,
+        SegmentRouteProposal proposal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(proposal);
+        ArgumentNullException.ThrowIfNull(proposal.Waypoints);
+        if (dbContext.Database.CurrentTransaction != null)
+            throw new InvalidOperationException("Segment route reconciliation owns its transaction boundary.");
+
+        var segment = await LoadAggregateAsync(dbContext, proposal.SegmentId, cancellationToken);
+        if (segment == null)
+            return new(false, ["Segment was not found."], []);
+
+        var requiredPlaceIds = proposal.Waypoints.Select(item => (Guid?)item.PlaceId)
+            .Append(proposal.FromPlaceId)
+            .Append(proposal.ToPlaceId)
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .Distinct()
+            .ToArray();
+        var placesById = await dbContext.Places
+            .Include(place => place.Region)
+            .Where(place => requiredPlaceIds.Contains(place.Id))
+            .ToDictionaryAsync(place => place.Id, cancellationToken);
+        var geometry = proposal.RouteGeometry == null ? null : (LineString)proposal.RouteGeometry.Copy();
+        var errors = Validate(segment.TripId, proposal, placesById, geometry);
+        var anchors = BuildAnchorChain(proposal, placesById);
+        if (errors.Count > 0)
+            return new(false, errors, anchors);
+
+        if (!dbContext.Database.IsRelational())
+        {
+            ApplyTrackedState(dbContext, segment, proposal, placesById, geometry);
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return new(true, [], anchors);
+        }
+
+        await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            await dbContext.Set<SegmentWaypoint>()
+                .Where(item => item.SegmentId == segment.Id)
+                .ExecuteDeleteAsync(cancellationToken);
+            DetachCurrentWaypoints(dbContext, segment);
+            ApplyTrackedState(dbContext, segment, proposal, placesById, geometry);
+            await dbContext.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+            return new(true, [], anchors);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            await ReloadAggregateAsync(dbContext, segment, cancellationToken);
+            throw;
+        }
+    }
+
+    /// <summary>Loads the complete tracked aggregate needed for mutation and failure recovery.</summary>
+    internal static Task<Segment?> LoadAggregateAsync(
         ApplicationDbContext dbContext,
         Guid segmentId,
         CancellationToken cancellationToken = default) =>
@@ -37,107 +113,147 @@ public static class SegmentRouteReconciler
                 .ThenInclude(waypoint => waypoint.Place).ThenInclude(place => place.Region)
             .SingleOrDefaultAsync(segment => segment.Id == segmentId, cancellationToken);
 
-    /// <summary>
-    /// Validates a complete proposal before changing the tracked segment, so rejection cannot partially
-    /// replace waypoint rows, endpoints, or geometry.
-    /// </summary>
-    public static SegmentRouteReconciliationResult Reconcile(
+    private static void ApplyTrackedState(
+        ApplicationDbContext dbContext,
         Segment segment,
-        Place? from,
-        Place? to,
-        IReadOnlyList<SegmentWaypointProposal> waypoints,
-        LineString? routeGeometry)
+        SegmentRouteProposal proposal,
+        IReadOnlyDictionary<Guid, Place> placesById,
+        LineString? geometry)
     {
-        ArgumentNullException.ThrowIfNull(segment);
-        ArgumentNullException.ThrowIfNull(waypoints);
-
-        var errors = Validate(segment.TripId, from, to, waypoints, routeGeometry);
-        if (errors.Count > 0)
+        if (!dbContext.Database.IsRelational())
         {
-            return new(false, errors, BuildAnchorChain(from, waypoints, to));
+            dbContext.RemoveRange(segment.Waypoints);
+            segment.Waypoints.Clear();
         }
 
-        segment.FromPlaceId = from?.Id;
-        segment.FromPlace = from;
-        segment.ToPlaceId = to?.Id;
-        segment.ToPlace = to;
-        segment.RouteGeometry = routeGeometry;
-        var existingByPlaceId = segment.Waypoints.ToDictionary(waypoint => waypoint.PlaceId);
-        var reconciledWaypoints = new List<SegmentWaypoint>(waypoints.Count);
-        foreach (var proposed in waypoints)
+        segment.FromPlaceId = proposal.FromPlaceId;
+        segment.FromPlace = proposal.FromPlaceId.HasValue ? placesById[proposal.FromPlaceId.Value] : null;
+        segment.ToPlaceId = proposal.ToPlaceId;
+        segment.ToPlace = proposal.ToPlaceId.HasValue ? placesById[proposal.ToPlaceId.Value] : null;
+        segment.RouteGeometry = geometry;
+        foreach (var proposed in proposal.Waypoints)
         {
-            if (!existingByPlaceId.TryGetValue(proposed.Place.Id, out var waypoint))
+            segment.Waypoints.Add(new SegmentWaypoint
             {
-                waypoint = new SegmentWaypoint
-                {
-                    SegmentId = segment.Id,
-                    Segment = segment,
-                    PlaceId = proposed.Place.Id
-                };
-            }
-
-            waypoint.Place = proposed.Place;
-            waypoint.Position = proposed.Position;
-            waypoint.RouteVertexIndex = proposed.RouteVertexIndex;
-            reconciledWaypoints.Add(waypoint);
+                SegmentId = segment.Id,
+                Segment = segment,
+                PlaceId = proposed.PlaceId,
+                Place = placesById[proposed.PlaceId],
+                Position = proposed.Position,
+                RouteVertexIndex = proposed.RouteVertexIndex
+            });
         }
+    }
 
-        segment.Waypoints = reconciledWaypoints;
+    private static void DetachCurrentWaypoints(ApplicationDbContext dbContext, Segment segment)
+    {
+        foreach (var waypoint in segment.Waypoints.ToArray())
+            dbContext.Entry(waypoint).State = EntityState.Detached;
+        segment.Waypoints = new List<SegmentWaypoint>();
+    }
 
-        return new(true, [], BuildAnchorChain(from, waypoints, to));
+    private static async Task ReloadAggregateAsync(
+        ApplicationDbContext dbContext,
+        Segment segment,
+        CancellationToken cancellationToken)
+    {
+        foreach (var entry in dbContext.ChangeTracker.Entries<SegmentWaypoint>()
+                     .Where(entry => entry.Entity.SegmentId == segment.Id).ToArray())
+            entry.State = EntityState.Detached;
+        await dbContext.Entry(segment).ReloadAsync(cancellationToken);
+        segment.Waypoints = new List<SegmentWaypoint>();
+        await dbContext.Entry(segment).Reference(item => item.FromPlace).LoadAsync(cancellationToken);
+        await dbContext.Entry(segment).Reference(item => item.ToPlace).LoadAsync(cancellationToken);
+        await dbContext.Entry(segment).Collection(item => item.Waypoints).Query()
+            .Include(item => item.Place).ThenInclude(place => place.Region)
+            .OrderBy(item => item.Position)
+            .LoadAsync(cancellationToken);
     }
 
     private static List<string> Validate(
         Guid tripId,
-        Place? from,
-        Place? to,
-        IReadOnlyList<SegmentWaypointProposal> waypoints,
+        SegmentRouteProposal proposal,
+        IReadOnlyDictionary<Guid, Place> placesById,
         LineString? geometry)
     {
         var errors = new List<string>();
-        if (waypoints.Count == 0)
+        if (proposal.Waypoints.Count > 0)
         {
-            // Legacy zero-waypoint segments retain their existing optional endpoint contract.
-            return errors;
+            ValidateIdentity("From place", proposal.FromPlaceId, placesById, errors);
+            ValidateIdentity("To place", proposal.ToPlaceId, placesById, errors);
         }
-
-        if (from == null) errors.Add("From place is required when a segment has waypoints.");
-        if (to == null) errors.Add("To place is required when a segment has waypoints.");
-        if (from != null && !HasValidLocation(from)) errors.Add("From place must have a valid SRID 4326 location when a segment has waypoints.");
-        if (to != null && !HasValidLocation(to)) errors.Add("To place must have a valid SRID 4326 location when a segment has waypoints.");
-        if (from != null && !BelongsToTrip(from, tripId)) errors.Add("From place must belong to the segment trip.");
-        if (to != null && !BelongsToTrip(to, tripId)) errors.Add("To place must belong to the segment trip.");
-
-        var placeIds = new HashSet<Guid>();
-        var positions = new HashSet<int>();
-        for (var index = 0; index < waypoints.Count; index++)
+        else
         {
-            var waypoint = waypoints[index];
-            if (waypoint.Position != index || !positions.Add(waypoint.Position))
+            ValidateOptionalIdentity("From place", proposal.FromPlaceId, placesById, errors);
+            ValidateOptionalIdentity("To place", proposal.ToPlaceId, placesById, errors);
+        }
+        for (var index = 0; index < proposal.Waypoints.Count; index++)
+        {
+            if (!placesById.ContainsKey(proposal.Waypoints[index].PlaceId))
+                errors.Add($"Waypoint place at position {index} was not found.");
+        }
+        if (errors.Count > 0) return errors;
+        if (proposal.Waypoints.Count == 0) return errors;
+
+        var from = placesById[proposal.FromPlaceId!.Value];
+        var to = placesById[proposal.ToPlaceId!.Value];
+        ValidateCanonicalPlace("From place", from, tripId, errors);
+        ValidateCanonicalPlace("To place", to, tripId, errors);
+        var placeIds = new HashSet<Guid>();
+        for (var index = 0; index < proposal.Waypoints.Count; index++)
+        {
+            var waypoint = proposal.Waypoints[index];
+            var place = placesById[waypoint.PlaceId];
+            if (waypoint.Position != index)
                 errors.Add("Waypoint positions must be unique and contiguous from zero in submitted order.");
-            if (!placeIds.Add(waypoint.Place.Id))
+            if (!placeIds.Add(waypoint.PlaceId))
                 errors.Add("Intermediate waypoint places must be unique within a segment.");
-            if (waypoint.Place.Id == from?.Id) errors.Add("A waypoint cannot equal the From place.");
-            if (waypoint.Place.Id == to?.Id) errors.Add("A waypoint cannot equal the To place.");
-            if (!BelongsToTrip(waypoint.Place, tripId)) errors.Add("Every waypoint place must belong to the segment trip.");
-            if (!HasValidLocation(waypoint.Place)) errors.Add("Every waypoint place must have a valid SRID 4326 location.");
+            if (waypoint.PlaceId == proposal.FromPlaceId) errors.Add("A waypoint cannot equal the From place.");
+            if (waypoint.PlaceId == proposal.ToPlaceId) errors.Add("A waypoint cannot equal the To place.");
+            ValidateCanonicalPlace("Every waypoint place", place, tripId, errors);
         }
 
         if (geometry == null)
         {
-            if (waypoints.Any(waypoint => waypoint.RouteVertexIndex.HasValue))
+            if (proposal.Waypoints.Any(waypoint => waypoint.RouteVertexIndex.HasValue))
                 errors.Add("Fallback geometry requires null waypoint route vertex indices.");
             return errors;
         }
 
-        ValidateCustomGeometry(from, to, waypoints, geometry, errors);
+        ValidateCustomGeometry(from, to, proposal.Waypoints, placesById, geometry, errors);
         return errors;
     }
 
+    private static void ValidateIdentity(
+        string label,
+        Guid? id,
+        IReadOnlyDictionary<Guid, Place> placesById,
+        List<string> errors)
+    {
+        if (!id.HasValue) errors.Add($"{label} is required when a segment has waypoints.");
+        else if (!placesById.ContainsKey(id.Value)) errors.Add($"{label} was not found.");
+    }
+
+    private static void ValidateOptionalIdentity(
+        string label,
+        Guid? id,
+        IReadOnlyDictionary<Guid, Place> placesById,
+        List<string> errors)
+    {
+        if (id.HasValue && !placesById.ContainsKey(id.Value)) errors.Add($"{label} was not found.");
+    }
+
+    private static void ValidateCanonicalPlace(string label, Place place, Guid tripId, List<string> errors)
+    {
+        if (place.Region?.TripId != tripId) errors.Add($"{label} must belong to the segment trip.");
+        if (!HasValidLocation(place)) errors.Add($"{label} must have a valid SRID 4326 location.");
+    }
+
     private static void ValidateCustomGeometry(
-        Place? from,
-        Place? to,
+        Place from,
+        Place to,
         IReadOnlyList<SegmentWaypointProposal> waypoints,
+        IReadOnlyDictionary<Guid, Place> placesById,
         LineString geometry,
         List<string> errors)
     {
@@ -146,10 +262,9 @@ public static class SegmentRouteReconciler
             errors.Add("Custom route geometry must be a valid SRID 4326 LineString with at least two vertices.");
             return;
         }
-
-        if (from?.Location != null && !CoordinatesMatch(geometry.GetCoordinateN(0), from.Location.Coordinate))
+        if (!CoordinatesMatch(geometry.GetCoordinateN(0), from.Location!.Coordinate))
             errors.Add("The first custom-route vertex must match the From place.");
-        if (to?.Location != null && !CoordinatesMatch(geometry.GetCoordinateN(geometry.NumPoints - 1), to.Location.Coordinate))
+        if (!CoordinatesMatch(geometry.GetCoordinateN(geometry.NumPoints - 1), to.Location!.Coordinate))
             errors.Add("The last custom-route vertex must match the To place.");
 
         var priorIndex = 0;
@@ -161,37 +276,28 @@ public static class SegmentRouteReconciler
                 errors.Add("Every waypoint requires a route vertex index for custom geometry.");
                 continue;
             }
-
             var vertexIndex = waypoint.RouteVertexIndex.Value;
             if (!usedIndices.Add(vertexIndex)) errors.Add("Waypoint route vertex indices must be unique.");
             if (vertexIndex <= priorIndex) errors.Add("Waypoint route vertex indices must increase in waypoint order.");
             if (vertexIndex <= 0 || vertexIndex >= geometry.NumPoints - 1)
-            {
                 errors.Add("Waypoint route vertex indices must identify interior route vertices.");
-            }
-            else if (waypoint.Place.Location != null
-                     && !CoordinatesMatch(geometry.GetCoordinateN(vertexIndex), waypoint.Place.Location.Coordinate))
-            {
+            else if (!CoordinatesMatch(geometry.GetCoordinateN(vertexIndex), placesById[waypoint.PlaceId].Location!.Coordinate))
                 errors.Add("Each indexed custom-route vertex must match its waypoint place.");
-            }
-
             priorIndex = vertexIndex;
         }
     }
 
     private static IReadOnlyList<Place> BuildAnchorChain(
-        Place? from,
-        IReadOnlyList<SegmentWaypointProposal> waypoints,
-        Place? to)
+        SegmentRouteProposal proposal,
+        IReadOnlyDictionary<Guid, Place> placesById)
     {
-        var anchors = new List<Place>(waypoints.Count + 2);
-        if (from != null) anchors.Add(from);
-        anchors.AddRange(waypoints.Select(waypoint => waypoint.Place));
-        if (to != null) anchors.Add(to);
+        var anchors = new List<Place>(proposal.Waypoints.Count + 2);
+        if (proposal.FromPlaceId.HasValue && placesById.TryGetValue(proposal.FromPlaceId.Value, out var from)) anchors.Add(from);
+        foreach (var waypoint in proposal.Waypoints)
+            if (placesById.TryGetValue(waypoint.PlaceId, out var place)) anchors.Add(place);
+        if (proposal.ToPlaceId.HasValue && placesById.TryGetValue(proposal.ToPlaceId.Value, out var to)) anchors.Add(to);
         return anchors;
     }
-
-    private static bool BelongsToTrip(Place place, Guid tripId) => place.Region != null && place.Region.TripId == tripId;
 
     private static bool HasValidLocation(Place place) =>
         place.Location is { IsEmpty: false, SRID: 4326 } location
@@ -201,12 +307,7 @@ public static class SegmentRouteReconciler
     private static bool CoordinatesMatch(Coordinate actual, Coordinate expected)
     {
         if (!double.IsFinite(actual.X) || !double.IsFinite(actual.Y)
-            || !double.IsFinite(expected.X) || !double.IsFinite(expected.Y))
-        {
-            return false;
-        }
-
-        // Decimal comparison keeps the contract's seven-decimal boundary inclusive despite binary rounding.
+            || !double.IsFinite(expected.X) || !double.IsFinite(expected.Y)) return false;
         const decimal tolerance = 0.0000001m;
         return Math.Abs((decimal)actual.X - (decimal)expected.X) <= tolerance
             && Math.Abs((decimal)actual.Y - (decimal)expected.Y) <= tolerance;

--- a/Services/SegmentRouteReconciler.cs
+++ b/Services/SegmentRouteReconciler.cs
@@ -1,0 +1,188 @@
+using NetTopologySuite.Geometries;
+using Wayfarer.Models;
+
+namespace Wayfarer.Services;
+
+/// <summary>Describes one proposed intermediate saved-place anchor.</summary>
+/// <param name="Place">The canonical saved place.</param>
+/// <param name="Position">Its zero-based position in the submitted sequence.</param>
+/// <param name="RouteVertexIndex">Its custom-route vertex index, or null for fallback geometry.</param>
+public sealed record SegmentWaypointProposal(Place Place, int Position, int? RouteVertexIndex);
+
+/// <summary>Reports whether a route proposal was applied and its effective saved-place anchor chain.</summary>
+/// <param name="Succeeded">Whether validation succeeded and the tracked aggregate was updated.</param>
+/// <param name="Errors">Deterministic aggregate validation errors.</param>
+/// <param name="EffectiveAnchorChain">The ordered saved-place anchors used by fallback rendering.</param>
+public sealed record SegmentRouteReconciliationResult(
+    bool Succeeded,
+    IReadOnlyList<string> Errors,
+    IReadOnlyList<Place> EffectiveAnchorChain);
+
+/// <summary>Validates and atomically applies endpoint, waypoint, and custom-route aggregate state.</summary>
+public static class SegmentRouteReconciler
+{
+    /// <summary>Maximum independent longitude or latitude difference accepted for an anchor vertex.</summary>
+    public const double CoordinateToleranceDegrees = 0.0000001d;
+
+    /// <summary>
+    /// Validates a complete proposal before changing the tracked segment, so rejection cannot partially
+    /// replace waypoint rows, endpoints, or geometry.
+    /// </summary>
+    public static SegmentRouteReconciliationResult Reconcile(
+        Segment segment,
+        Place? from,
+        Place? to,
+        IReadOnlyList<SegmentWaypointProposal> waypoints,
+        LineString? routeGeometry)
+    {
+        ArgumentNullException.ThrowIfNull(segment);
+        ArgumentNullException.ThrowIfNull(waypoints);
+
+        var errors = Validate(segment.TripId, from, to, waypoints, routeGeometry);
+        if (errors.Count > 0)
+        {
+            return new(false, errors, BuildAnchorChain(from, waypoints, to));
+        }
+
+        segment.FromPlaceId = from?.Id;
+        segment.FromPlace = from;
+        segment.ToPlaceId = to?.Id;
+        segment.ToPlace = to;
+        segment.RouteGeometry = routeGeometry;
+        segment.Waypoints.Clear();
+        foreach (var proposed in waypoints)
+        {
+            segment.Waypoints.Add(new SegmentWaypoint
+            {
+                SegmentId = segment.Id,
+                Segment = segment,
+                PlaceId = proposed.Place.Id,
+                Place = proposed.Place,
+                Position = proposed.Position,
+                RouteVertexIndex = proposed.RouteVertexIndex
+            });
+        }
+
+        return new(true, [], BuildAnchorChain(from, waypoints, to));
+    }
+
+    private static List<string> Validate(
+        Guid tripId,
+        Place? from,
+        Place? to,
+        IReadOnlyList<SegmentWaypointProposal> waypoints,
+        LineString? geometry)
+    {
+        var errors = new List<string>();
+        if (waypoints.Count == 0)
+        {
+            // Legacy zero-waypoint segments retain their existing optional endpoint contract.
+            return errors;
+        }
+
+        if (from == null) errors.Add("From place is required when a segment has waypoints.");
+        if (to == null) errors.Add("To place is required when a segment has waypoints.");
+        if (from?.Location == null) errors.Add("From place must have a location when a segment has waypoints.");
+        if (to?.Location == null) errors.Add("To place must have a location when a segment has waypoints.");
+        if (from != null && TripId(from) != tripId) errors.Add("From place must belong to the segment trip.");
+        if (to != null && TripId(to) != tripId) errors.Add("To place must belong to the segment trip.");
+
+        var placeIds = new HashSet<Guid>();
+        var positions = new HashSet<int>();
+        for (var index = 0; index < waypoints.Count; index++)
+        {
+            var waypoint = waypoints[index];
+            if (waypoint.Position != index || !positions.Add(waypoint.Position))
+                errors.Add("Waypoint positions must be unique and contiguous from zero in submitted order.");
+            if (!placeIds.Add(waypoint.Place.Id))
+                errors.Add("Intermediate waypoint places must be unique within a segment.");
+            if (waypoint.Place.Id == from?.Id) errors.Add("A waypoint cannot equal the From place.");
+            if (waypoint.Place.Id == to?.Id) errors.Add("A waypoint cannot equal the To place.");
+            if (TripId(waypoint.Place) != tripId) errors.Add("Every waypoint place must belong to the segment trip.");
+            if (waypoint.Place.Location == null) errors.Add("Every waypoint place must have a location.");
+        }
+
+        if (geometry == null)
+        {
+            if (waypoints.Any(waypoint => waypoint.RouteVertexIndex.HasValue))
+                errors.Add("Fallback geometry requires null waypoint route vertex indices.");
+            return errors;
+        }
+
+        ValidateCustomGeometry(from, to, waypoints, geometry, errors);
+        return errors;
+    }
+
+    private static void ValidateCustomGeometry(
+        Place? from,
+        Place? to,
+        IReadOnlyList<SegmentWaypointProposal> waypoints,
+        LineString geometry,
+        List<string> errors)
+    {
+        if (geometry.SRID != 4326 || geometry.IsEmpty || geometry.NumPoints < 2 || !geometry.IsValid)
+        {
+            errors.Add("Custom route geometry must be a valid SRID 4326 LineString with at least two vertices.");
+            return;
+        }
+
+        if (from?.Location != null && !CoordinatesMatch(geometry.GetCoordinateN(0), from.Location.Coordinate))
+            errors.Add("The first custom-route vertex must match the From place.");
+        if (to?.Location != null && !CoordinatesMatch(geometry.GetCoordinateN(geometry.NumPoints - 1), to.Location.Coordinate))
+            errors.Add("The last custom-route vertex must match the To place.");
+
+        var priorIndex = 0;
+        var usedIndices = new HashSet<int>();
+        foreach (var waypoint in waypoints)
+        {
+            if (!waypoint.RouteVertexIndex.HasValue)
+            {
+                errors.Add("Every waypoint requires a route vertex index for custom geometry.");
+                continue;
+            }
+
+            var vertexIndex = waypoint.RouteVertexIndex.Value;
+            if (!usedIndices.Add(vertexIndex)) errors.Add("Waypoint route vertex indices must be unique.");
+            if (vertexIndex <= priorIndex) errors.Add("Waypoint route vertex indices must increase in waypoint order.");
+            if (vertexIndex <= 0 || vertexIndex >= geometry.NumPoints - 1)
+            {
+                errors.Add("Waypoint route vertex indices must identify interior route vertices.");
+            }
+            else if (waypoint.Place.Location != null
+                     && !CoordinatesMatch(geometry.GetCoordinateN(vertexIndex), waypoint.Place.Location.Coordinate))
+            {
+                errors.Add("Each indexed custom-route vertex must match its waypoint place.");
+            }
+
+            priorIndex = vertexIndex;
+        }
+    }
+
+    private static IReadOnlyList<Place> BuildAnchorChain(
+        Place? from,
+        IReadOnlyList<SegmentWaypointProposal> waypoints,
+        Place? to)
+    {
+        var anchors = new List<Place>(waypoints.Count + 2);
+        if (from != null) anchors.Add(from);
+        anchors.AddRange(waypoints.Select(waypoint => waypoint.Place));
+        if (to != null) anchors.Add(to);
+        return anchors;
+    }
+
+    private static Guid TripId(Place place) => place.Region.TripId;
+
+    private static bool CoordinatesMatch(Coordinate actual, Coordinate expected)
+    {
+        if (!double.IsFinite(actual.X) || !double.IsFinite(actual.Y)
+            || !double.IsFinite(expected.X) || !double.IsFinite(expected.Y))
+        {
+            return false;
+        }
+
+        // Decimal comparison keeps the contract's seven-decimal boundary inclusive despite binary rounding.
+        const decimal tolerance = 0.0000001m;
+        return Math.Abs((decimal)actual.X - (decimal)expected.X) <= tolerance
+            && Math.Abs((decimal)actual.Y - (decimal)expected.Y) <= tolerance;
+    }
+}

--- a/Services/SegmentRouteReconciler.cs
+++ b/Services/SegmentRouteReconciler.cs
@@ -74,7 +74,9 @@ public static class SegmentRouteReconciler
         {
             await LockSegmentAsync(dbContext, proposal.SegmentId, cancellationToken);
 
-            await RefreshStaleCanonicalStateAsync(dbContext, proposal.SegmentId, cancellationToken);
+            var refreshScope = await LoadCanonicalRefreshScopeAsync(dbContext, proposal, cancellationToken);
+            if (refreshScope == null) return new(false, ["Segment was not found."], []);
+            RefreshStaleCanonicalState(dbContext, refreshScope);
             var segment = await LoadAggregateAsync(dbContext, proposal.SegmentId, cancellationToken);
             if (segment == null) return new(false, ["Segment was not found."], []);
             var placesById = await LoadProposalPlacesAsync(dbContext, proposal, cancellationToken);
@@ -135,43 +137,84 @@ public static class SegmentRouteReconciler
             cancellationToken);
     }
 
-    /// <summary>Refreshes unchanged identity-map values which could predate acquisition of the row lock.</summary>
-    private static async Task RefreshStaleCanonicalStateAsync(
+    /// <summary>Loads the bounded canonical identities and values needed after acquiring the Segment row lock.</summary>
+    private static async Task<CanonicalRefreshScope?> LoadCanonicalRefreshScopeAsync(
         ApplicationDbContext dbContext,
-        Guid segmentId,
+        SegmentRouteProposal proposal,
         CancellationToken cancellationToken)
     {
+        var segment = await dbContext.Segments.AsNoTracking()
+            .SingleOrDefaultAsync(item => item.Id == proposal.SegmentId, cancellationToken);
+        if (segment == null) return null;
+
+        var currentWaypointPlaceIds = await dbContext.Set<SegmentWaypoint>().AsNoTracking()
+            .Where(item => item.SegmentId == proposal.SegmentId)
+            .Select(item => item.PlaceId)
+            .ToArrayAsync(cancellationToken);
+        var placeIds = currentWaypointPlaceIds.Select(item => (Guid?)item)
+            .Concat(proposal.Waypoints.Select(item => (Guid?)item.PlaceId))
+            .Append(segment.FromPlaceId).Append(segment.ToPlaceId)
+            .Append(proposal.FromPlaceId).Append(proposal.ToPlaceId)
+            .Where(item => item.HasValue).Select(item => item!.Value).Distinct().ToArray();
+        var regionIds = await dbContext.Places.AsNoTracking()
+            .Where(item => placeIds.Contains(item.Id))
+            .Select(item => item.RegionId).Distinct().ToArrayAsync(cancellationToken);
+        var regions = await dbContext.Regions.AsNoTracking()
+            .Where(item => regionIds.Contains(item.Id)).ToArrayAsync(cancellationToken);
+        var tripIds = regions.Select(item => item.TripId).Append(segment.TripId).Distinct().ToArray();
+        var trips = await dbContext.Trips.AsNoTracking()
+            .Where(item => tripIds.Contains(item.Id)).ToArrayAsync(cancellationToken);
+        return new(segment, placeIds, regions, trips);
+    }
+
+    /// <summary>Refreshes only unchanged identity-map values in the target aggregate and proposal scope.</summary>
+    private static void RefreshStaleCanonicalState(
+        ApplicationDbContext dbContext,
+        CanonicalRefreshScope scope)
+    {
+        var segmentId = scope.Segment.Id;
         var trackedSegment = dbContext.ChangeTracker.Entries<Segment>()
             .SingleOrDefault(entry => entry.Entity.Id == segmentId);
         foreach (var entry in dbContext.ChangeTracker.Entries<SegmentWaypoint>()
                      .Where(entry => entry.Entity.SegmentId == segmentId).ToArray())
             entry.State = EntityState.Detached;
-        foreach (var entry in dbContext.ChangeTracker.Entries<Place>().ToArray()) entry.State = EntityState.Detached;
-        foreach (var entry in dbContext.ChangeTracker.Entries<Region>().ToArray()) entry.State = EntityState.Detached;
+        foreach (var entry in dbContext.ChangeTracker.Entries<Place>()
+                     .Where(entry => scope.PlaceIds.Contains(entry.Entity.Id)).ToArray())
+            entry.State = EntityState.Detached;
+        RefreshTrackedValues(dbContext.ChangeTracker.Entries<Region>(), scope.Regions, item => item.Id);
+        RefreshTrackedValues(dbContext.ChangeTracker.Entries<Trip>(), scope.Trips, item => item.Id);
         if (trackedSegment == null) return;
-        if (trackedSegment.State == EntityState.Detached)
-        {
-            var replacement = dbContext.ChangeTracker.Entries<Segment>()
-                .SingleOrDefault(entry => entry.Entity.Id == segmentId);
-            if (replacement != null) trackedSegment = replacement;
-            else
-            {
-                trackedSegment.Entity.FromPlace = null;
-                trackedSegment.Entity.ToPlace = null;
-                trackedSegment.Entity.Waypoints = [];
-                trackedSegment = dbContext.Attach(trackedSegment.Entity);
-            }
-        }
         trackedSegment.Entity.FromPlace = null;
         trackedSegment.Entity.ToPlace = null;
         trackedSegment.Entity.Waypoints = [];
-        var canonical = await dbContext.Segments.AsNoTracking()
-            .SingleOrDefaultAsync(item => item.Id == segmentId, cancellationToken);
-        if (canonical == null) return;
-        trackedSegment.CurrentValues.SetValues(canonical);
-        trackedSegment.OriginalValues.SetValues(canonical);
+        trackedSegment.CurrentValues.SetValues(scope.Segment);
+        trackedSegment.OriginalValues.SetValues(scope.Segment);
         trackedSegment.State = EntityState.Unchanged;
     }
+
+    /// <summary>Copies set-loaded canonical scalar values into matching unchanged tracked identities.</summary>
+    private static void RefreshTrackedValues<TEntity>(
+        IEnumerable<Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<TEntity>> trackedEntries,
+        IEnumerable<TEntity> canonicalEntities,
+        Func<TEntity, Guid> idSelector)
+        where TEntity : class
+    {
+        var canonicalById = canonicalEntities.ToDictionary(idSelector);
+        foreach (var entry in trackedEntries.Where(entry => canonicalById.ContainsKey(idSelector(entry.Entity))).ToArray())
+        {
+            var canonical = canonicalById[idSelector(entry.Entity)];
+            entry.CurrentValues.SetValues(canonical);
+            entry.OriginalValues.SetValues(canonical);
+            entry.State = EntityState.Unchanged;
+        }
+    }
+
+    /// <summary>Contains post-lock canonical identities and scalar values bounded to one proposal.</summary>
+    private sealed record CanonicalRefreshScope(
+        Segment Segment,
+        Guid[] PlaceIds,
+        Region[] Regions,
+        Trip[] Trips);
 
     private static LineString? CopyGeometry(SegmentRouteProposal proposal) =>
         proposal.RouteGeometry == null ? null : (LineString)proposal.RouteGeometry.Copy();

--- a/Services/SegmentRouteReconciler.cs
+++ b/Services/SegmentRouteReconciler.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Geometries;
+using System.Runtime.ExceptionServices;
 using Wayfarer.Models;
 
 namespace Wayfarer.Services;
@@ -39,8 +40,8 @@ public static class SegmentRouteReconciler
     public const double CoordinateToleranceDegrees = 0.0000001d;
 
     /// <summary>
-    /// Owns the transaction and SaveChanges boundary required to replace ordered waypoint rows without
-    /// exposing an intermediate PostgreSQL uniqueness collision.
+    /// Requires a clean caller context and owns the transaction, canonical Segment row lock, and SaveChanges
+    /// boundary required to replace ordered waypoint rows as one serialized aggregate proposal.
     /// </summary>
     public static async Task<SegmentRouteReconciliationResult> ReconcileAsync(
         ApplicationDbContext dbContext,
@@ -50,32 +51,19 @@ public static class SegmentRouteReconciler
         ArgumentNullException.ThrowIfNull(dbContext);
         ArgumentNullException.ThrowIfNull(proposal);
         ArgumentNullException.ThrowIfNull(proposal.Waypoints);
+        EnsureCleanContext(dbContext);
         if (dbContext.Database.CurrentTransaction != null)
             throw new InvalidOperationException("Segment route reconciliation owns its transaction boundary.");
 
-        var segment = await LoadAggregateAsync(dbContext, proposal.SegmentId, cancellationToken);
-        if (segment == null)
-            return new(false, ["Segment was not found."], []);
-
-        var requiredPlaceIds = proposal.Waypoints.Select(item => (Guid?)item.PlaceId)
-            .Append(proposal.FromPlaceId)
-            .Append(proposal.ToPlaceId)
-            .Where(id => id.HasValue)
-            .Select(id => id!.Value)
-            .Distinct()
-            .ToArray();
-        var placesById = await dbContext.Places
-            .Include(place => place.Region)
-            .Where(place => requiredPlaceIds.Contains(place.Id))
-            .ToDictionaryAsync(place => place.Id, cancellationToken);
-        var geometry = proposal.RouteGeometry == null ? null : (LineString)proposal.RouteGeometry.Copy();
-        var errors = Validate(segment.TripId, proposal, placesById, geometry);
-        var anchors = BuildAnchorChain(proposal, placesById);
-        if (errors.Count > 0)
-            return new(false, errors, anchors);
-
         if (!dbContext.Database.IsRelational())
         {
+            var segment = await LoadAggregateAsync(dbContext, proposal.SegmentId, cancellationToken);
+            if (segment == null) return new(false, ["Segment was not found."], []);
+            var placesById = await LoadProposalPlacesAsync(dbContext, proposal, cancellationToken);
+            var geometry = CopyGeometry(proposal);
+            var errors = Validate(segment.TripId, proposal, placesById, geometry);
+            var anchors = BuildAnchorChain(proposal, placesById);
+            if (errors.Count > 0) return new(false, errors, anchors);
             ApplyTrackedState(dbContext, segment, proposal, placesById, geometry);
             await dbContext.SaveChangesAsync(cancellationToken);
             return new(true, [], anchors);
@@ -84,6 +72,17 @@ public static class SegmentRouteReconciler
         await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
         try
         {
+            await LockSegmentAsync(dbContext, proposal.SegmentId, cancellationToken);
+
+            await RefreshStaleCanonicalStateAsync(dbContext, proposal.SegmentId, cancellationToken);
+            var segment = await LoadAggregateAsync(dbContext, proposal.SegmentId, cancellationToken);
+            if (segment == null) return new(false, ["Segment was not found."], []);
+            var placesById = await LoadProposalPlacesAsync(dbContext, proposal, cancellationToken);
+            var geometry = CopyGeometry(proposal);
+            var errors = Validate(segment.TripId, proposal, placesById, geometry);
+            var anchors = BuildAnchorChain(proposal, placesById);
+            if (errors.Count > 0) return new(false, errors, anchors);
+
             await dbContext.Set<SegmentWaypoint>()
                 .Where(item => item.SegmentId == segment.Id)
                 .ExecuteDeleteAsync(cancellationToken);
@@ -93,12 +92,101 @@ public static class SegmentRouteReconciler
             await transaction.CommitAsync(cancellationToken);
             return new(true, [], anchors);
         }
-        catch
+        catch (Exception originalFailure)
         {
-            await transaction.RollbackAsync(cancellationToken);
-            await ReloadAggregateAsync(dbContext, segment, cancellationToken);
+            var cleanupFailures = new List<Exception>();
+            try { await transaction.RollbackAsync(CancellationToken.None); }
+            catch (Exception rollbackFailure) { cleanupFailures.Add(rollbackFailure); }
+
+            try { await RecoverAggregateAsync(dbContext, proposal.SegmentId, CancellationToken.None); }
+            catch (Exception recoveryFailure) { cleanupFailures.Add(recoveryFailure); }
+
+            if (cleanupFailures.Count > 0)
+            {
+                try { await dbContext.DisposeAsync(); }
+                catch (Exception disposalFailure) { cleanupFailures.Add(disposalFailure); }
+                throw new AggregateException(
+                    "Segment route reconciliation failed and mandatory cleanup could not restore a reusable DbContext.",
+                    [originalFailure, .. cleanupFailures]);
+            }
+
+            ExceptionDispatchInfo.Capture(originalFailure).Throw();
             throw;
         }
+    }
+
+    /// <summary>Rejects pending caller work because this operation owns SaveChanges and recovery.</summary>
+    private static void EnsureCleanContext(ApplicationDbContext dbContext)
+    {
+        dbContext.ChangeTracker.DetectChanges();
+        if (dbContext.ChangeTracker.Entries().Any(entry =>
+                entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted))
+            throw new InvalidOperationException("Segment route reconciliation requires a clean DbContext.");
+    }
+
+    /// <summary>Locks only the canonical Segment row for the lifetime of the owned PostgreSQL transaction.</summary>
+    private static async Task LockSegmentAsync(
+        ApplicationDbContext dbContext,
+        Guid segmentId,
+        CancellationToken cancellationToken)
+    {
+        await dbContext.Database.ExecuteSqlInterpolatedAsync(
+            $"SELECT 1 FROM public.\"Segments\" WHERE \"Id\" = {segmentId} FOR UPDATE",
+            cancellationToken);
+    }
+
+    /// <summary>Refreshes unchanged identity-map values which could predate acquisition of the row lock.</summary>
+    private static async Task RefreshStaleCanonicalStateAsync(
+        ApplicationDbContext dbContext,
+        Guid segmentId,
+        CancellationToken cancellationToken)
+    {
+        var trackedSegment = dbContext.ChangeTracker.Entries<Segment>()
+            .SingleOrDefault(entry => entry.Entity.Id == segmentId);
+        foreach (var entry in dbContext.ChangeTracker.Entries<SegmentWaypoint>()
+                     .Where(entry => entry.Entity.SegmentId == segmentId).ToArray())
+            entry.State = EntityState.Detached;
+        foreach (var entry in dbContext.ChangeTracker.Entries<Place>().ToArray()) entry.State = EntityState.Detached;
+        foreach (var entry in dbContext.ChangeTracker.Entries<Region>().ToArray()) entry.State = EntityState.Detached;
+        if (trackedSegment == null) return;
+        if (trackedSegment.State == EntityState.Detached)
+        {
+            var replacement = dbContext.ChangeTracker.Entries<Segment>()
+                .SingleOrDefault(entry => entry.Entity.Id == segmentId);
+            if (replacement != null) trackedSegment = replacement;
+            else
+            {
+                trackedSegment.Entity.FromPlace = null;
+                trackedSegment.Entity.ToPlace = null;
+                trackedSegment.Entity.Waypoints = [];
+                trackedSegment = dbContext.Attach(trackedSegment.Entity);
+            }
+        }
+        trackedSegment.Entity.FromPlace = null;
+        trackedSegment.Entity.ToPlace = null;
+        trackedSegment.Entity.Waypoints = [];
+        var canonical = await dbContext.Segments.AsNoTracking()
+            .SingleOrDefaultAsync(item => item.Id == segmentId, cancellationToken);
+        if (canonical == null) return;
+        trackedSegment.CurrentValues.SetValues(canonical);
+        trackedSegment.OriginalValues.SetValues(canonical);
+        trackedSegment.State = EntityState.Unchanged;
+    }
+
+    private static LineString? CopyGeometry(SegmentRouteProposal proposal) =>
+        proposal.RouteGeometry == null ? null : (LineString)proposal.RouteGeometry.Copy();
+
+    private static async Task<Dictionary<Guid, Place>> LoadProposalPlacesAsync(
+        ApplicationDbContext dbContext,
+        SegmentRouteProposal proposal,
+        CancellationToken cancellationToken)
+    {
+        var requiredPlaceIds = proposal.Waypoints.Select(item => (Guid?)item.PlaceId)
+            .Append(proposal.FromPlaceId).Append(proposal.ToPlaceId)
+            .Where(id => id.HasValue).Select(id => id!.Value).Distinct().ToArray();
+        return await dbContext.Places.Include(place => place.Region)
+            .Where(place => requiredPlaceIds.Contains(place.Id))
+            .ToDictionaryAsync(place => place.Id, cancellationToken);
     }
 
     /// <summary>Loads the complete tracked aggregate needed for mutation and failure recovery.</summary>
@@ -152,15 +240,27 @@ public static class SegmentRouteReconciler
         segment.Waypoints = new List<SegmentWaypoint>();
     }
 
-    private static async Task ReloadAggregateAsync(
+    private static async Task RecoverAggregateAsync(
         ApplicationDbContext dbContext,
-        Segment segment,
+        Guid segmentId,
         CancellationToken cancellationToken)
     {
+        var segment = dbContext.ChangeTracker.Entries<Segment>()
+            .SingleOrDefault(entry => entry.Entity.Id == segmentId)?.Entity;
         foreach (var entry in dbContext.ChangeTracker.Entries<SegmentWaypoint>()
-                     .Where(entry => entry.Entity.SegmentId == segment.Id).ToArray())
+                     .Where(entry => entry.Entity.SegmentId == segmentId).ToArray())
             entry.State = EntityState.Detached;
-        await dbContext.Entry(segment).ReloadAsync(cancellationToken);
+        if (segment == null)
+        {
+            await LoadAggregateAsync(dbContext, segmentId, cancellationToken);
+            return;
+        }
+        var canonical = await dbContext.Segments.AsNoTracking()
+            .SingleAsync(item => item.Id == segmentId, cancellationToken);
+        var segmentEntry = dbContext.Entry(segment);
+        segmentEntry.CurrentValues.SetValues(canonical);
+        segmentEntry.OriginalValues.SetValues(canonical);
+        segmentEntry.State = EntityState.Unchanged;
         var endpointIds = new[] { segment.FromPlaceId, segment.ToPlaceId }
             .Where(id => id.HasValue).Select(id => id!.Value).Distinct().ToArray();
         var endpoints = await dbContext.Places.Include(item => item.Region)

--- a/docs/19-Database.md
+++ b/docs/19-Database.md
@@ -134,6 +134,32 @@ Route between two places with travel mode and geometry.
 | `DisplayOrder` | int | Sort order within trip |
 | `Notes` | string | Rich-text HTML notes |
 
+### SegmentWaypoint
+
+Ordered intermediate saved-place anchors are persisted as aggregate children rather than embedded
+identifiers in route coordinates.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SegmentId` | Guid | Owning segment; part of the composite primary key |
+| `PlaceId` | Guid | Referenced canonical saved place; part of the composite primary key |
+| `Position` | int | Zero-based contiguous waypoint order |
+| `RouteVertexIndex` | int? | Zero-based interior vertex in custom geometry; null for fallback geometry |
+
+Deleting a Segment cascades to its waypoint associations. The Place relationship is restrictive:
+an association never owns or deletes its saved Place. PostgreSQL enforces nonnegative positions,
+positive non-null route indices, unique places and positions per Segment, and unique non-null route
+indices per Segment. Same-trip ownership, contiguity, endpoint eligibility, saved-place locations,
+and coordinate matching remain server aggregate invariants because they cross rows or spatial values.
+
+`SegmentRouteReconciler` is the single route-aggregate boundary. It loads endpoints and ordered
+waypoint places, validates a complete proposal before changing tracked state, and leaves transaction
+and `SaveChanges` ownership with its caller. Null `RouteGeometry` remains null; fallback consumers use
+the effective anchor chain `From → waypoints by Position → To` without persisting a convenience line.
+Custom routes use SRID 4326 longitude/latitude coordinates and require every semantic anchor to match
+within `0.0000001` degrees independently on each axis. A closed loop reuses one canonical Place for
+both endpoints and never creates a duplicate Place or marker identity.
+
 Transport modes resolve through the administrator-managed `TransportProfiles` catalog. The durable segment `Mode` string remains compatible with public and interchange contracts; planning speeds are database configuration rather than documentation constants.
 
 ---

--- a/docs/19-Database.md
+++ b/docs/19-Database.md
@@ -153,16 +153,25 @@ indices per Segment. Same-trip ownership, contiguity, endpoint eligibility, save
 and coordinate matching remain server aggregate invariants because they cross rows or spatial values.
 
 `SegmentRouteReconciler` is the single route-aggregate persistence boundary. Its internal proposal
-contains only Segment and Place identities, waypoint scalars, and optional geometry. The reconciler
-loads canonical Segment, Place, Region, and Trip ownership state through its DbContext in bounded
-queries; detached caller-created Place graphs are never authoritative or attached.
+contains only Segment and Place identities, waypoint scalars, and optional geometry. The operation
+requires a clean caller `DbContext`: after change detection, any pre-existing Added, Modified, or Deleted
+entry is rejected before transaction creation, locking, loading, or mutation and remains caller-owned.
 
-The reconciler owns its transaction and `SaveChanges` boundary. After validation it replaces the
-complete waypoint association set inside one transaction, avoiding PostgreSQL's immediate unique-index
-collisions during arbitrary reorder while preserving the final indexes and checks. Provider failure
-rolls back and selectively reloads the affected aggregate without clearing unrelated tracked entities.
-Segment has no optimistic-concurrency token in this slice: transactions and database constraints keep
-each committed aggregate structurally valid, but user-facing conflict semantics remain a later API concern.
+For PostgreSQL, the reconciler begins its owned transaction and acquires `SELECT ... FOR UPDATE` on the
+canonical Segment row before loading mutable aggregate state. It then refreshes any unchanged tracked
+identity-map values and loads canonical endpoints, waypoint rows and Places, Region ownership, and Trip
+ownership under that lock. The lock is per Segment and remains held through deletion, final
+`SaveChangesAsync`, and commit, so a later reconciliation reloads after the earlier complete proposal
+commits. Different Segments are not serialized by an application-global lock.
+
+After validation, the reconciler replaces the complete waypoint association set inside the same
+transaction, avoiding PostgreSQL's immediate unique-index collisions during arbitrary reorder while
+preserving the final indexes and checks. Rollback and mandatory tracker repair use a non-cancelled cleanup
+path and restore only reconciliation-owned Segment, waypoint, and Trip timestamp state. If rollback or
+repair fails, the caller context is disposed and the resulting aggregate exception retains both the
+original and cleanup failures; an unsafe context is never presented as reusable. Segment has no
+optimistic-concurrency token in this slice: the later locked writer may win with one complete revalidated
+proposal, but no user-facing conflict semantics are claimed.
 
 Null `RouteGeometry` remains null; fallback consumers use the effective anchor chain
 `From → waypoints by Position → To` without persisting a convenience line. A proposed custom LineString

--- a/docs/19-Database.md
+++ b/docs/19-Database.md
@@ -152,13 +152,24 @@ positive non-null route indices, unique places and positions per Segment, and un
 indices per Segment. Same-trip ownership, contiguity, endpoint eligibility, saved-place locations,
 and coordinate matching remain server aggregate invariants because they cross rows or spatial values.
 
-`SegmentRouteReconciler` is the single route-aggregate boundary. It loads endpoints and ordered
-waypoint places, validates a complete proposal before changing tracked state, and leaves transaction
-and `SaveChanges` ownership with its caller. Null `RouteGeometry` remains null; fallback consumers use
-the effective anchor chain `From → waypoints by Position → To` without persisting a convenience line.
-Custom routes use SRID 4326 longitude/latitude coordinates and require every semantic anchor to match
-within `0.0000001` degrees independently on each axis. A closed loop reuses one canonical Place for
-both endpoints and never creates a duplicate Place or marker identity.
+`SegmentRouteReconciler` is the single route-aggregate persistence boundary. Its internal proposal
+contains only Segment and Place identities, waypoint scalars, and optional geometry. The reconciler
+loads canonical Segment, Place, Region, and Trip ownership state through its DbContext in bounded
+queries; detached caller-created Place graphs are never authoritative or attached.
+
+The reconciler owns its transaction and `SaveChanges` boundary. After validation it replaces the
+complete waypoint association set inside one transaction, avoiding PostgreSQL's immediate unique-index
+collisions during arbitrary reorder while preserving the final indexes and checks. Provider failure
+rolls back and selectively reloads the affected aggregate without clearing unrelated tracked entities.
+Segment has no optimistic-concurrency token in this slice: transactions and database constraints keep
+each committed aggregate structurally valid, but user-facing conflict semantics remain a later API concern.
+
+Null `RouteGeometry` remains null; fallback consumers use the effective anchor chain
+`From → waypoints by Position → To` without persisting a convenience line. A proposed custom LineString
+is defensively copied before validation, and only that validated copy is stored. Custom routes use SRID
+4326 longitude/latitude coordinates and require every semantic anchor to match within `0.0000001`
+degrees independently on each axis. A closed loop reuses one canonical Place for both endpoints and
+never creates a duplicate Place or marker identity.
 
 Transport modes resolve through the administrator-managed `TransportProfiles` catalog. The durable segment `Mode` string remains compatible with public and interchange contracts; planning speeds are database configuration rather than documentation constants.
 

--- a/tests/Wayfarer.Tests/Models/SegmentRouteReconcilerConcurrencyPostgresTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentRouteReconcilerConcurrencyPostgresTests.cs
@@ -1,0 +1,169 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NetTopologySuite.Geometries;
+using Wayfarer.Models;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Models;
+
+/// <summary>Proves PostgreSQL row-lock serialization for complete Segment route proposals.</summary>
+[Collection(PostgresImportTestCollection.Name)]
+public sealed class SegmentRouteReconcilerConcurrencyPostgresTests(PostgresImportTestFixture fixture)
+{
+    /// <summary>Forces the declared proposal order and proves the later locked proposal wins without mixed rows.</summary>
+    [PostgresTheory]
+    [InlineData(ProposalShape.Nonzero, ProposalShape.Zero)]
+    [InlineData(ProposalShape.Zero, ProposalShape.Nonzero)]
+    [InlineData(ProposalShape.Forward, ProposalShape.Reverse)]
+    public async Task SameSegment_ReconciliationsWaitThenCommitOneCompleteProposal(
+        ProposalShape firstShape,
+        ProposalShape secondShape)
+    {
+        var seeded = await SeedAsync(segmentCount: 1);
+        var gate = new SaveGateInterceptor();
+        await using var first = fixture.CreateContext(gate);
+        await using var second = fixture.CreateContext();
+        await first.Database.OpenConnectionAsync();
+        await second.Database.OpenConnectionAsync();
+        var secondPid = await BackendPidAsync(second);
+        var firstProposal = Proposal(seeded, seeded.SegmentIds[0], firstShape);
+        var secondProposal = Proposal(seeded, seeded.SegmentIds[0], secondShape);
+
+        var firstTask = SegmentRouteReconciler.ReconcileAsync(first, firstProposal);
+        await gate.SaveEntered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var secondTask = SegmentRouteReconciler.ReconcileAsync(second, secondProposal);
+        await WaitUntilBlockedAsync(secondPid);
+        gate.ReleaseSave.TrySetResult();
+        var results = await Task.WhenAll(firstTask, secondTask);
+
+        Assert.All(results, result => Assert.True(result.Succeeded));
+        await AssertStoredProposalAsync(secondProposal);
+    }
+
+    /// <summary>Holding one Segment row lock does not block reconciliation of another Segment.</summary>
+    [PostgresFact]
+    public async Task DifferentSegments_AreNotGloballySerialized()
+    {
+        var seeded = await SeedAsync(segmentCount: 2);
+        var gate = new SaveGateInterceptor();
+        await using var first = fixture.CreateContext(gate);
+        await using var second = fixture.CreateContext();
+        var firstTask = SegmentRouteReconciler.ReconcileAsync(first,
+            Proposal(seeded, seeded.SegmentIds[0], ProposalShape.Forward));
+        await gate.SaveEntered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var secondResult = await SegmentRouteReconciler.ReconcileAsync(second,
+            Proposal(seeded, seeded.SegmentIds[1], ProposalShape.Reverse)).WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(secondResult.Succeeded);
+        gate.ReleaseSave.TrySetResult();
+        Assert.True((await firstTask).Succeeded);
+    }
+
+    private async Task WaitUntilBlockedAsync(int backendPid)
+    {
+        await using var monitor = fixture.CreateContext();
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            await using var command = monitor.Database.GetDbConnection().CreateCommand();
+            if (command.Connection!.State != System.Data.ConnectionState.Open)
+                await command.Connection.OpenAsync();
+            command.CommandText = "SELECT cardinality(pg_blocking_pids(@pid))";
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "pid";
+            parameter.Value = backendPid;
+            command.Parameters.Add(parameter);
+            if (Convert.ToInt32(await command.ExecuteScalarAsync()) > 0) return;
+            await Task.Yield();
+        }
+        throw new TimeoutException("The second reconciliation did not enter a PostgreSQL lock wait.");
+    }
+
+    private static async Task<int> BackendPidAsync(ApplicationDbContext context)
+    {
+        await using var command = context.Database.GetDbConnection().CreateCommand();
+        command.CommandText = "SELECT pg_backend_pid()";
+        return Convert.ToInt32(await command.ExecuteScalarAsync());
+    }
+
+    private async Task AssertStoredProposalAsync(SegmentRouteProposal proposal)
+    {
+        await using var verification = fixture.CreateContext();
+        var segment = await verification.Segments.AsNoTracking().SingleAsync(item => item.Id == proposal.SegmentId);
+        var waypoints = await verification.Set<SegmentWaypoint>().AsNoTracking()
+            .Where(item => item.SegmentId == proposal.SegmentId).OrderBy(item => item.Position).ToArrayAsync();
+        Assert.Equal(proposal.FromPlaceId, segment.FromPlaceId);
+        Assert.Equal(proposal.ToPlaceId, segment.ToPlaceId);
+        Assert.Equal(proposal.Waypoints.Select(item => item.PlaceId), waypoints.Select(item => item.PlaceId));
+        Assert.Equal(proposal.Waypoints.Select(item => item.Position), waypoints.Select(item => item.Position));
+        Assert.Equal(proposal.Waypoints.Select(item => item.RouteVertexIndex), waypoints.Select(item => item.RouteVertexIndex));
+        Assert.Equal(proposal.RouteGeometry?.AsText(), segment.RouteGeometry?.AsText());
+    }
+
+    private static SegmentRouteProposal Proposal(Seeded seeded, Guid segmentId, ProposalShape shape)
+    {
+        if (shape == ProposalShape.Zero) return new(segmentId, null, null, [], null);
+        var ids = shape == ProposalShape.Reverse ? seeded.WaypointIds.Reverse().ToArray() : seeded.WaypointIds;
+        var waypoints = ids.Select((id, index) => new SegmentWaypointProposal(id, index, index + 1)).ToArray();
+        var coordinates = new[] { seeded.FromId }.Concat(ids).Append(seeded.ToId)
+            .Select(id => seeded.Coordinates[id]).ToArray();
+        return new(segmentId, seeded.FromId, seeded.ToId, waypoints, new LineString(coordinates) { SRID = 4326 });
+    }
+
+    private async Task<Seeded> SeedAsync(int segmentCount)
+    {
+        var user = await fixture.CreateUserAsync();
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = user.Id, Name = "Concurrent waypoint fixture" };
+        var region = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = user.Id, Name = "Route" };
+        var places = Enumerable.Range(1, 6).Select(index => new Place
+        {
+            Id = Guid.NewGuid(), Region = region, RegionId = region.Id, UserId = user.Id,
+            Name = $"Anchor {index}", Location = new Point(index, index) { SRID = 4326 }
+        }).ToArray();
+        foreach (var place in places) region.Places.Add(place);
+        trip.Regions.Add(region);
+        var segments = Enumerable.Range(0, segmentCount).Select(index => new Segment
+        {
+            Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = user.Id, Mode = "walk", DisplayOrder = index
+        }).ToArray();
+        foreach (var segment in segments) trip.Segments.Add(segment);
+        fixture.RegisterTrip(trip.Id);
+        await using var context = fixture.CreateContext();
+        context.Trips.Add(trip);
+        await context.SaveChangesAsync();
+        return new(segments.Select(item => item.Id).ToArray(), places[0].Id, places[^1].Id,
+            places[1..^1].Select(item => item.Id).ToArray(), places.ToDictionary(item => item.Id, item => item.Location!.Coordinate));
+    }
+
+    /// <summary>Identifies the complete aggregate proposal used by one concurrent writer.</summary>
+    public enum ProposalShape { Zero, Nonzero, Forward, Reverse }
+
+    private sealed record Seeded(
+        Guid[] SegmentIds,
+        Guid FromId,
+        Guid ToId,
+        Guid[] WaypointIds,
+        Dictionary<Guid, Coordinate> Coordinates);
+
+    private sealed class SaveGateInterceptor : SaveChangesInterceptor
+    {
+        /// <summary>Signals that the first writer holds its lock and has reached final persistence.</summary>
+        internal TaskCompletionSource SaveEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Releases the first writer without relying on elapsed time.</summary>
+        internal TaskCompletionSource ReleaseSave { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            SaveEntered.TrySetResult();
+            await ReleaseSave.Task.WaitAsync(cancellationToken);
+            return result;
+        }
+    }
+}

--- a/tests/Wayfarer.Tests/Models/SegmentRouteReconcilerTrackerScopePostgresTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentRouteReconcilerTrackerScopePostgresTests.cs
@@ -1,0 +1,216 @@
+using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Geometries;
+using Wayfarer.Models;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Models;
+
+/// <summary>Verifies that canonical route refresh remains scoped to the reconciled aggregate and proposal.</summary>
+[Collection(PostgresImportTestCollection.Name)]
+public sealed class SegmentRouteReconcilerTrackerScopePostgresTests(PostgresImportTestFixture fixture)
+{
+    /// <summary>Successful reconciliation preserves unrelated tracked work for a later caller save.</summary>
+    [PostgresFact]
+    public async Task Reconcile_Success_PreservesAndPersistsUnrelatedTrackedEntities()
+    {
+        var seeded = await SeedAsync();
+        await using var context = fixture.CreateContext();
+        var unrelatedPlace = await context.Places.SingleAsync(item => item.Id == seeded.UnrelatedPlaceId);
+        var unrelatedRegion = await context.Regions.SingleAsync(item => item.Id == seeded.UnrelatedRegionId);
+        var unrelatedSegment = await context.Segments.SingleAsync(item => item.Id == seeded.UnrelatedSegmentId);
+        var unrelatedTrip = await context.Trips.SingleAsync(item => item.Id == seeded.UnrelatedTripId);
+        var originalSegmentMode = unrelatedSegment.Mode;
+        var originalTripName = unrelatedTrip.Name;
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context, ValidProposal(seeded));
+
+        Assert.True(result.Succeeded);
+        AssertUnchanged(context, unrelatedPlace, unrelatedRegion, unrelatedSegment, unrelatedTrip);
+        Assert.Equal(originalSegmentMode, unrelatedSegment.Mode);
+        Assert.Equal(originalTripName, unrelatedTrip.Name);
+        unrelatedPlace.Name = "Caller place edit";
+        unrelatedRegion.Name = "Caller region edit";
+        context.ChangeTracker.DetectChanges();
+        Assert.Equal(EntityState.Modified, context.Entry(unrelatedPlace).State);
+        Assert.Equal(EntityState.Modified, context.Entry(unrelatedRegion).State);
+        await context.SaveChangesAsync();
+
+        await using var verification = fixture.CreateContext();
+        Assert.Equal("Caller place edit", await verification.Places
+            .Where(item => item.Id == unrelatedPlace.Id).Select(item => item.Name).SingleAsync());
+        Assert.Equal("Caller region edit", await verification.Regions
+            .Where(item => item.Id == unrelatedRegion.Id).Select(item => item.Name).SingleAsync());
+    }
+
+    /// <summary>Validation rejection leaves unrelated tracked entities available for later caller work.</summary>
+    [PostgresFact]
+    public async Task Reconcile_ValidationFailure_PreservesAndPersistsUnrelatedTrackedEntities()
+    {
+        var seeded = await SeedAsync();
+        await using var context = fixture.CreateContext();
+        var unrelatedPlace = await context.Places.SingleAsync(item => item.Id == seeded.UnrelatedPlaceId);
+        var unrelatedRegion = await context.Regions.SingleAsync(item => item.Id == seeded.UnrelatedRegionId);
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(seeded.TargetSegmentId, seeded.FromPlaceId, seeded.ToPlaceId,
+                [new(seeded.FromPlaceId, 0, null)], null));
+
+        Assert.False(result.Succeeded);
+        AssertUnchanged(context, unrelatedPlace, unrelatedRegion);
+        await PersistAndVerifyUnrelatedEditsAsync(context, unrelatedPlace, unrelatedRegion, "validation");
+    }
+
+    /// <summary>A missing target Segment does not disturb unrelated tracked entities or leave a transaction open.</summary>
+    [PostgresFact]
+    public async Task Reconcile_MissingSegment_PreservesAndPersistsUnrelatedTrackedEntities()
+    {
+        var seeded = await SeedAsync();
+        await using var context = fixture.CreateContext();
+        var unrelatedPlace = await context.Places.SingleAsync(item => item.Id == seeded.UnrelatedPlaceId);
+        var unrelatedRegion = await context.Regions.SingleAsync(item => item.Id == seeded.UnrelatedRegionId);
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            ValidProposal(seeded) with { SegmentId = Guid.NewGuid() });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(["Segment was not found."], result.Errors);
+        Assert.Null(context.Database.CurrentTransaction);
+        AssertUnchanged(context, unrelatedPlace, unrelatedRegion);
+        await PersistAndVerifyUnrelatedEditsAsync(context, unrelatedPlace, unrelatedRegion, "missing");
+    }
+
+    /// <summary>A relevant Place already in the identity map is refreshed before coordinate validation.</summary>
+    [PostgresFact]
+    public async Task Reconcile_RelevantStalePlace_UsesCanonicalCoordinates()
+    {
+        var seeded = await SeedAsync();
+        await using var context = fixture.CreateContext();
+        _ = await context.Places.SingleAsync(item => item.Id == seeded.WaypointPlaceId);
+        await using (var external = fixture.CreateContext())
+        {
+            var waypoint = await external.Places.SingleAsync(item => item.Id == seeded.WaypointPlaceId);
+            waypoint.Location = Point(20, 20);
+            await external.SaveChangesAsync();
+        }
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(seeded.TargetSegmentId, seeded.FromPlaceId, seeded.ToPlaceId,
+                [new(seeded.WaypointPlaceId, 0, 1)], Line((1, 1), (2, 2), (3, 3))));
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Errors, error => error.Contains("match", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>A relevant Region already in the identity map cannot retain stale Trip ownership authority.</summary>
+    [PostgresFact]
+    public async Task Reconcile_RelevantStaleRegion_UsesCanonicalTripOwnership()
+    {
+        var seeded = await SeedAsync();
+        await using var context = fixture.CreateContext();
+        _ = await context.Places.Include(item => item.Region)
+            .SingleAsync(item => item.Id == seeded.WaypointPlaceId);
+        await using (var external = fixture.CreateContext())
+        {
+            var region = await external.Regions.SingleAsync(item => item.Id == seeded.TargetRegionId);
+            region.TripId = seeded.UnrelatedTripId;
+            await external.SaveChangesAsync();
+        }
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context, ValidProposal(seeded));
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("Every waypoint place must belong to the segment trip.", result.Errors);
+    }
+
+    private async Task<SeededScope> SeedAsync()
+    {
+        var user = await fixture.CreateUserAsync();
+        var targetTrip = new Trip { Id = Guid.NewGuid(), UserId = user.Id, Name = "Target trip" };
+        var targetRegion = new Region
+        {
+            Id = Guid.NewGuid(), Trip = targetTrip, TripId = targetTrip.Id, UserId = user.Id, Name = "Target region"
+        };
+        var targetPlaces = Enumerable.Range(1, 3).Select(index => new Place
+        {
+            Id = Guid.NewGuid(), Region = targetRegion, RegionId = targetRegion.Id, UserId = user.Id,
+            Name = $"Target {index}", Location = Point(index, index)
+        }).ToArray();
+        var targetSegment = new Segment
+        {
+            Id = Guid.NewGuid(), Trip = targetTrip, TripId = targetTrip.Id, UserId = user.Id, Mode = "walk"
+        };
+        targetTrip.Regions.Add(targetRegion);
+        targetTrip.Segments.Add(targetSegment);
+        foreach (var place in targetPlaces) targetRegion.Places.Add(place);
+
+        var unrelatedTrip = new Trip { Id = Guid.NewGuid(), UserId = user.Id, Name = "Unrelated trip" };
+        var unrelatedRegion = new Region
+        {
+            Id = Guid.NewGuid(), Trip = unrelatedTrip, TripId = unrelatedTrip.Id, UserId = user.Id, Name = "Unrelated region"
+        };
+        var unrelatedPlace = new Place
+        {
+            Id = Guid.NewGuid(), Region = unrelatedRegion, RegionId = unrelatedRegion.Id, UserId = user.Id,
+            Name = "Unrelated place", Location = Point(9, 9)
+        };
+        var unrelatedSegment = new Segment
+        {
+            Id = Guid.NewGuid(), Trip = unrelatedTrip, TripId = unrelatedTrip.Id, UserId = user.Id, Mode = "rail"
+        };
+        unrelatedTrip.Regions.Add(unrelatedRegion);
+        unrelatedTrip.Segments.Add(unrelatedSegment);
+        unrelatedRegion.Places.Add(unrelatedPlace);
+
+        fixture.RegisterTrip(targetTrip.Id);
+        fixture.RegisterTrip(unrelatedTrip.Id);
+        await using var seed = fixture.CreateContext();
+        seed.Trips.AddRange(targetTrip, unrelatedTrip);
+        await seed.SaveChangesAsync();
+        return new(targetTrip.Id, targetRegion.Id, targetSegment.Id, targetPlaces[0].Id, targetPlaces[1].Id,
+            targetPlaces[2].Id, unrelatedTrip.Id, unrelatedRegion.Id, unrelatedPlace.Id, unrelatedSegment.Id);
+    }
+
+    private static SegmentRouteProposal ValidProposal(SeededScope seeded) =>
+        new(seeded.TargetSegmentId, seeded.FromPlaceId, seeded.ToPlaceId,
+            [new(seeded.WaypointPlaceId, 0, null)], null);
+
+    private async Task PersistAndVerifyUnrelatedEditsAsync(
+        ApplicationDbContext context,
+        Place place,
+        Region region,
+        string suffix)
+    {
+        place.Name = $"Place after {suffix}";
+        region.Name = $"Region after {suffix}";
+        await context.SaveChangesAsync();
+        await using var verification = fixture.CreateContext();
+        Assert.Equal(place.Name, await verification.Places.Where(item => item.Id == place.Id)
+            .Select(item => item.Name).SingleAsync());
+        Assert.Equal(region.Name, await verification.Regions.Where(item => item.Id == region.Id)
+            .Select(item => item.Name).SingleAsync());
+    }
+
+    private static void AssertUnchanged(ApplicationDbContext context, params object[] entities)
+    {
+        foreach (var entity in entities) Assert.Equal(EntityState.Unchanged, context.Entry(entity).State);
+    }
+
+    private static Point Point(double x, double y) => new(x, y) { SRID = 4326 };
+
+    private static LineString Line(params (double X, double Y)[] points) =>
+        new(points.Select(point => new Coordinate(point.X, point.Y)).ToArray()) { SRID = 4326 };
+
+    private sealed record SeededScope(
+        Guid TargetTripId,
+        Guid TargetRegionId,
+        Guid TargetSegmentId,
+        Guid FromPlaceId,
+        Guid WaypointPlaceId,
+        Guid ToPlaceId,
+        Guid UnrelatedTripId,
+        Guid UnrelatedRegionId,
+        Guid UnrelatedPlaceId,
+        Guid UnrelatedSegmentId);
+}

--- a/tests/Wayfarer.Tests/Models/SegmentWaypointMigrationTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentWaypointMigrationTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Wayfarer.Migrations;
+using Xunit;
+
+namespace Wayfarer.Tests.Models;
+
+/// <summary>Verifies the generated waypoint migration operations without claiming provider execution.</summary>
+public sealed class SegmentWaypointMigrationTests
+{
+    /// <summary>Proves Up adds only the waypoint table and its supporting indexes.</summary>
+    [Fact]
+    public void Up_CreatesFocusedWaypointSchema()
+    {
+        var operations = Operations("Up");
+        var table = Assert.Single(operations.OfType<CreateTableOperation>());
+
+        Assert.Equal("SegmentWaypoints", table.Name);
+        Assert.Equal(["SegmentId", "PlaceId"], table.PrimaryKey!.Columns);
+        Assert.Equal(2, table.ForeignKeys.Count);
+        Assert.Equal(2, table.CheckConstraints.Count);
+        Assert.Equal(3, operations.OfType<CreateIndexOperation>().Count());
+        Assert.DoesNotContain(operations, operation => operation is AddColumnOperation or AlterColumnOperation or SqlOperation);
+    }
+
+    /// <summary>Proves Down removes only the schema introduced by issue 404.</summary>
+    [Fact]
+    public void Down_DropsOnlyWaypointTable()
+    {
+        var operation = Assert.Single(Operations("Down"));
+        var drop = Assert.IsType<DropTableOperation>(operation);
+
+        Assert.Equal("SegmentWaypoints", drop.Name);
+    }
+
+    private static List<MigrationOperation> Operations(string methodName)
+    {
+        var migration = new AddSegmentWaypoints();
+        var builder = new MigrationBuilder("Npgsql.EntityFrameworkCore.PostgreSQL");
+        typeof(AddSegmentWaypoints)
+            .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(migration, [builder]);
+        return builder.Operations;
+    }
+}

--- a/tests/Wayfarer.Tests/Models/SegmentWaypointModelTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentWaypointModelTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Wayfarer.Models;
 using Wayfarer.Tests.Infrastructure;
 using Xunit;
@@ -13,7 +15,7 @@ public sealed class SegmentWaypointModelTests : TestBase
     public void RuntimeModel_DefinesWaypointPersistenceContract()
     {
         using var context = CreateDbContext();
-        var entity = context.Model.FindEntityType(typeof(SegmentWaypoint));
+        var entity = context.GetService<IDesignTimeModel>().Model.FindEntityType(typeof(SegmentWaypoint));
 
         Assert.NotNull(entity);
         Assert.Equal("SegmentWaypoints", entity!.GetTableName());

--- a/tests/Wayfarer.Tests/Models/SegmentWaypointModelTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentWaypointModelTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Wayfarer.Models;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Models;
+
+/// <summary>Verifies the persisted waypoint entity and its relational model contract.</summary>
+public sealed class SegmentWaypointModelTests : TestBase
+{
+    /// <summary>Proves the runtime model exposes the required keys, checks, indexes, and delete behavior.</summary>
+    [Fact]
+    public void RuntimeModel_DefinesWaypointPersistenceContract()
+    {
+        using var context = CreateDbContext();
+        var entity = context.Model.FindEntityType(typeof(SegmentWaypoint));
+
+        Assert.NotNull(entity);
+        Assert.Equal("SegmentWaypoints", entity!.GetTableName());
+        Assert.Equal([nameof(SegmentWaypoint.SegmentId), nameof(SegmentWaypoint.PlaceId)],
+            entity.FindPrimaryKey()!.Properties.Select(property => property.Name));
+        Assert.Contains(entity.GetIndexes(), index =>
+            index.IsUnique && index.Properties.Select(property => property.Name).SequenceEqual([nameof(SegmentWaypoint.SegmentId), nameof(SegmentWaypoint.Position)]));
+        Assert.Contains(entity.GetIndexes(), index =>
+            index.IsUnique
+            && index.Properties.Select(property => property.Name).SequenceEqual([nameof(SegmentWaypoint.SegmentId), nameof(SegmentWaypoint.RouteVertexIndex)])
+            && index.GetFilter() == "\"RouteVertexIndex\" IS NOT NULL");
+        Assert.Contains(entity.GetCheckConstraints(), constraint => constraint.Name == "CK_SegmentWaypoint_Position");
+        Assert.Contains(entity.GetCheckConstraints(), constraint => constraint.Name == "CK_SegmentWaypoint_RouteVertexIndex");
+
+        var segmentForeignKey = entity.GetForeignKeys().Single(key => key.PrincipalEntityType.ClrType == typeof(Segment));
+        var placeForeignKey = entity.GetForeignKeys().Single(key => key.PrincipalEntityType.ClrType == typeof(Place));
+        Assert.Equal(DeleteBehavior.Cascade, segmentForeignKey.DeleteBehavior);
+        Assert.Equal(DeleteBehavior.Restrict, placeForeignKey.DeleteBehavior);
+    }
+}

--- a/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
@@ -161,6 +161,40 @@ public sealed class SegmentWaypointPostgresTests
         Assert.Null(await verification.Segments.Where(item => item.Id == segment.Id).Select(item => item.RouteGeometry).SingleAsync());
     }
 
+    /// <summary>Reordering persisted rows must not collide with PostgreSQL's immediate position uniqueness check.</summary>
+    [PostgresFact]
+    public async Task Reconcile_PersistedSwap_SucceedsWithoutIntermediatePositionCollision()
+    {
+        _fixture.RequireAvailable();
+        var seeded = await SeedPlacesAsync();
+        var segment = NewSegment(seeded, 1);
+        await using (var seedContext = _fixture.CreateContext())
+        {
+            var places = await seedContext.Places.Include(place => place.Region)
+                .Where(place => seeded.PlaceIds.Contains(place.Id))
+                .ToDictionaryAsync(place => place.Id);
+            seedContext.Segments.Add(segment);
+            Assert.True(SegmentRouteReconciler.Reconcile(segment, places[seeded.PlaceIds[0]], places[seeded.PlaceIds[3]],
+                [new(places[seeded.PlaceIds[1]], 0, null), new(places[seeded.PlaceIds[2]], 1, null)], null).Succeeded);
+            await seedContext.SaveChangesAsync();
+        }
+
+        await using var context = _fixture.CreateContext();
+        var aggregate = await SegmentRouteReconciler.LoadAggregateAsync(context, segment.Id);
+        Assert.NotNull(aggregate);
+        var original = aggregate!.Waypoints.OrderBy(item => item.Position).ToArray();
+
+        var result = SegmentRouteReconciler.Reconcile(aggregate, aggregate.FromPlace, aggregate.ToPlace,
+            [new(original[1].Place, 0, null), new(original[0].Place, 1, null)], null);
+
+        Assert.True(result.Succeeded);
+        await context.SaveChangesAsync();
+        await using var verification = _fixture.CreateContext();
+        Assert.Equal([original[1].PlaceId, original[0].PlaceId],
+            await verification.Set<SegmentWaypoint>().Where(item => item.SegmentId == segment.Id)
+                .OrderBy(item => item.Position).Select(item => item.PlaceId).ToListAsync());
+    }
+
     private async Task<(Guid SegmentId, Guid FirstPlaceId, Guid SecondPlaceId, Guid ForeignPlaceId)> SeedAggregateAsync()
     {
         var seeded = await SeedPlacesAsync(includeForeignTrip: true);

--- a/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
@@ -53,6 +53,8 @@ public sealed class SegmentWaypointPostgresTests
         await migrator.MigrateAsync(PreviousMigration);
         Assert.False(await TableExistsAsync(context, "SegmentWaypoints"));
         Assert.True(await TableExistsAsync(context, "Segments"));
+        await migrator.MigrateAsync();
+        Assert.True(await TableExistsAsync(context, "SegmentWaypoints"));
         await transaction.RollbackAsync();
     }
 
@@ -240,15 +242,18 @@ public sealed class SegmentWaypointPostgresTests
         var interceptor = new FailNextSaveInterceptor();
         await using var context = _fixture.CreateContext(interceptor);
         var segment = await SegmentRouteReconciler.LoadAggregateAsync(context, aggregate.SegmentId);
-        var unrelated = await context.Places.SingleAsync(item => item.Id == aggregate.AdditionalPlaceId);
+        var unrelated = await context.Users.FirstAsync();
         var original = segment!.Waypoints.OrderBy(item => item.Position).Select(item => item.PlaceId).ToArray();
+        var originalFromPlaceId = segment.FromPlaceId;
         interceptor.Arm();
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => SegmentRouteReconciler.ReconcileAsync(context,
-            new(segment.Id, segment.FromPlaceId, segment.ToPlaceId,
+            new(segment.Id, aggregate.AdditionalPlaceId, segment.ToPlaceId,
                 original.Reverse().Select((id, position) => new SegmentWaypointProposal(id, position, null)).ToArray(), null)));
 
         Assert.Equal(original, segment.Waypoints.OrderBy(item => item.Position).Select(item => item.PlaceId));
+        Assert.Equal(originalFromPlaceId, segment.FromPlaceId);
+        Assert.Equal(originalFromPlaceId, segment.FromPlace!.Id);
         Assert.Equal(EntityState.Unchanged, context.Entry(segment).State);
         Assert.Equal(EntityState.Unchanged, context.Entry(unrelated).State);
         Assert.DoesNotContain(context.ChangeTracker.Entries(), entry =>

--- a/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
@@ -47,7 +47,7 @@ public sealed class SegmentWaypointPostgresTests
         Assert.Equal(12.345d, segment.EstimatedDistanceKm);
         Assert.Equal(4, segment.DisplayOrder);
         Assert.Equal("legacy notes", segment.Notes);
-        Assert.Empty(await context.SegmentWaypoints.Where(item => item.SegmentId == segmentId).ToListAsync());
+        Assert.Empty(await context.Set<SegmentWaypoint>().Where(item => item.SegmentId == segmentId).ToListAsync());
 
         await migrator.MigrateAsync(PreviousMigration);
         Assert.False(await TableExistsAsync(context, "SegmentWaypoints"));
@@ -63,17 +63,26 @@ public sealed class SegmentWaypointPostgresTests
         var aggregate = await SeedAggregateAsync();
         await using var context = _fixture.CreateContext();
 
+        await AssertInsertFailsAsync(context, aggregate.SegmentId, aggregate.FirstPlaceId, 1, null);
+        await AssertInsertFailsAsync(context, Guid.NewGuid(), aggregate.SecondPlaceId, 1, null);
+        await AssertInsertFailsAsync(context, aggregate.SegmentId, Guid.NewGuid(), 1, null);
         await AssertInsertFailsAsync(context, aggregate.SegmentId, aggregate.SecondPlaceId, -1, null);
         await AssertInsertFailsAsync(context, aggregate.SegmentId, aggregate.SecondPlaceId, 1, 0);
         await AssertInsertFailsAsync(context, aggregate.SegmentId, aggregate.SecondPlaceId, 0, null);
         await AssertInsertFailsAsync(context, aggregate.SegmentId, aggregate.SecondPlaceId, 1, 2);
+
+        // PostgreSQL's partial index permits multiple null mappings while still rejecting duplicate custom indices.
+        await context.Database.ExecuteSqlInterpolatedAsync(
+            $"""INSERT INTO public."SegmentWaypoints" ("SegmentId", "PlaceId", "Position", "RouteVertexIndex") VALUES ({aggregate.SegmentId}, {aggregate.SecondPlaceId}, {1}, {null as int?})""");
+        await context.Database.ExecuteSqlInterpolatedAsync(
+            $"""DELETE FROM public."SegmentWaypoints" WHERE "SegmentId" = {aggregate.SegmentId} AND "PlaceId" = {aggregate.SecondPlaceId}""");
 
         await Assert.ThrowsAsync<PostgresException>(() => context.Database.ExecuteSqlInterpolatedAsync(
             $"""DELETE FROM public."Places" WHERE "Id" = {aggregate.FirstPlaceId}"""));
         Assert.True(await context.Segments.AsNoTracking().AnyAsync(item => item.Id == aggregate.SegmentId));
 
         await context.Database.ExecuteSqlInterpolatedAsync($"""DELETE FROM public."Segments" WHERE "Id" = {aggregate.SegmentId}""");
-        Assert.False(await context.SegmentWaypoints.AsNoTracking().AnyAsync(item => item.SegmentId == aggregate.SegmentId));
+        Assert.False(await context.Set<SegmentWaypoint>().AsNoTracking().AnyAsync(item => item.SegmentId == aggregate.SegmentId));
     }
 
     /// <summary>Persists representative fallback, custom, and canonical closed-loop aggregates through the reconciler.</summary>
@@ -97,8 +106,8 @@ public sealed class SegmentWaypointPostgresTests
             [new(places[seeded.PlaceIds[1]], 0, null)], null).Succeeded);
 
         await context.SaveChangesAsync();
-        Assert.Equal(4, await context.SegmentWaypoints.CountAsync(item => item.SegmentId == fallback.Id || item.SegmentId == custom.Id || item.SegmentId == loop.Id));
-        Assert.Equal([1, 3], await context.SegmentWaypoints.Where(item => item.SegmentId == custom.Id).OrderBy(item => item.Position).Select(item => item.RouteVertexIndex!.Value).ToListAsync());
+        Assert.Equal(4, await context.Set<SegmentWaypoint>().CountAsync(item => item.SegmentId == fallback.Id || item.SegmentId == custom.Id || item.SegmentId == loop.Id));
+        Assert.Equal([1, 3], await context.Set<SegmentWaypoint>().Where(item => item.SegmentId == custom.Id).OrderBy(item => item.Position).Select(item => item.RouteVertexIndex!.Value).ToListAsync());
     }
 
     /// <summary>Proves rejection inside a real transaction leaves the stored and tracked aggregate unchanged.</summary>
@@ -124,7 +133,32 @@ public sealed class SegmentWaypointPostgresTests
         Assert.Equal(originalWaypointId, Assert.Single(segment.Waypoints).PlaceId);
         await transaction.CommitAsync();
         await using var verification = _fixture.CreateContext();
-        Assert.Equal(originalWaypointId, await verification.SegmentWaypoints.Where(item => item.SegmentId == segment.Id).Select(item => item.PlaceId).SingleAsync());
+        Assert.Equal(originalWaypointId, await verification.Set<SegmentWaypoint>().Where(item => item.SegmentId == segment.Id).Select(item => item.PlaceId).SingleAsync());
+    }
+
+    /// <summary>Proves the aggregate loader retrieves ordered waypoint places and supports one-unit-of-work updates.</summary>
+    [PostgresFact]
+    public async Task AggregateLoader_LoadsOrderedGraph_AndPersistsAcceptedUpdateOnce()
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedAggregateAsync();
+        await using var context = _fixture.CreateContext();
+        var segment = await SegmentRouteReconciler.LoadAggregateAsync(context, aggregate.SegmentId);
+        var replacement = await context.Places.Include(place => place.Region).SingleAsync(place => place.Id == aggregate.SecondPlaceId);
+
+        Assert.NotNull(segment);
+        Assert.NotNull(segment!.FromPlace?.Region);
+        Assert.NotNull(segment.ToPlace?.Region);
+        Assert.NotNull(Assert.Single(segment.Waypoints).Place.Region);
+        var result = SegmentRouteReconciler.Reconcile(segment, segment.FromPlace, segment.ToPlace, [new(replacement, 0, null)], null);
+
+        Assert.True(result.Succeeded);
+        await context.SaveChangesAsync();
+        await using var verification = _fixture.CreateContext();
+        var stored = await verification.Set<SegmentWaypoint>().SingleAsync(item => item.SegmentId == segment.Id);
+        Assert.Equal(replacement.Id, stored.PlaceId);
+        Assert.Null(stored.RouteVertexIndex);
+        Assert.Null(await verification.Segments.Where(item => item.Id == segment.Id).Select(item => item.RouteGeometry).SingleAsync());
     }
 
     private async Task<(Guid SegmentId, Guid FirstPlaceId, Guid SecondPlaceId, Guid ForeignPlaceId)> SeedAggregateAsync()

--- a/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
@@ -264,6 +264,104 @@ public sealed class SegmentWaypointPostgresTests
             .OrderBy(item => item.Position).Select(item => item.PlaceId).ToArrayAsync());
     }
 
+    /// <summary>Rejects a dirty caller context before reconciliation can save or overwrite its pending Trip edit.</summary>
+    [PostgresFact]
+    public async Task Reconcile_DirtyContextRejectsAndPreservesPendingTripEdit()
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedOrderedAggregateAsync();
+        await using var context = _fixture.CreateContext();
+        var segment = await context.Segments.SingleAsync(item => item.Id == aggregate.SegmentId);
+        var trip = await context.Trips.SingleAsync(item => item.Id == segment.TripId);
+        trip.Name = "Pending caller edit";
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => SegmentRouteReconciler.ReconcileAsync(context,
+            new(segment.Id, aggregate.FromPlaceId, aggregate.ToPlaceId, [], null)));
+
+        Assert.Contains("clean", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("Pending caller edit", trip.Name);
+        Assert.Equal(EntityState.Modified, context.Entry(trip).State);
+        await using var verification = _fixture.CreateContext();
+        Assert.NotEqual("Pending caller edit", await verification.Trips.Where(item => item.Id == trip.Id).Select(item => item.Name).SingleAsync());
+        Assert.Equal(aggregate.WaypointIds, await verification.Set<SegmentWaypoint>()
+            .Where(item => item.SegmentId == segment.Id).OrderBy(item => item.Position).Select(item => item.PlaceId).ToArrayAsync());
+    }
+
+    /// <summary>Uses a non-cancelled cleanup path after cancellation occurs after destructive waypoint deletion.</summary>
+    [PostgresFact]
+    public async Task Reconcile_CancellationAfterDeleteRollsBackAndLeavesReusableContext()
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedOrderedAggregateAsync();
+        using var cancellation = new CancellationTokenSource();
+        var interceptor = new CancelNextSaveInterceptor(cancellation);
+        await using var context = _fixture.CreateContext(interceptor);
+        var segment = await SegmentRouteReconciler.LoadAggregateAsync(context, aggregate.SegmentId);
+        var original = segment!.Waypoints.OrderBy(item => item.Position).Select(item => item.PlaceId).ToArray();
+        interceptor.Arm();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => SegmentRouteReconciler.ReconcileAsync(context,
+            new(segment.Id, aggregate.FromPlaceId, aggregate.ToPlaceId, [], null), cancellation.Token));
+
+        Assert.True(cancellation.IsCancellationRequested);
+        Assert.Equal(original, segment.Waypoints.OrderBy(item => item.Position).Select(item => item.PlaceId));
+        Assert.DoesNotContain(context.ChangeTracker.Entries(), entry =>
+            entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted);
+        await context.SaveChangesAsync(CancellationToken.None);
+        await using var verification = _fixture.CreateContext();
+        Assert.Equal(original, await verification.Set<SegmentWaypoint>().Where(item => item.SegmentId == segment.Id)
+            .OrderBy(item => item.Position).Select(item => item.PlaceId).ToArrayAsync());
+    }
+
+    /// <summary>Surfaces both operation and rollback failures and invalidates the unsafe caller context.</summary>
+    [PostgresFact]
+    public async Task Reconcile_RollbackFailurePreservesBothFailuresAndInvalidatesContext()
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedOrderedAggregateAsync();
+        var interceptor = new SaveAndRollbackFailureInterceptor();
+        await using var context = _fixture.CreateContext(interceptor);
+        interceptor.Arm();
+
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => SegmentRouteReconciler.ReconcileAsync(context,
+            new(aggregate.SegmentId, aggregate.FromPlaceId, aggregate.ToPlaceId, [], null)));
+
+        Assert.Contains("Forced waypoint persistence failure.", exception.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Forced waypoint rollback failure.", exception.ToString(), StringComparison.Ordinal);
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => context.Segments.CountAsync());
+    }
+
+    /// <summary>Requires concurrent same-Segment proposals to acquire the provider row lock before aggregate loading.</summary>
+    [PostgresFact]
+    public async Task Reconcile_ConcurrentSameSegmentProposalsUseCanonicalRowLock()
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedOrderedAggregateAsync();
+        var firstLock = new SegmentLockCommandInterceptor();
+        var secondLock = new SegmentLockCommandInterceptor();
+        await using var first = _fixture.CreateContext(firstLock);
+        await using var second = _fixture.CreateContext(secondLock);
+        var firstProposal = aggregate.WaypointIds.Reverse()
+            .Select((id, position) => new SegmentWaypointProposal(id, position, null)).ToArray();
+        var secondProposal = new[] { aggregate.AdditionalPlaceId }
+            .Select((id, position) => new SegmentWaypointProposal(id, position, null)).ToArray();
+
+        var results = await Task.WhenAll(
+            SegmentRouteReconciler.ReconcileAsync(first,
+                new(aggregate.SegmentId, aggregate.FromPlaceId, aggregate.ToPlaceId, firstProposal, null)),
+            SegmentRouteReconciler.ReconcileAsync(second,
+                new(aggregate.SegmentId, aggregate.FromPlaceId, aggregate.ToPlaceId, secondProposal, null)));
+
+        Assert.All(results, result => Assert.True(result.Succeeded));
+        Assert.Equal(1, firstLock.LockCount);
+        Assert.Equal(1, secondLock.LockCount);
+        await using var verification = _fixture.CreateContext();
+        var stored = await verification.Set<SegmentWaypoint>().Where(item => item.SegmentId == aggregate.SegmentId)
+            .OrderBy(item => item.Position).Select(item => item.PlaceId).ToArrayAsync();
+        Assert.True(stored.SequenceEqual(firstProposal.Select(item => item.PlaceId))
+            || stored.SequenceEqual(secondProposal.Select(item => item.PlaceId)));
+    }
+
     /// <summary>PostgreSQL persistence retains the validated geometry copy after caller mutation.</summary>
     [PostgresFact]
     public async Task Reconcile_DefensiveGeometryCopy_PersistsCanonicalCoordinates()
@@ -405,6 +503,69 @@ public sealed class SegmentWaypointPostgresTests
             if (!_armed) return base.SavingChangesAsync(eventData, result, cancellationToken);
             _armed = false;
             throw new InvalidOperationException("Forced waypoint persistence failure.");
+        }
+    }
+
+    private sealed class CancelNextSaveInterceptor(CancellationTokenSource cancellation) : SaveChangesInterceptor
+    {
+        private bool _armed;
+
+        /// <summary>Arms cancellation at the SaveChanges seam after the reconciler's provider-side deletion.</summary>
+        internal void Arm() => _armed = true;
+
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_armed) return base.SavingChangesAsync(eventData, result, cancellationToken);
+            _armed = false;
+            cancellation.Cancel();
+            throw new OperationCanceledException("Forced cancellation after waypoint deletion.", cancellation.Token);
+        }
+    }
+
+    private sealed class SaveAndRollbackFailureInterceptor : SaveChangesInterceptor, IDbTransactionInterceptor
+    {
+        private bool _armed;
+
+        /// <summary>Arms paired persistence and rollback failures for context-invalidation coverage.</summary>
+        internal void Arm() => _armed = true;
+
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_armed) return base.SavingChangesAsync(eventData, result, cancellationToken);
+            throw new InvalidOperationException("Forced waypoint persistence failure.");
+        }
+
+        public Task TransactionRollingBackAsync(
+            System.Data.Common.DbTransaction transaction,
+            TransactionEventData eventData,
+            CancellationToken cancellationToken = default)
+        {
+            _armed = false;
+            throw new InvalidOperationException("Forced waypoint rollback failure.");
+        }
+    }
+
+
+    private sealed class SegmentLockCommandInterceptor : DbCommandInterceptor
+    {
+        /// <summary>Gets the number of canonical Segment row-lock commands executed by one reconciliation.</summary>
+        internal int LockCount { get; private set; }
+
+        public override ValueTask<InterceptionResult<System.Data.Common.DbDataReader>> ReaderExecutingAsync(
+            System.Data.Common.DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<System.Data.Common.DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (command.CommandText.Contains("FOR UPDATE", StringComparison.OrdinalIgnoreCase)
+                && command.CommandText.Contains("Segments", StringComparison.Ordinal)) LockCount++;
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
         }
     }
 }

--- a/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
@@ -319,9 +319,10 @@ public sealed class SegmentWaypointPostgresTests
     {
         _fixture.RequireAvailable();
         var aggregate = await SeedOrderedAggregateAsync();
-        var interceptor = new SaveAndRollbackFailureInterceptor();
-        await using var context = _fixture.CreateContext(interceptor);
-        interceptor.Arm();
+        var saveFailure = new FailNextSaveInterceptor();
+        var rollbackFailure = new RollbackFailureInterceptor();
+        await using var context = _fixture.CreateContext(saveFailure, rollbackFailure);
+        saveFailure.Arm();
 
         var exception = await Assert.ThrowsAnyAsync<Exception>(() => SegmentRouteReconciler.ReconcileAsync(context,
             new(aggregate.SegmentId, aggregate.FromPlaceId, aggregate.ToPlaceId, [], null)));
@@ -525,28 +526,15 @@ public sealed class SegmentWaypointPostgresTests
         }
     }
 
-    private sealed class SaveAndRollbackFailureInterceptor : SaveChangesInterceptor, IDbTransactionInterceptor
+    private sealed class RollbackFailureInterceptor : DbTransactionInterceptor
     {
-        private bool _armed;
-
-        /// <summary>Arms paired persistence and rollback failures for context-invalidation coverage.</summary>
-        internal void Arm() => _armed = true;
-
-        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
-            DbContextEventData eventData,
-            InterceptionResult<int> result,
-            CancellationToken cancellationToken = default)
-        {
-            if (!_armed) return base.SavingChangesAsync(eventData, result, cancellationToken);
-            throw new InvalidOperationException("Forced waypoint persistence failure.");
-        }
-
-        public Task TransactionRollingBackAsync(
+        /// <summary>Fails mandatory asynchronous rollback to exercise context invalidation.</summary>
+        public override ValueTask<InterceptionResult> TransactionRollingBackAsync(
             System.Data.Common.DbTransaction transaction,
             TransactionEventData eventData,
+            InterceptionResult result,
             CancellationToken cancellationToken = default)
         {
-            _armed = false;
             throw new InvalidOperationException("Forced waypoint rollback failure.");
         }
     }
@@ -566,6 +554,17 @@ public sealed class SegmentWaypointPostgresTests
             if (command.CommandText.Contains("FOR UPDATE", StringComparison.OrdinalIgnoreCase)
                 && command.CommandText.Contains("Segments", StringComparison.Ordinal)) LockCount++;
             return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            System.Data.Common.DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (command.CommandText.Contains("FOR UPDATE", StringComparison.OrdinalIgnoreCase)
+                && command.CommandText.Contains("Segments", StringComparison.Ordinal)) LockCount++;
+            return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
         }
     }
 }

--- a/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
@@ -1,0 +1,193 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
+using NetTopologySuite.Geometries;
+using Wayfarer.Models;
+using Wayfarer.Services;
+using Wayfarer.Tests.Infrastructure;
+using Xunit;
+
+namespace Wayfarer.Tests.Models;
+
+/// <summary>Executes waypoint migration, constraint, relationship, and transaction behavior on PostgreSQL.</summary>
+[Collection(PostgresImportTestCollection.Name)]
+public sealed class SegmentWaypointPostgresTests
+{
+    private const string PreviousMigration = "20260728152323_AdminManagedTransportProfiles";
+    private readonly PostgresImportTestFixture _fixture;
+
+    /// <summary>Initializes provider tests over the guarded isolated database fixture.</summary>
+    public SegmentWaypointPostgresTests(PostgresImportTestFixture fixture) => _fixture = fixture;
+
+    /// <summary>Executes exact-base upgrade and downgrade while preserving every legacy Segment value.</summary>
+    [PostgresFact]
+    public async Task MigrationUpAndDown_PreservesLegacySegments_AndOnlyAddsWaypointSchema()
+    {
+        _fixture.RequireAvailable();
+        var user = await _fixture.CreateUserAsync();
+        var tripId = Guid.NewGuid();
+        var segmentId = Guid.NewGuid();
+        _fixture.RegisterTrip(tripId);
+        await using var context = _fixture.CreateContext();
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        var migrator = context.GetService<IMigrator>();
+        await migrator.MigrateAsync(PreviousMigration);
+        await context.Database.ExecuteSqlInterpolatedAsync(
+            $"""INSERT INTO public."Trips" ("Id", "UserId", "Name", "IsPublic", "ShareProgressEnabled", "UpdatedAt") VALUES ({tripId}, {user.Id}, {"Legacy waypoint fixture"}, FALSE, FALSE, CURRENT_TIMESTAMP)""");
+        await context.Database.ExecuteSqlInterpolatedAsync(
+            $"""INSERT INTO public."Segments" ("Id", "UserId", "TripId", "Mode", "EstimatedDuration", "EstimatedDistanceKm", "DisplayOrder", "Notes") VALUES ({segmentId}, {user.Id}, {tripId}, {"walk"}, {TimeSpan.FromMinutes(37)}, {12.345d}, {4}, {"legacy notes"})""");
+
+        await migrator.MigrateAsync();
+
+        var segment = await context.Segments.AsNoTracking().SingleAsync(item => item.Id == segmentId);
+        Assert.Equal("walk", segment.Mode);
+        Assert.Equal(TimeSpan.FromMinutes(37), segment.EstimatedDuration);
+        Assert.Equal(12.345d, segment.EstimatedDistanceKm);
+        Assert.Equal(4, segment.DisplayOrder);
+        Assert.Equal("legacy notes", segment.Notes);
+        Assert.Empty(await context.SegmentWaypoints.Where(item => item.SegmentId == segmentId).ToListAsync());
+
+        await migrator.MigrateAsync(PreviousMigration);
+        Assert.False(await TableExistsAsync(context, "SegmentWaypoints"));
+        Assert.True(await TableExistsAsync(context, "Segments"));
+        await transaction.RollbackAsync();
+    }
+
+    /// <summary>Proves real PostgreSQL checks, unique constraints, filtered indexes, and both FK policies.</summary>
+    [PostgresFact]
+    public async Task ProviderConstraints_EnforceRangesUniquenessCascadeAndRestriction()
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedAggregateAsync();
+        await using var context = _fixture.CreateContext();
+
+        await AssertInsertFailsAsync(context, aggregate.SegmentId, aggregate.SecondPlaceId, -1, null);
+        await AssertInsertFailsAsync(context, aggregate.SegmentId, aggregate.SecondPlaceId, 1, 0);
+        await AssertInsertFailsAsync(context, aggregate.SegmentId, aggregate.SecondPlaceId, 0, null);
+        await AssertInsertFailsAsync(context, aggregate.SegmentId, aggregate.SecondPlaceId, 1, 2);
+
+        await Assert.ThrowsAsync<PostgresException>(() => context.Database.ExecuteSqlInterpolatedAsync(
+            $"""DELETE FROM public."Places" WHERE "Id" = {aggregate.FirstPlaceId}"""));
+        Assert.True(await context.Segments.AsNoTracking().AnyAsync(item => item.Id == aggregate.SegmentId));
+
+        await context.Database.ExecuteSqlInterpolatedAsync($"""DELETE FROM public."Segments" WHERE "Id" = {aggregate.SegmentId}""");
+        Assert.False(await context.SegmentWaypoints.AsNoTracking().AnyAsync(item => item.SegmentId == aggregate.SegmentId));
+    }
+
+    /// <summary>Persists representative fallback, custom, and canonical closed-loop aggregates through the reconciler.</summary>
+    [PostgresFact]
+    public async Task ValidAggregates_PersistFallbackCustomAndClosedLoopMappings()
+    {
+        _fixture.RequireAvailable();
+        var seeded = await SeedPlacesAsync();
+        await using var context = _fixture.CreateContext();
+        var places = await context.Places.Include(place => place.Region).Where(place => seeded.PlaceIds.Contains(place.Id)).ToDictionaryAsync(place => place.Id);
+
+        var fallback = NewSegment(seeded, 1);
+        var custom = NewSegment(seeded, 2);
+        var loop = NewSegment(seeded, 3);
+        context.Segments.AddRange(fallback, custom, loop);
+        Assert.True(SegmentRouteReconciler.Reconcile(fallback, places[seeded.PlaceIds[0]], places[seeded.PlaceIds[2]], [new(places[seeded.PlaceIds[1]], 0, null)], null).Succeeded);
+        Assert.True(SegmentRouteReconciler.Reconcile(custom, places[seeded.PlaceIds[0]], places[seeded.PlaceIds[3]],
+            [new(places[seeded.PlaceIds[1]], 0, 1), new(places[seeded.PlaceIds[2]], 1, 3)],
+            Line((1, 1), (2, 2), (2.5, 2.5), (3, 3), (4, 4))).Succeeded);
+        Assert.True(SegmentRouteReconciler.Reconcile(loop, places[seeded.PlaceIds[0]], places[seeded.PlaceIds[0]],
+            [new(places[seeded.PlaceIds[1]], 0, null)], null).Succeeded);
+
+        await context.SaveChangesAsync();
+        Assert.Equal(4, await context.SegmentWaypoints.CountAsync(item => item.SegmentId == fallback.Id || item.SegmentId == custom.Id || item.SegmentId == loop.Id));
+        Assert.Equal([1, 3], await context.SegmentWaypoints.Where(item => item.SegmentId == custom.Id).OrderBy(item => item.Position).Select(item => item.RouteVertexIndex!.Value).ToListAsync());
+    }
+
+    /// <summary>Proves rejection inside a real transaction leaves the stored and tracked aggregate unchanged.</summary>
+    [PostgresFact]
+    public async Task InvalidReconciliation_DoesNotPartiallyPersistOrMutateTrackedAggregate()
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedAggregateAsync();
+        await using var context = _fixture.CreateContext();
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        var segment = await context.Segments
+            .Include(item => item.FromPlace).ThenInclude(place => place!.Region)
+            .Include(item => item.ToPlace).ThenInclude(place => place!.Region)
+            .Include(item => item.Waypoints).ThenInclude(waypoint => waypoint.Place).ThenInclude(place => place.Region)
+            .SingleAsync(item => item.Id == aggregate.SegmentId);
+        var originalWaypointId = Assert.Single(segment.Waypoints).PlaceId;
+        var foreignTripPlace = await context.Places.Include(place => place.Region).SingleAsync(place => place.Id == aggregate.ForeignPlaceId);
+
+        var result = SegmentRouteReconciler.Reconcile(segment, segment.FromPlace, segment.ToPlace, [new(foreignTripPlace, 0, null)], null);
+        await context.SaveChangesAsync();
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(originalWaypointId, Assert.Single(segment.Waypoints).PlaceId);
+        await transaction.CommitAsync();
+        await using var verification = _fixture.CreateContext();
+        Assert.Equal(originalWaypointId, await verification.SegmentWaypoints.Where(item => item.SegmentId == segment.Id).Select(item => item.PlaceId).SingleAsync());
+    }
+
+    private async Task<(Guid SegmentId, Guid FirstPlaceId, Guid SecondPlaceId, Guid ForeignPlaceId)> SeedAggregateAsync()
+    {
+        var seeded = await SeedPlacesAsync(includeForeignTrip: true);
+        await using var context = _fixture.CreateContext();
+        var places = await context.Places.Include(place => place.Region).Where(place => seeded.PlaceIds.Contains(place.Id)).ToDictionaryAsync(place => place.Id);
+        var segment = NewSegment(seeded, 1);
+        context.Segments.Add(segment);
+        Assert.True(SegmentRouteReconciler.Reconcile(segment, places[seeded.PlaceIds[0]], places[seeded.PlaceIds[2]], [new(places[seeded.PlaceIds[1]], 0, 2)],
+            Line((1, 1), (1.5, 1.5), (2, 2), (3, 3))).Succeeded);
+        await context.SaveChangesAsync();
+        return (segment.Id, seeded.PlaceIds[1], seeded.PlaceIds[3], seeded.ForeignPlaceId!.Value);
+    }
+
+    private async Task<(Guid TripId, string UserId, Guid[] PlaceIds, Guid? ForeignPlaceId)> SeedPlacesAsync(bool includeForeignTrip = false)
+    {
+        var user = await _fixture.CreateUserAsync();
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = user.Id, Name = "Waypoint provider fixture" };
+        var region = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = user.Id, Name = "Route" };
+        var places = Enumerable.Range(1, 4).Select(index => new Place
+        {
+            Id = Guid.NewGuid(), Region = region, RegionId = region.Id, UserId = user.Id, Name = $"Place {index}", Location = new Point(index, index) { SRID = 4326 }
+        }).ToArray();
+        trip.Regions.Add(region);
+        foreach (var place in places) region.Places.Add(place);
+        _fixture.RegisterTrip(trip.Id);
+        await using var context = _fixture.CreateContext();
+        context.Trips.Add(trip);
+        Guid? foreignPlaceId = null;
+        if (includeForeignTrip)
+        {
+            var foreignTrip = new Trip { Id = Guid.NewGuid(), UserId = user.Id, Name = "Foreign trip" };
+            var foreignRegion = new Region { Id = Guid.NewGuid(), Trip = foreignTrip, TripId = foreignTrip.Id, UserId = user.Id, Name = "Foreign" };
+            var foreign = new Place { Id = Guid.NewGuid(), Region = foreignRegion, RegionId = foreignRegion.Id, UserId = user.Id, Name = "Foreign", Location = new Point(9, 9) { SRID = 4326 } };
+            foreignTrip.Regions.Add(foreignRegion);
+            foreignRegion.Places.Add(foreign);
+            context.Trips.Add(foreignTrip);
+            _fixture.RegisterTrip(foreignTrip.Id);
+            foreignPlaceId = foreign.Id;
+        }
+        await context.SaveChangesAsync();
+        return (trip.Id, user.Id, places.Select(place => place.Id).ToArray(), foreignPlaceId);
+    }
+
+    private static Segment NewSegment((Guid TripId, string UserId, Guid[] PlaceIds, Guid? ForeignPlaceId) seeded, int order) =>
+        new() { Id = Guid.NewGuid(), TripId = seeded.TripId, UserId = seeded.UserId, Mode = "walk", DisplayOrder = order };
+
+    private static LineString Line(params (double X, double Y)[] points) =>
+        new(points.Select(point => new Coordinate(point.X, point.Y)).ToArray()) { SRID = 4326 };
+
+    private static async Task AssertInsertFailsAsync(ApplicationDbContext context, Guid segmentId, Guid placeId, int position, int? routeVertexIndex)
+    {
+        await Assert.ThrowsAsync<PostgresException>(() => context.Database.ExecuteSqlInterpolatedAsync(
+            $"""INSERT INTO public."SegmentWaypoints" ("SegmentId", "PlaceId", "Position", "RouteVertexIndex") VALUES ({segmentId}, {placeId}, {position}, {routeVertexIndex})"""));
+    }
+
+    private static async Task<bool> TableExistsAsync(ApplicationDbContext context, string table)
+    {
+        await using var command = context.Database.GetDbConnection().CreateCommand();
+        command.Transaction = context.Database.CurrentTransaction!.GetDbTransaction();
+        command.CommandText = "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = @table)";
+        command.Parameters.Add(new NpgsqlParameter("table", table));
+        return (bool)(await command.ExecuteScalarAsync())!;
+    }
+}

--- a/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
+++ b/tests/Wayfarer.Tests/Models/SegmentWaypointPostgresTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Npgsql;
 using NetTopologySuite.Geometries;
 using Wayfarer.Models;
@@ -98,14 +99,15 @@ public sealed class SegmentWaypointPostgresTests
         var custom = NewSegment(seeded, 2);
         var loop = NewSegment(seeded, 3);
         context.Segments.AddRange(fallback, custom, loop);
-        Assert.True(SegmentRouteReconciler.Reconcile(fallback, places[seeded.PlaceIds[0]], places[seeded.PlaceIds[2]], [new(places[seeded.PlaceIds[1]], 0, null)], null).Succeeded);
-        Assert.True(SegmentRouteReconciler.Reconcile(custom, places[seeded.PlaceIds[0]], places[seeded.PlaceIds[3]],
-            [new(places[seeded.PlaceIds[1]], 0, 1), new(places[seeded.PlaceIds[2]], 1, 3)],
-            Line((1, 1), (2, 2), (2.5, 2.5), (3, 3), (4, 4))).Succeeded);
-        Assert.True(SegmentRouteReconciler.Reconcile(loop, places[seeded.PlaceIds[0]], places[seeded.PlaceIds[0]],
-            [new(places[seeded.PlaceIds[1]], 0, null)], null).Succeeded);
-
         await context.SaveChangesAsync();
+        Assert.True((await SegmentRouteReconciler.ReconcileAsync(context,
+            new(fallback.Id, seeded.PlaceIds[0], seeded.PlaceIds[2], [new(seeded.PlaceIds[1], 0, null)], null))).Succeeded);
+        Assert.True((await SegmentRouteReconciler.ReconcileAsync(context,
+            new(custom.Id, seeded.PlaceIds[0], seeded.PlaceIds[3],
+                [new(seeded.PlaceIds[1], 0, 1), new(seeded.PlaceIds[2], 1, 3)],
+                Line((1, 1), (2, 2), (2.5, 2.5), (3, 3), (4, 4))))).Succeeded);
+        Assert.True((await SegmentRouteReconciler.ReconcileAsync(context,
+            new(loop.Id, seeded.PlaceIds[0], seeded.PlaceIds[0], [new(seeded.PlaceIds[1], 0, null)], null))).Succeeded);
         Assert.Equal(4, await context.Set<SegmentWaypoint>().CountAsync(item => item.SegmentId == fallback.Id || item.SegmentId == custom.Id || item.SegmentId == loop.Id));
         Assert.Equal([1, 3], await context.Set<SegmentWaypoint>().Where(item => item.SegmentId == custom.Id).OrderBy(item => item.Position).Select(item => item.RouteVertexIndex!.Value).ToListAsync());
     }
@@ -117,21 +119,17 @@ public sealed class SegmentWaypointPostgresTests
         _fixture.RequireAvailable();
         var aggregate = await SeedAggregateAsync();
         await using var context = _fixture.CreateContext();
-        await using var transaction = await context.Database.BeginTransactionAsync();
         var segment = await context.Segments
             .Include(item => item.FromPlace).ThenInclude(place => place!.Region)
             .Include(item => item.ToPlace).ThenInclude(place => place!.Region)
             .Include(item => item.Waypoints).ThenInclude(waypoint => waypoint.Place).ThenInclude(place => place.Region)
             .SingleAsync(item => item.Id == aggregate.SegmentId);
         var originalWaypointId = Assert.Single(segment.Waypoints).PlaceId;
-        var foreignTripPlace = await context.Places.Include(place => place.Region).SingleAsync(place => place.Id == aggregate.ForeignPlaceId);
-
-        var result = SegmentRouteReconciler.Reconcile(segment, segment.FromPlace, segment.ToPlace, [new(foreignTripPlace, 0, null)], null);
-        await context.SaveChangesAsync();
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(segment.Id, segment.FromPlaceId, segment.ToPlaceId, [new(aggregate.ForeignPlaceId, 0, null)], null));
 
         Assert.False(result.Succeeded);
         Assert.Equal(originalWaypointId, Assert.Single(segment.Waypoints).PlaceId);
-        await transaction.CommitAsync();
         await using var verification = _fixture.CreateContext();
         Assert.Equal(originalWaypointId, await verification.Set<SegmentWaypoint>().Where(item => item.SegmentId == segment.Id).Select(item => item.PlaceId).SingleAsync());
     }
@@ -144,19 +142,17 @@ public sealed class SegmentWaypointPostgresTests
         var aggregate = await SeedAggregateAsync();
         await using var context = _fixture.CreateContext();
         var segment = await SegmentRouteReconciler.LoadAggregateAsync(context, aggregate.SegmentId);
-        var replacement = await context.Places.Include(place => place.Region).SingleAsync(place => place.Id == aggregate.SecondPlaceId);
-
         Assert.NotNull(segment);
         Assert.NotNull(segment!.FromPlace?.Region);
         Assert.NotNull(segment.ToPlace?.Region);
         Assert.NotNull(Assert.Single(segment.Waypoints).Place.Region);
-        var result = SegmentRouteReconciler.Reconcile(segment, segment.FromPlace, segment.ToPlace, [new(replacement, 0, null)], null);
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(segment.Id, segment.FromPlaceId, segment.ToPlaceId, [new(aggregate.SecondPlaceId, 0, null)], null));
 
         Assert.True(result.Succeeded);
-        await context.SaveChangesAsync();
         await using var verification = _fixture.CreateContext();
         var stored = await verification.Set<SegmentWaypoint>().SingleAsync(item => item.SegmentId == segment.Id);
-        Assert.Equal(replacement.Id, stored.PlaceId);
+        Assert.Equal(aggregate.SecondPlaceId, stored.PlaceId);
         Assert.Null(stored.RouteVertexIndex);
         Assert.Null(await verification.Segments.Where(item => item.Id == segment.Id).Select(item => item.RouteGeometry).SingleAsync());
     }
@@ -174,9 +170,10 @@ public sealed class SegmentWaypointPostgresTests
                 .Where(place => seeded.PlaceIds.Contains(place.Id))
                 .ToDictionaryAsync(place => place.Id);
             seedContext.Segments.Add(segment);
-            Assert.True(SegmentRouteReconciler.Reconcile(segment, places[seeded.PlaceIds[0]], places[seeded.PlaceIds[3]],
-                [new(places[seeded.PlaceIds[1]], 0, null), new(places[seeded.PlaceIds[2]], 1, null)], null).Succeeded);
             await seedContext.SaveChangesAsync();
+            Assert.True((await SegmentRouteReconciler.ReconcileAsync(seedContext,
+                new(segment.Id, seeded.PlaceIds[0], seeded.PlaceIds[3],
+                    [new(seeded.PlaceIds[1], 0, null), new(seeded.PlaceIds[2], 1, null)], null))).Succeeded);
         }
 
         await using var context = _fixture.CreateContext();
@@ -184,15 +181,127 @@ public sealed class SegmentWaypointPostgresTests
         Assert.NotNull(aggregate);
         var original = aggregate!.Waypoints.OrderBy(item => item.Position).ToArray();
 
-        var result = SegmentRouteReconciler.Reconcile(aggregate, aggregate.FromPlace, aggregate.ToPlace,
-            [new(original[1].Place, 0, null), new(original[0].Place, 1, null)], null);
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(aggregate.Id, aggregate.FromPlaceId, aggregate.ToPlaceId,
+                [new(original[1].PlaceId, 0, null), new(original[0].PlaceId, 1, null)], null));
 
         Assert.True(result.Succeeded);
-        await context.SaveChangesAsync();
         await using var verification = _fixture.CreateContext();
         Assert.Equal([original[1].PlaceId, original[0].PlaceId],
             await verification.Set<SegmentWaypoint>().Where(item => item.SegmentId == segment.Id)
                 .OrderBy(item => item.Position).Select(item => item.PlaceId).ToListAsync());
+    }
+
+    /// <summary>Arbitrary persisted reorder shapes replace the complete association set atomically.</summary>
+    [PostgresTheory]
+    [InlineData(3, 2, 1, 0)]
+    [InlineData(1, 2, 3, 0)]
+    public async Task Reconcile_PersistedMultiWaypointReorder_CommitsContiguousOrder(params int[] order)
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedOrderedAggregateAsync();
+        await using var context = _fixture.CreateContext();
+        var proposal = order.Select((sourceIndex, position) =>
+            new SegmentWaypointProposal(aggregate.WaypointIds[sourceIndex], position, null)).ToArray();
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(aggregate.SegmentId, aggregate.FromPlaceId, aggregate.ToPlaceId, proposal, null));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(order.Select(index => aggregate.WaypointIds[index]),
+            await context.Set<SegmentWaypoint>().Where(item => item.SegmentId == aggregate.SegmentId)
+                .OrderBy(item => item.Position).Select(item => item.PlaceId).ToListAsync());
+    }
+
+    /// <summary>Add, remove, and reorder are committed as one complete PostgreSQL association replacement.</summary>
+    [PostgresFact]
+    public async Task Reconcile_AddRemoveAndReorder_CommitsOneFinalSet()
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedOrderedAggregateAsync();
+        await using var context = _fixture.CreateContext();
+        var expected = new[] { aggregate.WaypointIds[2], aggregate.AdditionalPlaceId, aggregate.WaypointIds[0] };
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(aggregate.SegmentId, aggregate.FromPlaceId, aggregate.ToPlaceId,
+                expected.Select((id, position) => new SegmentWaypointProposal(id, position, null)).ToArray(), null));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(expected, await context.Set<SegmentWaypoint>().Where(item => item.SegmentId == aggregate.SegmentId)
+            .OrderBy(item => item.Position).Select(item => item.PlaceId).ToArrayAsync());
+    }
+
+    /// <summary>A provider failure after deletion rolls back storage and selectively reloads usable tracked state.</summary>
+    [PostgresFact]
+    public async Task Reconcile_ProviderFailure_RollsBackAndRestoresTrackedAggregate()
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedOrderedAggregateAsync();
+        var interceptor = new FailNextSaveInterceptor();
+        await using var context = _fixture.CreateContext(interceptor);
+        var segment = await SegmentRouteReconciler.LoadAggregateAsync(context, aggregate.SegmentId);
+        var unrelated = await context.Places.SingleAsync(item => item.Id == aggregate.AdditionalPlaceId);
+        var original = segment!.Waypoints.OrderBy(item => item.Position).Select(item => item.PlaceId).ToArray();
+        interceptor.Arm();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => SegmentRouteReconciler.ReconcileAsync(context,
+            new(segment.Id, segment.FromPlaceId, segment.ToPlaceId,
+                original.Reverse().Select((id, position) => new SegmentWaypointProposal(id, position, null)).ToArray(), null)));
+
+        Assert.Equal(original, segment.Waypoints.OrderBy(item => item.Position).Select(item => item.PlaceId));
+        Assert.Equal(EntityState.Unchanged, context.Entry(segment).State);
+        Assert.Equal(EntityState.Unchanged, context.Entry(unrelated).State);
+        Assert.DoesNotContain(context.ChangeTracker.Entries(), entry =>
+            entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted);
+        await context.SaveChangesAsync();
+        await using var verification = _fixture.CreateContext();
+        Assert.Equal(original, await verification.Set<SegmentWaypoint>().Where(item => item.SegmentId == segment.Id)
+            .OrderBy(item => item.Position).Select(item => item.PlaceId).ToArrayAsync());
+    }
+
+    /// <summary>PostgreSQL persistence retains the validated geometry copy after caller mutation.</summary>
+    [PostgresFact]
+    public async Task Reconcile_DefensiveGeometryCopy_PersistsCanonicalCoordinates()
+    {
+        _fixture.RequireAvailable();
+        var seeded = await SeedPlacesAsync();
+        var segment = NewSegment(seeded, 7);
+        await using var context = _fixture.CreateContext();
+        context.Segments.Add(segment);
+        await context.SaveChangesAsync();
+        var geometry = Line((1, 1), (2, 2), (3, 3));
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(segment.Id, seeded.PlaceIds[0], seeded.PlaceIds[2], [new(seeded.PlaceIds[1], 0, 1)], geometry));
+        geometry.GetCoordinateN(1).X = 99;
+        geometry.SRID = 3857;
+
+        Assert.True(result.Succeeded);
+        Assert.NotSame(geometry, segment.RouteGeometry);
+        await using var verification = _fixture.CreateContext();
+        var stored = await verification.Segments.Where(item => item.Id == segment.Id).Select(item => item.RouteGeometry).SingleAsync();
+        Assert.Equal(2, stored!.GetCoordinateN(1).X);
+        Assert.Equal(4326, stored.SRID);
+    }
+
+    /// <summary>Canonical provider loading distinguishes missing and cross-trip proposal identities.</summary>
+    [PostgresFact]
+    public async Task Reconcile_CanonicalIdentityFailures_AreDeterministicAndAtomic()
+    {
+        _fixture.RequireAvailable();
+        var aggregate = await SeedAggregateAsync();
+        await using var context = _fixture.CreateContext();
+        var missing = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(aggregate.SegmentId, Guid.NewGuid(), aggregate.SecondPlaceId, [new(Guid.NewGuid(), 0, null)], null));
+        var crossTrip = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(aggregate.SegmentId, aggregate.FirstPlaceId, aggregate.SecondPlaceId,
+                [new(aggregate.ForeignPlaceId, 0, null)], null));
+
+        Assert.Contains("From place was not found.", missing.Errors);
+        Assert.Contains("Waypoint place at position 0 was not found.", missing.Errors);
+        Assert.Contains("Every waypoint place must belong to the segment trip.", crossTrip.Errors);
+        Assert.DoesNotContain(context.ChangeTracker.Entries(), entry =>
+            entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted);
     }
 
     private async Task<(Guid SegmentId, Guid FirstPlaceId, Guid SecondPlaceId, Guid ForeignPlaceId)> SeedAggregateAsync()
@@ -202,10 +311,26 @@ public sealed class SegmentWaypointPostgresTests
         var places = await context.Places.Include(place => place.Region).Where(place => seeded.PlaceIds.Contains(place.Id)).ToDictionaryAsync(place => place.Id);
         var segment = NewSegment(seeded, 1);
         context.Segments.Add(segment);
-        Assert.True(SegmentRouteReconciler.Reconcile(segment, places[seeded.PlaceIds[0]], places[seeded.PlaceIds[2]], [new(places[seeded.PlaceIds[1]], 0, 2)],
-            Line((1, 1), (1.5, 1.5), (2, 2), (3, 3))).Succeeded);
         await context.SaveChangesAsync();
+        Assert.True((await SegmentRouteReconciler.ReconcileAsync(context,
+            new(segment.Id, seeded.PlaceIds[0], seeded.PlaceIds[2], [new(seeded.PlaceIds[1], 0, 2)],
+                Line((1, 1), (1.5, 1.5), (2, 2), (3, 3))))).Succeeded);
         return (segment.Id, seeded.PlaceIds[1], seeded.PlaceIds[3], seeded.ForeignPlaceId!.Value);
+    }
+
+    private async Task<(Guid SegmentId, Guid FromPlaceId, Guid ToPlaceId, Guid[] WaypointIds, Guid AdditionalPlaceId)> SeedOrderedAggregateAsync()
+    {
+        var seeded = await SeedPlacesAsync();
+        var segment = NewSegment(seeded, 8);
+        await using var context = _fixture.CreateContext();
+        context.Segments.Add(segment);
+        await context.SaveChangesAsync();
+        var waypointIds = seeded.PlaceIds[1..5];
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(segment.Id, seeded.PlaceIds[0], seeded.PlaceIds[5],
+                waypointIds.Select((id, position) => new SegmentWaypointProposal(id, position, null)).ToArray(), null));
+        Assert.True(result.Succeeded);
+        return (segment.Id, seeded.PlaceIds[0], seeded.PlaceIds[5], waypointIds, seeded.PlaceIds[6]);
     }
 
     private async Task<(Guid TripId, string UserId, Guid[] PlaceIds, Guid? ForeignPlaceId)> SeedPlacesAsync(bool includeForeignTrip = false)
@@ -213,7 +338,7 @@ public sealed class SegmentWaypointPostgresTests
         var user = await _fixture.CreateUserAsync();
         var trip = new Trip { Id = Guid.NewGuid(), UserId = user.Id, Name = "Waypoint provider fixture" };
         var region = new Region { Id = Guid.NewGuid(), Trip = trip, TripId = trip.Id, UserId = user.Id, Name = "Route" };
-        var places = Enumerable.Range(1, 4).Select(index => new Place
+        var places = Enumerable.Range(1, 7).Select(index => new Place
         {
             Id = Guid.NewGuid(), Region = region, RegionId = region.Id, UserId = user.Id, Name = $"Place {index}", Location = new Point(index, index) { SRID = 4326 }
         }).ToArray();
@@ -257,5 +382,24 @@ public sealed class SegmentWaypointPostgresTests
         command.CommandText = "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = @table)";
         command.Parameters.Add(new NpgsqlParameter("table", table));
         return (bool)(await command.ExecuteScalarAsync())!;
+    }
+
+    private sealed class FailNextSaveInterceptor : SaveChangesInterceptor
+    {
+        private bool _armed;
+
+        /// <summary>Arms one deterministic persistence failure after provider-side waypoint deletion.</summary>
+        internal void Arm() => _armed = true;
+
+        /// <summary>Throws once at the SaveChanges seam used to insert the final association set.</summary>
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_armed) return base.SavingChangesAsync(eventData, result, cancellationToken);
+            _armed = false;
+            throw new InvalidOperationException("Forced waypoint persistence failure.");
+        }
     }
 }

--- a/tests/Wayfarer.Tests/Services/SegmentRouteReconcilerTests.cs
+++ b/tests/Wayfarer.Tests/Services/SegmentRouteReconcilerTests.cs
@@ -166,6 +166,46 @@ public sealed class SegmentRouteReconcilerTests
         Assert.True(result.Succeeded);
     }
 
+    /// <summary>Caller-created place graphs cannot establish authoritative trip ownership.</summary>
+    [Fact]
+    public void Reconcile_FabricatedPlaceOwnership_IsRejected()
+    {
+        var tripId = Guid.NewGuid();
+        var from = Place(tripId, 1, 1);
+        var to = Place(tripId, 3, 3);
+        var fabricated = Place(tripId, 2, 2);
+
+        var result = SegmentRouteReconciler.Reconcile(
+            Segment(tripId),
+            from,
+            to,
+            [new(fabricated, 0, null)],
+            null);
+
+        Assert.False(result.Succeeded);
+    }
+
+    /// <summary>The accepted custom route must not retain caller-owned mutable geometry state.</summary>
+    [Fact]
+    public void Reconcile_CustomGeometryMutation_DoesNotChangeAcceptedRoute()
+    {
+        var tripId = Guid.NewGuid();
+        var from = Place(tripId, 1, 1);
+        var via = Place(tripId, 2, 2);
+        var to = Place(tripId, 3, 3);
+        var geometry = Line(Coordinate(1, 1), Coordinate(2, 2), Coordinate(3, 3));
+        var segment = Segment(tripId);
+
+        var result = SegmentRouteReconciler.Reconcile(segment, from, to, [new(via, 0, 1)], geometry);
+        geometry.GetCoordinateN(1).X = 99;
+        geometry.SRID = 3857;
+
+        Assert.True(result.Succeeded);
+        Assert.NotSame(geometry, segment.RouteGeometry);
+        Assert.Equal(2, segment.RouteGeometry!.GetCoordinateN(1).X);
+        Assert.Equal(4326, segment.RouteGeometry.SRID);
+    }
+
     private static Segment Segment(Guid? tripId = null) => new() { Id = Guid.NewGuid(), TripId = tripId ?? Guid.NewGuid(), UserId = "owner" };
 
     private static Place Place(Guid tripId, double? longitude, double? latitude, int srid = 4326) => new()

--- a/tests/Wayfarer.Tests/Services/SegmentRouteReconcilerTests.cs
+++ b/tests/Wayfarer.Tests/Services/SegmentRouteReconcilerTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using NetTopologySuite.Geometries;
 using Wayfarer.Models;
 using Wayfarer.Services;
@@ -5,229 +7,237 @@ using Xunit;
 
 namespace Wayfarer.Tests.Services;
 
-/// <summary>Verifies the server-authoritative segment route aggregate invariants.</summary>
+/// <summary>Verifies canonical loading, validation, and defensive route ownership.</summary>
 public sealed class SegmentRouteReconcilerTests
 {
-    /// <summary>Legacy zero-waypoint segments retain optional endpoints and geometry.</summary>
+    /// <summary>Legacy zero-waypoint segments retain optional endpoints and receive a defensive geometry copy.</summary>
     [Fact]
-    public void Reconcile_ZeroWaypoints_PreservesLegacyCompatibility()
+    public async Task ReconcileAsync_ZeroWaypoints_PreservesLegacyCompatibility()
     {
-        var segment = Segment();
-        var geometry = Line(Coordinate(1, 1), Coordinate(2, 2));
+        await using var context = CreateContext();
+        var seeded = await SeedAsync(context);
+        var geometry = Line((1, 1), (2, 2));
 
-        var result = SegmentRouteReconciler.Reconcile(segment, null, null, [], geometry);
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(seeded.SegmentId, null, null, [], geometry));
 
         Assert.True(result.Succeeded);
+        var segment = await context.Segments.SingleAsync(item => item.Id == seeded.SegmentId);
         Assert.Null(segment.FromPlaceId);
         Assert.Null(segment.ToPlaceId);
-        Assert.Same(geometry, segment.RouteGeometry);
+        Assert.NotSame(geometry, segment.RouteGeometry);
         Assert.Empty(segment.Waypoints);
     }
 
-    /// <summary>A valid fallback proposal retains null geometry and produces its deterministic anchor chain.</summary>
+    /// <summary>A valid fallback proposal commits canonical endpoints and deterministic waypoint order.</summary>
     [Fact]
-    public void Reconcile_ValidFallback_ProducesOrderedAnchorChain()
+    public async Task ReconcileAsync_ValidFallback_UsesCanonicalAnchorChain()
     {
-        var tripId = Guid.NewGuid();
-        var from = Place(tripId, 1, 1);
-        var via = Place(tripId, 2, 2);
-        var to = Place(tripId, 3, 3);
-        var segment = Segment(tripId);
+        await using var context = CreateContext();
+        var seeded = await SeedAsync(context);
 
-        var result = SegmentRouteReconciler.Reconcile(segment, from, to, [new(via, 0, null)], null);
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            Proposal(seeded, [new(seeded.PlaceIds[1], 0, null)], null));
 
         Assert.True(result.Succeeded);
-        Assert.Null(segment.RouteGeometry);
-        Assert.Collection(segment.Waypoints, waypoint =>
-        {
-            Assert.Equal(via.Id, waypoint.PlaceId);
-            Assert.Equal(0, waypoint.Position);
-            Assert.Null(waypoint.RouteVertexIndex);
-        });
-        Assert.Equal([from.Location!.Coordinate, via.Location!.Coordinate, to.Location!.Coordinate],
-            result.EffectiveAnchorChain.Select(place => place.Location!.Coordinate), CoordinateComparer.Instance);
+        Assert.Equal(seeded.PlaceIds, result.EffectiveAnchorChain.Select(item => item.Id));
+        var waypoint = await context.Set<SegmentWaypoint>().SingleAsync();
+        Assert.Equal(seeded.PlaceIds[1], waypoint.PlaceId);
+        Assert.Equal(0, waypoint.Position);
+        Assert.Null(waypoint.RouteVertexIndex);
     }
 
-    /// <summary>A closed loop reuses one canonical endpoint place without duplicating it.</summary>
+    /// <summary>Canonical endpoint identity may be reused for an approved closed loop.</summary>
     [Fact]
-    public void Reconcile_ValidClosedLoop_UsesCanonicalEndpointPlace()
+    public async Task ReconcileAsync_ClosedLoop_UsesOneCanonicalEndpoint()
     {
-        var tripId = Guid.NewGuid();
-        var endpoint = Place(tripId, 1, 1);
-        var via = Place(tripId, 2, 2);
-        var segment = Segment(tripId);
+        await using var context = CreateContext();
+        var seeded = await SeedAsync(context);
 
-        var result = SegmentRouteReconciler.Reconcile(segment, endpoint, endpoint, [new(via, 0, null)], null);
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(seeded.SegmentId, seeded.PlaceIds[0], seeded.PlaceIds[0],
+                [new(seeded.PlaceIds[1], 0, null)], null));
 
         Assert.True(result.Succeeded);
-        Assert.Equal(endpoint.Id, segment.FromPlaceId);
-        Assert.Equal(endpoint.Id, segment.ToPlaceId);
-        Assert.Equal(endpoint.Id, result.EffectiveAnchorChain[0].Id);
-        Assert.Equal(endpoint.Id, result.EffectiveAnchorChain[^1].Id);
+        Assert.Equal(seeded.PlaceIds[0], result.EffectiveAnchorChain[0].Id);
+        Assert.Equal(seeded.PlaceIds[0], result.EffectiveAnchorChain[^1].Id);
     }
 
-    /// <summary>A zero-waypoint fallback loop retains two route positions with one saved-place identity.</summary>
+    /// <summary>Custom geometry is validated and stored as the same defensive copy.</summary>
     [Fact]
-    public void Reconcile_ZeroWaypointClosedLoop_ProducesZeroDistanceFallback()
+    public async Task ReconcileAsync_CustomGeometry_StoresValidatedDefensiveCopy()
     {
-        var tripId = Guid.NewGuid();
-        var endpoint = Place(tripId, 1, 1);
+        await using var context = CreateContext();
+        var seeded = await SeedAsync(context);
+        var geometry = Line((1, 1), (2, 2), (3, 3));
 
-        var result = SegmentRouteReconciler.Reconcile(Segment(tripId), endpoint, endpoint, [], null);
-
-        Assert.True(result.Succeeded);
-        Assert.Equal(2, result.EffectiveAnchorChain.Count);
-        Assert.Same(result.EffectiveAnchorChain[0], result.EffectiveAnchorChain[1]);
-        Assert.True(result.EffectiveAnchorChain[0].Location!.Coordinate.Equals2D(result.EffectiveAnchorChain[1].Location!.Coordinate));
-    }
-
-    /// <summary>A custom route accepts complete ordered interior anchor mappings.</summary>
-    [Fact]
-    public void Reconcile_ValidCustomGeometry_AcceptsOrderedWaypointIndices()
-    {
-        var tripId = Guid.NewGuid();
-        var from = Place(tripId, 1, 1);
-        var first = Place(tripId, 2, 2);
-        var second = Place(tripId, 4, 4);
-        var to = Place(tripId, 5, 5);
-        var geometry = Line(Coordinate(1, 1), Coordinate(1.5, 1.5), Coordinate(2, 2), Coordinate(3, 3), Coordinate(4, 4), Coordinate(5, 5));
-        var segment = Segment(tripId);
-
-        var result = SegmentRouteReconciler.Reconcile(segment, from, to, [new(first, 0, 2), new(second, 1, 4)], geometry);
-
-        Assert.True(result.Succeeded);
-        Assert.Same(geometry, segment.RouteGeometry);
-        Assert.Equal([2, 4], segment.Waypoints.Select(waypoint => waypoint.RouteVertexIndex));
-    }
-
-    /// <summary>Representative invalid proposals reject without changing tracked aggregate state.</summary>
-    [Theory]
-    [MemberData(nameof(InvalidProposals))]
-    public void Reconcile_InvalidProposal_LeavesAggregateUnchanged(
-        Func<Guid, Place, Place, Place, (Place?, Place?, SegmentWaypointProposal[], LineString?)> proposal)
-    {
-        var tripId = Guid.NewGuid();
-        var originalFrom = Place(tripId, 10, 10);
-        var originalTo = Place(tripId, 11, 11);
-        var candidate = Place(tripId, 2, 2);
-        var segment = Segment(tripId);
-        segment.FromPlaceId = originalFrom.Id;
-        segment.FromPlace = originalFrom;
-        segment.ToPlaceId = originalTo.Id;
-        segment.ToPlace = originalTo;
-        segment.Waypoints.Add(new SegmentWaypoint { SegmentId = segment.Id, PlaceId = candidate.Id, Place = candidate, Position = 0 });
-        var before = Snapshot(segment);
-        var proposed = proposal(tripId, originalFrom, originalTo, candidate);
-
-        var result = SegmentRouteReconciler.Reconcile(segment, proposed.Item1, proposed.Item2, proposed.Item3, proposed.Item4);
-
-        Assert.False(result.Succeeded);
-        Assert.NotEmpty(result.Errors);
-        Assert.Equal(before, Snapshot(segment));
-    }
-
-    /// <summary>Enumerates ownership, ordering, endpoint, location, and geometry rejection cases.</summary>
-    public static TheoryData<Func<Guid, Place, Place, Place, (Place?, Place?, SegmentWaypointProposal[], LineString?)>> InvalidProposals => new()
-    {
-        (tripId, from, to, via) => (from, to, [new(Place(Guid.NewGuid(), 2, 2), 0, null)], null),
-        (tripId, from, to, via) => (from, to, [new(via, 0, null), new(via, 1, null)], null),
-        (tripId, from, to, via) => (from, to, [new(from, 0, null)], null),
-        (tripId, from, to, via) => (from, to, [new(to, 0, null)], null),
-        (tripId, from, to, via) => (null, to, [new(via, 0, null)], null),
-        (tripId, from, to, via) => (from, null, [new(via, 0, null)], null),
-        (tripId, from, to, via) => (Place(tripId, null, null), to, [new(via, 0, null)], null),
-        (tripId, from, to, via) => (from, Place(tripId, null, null), [new(via, 0, null)], null),
-        (tripId, from, to, via) => (from, to, [new(Place(tripId, null, null), 0, null)], null),
-        (tripId, from, to, via) => (from, to, [new(Place(tripId, 2, 2, 3857), 0, null)], null),
-        (tripId, from, to, via) => (from, to, [new(via, 1, null)], null),
-        (tripId, from, to, via) => (from, to, [new(via, 0, null), new(Place(tripId, 3, 3), 0, null)], null),
-        (tripId, from, to, via) => (from, to, [new(via, 0, null)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(11, 11))),
-        (tripId, from, to, via) => (from, to, [new(via, 0, 1)], null),
-        (tripId, from, to, via) => (from, to, [new(via, 0, 1), new(Place(tripId, 3, 3), 1, 1)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(3, 3), Coordinate(11, 11))),
-        (tripId, from, to, via) => (from, to, [new(via, 0, 2), new(Place(tripId, 3, 3), 1, 1)], Line(Coordinate(10, 10), Coordinate(3, 3), Coordinate(2, 2), Coordinate(11, 11))),
-        (tripId, from, to, via) => (from, to, [new(via, 0, 0)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(11, 11))),
-        (tripId, from, to, via) => (from, to, [new(via, 0, 2)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(11, 11))),
-        (tripId, from, to, via) => (from, to, [new(via, 0, 1)], Line(Coordinate(10, 10), Coordinate(2.000001, 2), Coordinate(11, 11))),
-        (tripId, from, to, via) => (from, from, [new(via, 0, 1)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(10.000001, 10)))
-    };
-
-    /// <summary>The inclusive tolerance boundary is accepted independently on both axes.</summary>
-    [Fact]
-    public void Reconcile_CoordinateAtToleranceBoundary_IsAccepted()
-    {
-        var tripId = Guid.NewGuid();
-        var from = Place(tripId, 1, 1);
-        var via = Place(tripId, 2, 2);
-        var to = Place(tripId, 3, 3);
-        var geometry = Line(Coordinate(1.0000001, 0.9999999), Coordinate(2.0000001, 1.9999999), Coordinate(3.0000001, 2.9999999));
-
-        var result = SegmentRouteReconciler.Reconcile(Segment(tripId), from, to, [new(via, 0, 1)], geometry);
-
-        Assert.True(result.Succeeded);
-    }
-
-    /// <summary>Caller-created place graphs cannot establish authoritative trip ownership.</summary>
-    [Fact]
-    public void Reconcile_FabricatedPlaceOwnership_IsRejected()
-    {
-        var tripId = Guid.NewGuid();
-        var from = Place(tripId, 1, 1);
-        var to = Place(tripId, 3, 3);
-        var fabricated = Place(tripId, 2, 2);
-
-        var result = SegmentRouteReconciler.Reconcile(
-            Segment(tripId),
-            from,
-            to,
-            [new(fabricated, 0, null)],
-            null);
-
-        Assert.False(result.Succeeded);
-    }
-
-    /// <summary>The accepted custom route must not retain caller-owned mutable geometry state.</summary>
-    [Fact]
-    public void Reconcile_CustomGeometryMutation_DoesNotChangeAcceptedRoute()
-    {
-        var tripId = Guid.NewGuid();
-        var from = Place(tripId, 1, 1);
-        var via = Place(tripId, 2, 2);
-        var to = Place(tripId, 3, 3);
-        var geometry = Line(Coordinate(1, 1), Coordinate(2, 2), Coordinate(3, 3));
-        var segment = Segment(tripId);
-
-        var result = SegmentRouteReconciler.Reconcile(segment, from, to, [new(via, 0, 1)], geometry);
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            Proposal(seeded, [new(seeded.PlaceIds[1], 0, 1)], geometry));
+        var segment = await context.Segments.SingleAsync(item => item.Id == seeded.SegmentId);
+        var storedCopy = segment.RouteGeometry;
         geometry.GetCoordinateN(1).X = 99;
         geometry.SRID = 3857;
 
         Assert.True(result.Succeeded);
-        Assert.NotSame(geometry, segment.RouteGeometry);
-        Assert.Equal(2, segment.RouteGeometry!.GetCoordinateN(1).X);
-        Assert.Equal(4326, segment.RouteGeometry.SRID);
+        Assert.NotSame(geometry, storedCopy);
+        Assert.Equal(2, storedCopy!.GetCoordinateN(1).X);
+        Assert.Equal(4326, storedCopy.SRID);
     }
 
-    private static Segment Segment(Guid? tripId = null) => new() { Id = Guid.NewGuid(), TripId = tripId ?? Guid.NewGuid(), UserId = "owner" };
-
-    private static Place Place(Guid tripId, double? longitude, double? latitude, int srid = 4326) => new()
+    /// <summary>Caller-created Place graphs cannot enter the identity-only proposal boundary.</summary>
+    [Fact]
+    public async Task ReconcileAsync_FabricatedDetachedPlace_CannotInfluenceCanonicalState()
     {
-        Id = Guid.NewGuid(),
-        Region = new Region { Id = Guid.NewGuid(), TripId = tripId, UserId = "owner" },
-        RegionId = Guid.NewGuid(),
-        UserId = "owner",
-        Location = longitude.HasValue ? new Point(longitude.Value, latitude!.Value) { SRID = srid } : null
-    };
+        await using var context = CreateContext();
+        var seeded = await SeedAsync(context);
+        var fabricated = new Place
+        {
+            Id = seeded.PlaceIds[1],
+            Region = new Region { TripId = seeded.TripId },
+            Location = new Point(99, 99) { SRID = 4326 }
+        };
 
-    private static Coordinate Coordinate(double x, double y) => new(x, y);
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            Proposal(seeded, [new(fabricated.Id, 0, 1)], Line((1, 1), (99, 99), (3, 3))));
 
-    private static LineString Line(params Coordinate[] coordinates) => new(coordinates) { SRID = 4326 };
-
-    private static string Snapshot(Segment segment) =>
-        $"{segment.FromPlaceId}|{segment.ToPlaceId}|{segment.RouteGeometry?.AsText()}|{string.Join(';', segment.Waypoints.Select(waypoint => $"{waypoint.PlaceId}:{waypoint.Position}:{waypoint.RouteVertexIndex}"))}";
-
-    private sealed class CoordinateComparer : IEqualityComparer<Coordinate>
-    {
-        internal static readonly CoordinateComparer Instance = new();
-        public bool Equals(Coordinate? left, Coordinate? right) => left?.Equals2D(right) == true;
-        public int GetHashCode(Coordinate coordinate) => HashCode.Combine(coordinate.X, coordinate.Y);
+        Assert.False(result.Succeeded);
+        Assert.DoesNotContain(context.ChangeTracker.Entries<Place>(), entry => ReferenceEquals(entry.Entity, fabricated));
+        Assert.Empty(await context.Set<SegmentWaypoint>().ToListAsync());
     }
+
+    /// <summary>Canonical coordinates, rather than stale caller assumptions, authorize a custom route.</summary>
+    [Fact]
+    public async Task ReconcileAsync_CanonicalLocation_IsUsedForValidation()
+    {
+        await using var context = CreateContext();
+        var seeded = await SeedAsync(context);
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            Proposal(seeded, [new(seeded.PlaceIds[1], 0, 1)], Line((1, 1), (2, 2), (3, 3))));
+
+        Assert.True(result.Succeeded);
+    }
+
+    /// <summary>Missing endpoint and waypoint identities produce deterministic distinct errors.</summary>
+    [Fact]
+    public async Task ReconcileAsync_MissingIdentities_AreDistinguished()
+    {
+        await using var context = CreateContext();
+        var seeded = await SeedAsync(context);
+        var missingEndpoint = Guid.NewGuid();
+        var missingWaypoint = Guid.NewGuid();
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(seeded.SegmentId, missingEndpoint, seeded.PlaceIds[2], [new(missingWaypoint, 0, null)], null));
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("From place was not found.", result.Errors);
+        Assert.Contains("Waypoint place at position 0 was not found.", result.Errors);
+    }
+
+    /// <summary>Canonical cross-trip endpoint and waypoint ownership failures are distinguished by label.</summary>
+    [Fact]
+    public async Task ReconcileAsync_CrossTripIdentities_AreRejected()
+    {
+        await using var context = CreateContext();
+        var seeded = await SeedAsync(context, includeForeign: true);
+
+        var endpoint = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(seeded.SegmentId, seeded.ForeignPlaceId, seeded.PlaceIds[2], [new(seeded.PlaceIds[1], 0, null)], null));
+        var waypoint = await SegmentRouteReconciler.ReconcileAsync(context,
+            new(seeded.SegmentId, seeded.PlaceIds[0], seeded.PlaceIds[2], [new(seeded.ForeignPlaceId!.Value, 0, null)], null));
+
+        Assert.Contains("From place must belong to the segment trip.", endpoint.Errors);
+        Assert.Contains("Every waypoint place must belong to the segment trip.", waypoint.Errors);
+    }
+
+    /// <summary>Representative malformed proposals leave tracked and persisted aggregate state unchanged.</summary>
+    [Theory]
+    [InlineData(1, false)]
+    [InlineData(0, true)]
+    public async Task ReconcileAsync_InvalidProposal_IsAtomic(int position, bool duplicateEndpoint)
+    {
+        await using var context = CreateContext();
+        var seeded = await SeedAsync(context);
+        var original = await SegmentRouteReconciler.ReconcileAsync(context,
+            Proposal(seeded, [new(seeded.PlaceIds[1], 0, null)], null));
+        Assert.True(original.Succeeded);
+        var before = await SnapshotAsync(context, seeded.SegmentId);
+        var waypointId = duplicateEndpoint ? seeded.PlaceIds[0] : seeded.PlaceIds[1];
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context,
+            Proposal(seeded, [new(waypointId, position, null)], null));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(before, await SnapshotAsync(context, seeded.SegmentId));
+        Assert.DoesNotContain(context.ChangeTracker.Entries(), entry =>
+            entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted);
+    }
+
+    /// <summary>The inclusive seven-decimal coordinate tolerance remains accepted.</summary>
+    [Fact]
+    public async Task ReconcileAsync_CoordinateAtToleranceBoundary_IsAccepted()
+    {
+        await using var context = CreateContext();
+        var seeded = await SeedAsync(context);
+
+        var result = await SegmentRouteReconciler.ReconcileAsync(context, Proposal(seeded,
+            [new(seeded.PlaceIds[1], 0, 1)],
+            Line((1.0000001, 0.9999999), (2.0000001, 1.9999999), (3.0000001, 2.9999999))));
+
+        Assert.True(result.Succeeded);
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var services = new ServiceCollection().AddEntityFrameworkInMemoryDatabase().BuildServiceProvider();
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new(options, services);
+    }
+
+    private static async Task<SeededAggregate> SeedAsync(ApplicationDbContext context, bool includeForeign = false)
+    {
+        var user = new ApplicationUser { Id = Guid.NewGuid().ToString(), UserName = Guid.NewGuid().ToString(), DisplayName = "owner" };
+        var trip = new Trip { Id = Guid.NewGuid(), UserId = user.Id, User = user, Name = "trip" };
+        var region = new Region { Id = Guid.NewGuid(), TripId = trip.Id, Trip = trip, UserId = user.Id, Name = "region" };
+        var places = Enumerable.Range(1, 3).Select(index => new Place
+        {
+            Id = Guid.NewGuid(), RegionId = region.Id, Region = region, UserId = user.Id,
+            Name = $"place {index}", Location = new Point(index, index) { SRID = 4326 }
+        }).ToArray();
+        var segment = new Segment { Id = Guid.NewGuid(), TripId = trip.Id, Trip = trip, UserId = user.Id, Mode = "walk" };
+        context.AddRange(user, trip, region, segment);
+        context.Places.AddRange(places);
+        Guid? foreignPlaceId = null;
+        if (includeForeign)
+        {
+            var foreignTrip = new Trip { Id = Guid.NewGuid(), UserId = user.Id, User = user, Name = "foreign" };
+            var foreignRegion = new Region { Id = Guid.NewGuid(), TripId = foreignTrip.Id, Trip = foreignTrip, UserId = user.Id, Name = "foreign" };
+            var foreign = new Place { Id = Guid.NewGuid(), RegionId = foreignRegion.Id, Region = foreignRegion, UserId = user.Id, Name = "foreign", Location = new Point(9, 9) { SRID = 4326 } };
+            context.AddRange(foreignTrip, foreignRegion, foreign);
+            foreignPlaceId = foreign.Id;
+        }
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+        return new(segment.Id, trip.Id, places.Select(item => item.Id).ToArray(), foreignPlaceId);
+    }
+
+    private static SegmentRouteProposal Proposal(
+        SeededAggregate seeded,
+        IReadOnlyList<SegmentWaypointProposal> waypoints,
+        LineString? geometry) =>
+        new(seeded.SegmentId, seeded.PlaceIds[0], seeded.PlaceIds[2], waypoints, geometry);
+
+    private static LineString Line(params (double X, double Y)[] points) =>
+        new(points.Select(point => new Coordinate(point.X, point.Y)).ToArray()) { SRID = 4326 };
+
+    private static async Task<string> SnapshotAsync(ApplicationDbContext context, Guid segmentId)
+    {
+        var segment = await SegmentRouteReconciler.LoadAggregateAsync(context, segmentId);
+        return $"{segment!.FromPlaceId}|{segment.ToPlaceId}|{segment.RouteGeometry?.AsText()}|{string.Join(';', segment.Waypoints.OrderBy(item => item.Position).Select(item => $"{item.PlaceId}:{item.Position}:{item.RouteVertexIndex}"))}";
+    }
+
+    private sealed record SeededAggregate(Guid SegmentId, Guid TripId, Guid[] PlaceIds, Guid? ForeignPlaceId);
 }

--- a/tests/Wayfarer.Tests/Services/SegmentRouteReconcilerTests.cs
+++ b/tests/Wayfarer.Tests/Services/SegmentRouteReconcilerTests.cs
@@ -45,7 +45,7 @@ public sealed class SegmentRouteReconcilerTests
             Assert.Null(waypoint.RouteVertexIndex);
         });
         Assert.Equal([from.Location!.Coordinate, via.Location!.Coordinate, to.Location!.Coordinate],
-            result.EffectiveAnchorChain.Select(point => point.Coordinate), CoordinateComparer.Instance);
+            result.EffectiveAnchorChain.Select(place => place.Location!.Coordinate), CoordinateComparer.Instance);
     }
 
     /// <summary>A closed loop reuses one canonical endpoint place without duplicating it.</summary>
@@ -89,7 +89,7 @@ public sealed class SegmentRouteReconcilerTests
     [Theory]
     [MemberData(nameof(InvalidProposals))]
     public void Reconcile_InvalidProposal_LeavesAggregateUnchanged(
-        Func<Guid, Place, Place, Place, (Place? From, Place? To, SegmentWaypointProposal[] Waypoints, LineString? Geometry)> proposal)
+        Func<Guid, Place, Place, Place, (Place?, Place?, SegmentWaypointProposal[], LineString?)> proposal)
     {
         var tripId = Guid.NewGuid();
         var originalFrom = Place(tripId, 10, 10);
@@ -104,7 +104,7 @@ public sealed class SegmentRouteReconcilerTests
         var before = Snapshot(segment);
         var proposed = proposal(tripId, originalFrom, originalTo, candidate);
 
-        var result = SegmentRouteReconciler.Reconcile(segment, proposed.From, proposed.To, proposed.Waypoints, proposed.Geometry);
+        var result = SegmentRouteReconciler.Reconcile(segment, proposed.Item1, proposed.Item2, proposed.Item3, proposed.Item4);
 
         Assert.False(result.Succeeded);
         Assert.NotEmpty(result.Errors);

--- a/tests/Wayfarer.Tests/Services/SegmentRouteReconcilerTests.cs
+++ b/tests/Wayfarer.Tests/Services/SegmentRouteReconcilerTests.cs
@@ -1,0 +1,175 @@
+using NetTopologySuite.Geometries;
+using Wayfarer.Models;
+using Wayfarer.Services;
+using Xunit;
+
+namespace Wayfarer.Tests.Services;
+
+/// <summary>Verifies the server-authoritative segment route aggregate invariants.</summary>
+public sealed class SegmentRouteReconcilerTests
+{
+    /// <summary>Legacy zero-waypoint segments retain optional endpoints and geometry.</summary>
+    [Fact]
+    public void Reconcile_ZeroWaypoints_PreservesLegacyCompatibility()
+    {
+        var segment = Segment();
+        var geometry = Line(Coordinate(1, 1), Coordinate(2, 2));
+
+        var result = SegmentRouteReconciler.Reconcile(segment, null, null, [], geometry);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(segment.FromPlaceId);
+        Assert.Null(segment.ToPlaceId);
+        Assert.Same(geometry, segment.RouteGeometry);
+        Assert.Empty(segment.Waypoints);
+    }
+
+    /// <summary>A valid fallback proposal retains null geometry and produces its deterministic anchor chain.</summary>
+    [Fact]
+    public void Reconcile_ValidFallback_ProducesOrderedAnchorChain()
+    {
+        var tripId = Guid.NewGuid();
+        var from = Place(tripId, 1, 1);
+        var via = Place(tripId, 2, 2);
+        var to = Place(tripId, 3, 3);
+        var segment = Segment(tripId);
+
+        var result = SegmentRouteReconciler.Reconcile(segment, from, to, [new(via, 0, null)], null);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(segment.RouteGeometry);
+        Assert.Collection(segment.Waypoints, waypoint =>
+        {
+            Assert.Equal(via.Id, waypoint.PlaceId);
+            Assert.Equal(0, waypoint.Position);
+            Assert.Null(waypoint.RouteVertexIndex);
+        });
+        Assert.Equal([from.Location!.Coordinate, via.Location!.Coordinate, to.Location!.Coordinate],
+            result.EffectiveAnchorChain.Select(point => point.Coordinate), CoordinateComparer.Instance);
+    }
+
+    /// <summary>A closed loop reuses one canonical endpoint place without duplicating it.</summary>
+    [Fact]
+    public void Reconcile_ValidClosedLoop_UsesCanonicalEndpointPlace()
+    {
+        var tripId = Guid.NewGuid();
+        var endpoint = Place(tripId, 1, 1);
+        var via = Place(tripId, 2, 2);
+        var segment = Segment(tripId);
+
+        var result = SegmentRouteReconciler.Reconcile(segment, endpoint, endpoint, [new(via, 0, null)], null);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(endpoint.Id, segment.FromPlaceId);
+        Assert.Equal(endpoint.Id, segment.ToPlaceId);
+        Assert.Equal(endpoint.Id, result.EffectiveAnchorChain[0].Id);
+        Assert.Equal(endpoint.Id, result.EffectiveAnchorChain[^1].Id);
+    }
+
+    /// <summary>A custom route accepts complete ordered interior anchor mappings.</summary>
+    [Fact]
+    public void Reconcile_ValidCustomGeometry_AcceptsOrderedWaypointIndices()
+    {
+        var tripId = Guid.NewGuid();
+        var from = Place(tripId, 1, 1);
+        var first = Place(tripId, 2, 2);
+        var second = Place(tripId, 4, 4);
+        var to = Place(tripId, 5, 5);
+        var geometry = Line(Coordinate(1, 1), Coordinate(1.5, 1.5), Coordinate(2, 2), Coordinate(3, 3), Coordinate(4, 4), Coordinate(5, 5));
+        var segment = Segment(tripId);
+
+        var result = SegmentRouteReconciler.Reconcile(segment, from, to, [new(first, 0, 2), new(second, 1, 4)], geometry);
+
+        Assert.True(result.Succeeded);
+        Assert.Same(geometry, segment.RouteGeometry);
+        Assert.Equal([2, 4], segment.Waypoints.Select(waypoint => waypoint.RouteVertexIndex));
+    }
+
+    /// <summary>Representative invalid proposals reject without changing tracked aggregate state.</summary>
+    [Theory]
+    [MemberData(nameof(InvalidProposals))]
+    public void Reconcile_InvalidProposal_LeavesAggregateUnchanged(
+        Func<Guid, Place, Place, Place, (Place? From, Place? To, SegmentWaypointProposal[] Waypoints, LineString? Geometry)> proposal)
+    {
+        var tripId = Guid.NewGuid();
+        var originalFrom = Place(tripId, 10, 10);
+        var originalTo = Place(tripId, 11, 11);
+        var candidate = Place(tripId, 2, 2);
+        var segment = Segment(tripId);
+        segment.FromPlaceId = originalFrom.Id;
+        segment.FromPlace = originalFrom;
+        segment.ToPlaceId = originalTo.Id;
+        segment.ToPlace = originalTo;
+        segment.Waypoints.Add(new SegmentWaypoint { SegmentId = segment.Id, PlaceId = candidate.Id, Place = candidate, Position = 0 });
+        var before = Snapshot(segment);
+        var proposed = proposal(tripId, originalFrom, originalTo, candidate);
+
+        var result = SegmentRouteReconciler.Reconcile(segment, proposed.From, proposed.To, proposed.Waypoints, proposed.Geometry);
+
+        Assert.False(result.Succeeded);
+        Assert.NotEmpty(result.Errors);
+        Assert.Equal(before, Snapshot(segment));
+    }
+
+    /// <summary>Enumerates ownership, ordering, endpoint, location, and geometry rejection cases.</summary>
+    public static TheoryData<Func<Guid, Place, Place, Place, (Place?, Place?, SegmentWaypointProposal[], LineString?)>> InvalidProposals => new()
+    {
+        (tripId, from, to, via) => (from, to, [new(Place(Guid.NewGuid(), 2, 2), 0, null)], null),
+        (tripId, from, to, via) => (from, to, [new(via, 0, null), new(via, 1, null)], null),
+        (tripId, from, to, via) => (from, to, [new(from, 0, null)], null),
+        (tripId, from, to, via) => (from, to, [new(to, 0, null)], null),
+        (tripId, from, to, via) => (null, to, [new(via, 0, null)], null),
+        (tripId, from, to, via) => (from, null, [new(via, 0, null)], null),
+        (tripId, from, to, via) => (from, to, [new(Place(tripId, null, null), 0, null)], null),
+        (tripId, from, to, via) => (from, to, [new(via, 1, null)], null),
+        (tripId, from, to, via) => (from, to, [new(via, 0, null), new(Place(tripId, 3, 3), 0, null)], null),
+        (tripId, from, to, via) => (from, to, [new(via, 0, null)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(11, 11))),
+        (tripId, from, to, via) => (from, to, [new(via, 0, 1)], null),
+        (tripId, from, to, via) => (from, to, [new(via, 0, 1), new(Place(tripId, 3, 3), 1, 1)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(3, 3), Coordinate(11, 11))),
+        (tripId, from, to, via) => (from, to, [new(via, 0, 2), new(Place(tripId, 3, 3), 1, 1)], Line(Coordinate(10, 10), Coordinate(3, 3), Coordinate(2, 2), Coordinate(11, 11))),
+        (tripId, from, to, via) => (from, to, [new(via, 0, 0)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(11, 11))),
+        (tripId, from, to, via) => (from, to, [new(via, 0, 2)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(11, 11))),
+        (tripId, from, to, via) => (from, to, [new(via, 0, 1)], Line(Coordinate(10, 10), Coordinate(2.000001, 2), Coordinate(11, 11))),
+        (tripId, from, to, via) => (from, from, [new(via, 0, 1)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(10.000001, 10)))
+    };
+
+    /// <summary>The inclusive tolerance boundary is accepted independently on both axes.</summary>
+    [Fact]
+    public void Reconcile_CoordinateAtToleranceBoundary_IsAccepted()
+    {
+        var tripId = Guid.NewGuid();
+        var from = Place(tripId, 1, 1);
+        var via = Place(tripId, 2, 2);
+        var to = Place(tripId, 3, 3);
+        var geometry = Line(Coordinate(1.0000001, 0.9999999), Coordinate(2.0000001, 1.9999999), Coordinate(3.0000001, 2.9999999));
+
+        var result = SegmentRouteReconciler.Reconcile(Segment(tripId), from, to, [new(via, 0, 1)], geometry);
+
+        Assert.True(result.Succeeded);
+    }
+
+    private static Segment Segment(Guid? tripId = null) => new() { Id = Guid.NewGuid(), TripId = tripId ?? Guid.NewGuid(), UserId = "owner" };
+
+    private static Place Place(Guid tripId, double? longitude, double? latitude) => new()
+    {
+        Id = Guid.NewGuid(),
+        Region = new Region { Id = Guid.NewGuid(), TripId = tripId, UserId = "owner" },
+        RegionId = Guid.NewGuid(),
+        UserId = "owner",
+        Location = longitude.HasValue ? new Point(longitude.Value, latitude!.Value) { SRID = 4326 } : null
+    };
+
+    private static Coordinate Coordinate(double x, double y) => new(x, y);
+
+    private static LineString Line(params Coordinate[] coordinates) => new(coordinates) { SRID = 4326 };
+
+    private static string Snapshot(Segment segment) =>
+        $"{segment.FromPlaceId}|{segment.ToPlaceId}|{segment.RouteGeometry?.AsText()}|{string.Join(';', segment.Waypoints.Select(waypoint => $"{waypoint.PlaceId}:{waypoint.Position}:{waypoint.RouteVertexIndex}"))}";
+
+    private sealed class CoordinateComparer : IEqualityComparer<Coordinate>
+    {
+        internal static readonly CoordinateComparer Instance = new();
+        public bool Equals(Coordinate? left, Coordinate? right) => left?.Equals2D(right) == true;
+        public int GetHashCode(Coordinate coordinate) => HashCode.Combine(coordinate.X, coordinate.Y);
+    }
+}

--- a/tests/Wayfarer.Tests/Services/SegmentRouteReconcilerTests.cs
+++ b/tests/Wayfarer.Tests/Services/SegmentRouteReconcilerTests.cs
@@ -66,6 +66,21 @@ public sealed class SegmentRouteReconcilerTests
         Assert.Equal(endpoint.Id, result.EffectiveAnchorChain[^1].Id);
     }
 
+    /// <summary>A zero-waypoint fallback loop retains two route positions with one saved-place identity.</summary>
+    [Fact]
+    public void Reconcile_ZeroWaypointClosedLoop_ProducesZeroDistanceFallback()
+    {
+        var tripId = Guid.NewGuid();
+        var endpoint = Place(tripId, 1, 1);
+
+        var result = SegmentRouteReconciler.Reconcile(Segment(tripId), endpoint, endpoint, [], null);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, result.EffectiveAnchorChain.Count);
+        Assert.Same(result.EffectiveAnchorChain[0], result.EffectiveAnchorChain[1]);
+        Assert.True(result.EffectiveAnchorChain[0].Location!.Coordinate.Equals2D(result.EffectiveAnchorChain[1].Location!.Coordinate));
+    }
+
     /// <summary>A custom route accepts complete ordered interior anchor mappings.</summary>
     [Fact]
     public void Reconcile_ValidCustomGeometry_AcceptsOrderedWaypointIndices()
@@ -120,7 +135,10 @@ public sealed class SegmentRouteReconcilerTests
         (tripId, from, to, via) => (from, to, [new(to, 0, null)], null),
         (tripId, from, to, via) => (null, to, [new(via, 0, null)], null),
         (tripId, from, to, via) => (from, null, [new(via, 0, null)], null),
+        (tripId, from, to, via) => (Place(tripId, null, null), to, [new(via, 0, null)], null),
+        (tripId, from, to, via) => (from, Place(tripId, null, null), [new(via, 0, null)], null),
         (tripId, from, to, via) => (from, to, [new(Place(tripId, null, null), 0, null)], null),
+        (tripId, from, to, via) => (from, to, [new(Place(tripId, 2, 2, 3857), 0, null)], null),
         (tripId, from, to, via) => (from, to, [new(via, 1, null)], null),
         (tripId, from, to, via) => (from, to, [new(via, 0, null), new(Place(tripId, 3, 3), 0, null)], null),
         (tripId, from, to, via) => (from, to, [new(via, 0, null)], Line(Coordinate(10, 10), Coordinate(2, 2), Coordinate(11, 11))),
@@ -150,13 +168,13 @@ public sealed class SegmentRouteReconcilerTests
 
     private static Segment Segment(Guid? tripId = null) => new() { Id = Guid.NewGuid(), TripId = tripId ?? Guid.NewGuid(), UserId = "owner" };
 
-    private static Place Place(Guid tripId, double? longitude, double? latitude) => new()
+    private static Place Place(Guid tripId, double? longitude, double? latitude, int srid = 4326) => new()
     {
         Id = Guid.NewGuid(),
         Region = new Region { Id = Guid.NewGuid(), TripId = tripId, UserId = "owner" },
         RegionId = Guid.NewGuid(),
         UserId = "owner",
-        Location = longitude.HasValue ? new Point(longitude.Value, latitude!.Value) { SRID = 4326 } : null
+        Location = longitude.HasValue ? new Point(longitude.Value, latitude!.Value) { SRID = srid } : null
     };
 
     private static Coordinate Coordinate(double x, double y) => new(x, y);


### PR DESCRIPTION
## Summary

- add the explicit ordered `SegmentWaypoint` aggregate child
- add PostgreSQL-backed schema constraints, indexes, cascade/restrict behavior, and migration rollback
- add the internal `SegmentRouteReconciler` boundary for canonical loading and aggregate invariants
- support ordered fallback anchors, custom route vertex mappings, and closed loops
- serialize same-Segment reconciliation with a PostgreSQL row lock
- make persisted reorder, cancellation recovery, cleanup failure, and tracker refresh deterministic
- keep the foundation unexposed to editor, API, viewer, clone, KML, lifecycle, measurement, and mobile consumers

## Contract

Implements `WP` and the #404-owned portion of `LOOP` from #388.

The reconciler validates and commits one complete Segment route aggregate. It accepts scalar identities, loads canonical database state after acquiring the Segment lock, defensively copies geometry, and rejects invalid proposals without partial persistence.

## Migration notes

Migration `20260802085255_AddSegmentWaypoints`:

- creates `SegmentWaypoints`
- uses composite identity `(SegmentId, PlaceId)`
- adds zero-based `Position` and nullable `RouteVertexIndex`
- cascades association deletion from Segment
- restricts Place deletion
- enforces Position/index checks and per-Segment uniqueness
- creates no waypoint rows for existing Segments
- rewrites no existing Segment data
- Down removes only the new table

Exact-base Up, Down, and re-Up were executed on PostgreSQL 17.2/PostGIS 3.5.0. EF reports no pending model changes.

## Correctness boundaries

- canonical Segment/Place/Region/Trip state is loaded after a transaction-scoped `FOR UPDATE` lock
- same-Segment reconciliations serialize; different Segments remain independent
- persisted reorders use transactionally contained delete/reinsert
- dirty caller contexts are rejected before mutation
- cancellation cleanup uses a non-cancelled cleanup path
- cleanup failure invalidates the context and retains operation/cleanup failures
- refresh is scoped to target/current/proposed identities and preserves unrelated tracking
- no optimistic-concurrency conflict semantics are exposed in this foundation slice

## Validation

- final strict review: `READY FOR PR`
- isolated PostgreSQL provider review: 25 passed, 0 failed, 0 skipped
- focused reconciler/model/migration/provider/Segment/TransportProfile selection: 73 passed, 0 failed, 0 skipped
- configured unfiltered Release suite: 1,966 passed, 0 failed, 0 skipped
- real Playwright rendering prerequisite: passed
- `dotnet ef migrations has-pending-model-changes --no-build`: passed
- Release build: passed with 0 errors
- LOC policy: passed; cohesive 504/428 LOC warnings reviewed and accepted, no hard-cap violation
- `git diff --check origin/main...HEAD`: passed
- exposure searches: passed

Existing AngleSharp and SQLitePCLRaw advisories remain unchanged and outside this slice.

## Scope

No editor/public DTO, TypeScript/Vue, viewer, lifecycle, measurement, clone, KML/import/export, #389, or WayfarerMobile behavior is introduced. This merges only as an unexposed backend foundation.

Closes #404

Related: #388, #403, #405