### PR TITLE
fix(deps): patch vulnerable frontend and backend packages

### DIFF
--- a/Wayfarer.csproj
+++ b/Wayfarer.csproj
@@ -19,7 +19,7 @@
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="33.1.0" />
         <PackageReference Include="GeoTimeZone" Version="6.0.0" />
-        <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
+        <PackageReference Include="HtmlSanitizer" Version="9.2.995" />
 
 
         <!-- EF Core packages for .NET 10 -->
@@ -31,6 +31,8 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+        <!-- Override EF Core's vulnerable SQLite native bundle until its dependency floor advances. -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,9 +1154,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary\n\n- update the transitive nanoid lock resolution from 3.3.16 to 3.3.18\n- update HtmlSanitizer to 9.2.995, replacing vulnerable AngleSharp 0.17.1 with 1.7.1\n- override EF Core's SQLite native bundle with SQLitePCLRaw.bundle_e_sqlite3 2.1.12\n\n## Why\n\nThis resolves Dependabot alert #78 and the two NuGet audit advisories previously reported during builds. The PR intentionally excludes unrelated dependency upgrades.\n\n## Validation\n\n- npm audit: 0 vulnerabilities\n- production NuGet graph: 0 vulnerable packages\n- test NuGet graph: 0 vulnerable packages\n- frontend client tests: 5 passed\n- npm production build: passed\n- Debug build: passed with 0 warnings and 0 errors\n- Release build: passed with 0 warnings and 0 errors\n- local Release suite with installed Chromium: 1,972 passed, 0 failed, 96 PostgreSQL tests skipped because no isolated provider connection was configured\n- LOC checker: passed\n- git diff --check: passed\n\n## Database\n\nNo schema or migration changes. The SQLitePCLRaw reference is a security override for EF Core's current transitive dependency.